### PR TITLE
Fixed the implementation of md5 for IO 

### DIFF
--- a/src/S3.jl
+++ b/src/S3.jl
@@ -498,7 +498,7 @@ end
 
 function describe_object(env::AWSEnv, bkt::String, key::String; options::GetObjectOptions=GetObjectOptions(), version_id::String="")
     ro = RO(:HEAD, bkt, key)
-    ro.http_hdrs = http_headers(options)
+    ro.http_hdrs = http_headers(Tuple[], options)
     if (version_id != "") ro.sub_res=[("versionId", version_id)] end
 
     s3_resp = do_request(env, ro)

--- a/src/crypto.jl
+++ b/src/crypto.jl
@@ -23,18 +23,18 @@ export md5_file
 md5(s::String) = digest(MD_MD5, s)
 
 function md5(s::IO)
-    md = MD(MD_MD5)
+    md = MbedTLS.MD(MD_MD5)
     success = false
     try
         while !eof(s)
             b = read(s, UInt8, min(nb_available(s), 65536))    # Read in 64 K chunks....
-            write(md, b)
+            MbedTLS.write(md, b)
         end
-        d = finish!(md)
+        d = MbedTLS.finish!(md)
         success = true
         return d
     finally
-        success || finish!(md)
+        success || MbedTLS.finish!(md)
     end
 end
 export md5


### PR DESCRIPTION
Due to changes in the exported functions from MbedTLS, the md5 implementation for IO was not working anymore. This pull-request solves the issue.