### PR TITLE
fix constant redefinition

### DIFF
--- a/src/AWS.jl
+++ b/src/AWS.jl
@@ -35,7 +35,6 @@ function __init__()
     global AWS_ID = ""
     global AWS_SECKEY = ""
     global AWS_REGION = US_EAST_1
-    global const AWS_TOKEN = ""
     global AWS_TOKEN = ""
     if haskey(ENV, "AWS_ID") && haskey(ENV, "AWS_SECKEY")
         AWS_ID = ENV["AWS_ID"]


### PR DESCRIPTION
`AWS_TOKEN` was being defined twice differently (likely from git reconcilation), resulting in:

```
julia> using AWS
INFO: Precompiling module AWS.
WARNING: redefining constant AWS_TOKEN
use default region: us-east-1
```