### PR TITLE
List many objects

### DIFF
--- a/src/S3.jl
+++ b/src/S3.jl
@@ -987,15 +987,13 @@ function list_objects_details(awsEnv::AWSEnv, bkt::AbstractString, prefix::Abstr
         more = true
 
         while more
-            bucket_options = AWS.S3.GetBucketOptions(delimiter="/", prefix=prefix, marker=marker, max_keys=max_keys);
+            bucket_options = AWS.S3.GetBucketOptions(delimiter="/", prefix=prefix, marker=marker, max_keys=max_keys)
             resp = AWS.S3.get_bkt(awsEnv, bkt; options=bucket_options)
 
             more = resp.obj.isTruncated
             marker = resp.obj.nextMarker
 
-            for content in resp.obj.contents
-                put!(c, content)
-            end
+            put!.(c, resp.obj.contents)
         end
     end
 

--- a/src/S3.jl
+++ b/src/S3.jl
@@ -965,7 +965,11 @@ function list_objects(awsEnv::AWSEnv, bkt::AbstractString, prefix::AbstractStrin
             marker = resp.obj.nextMarker
 
             for content in resp.obj.contents
-                fname = replace(content.key, prefix, "")
+                if startswith(content.key, prefix)
+                    fname = content.key[length(prefix)+1:end]
+                else
+                    fname = content.key
+                end
 
                 if ismatch(re, fname)
                     if details

--- a/src/S3.jl
+++ b/src/S3.jl
@@ -261,9 +261,9 @@ end
 split a s3 path to bucket name and key
 """
 function splits3(path::AbstractString)
-    path = replace(path, "s3://", "")
+    path = replace(path, r"^s3://", s"")
     bkt, key = split(path, "/", limit = 2)
-    return string(bkt), string(key)
+    return String(bkt), String(key)
 end
 
 """

--- a/src/s3_types.jl
+++ b/src/s3_types.jl
@@ -16,9 +16,9 @@ macro add_amz_hdr(hdrs, name, value)
     end
 end
 
-macro chk_n_add(name, value)
+macro chk_n_add(arr, name, value)
     quote
-        if ($(esc(value)) != nothing) push!(arr, ($(esc(name)), string($(esc(value)))  )) end
+        if ($(esc(value)) != nothing) push!($(esc(arr)), ($(esc(name)), string($(esc(value)))  )) end
     end
 end
 
@@ -799,10 +799,10 @@ function amz_headers(hdrs, o::PutObjectOptions)
 end
 
 function http_headers(arr, o::PutObjectOptions)
-    @chk_n_add("Cache-Control", o.cache_control)
-    @chk_n_add("Content-Disposition", o.content_disposition)
-    @chk_n_add("Content-Encoding", o.content_encoding)
-    @chk_n_add("Expires", rfc1123_date(o.expires))
+    @chk_n_add(arr, "Cache-Control", o.cache_control)
+    @chk_n_add(arr, "Content-Disposition", o.content_disposition)
+    @chk_n_add(arr, "Content-Encoding", o.content_encoding)
+    @chk_n_add(arr, "Expires", rfc1123_date(o.expires))
     arr
 end
 export PutObjectOptions
@@ -831,21 +831,21 @@ type GetObjectOptions
         end
 end
 function http_headers(arr, o::GetObjectOptions)
-    @chk_n_add("Range", o.range)
-    @chk_n_add("If-Modified-Since", rfc1123_date(o.if_modified_since))
-    @chk_n_add("If-Unmodified-Since", rfc1123_date(o.if_unmodified_since))
-    @chk_n_add("If-Match", o.if_match)
-    @chk_n_add("If-None-Match", o.if_none_match)
+    @chk_n_add(arr, "Range", o.range)
+    @chk_n_add(arr, "If-Modified-Since", rfc1123_date(o.if_modified_since))
+    @chk_n_add(arr, "If-Unmodified-Since", rfc1123_date(o.if_unmodified_since))
+    @chk_n_add(arr, "If-Match", o.if_match)
+    @chk_n_add(arr, "If-None-Match", o.if_none_match)
     arr
 end
 
 function query_params(arr, o::GetObjectOptions)
-    @chk_n_add("response-cont-typ", o.response_cont_typ)
-    @chk_n_add("response-content-language", o.response_content_language)
-    @chk_n_add("response-expires", o.response_expires)
-    @chk_n_add("response-cache-control", o.response_cache_control)
-    @chk_n_add("response-content-disposition", o.response_content_disposition)
-    @chk_n_add("response-content-encoding", o.response_content_encoding)
+    @chk_n_add(arr, "response-cont-typ", o.response_cont_typ)
+    @chk_n_add(arr, "response-content-language", o.response_content_language)
+    @chk_n_add(arr, "response-expires", o.response_expires)
+    @chk_n_add(arr, "response-cache-control", o.response_cache_control)
+    @chk_n_add(arr, "response-content-disposition", o.response_content_disposition)
+    @chk_n_add(arr, "response-content-encoding", o.response_content_encoding)
     arr
 end
 export GetObjectOptions
@@ -903,11 +903,11 @@ type GetBucketUploadsOptions
     end
 end
 function get_subres(arr, o::GetBucketUploadsOptions)
-    @chk_n_add("delimiter", o.delimiter)
-    @chk_n_add("key-marker", o.key_marker)
-    @chk_n_add("max-uploads", o.max_uploads)
-    @chk_n_add("prefix", o.prefix)
-    @chk_n_add("upload-id-marker", o.upload_id_marker)
+    @chk_n_add(arr, "delimiter", o.delimiter)
+    @chk_n_add(arr, "key-marker", o.key_marker)
+    @chk_n_add(arr, "max-uploads", o.max_uploads)
+    @chk_n_add(arr, "prefix", o.prefix)
+    @chk_n_add(arr, "upload-id-marker", o.upload_id_marker)
     arr
 end
 export GetBucketUploadsOptions
@@ -925,11 +925,11 @@ type GetBucketObjectVersionsOptions
     end
 end
 function get_subres(arr, o::GetBucketObjectVersionsOptions)
-    @chk_n_add("delimiter", o.delimiter)
-    @chk_n_add("key-marker", o.key_marker)
-    @chk_n_add("max-keys", o.max_keys)
-    @chk_n_add("prefix", o.prefix)
-    @chk_n_add("version-id-marker", o.version_id_marker)
+    @chk_n_add(arr, "delimiter", o.delimiter)
+    @chk_n_add(arr, "key-marker", o.key_marker)
+    @chk_n_add(arr, "max-keys", o.max_keys)
+    @chk_n_add(arr, "prefix", o.prefix)
+    @chk_n_add(arr, "version-id-marker", o.version_id_marker)
     arr
 end
 export GetBucketObjectVersionsOptions
@@ -943,10 +943,10 @@ type GetBucketOptions
     GetBucketOptions(;delimiter=nothing, marker=nothing, max_keys=nothing, prefix=nothing) = new(delimiter, marker, max_keys, prefix)
 end
 function get_subres(arr, o::GetBucketOptions)
-    @chk_n_add("delimiter", o.delimiter)
-    @chk_n_add("marker", o.marker)
-    @chk_n_add("max-keys", o.max_keys)
-    @chk_n_add("prefix", o.prefix)
+    @chk_n_add(arr, "delimiter", o.delimiter)
+    @chk_n_add(arr, "marker", o.marker)
+    @chk_n_add(arr, "max-keys", o.max_keys)
+    @chk_n_add(arr, "prefix", o.prefix)
     arr
 end
 export GetBucketOptions

--- a/test/tests3.jl
+++ b/test/tests3.jl
@@ -64,7 +64,7 @@ function test_bucket_ops(env)
     @test collect(objs) == ["file1", "file2", "file3"]
 
     info("list objects with details")
-    (bkt,objs) = S3.list_objects(env, bkt, "fi", details=true)
+    (bkt,objs) = S3.list_objects_details(env, bkt, "fi")
     @test [o.key for o in objs] == ["file1", "file2", "file3"]
 
     info("delete file 1")

--- a/test/tests3.jl
+++ b/test/tests3.jl
@@ -59,6 +59,14 @@ function test_bucket_ops(env)
     #info("Sleep for 10 secs ....")
     #sleep(10)
 
+    info("list objects")
+    (bkt,objs) = S3.list_objects(env, bkt, "fi")
+    @test collect(objs) == ["file1", "file2", "file3"]
+
+    info("list objects with details")
+    (bkt,objs) = S3.list_objects(env, bkt, "fi", details=true)
+    @test [o.key for o in objs] == ["file1", "file2", "file3"]
+
     info("delete file 1")
     resp = S3.del_object(env, bkt, "file1")
     check_resp(resp, String)


### PR DESCRIPTION
This PR depends on #108.

Changes:

* `list_objects` can return all objects in a bucket. Not just the first 1000.
* `list_objects` returns a Channel instead of an Array to stream results of long listings.
* `list_objects_details` returns details of a listing, such as timestamp of last modified and etag in `AWS.S3.Contents` objects.