### PR TITLE
Update build.jl

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -2,7 +2,7 @@ using BinDeps
 
 @BinDeps.setup
 
-@windows_only begin
+@static if is_windows() begin
   crypto = library_dependency("libcrypto", aliases = ["libcrypto-10"])
   using WinRPM
   provides(WinRPM.RPM, "openssl", crypto, os = :Windows )


### PR DESCRIPTION
fix a warning in Julia 0.5.2
```
WARNING: `@windows_only` is deprecated, use `@static if is_windows()` instead
 in depwarn(::String, ::Symbol) at ./deprecated.jl:64
 in @windows_only(::Any) at ./deprecated.jl:489
 in include_from_node1(::String) at ./loading.jl:488
 in evalfile(::String, ::Array{String,1}) at ./loading.jl:504 (repeats 2 times)
 in cd(::##2#4, ::String) at ./file.jl:59
 in (::##1#3)(::IOStream) at ./none:13
 in open(::##1#3, ::String, ::String) at ./iostream.jl:113
 in eval(::Module, ::Any) at ./boot.jl:234
 in process_options(::Base.JLOptions) at ./client.jl:242
 in _start() at ./client.jl:321
while loading /home/travis/.julia/v0.5/AWS/deps/build.jl, in expression starting on line 5
```