### PR TITLE
Ptr{None} -> Ptr{Void}

### DIFF
--- a/src/crypto.jl
+++ b/src/crypto.jl
@@ -20,7 +20,7 @@ end
 
 typealias size_t Csize_t
 
-@c Ptr{Uint8} HMAC (Ptr{EVP_MD}, Ptr{None}, Int32, Ptr{Uint8}, size_t, Ptr{Uint8}, Ptr{Uint32}) libcrypto
+@c Ptr{Uint8} HMAC (Ptr{EVP_MD}, Ptr{Void}, Int32, Ptr{Uint8}, size_t, Ptr{Uint8}, Ptr{Uint32}) libcrypto
 @c Ptr{Uint8} MD5 (Ptr{Uint8}, size_t, Ptr{Uint8}) libcrypto
 
 @c Ptr{EVP_MD} EVP_md5 () libcrypto
@@ -29,7 +29,7 @@ typealias size_t Csize_t
 
 @c Ptr{EVP_MD_CTX} EVP_MD_CTX_create () libcrypto
 @c Int32 EVP_DigestInit_ex (Ptr{EVP_MD_CTX}, Ptr{EVP_MD}, Ptr{ENGINE}) libcrypto
-@c Int32 EVP_DigestUpdate (Ptr{EVP_MD_CTX}, Ptr{None}, size_t) libcrypto
+@c Int32 EVP_DigestUpdate (Ptr{EVP_MD_CTX}, Ptr{Void}, size_t) libcrypto
 @c Int32 EVP_DigestFinal_ex (Ptr{EVP_MD_CTX}, Ptr{Uint8}, Ptr{Uint32}) libcrypto
 @c None EVP_MD_CTX_destroy (Ptr{EVP_MD_CTX},) libcrypto
 


### PR DESCRIPTION
Ptr{None} is deprecated, see https://github.com/JuliaLang/julia/issues/8423

Please check that this is correct, I just searched for usages in packages registered in METADATA, and might have made mistakes.
