### PR TITLE
use 'String(bkt)' instead of 'string(bkt)' on julia 0.6

### DIFF
--- a/src/S3.jl
+++ b/src/S3.jl
@@ -261,9 +261,9 @@ end
 split a s3 path to bucket name and key
 """
 function splits3(path::AbstractString)
-    path = replace(path, "s3://", "")
+    path = replace(path, r"^s3://", s"")
     bkt, key = split(path, "/", limit = 2)
-    return string(bkt), string(key)
+    return String(bkt), String(key)
 end
 
 """


### PR DESCRIPTION
`f(bkt::String, key::String, ...)` accepts SubString on 0.4 but not on 0.5 and 0.6. This PR returns String instead of SubString from `splits3`.

Another option would be to change the interface of many other functions to accept `f(bkt::AbstractString, key::AbstractString, ...)` instead of `f(bkt::String, key::String, ...)`

Sidenote: I'm not sure if `string(bkt)` was needed as `string(bkt) === bkt` on both julia 0.3, 0.4, 0.5 and 0.6 if `(bkt,key) = split("a/b", '/')`.