### PR TITLE
fix an issue for julia 0.5

### DIFF
--- a/src/show.jl
+++ b/src/show.jl
@@ -50,7 +50,7 @@ end
 # Create default show method for all types
 for m in [AWS, AWS.EC2, AWS.S3]
     for n in names(m)
-        t = (m).(n)
+        t = getfield(m, n)
         if isa(t,Type)
             @eval @show_func $n $t
         end


### PR DESCRIPTION
fix this error in julia 0.5

```
WARNING: Base.ASCIIString is deprecated, use String instead.
  likely near /root/.julia/v0.5/AWS/src/sqs_types.jl:747
WARNING: Base.ASCIIString is deprecated, use String instead.
  likely near /root/.julia/v0.5/AWS/src/sqs_types.jl:747
WARNING: Base.ASCIIString is deprecated, use String instead.
  likely near /root/.julia/v0.5/AWS/src/sqs_types.jl:760
WARNING: Base.ASCIIString is deprecated, use String instead.
  likely near /root/.julia/v0.5/AWS/src/sqs_types.jl:775
WARNING: Base.ASCIIString is deprecated, use String instead.
  likely near /root/.julia/v0.5/AWS/src/sqs_types.jl:775
WARNING: Base.ASCIIString is deprecated, use String instead.
  likely near /root/.julia/v0.5/AWS/src/sqs_types.jl:785
WARNING: Base.ASCIIString is deprecated, use String instead.
  likely near /root/.julia/v0.5/AWS/src/show.jl:10
WARNING: AWS.(Symbol("@parse_vector")) is deprecated; use AWS.Symbol("@parse_vector") or getfield(AWS, Symbol("@parse_vector")) instead.
 in depwarn(::String, ::Symbol) at ./deprecated.jl:64
 in broadcast(::Module, ::Symbol) at ./deprecated.jl:377
 in macro expansion; at /root/.julia/v0.5/AWS/src/show.jl:53 [inlined]
 in anonymous at ./<missing>:?
 in include_from_node1(::String) at ./loading.jl:488 (repeats 2 times)
 in macro expansion; at ./none:2 [inlined]
 in anonymous at ./<missing>:?
 in eval(::Module, ::Any) at ./boot.jl:234
 in process_options(::Base.JLOptions) at ./client.jl:239
 in _start() at ./client.jl:318
while loading /root/.julia/v0.5/AWS/src/show.jl, in expression starting on line 51
```
