### PR TITLE
Added REST JSON request functionality

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,6 @@ Mocking = "78c3b35d-d492-501b-9361-3d52fe80e533"
 OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 Retry = "20febd7b-183b-5ae2-ac4a-720e7ce64774"
 Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
-SymDict = "2da68c74-98d7-5633-99d6-8493888d7b1e"
 XMLDict = "228000da-037f-5747-90a9-8195ccbf91a5"
 
 [compat]
@@ -27,7 +26,6 @@ MbedTLS = "0.6, 0.7, 1"
 Mocking = "0.7"
 OrderedCollections = "1"
 Retry = "0.3, 0.4"
-SymDict = "0.3"
 XMLDict = "0.3, 0.4"
 julia = "1"
 

--- a/src/AWS.jl
+++ b/src/AWS.jl
@@ -58,10 +58,10 @@ struct RestJSONService
     name::String
     api_version::String
 
-    service_specifics::LittleDict{String, AbstractDict}
+    service_specific_headers::LittleDict{String, String}
 
-    RestJSONService(name::String, api_version::String) = new(name, api_version, Dict())
-    RestJSONService(name::String, api_version::String, service_specifics::LittleDict{String, <:AbstractDict}) = new(name, api_version, service_specifics)
+    RestJSONService(name::String, api_version::String) = new(name, api_version, LittleDict())
+    RestJSONService(name::String, api_version::String, service_specific_headers::LittleDict{String, String}) = new(name, api_version, service_specific_headers)
 end
 
 # Needs to be included after the definition of struct otherwise it cannot find them
@@ -454,8 +454,8 @@ function (service::RestJSONService)(aws::AWS.AWSConfig, request_method::String, 
 
     request[:headers] = Dict{String, String}(get(args, "headers", []))
 
-    if haskey(service.service_specifics, "headers")
-        request[:headers] = merge(request[:headers], service.service_specifics["headers"])
+    if !isempty(service.service_specific_headers)
+        request[:headers] = merge(request[:headers], service.service_specific_headers)
     end
 
     request[:headers]["Content-Type"] = "application/json"

--- a/src/AWS.jl
+++ b/src/AWS.jl
@@ -182,7 +182,7 @@ function _sign_aws4!(aws::AWSConfig, request::Request, time::DateTime)
     end
 
     # Sort and lowercase() Headers to produce canonical form...
-    canonical_headers = ["$(lowercase(k)):$(strip(v))" for (k,v) in request.headers]
+    canonical_headers = join(sort(["$(lowercase(k)):$(strip(v))" for (k,v) in request.headers]), "\n")
     signed_headers = join(sort([lowercase(k) for k in keys(request.headers)]), ";")
 
     # Sort Query String...
@@ -195,7 +195,7 @@ function _sign_aws4!(aws::AWSConfig, request::Request, time::DateTime)
         request.request_method, "\n",
         request.service == "s3" ? uri.path : HTTP.escapepath(uri.path), "\n",
         HTTP.escapeuri(query), "\n",
-        join(sort(canonical_headers), "\n"), "\n\n",
+        canonical_headers, "\n\n",
         signed_headers, "\n",
         content_hash
     )

--- a/src/AWS.jl
+++ b/src/AWS.jl
@@ -401,6 +401,11 @@ function (service::RestXMLService)(aws::AWSConfig, request_method::String, reque
         request_method=request_method,
         content=get(args, "body", ""),
         headers=LittleDict{String, String}(get(args, "headers", [])),
+        return_stream=get(args, "return_stream", false),
+        http_options=get(args, "http_options", []),
+        response_stream=get(args, "response_stream", nothing),
+        return_raw=get(args, "return_raw", false),
+        ordered_json_dict=get(args, "ordered_json_dict", true),
     )
 
     delete!(args, "headers")
@@ -465,6 +470,11 @@ function (service::RestJSONService)(
         request_method=request_method,
         headers=LittleDict{String, String}(get(args, "headers", [])),
         resource = _generate_rest_resource(request_uri, args),
+        return_stream=get(args, "return_stream", false),
+        http_options=get(args, "http_options", []),
+        response_stream=get(args, "response_stream", nothing),
+        return_raw=get(args, "return_raw", false),
+        ordered_json_dict=get(args, "ordered_json_dict", true),
     )
 
     request.url = _generate_service_url(aws.region, request.service, request.resource)

--- a/src/AWS.jl
+++ b/src/AWS.jl
@@ -58,9 +58,9 @@ struct RestJSONService
     api_version::String
 
     service_specific_headers::LittleDict{String, String}
-
-    RestJSONService(name::String, api_version::String, service_specific_headers::LittleDict{String, String}=LittleDict{String, String}()) = new(name, api_version, service_specific_headers)
 end
+
+RestJSONService(name::String, api_version::String) = RestJSONService(name, api_version, LittleDict{String, String}())
 
 Base.@kwdef mutable struct Request
     service::String

--- a/src/AWS.jl
+++ b/src/AWS.jl
@@ -395,7 +395,7 @@ function (service::RestXMLService)(aws::AWSConfig, request_method::String, reque
     )
 
     if haskey(args, "response_dict_type")
-        request.response_dict_type = get(args, "response_dict_type")
+        request.response_dict_type = args["response_dict_type"]
     end
 
     delete!(args, "headers")
@@ -466,7 +466,7 @@ function (service::RestJSONService)(
     )
 
     if haskey(args, "response_dict_type")
-        request.response_dict_type = get(args, "response_dict_type")
+        request.response_dict_type = args["response_dict_type"]
     end
 
     request.url = _generate_service_url(aws.region, request.service, request.resource)

--- a/src/AWSMetadataUtilities.jl
+++ b/src/AWSMetadataUtilities.jl
@@ -137,7 +137,7 @@ function _generate_low_level_definition(service::Dict)
     service_specifics = LittleDict{String, String}()
 
     if service_id == "glacier"
-        service_specifics[service_id] = "LittleDict(\"headers\" => Dict(\"x-amz-glacier-version\" => \"$(service["apiVersion"])\"))"
+        service_specifics[service_id] = "LittleDict(\"x-amz-glacier-version\" => \"$(service["apiVersion"])\")"
     end
 
     if protocol == "rest-xml"

--- a/src/AWSMetadataUtilities.jl
+++ b/src/AWSMetadataUtilities.jl
@@ -134,11 +134,19 @@ function _generate_low_level_definition(service::Dict)
     service_id = replace(lowercase(service["serviceId"]), ' ' => '_')
     api_version = service["apiVersion"]
 
+    service_specifics = Dict(
+        "glacier" => "Dict(:headers => Dict(\"x-amz-glacier-version\" => \"2012-06-01\"))"
+    )
+
     if protocol == "rest-xml"
         return "const $service_id = AWS.RestXMLService(\"$service_name\", \"$api_version\")"
     elseif protocol in ["ec2", "query"]
         return "const $service_id = AWS.QueryService(\"$service_name\", \"$api_version\")"
     elseif protocol == "rest-json"
+         if haskey(service_specifics, service_id)
+             return "const $service_id = AWS.RestJSONService(\"$service_name\", \"$api_version\", $(service_specifics[service_id]))"
+         end
+
         return "const $service_id = AWS.RestJSONService(\"$service_name\", \"$api_version\")"
     elseif protocol == "json"
         json_version = service["jsonVersion"]

--- a/src/AWSMetadataUtilities.jl
+++ b/src/AWSMetadataUtilities.jl
@@ -3,7 +3,7 @@ module AWSMetadataUtilities
 include("AWSExceptions.jl")
 
 using .AWSExceptions
-using OrderedCollections: OrderedDict
+using OrderedCollections: OrderedDict, LittleDict
 using HTTP
 using JSON
 
@@ -134,9 +134,11 @@ function _generate_low_level_definition(service::Dict)
     service_id = replace(lowercase(service["serviceId"]), ' ' => '_')
     api_version = service["apiVersion"]
 
-    service_specifics = Dict(
-        "glacier" => "Dict(:headers => Dict(\"x-amz-glacier-version\" => \"2012-06-01\"))"
-    )
+    service_specifics = LittleDict{String, String}()
+
+    if service_id == "glacier"
+        service_specifics[service_id] = "LittleDict(\"headers\" => Dict(\"x-amz-glacier-version\" => \"$(service["apiVersion"])\"))"
+    end
 
     if protocol == "rest-xml"
         return "const $service_id = AWS.RestXMLService(\"$service_name\", \"$api_version\")"

--- a/src/AWSServices.jl
+++ b/src/AWSServices.jl
@@ -3,6 +3,7 @@
 module AWSServices
 
 using AWS
+using OrderedCollections: LittleDict
 
 const accessanalyzer = AWS.RestJSONService("access-analyzer", "2019-11-01")
 const acm = AWS.JSONService("acm", "2015-12-08", "1.1", "CertificateManager")
@@ -38,6 +39,7 @@ const cloudtrail = AWS.JSONService("cloudtrail", "2013-11-01", "1.1", "com.amazo
 const cloudwatch = AWS.QueryService("monitoring", "2010-08-01")
 const cloudwatch_events = AWS.JSONService("events", "2015-10-07", "1.1", "AWSEvents")
 const cloudwatch_logs = AWS.JSONService("logs", "2014-03-28", "1.1", "Logs_20140328")
+const codeartifact = AWS.RestJSONService("codeartifact", "2018-09-22")
 const codebuild = AWS.JSONService("codebuild", "2016-10-06", "1.1", "CodeBuild_20161006")
 const codecommit = AWS.JSONService("codecommit", "2015-04-13", "1.1", "CodeCommit_20150413")
 const codedeploy = AWS.JSONService("codedeploy", "2014-10-06", "1.1", "CodeDeploy_20141006")
@@ -94,13 +96,14 @@ const forecastquery = AWS.JSONService("forecastquery", "2018-06-26", "1.1", "Ama
 const frauddetector = AWS.JSONService("frauddetector", "2019-11-15", "1.1", "AWSHawksNestServiceFacade")
 const fsx = AWS.JSONService("fsx", "2018-03-01", "1.1", "AWSSimbaAPIService_v20180301")
 const gamelift = AWS.JSONService("gamelift", "2015-10-01", "1.1", "GameLift")
-const glacier = AWS.RestJSONService("glacier", "2012-06-01")
+const glacier = AWS.RestJSONService("glacier", "2012-06-01", LittleDict("headers" => LittleDict("x-amz-glacier-version" => "2012-06-01")))
 const global_accelerator = AWS.JSONService("globalaccelerator", "2018-08-08", "1.1", "GlobalAccelerator_V20180706")
 const glue = AWS.JSONService("glue", "2017-03-31", "1.1", "AWSGlue")
 const greengrass = AWS.RestJSONService("greengrass", "2017-06-07")
 const groundstation = AWS.RestJSONService("groundstation", "2019-05-23")
 const guardduty = AWS.RestJSONService("guardduty", "2017-11-28")
 const health = AWS.JSONService("health", "2016-08-04", "1.1", "AWSHealth_20160804")
+const honeycode = AWS.RestJSONService("honeycode", "2020-03-01")
 const iam = AWS.QueryService("iam", "2010-05-08")
 const imagebuilder = AWS.RestJSONService("imagebuilder", "2019-12-02")
 const importexport = AWS.QueryService("importexport", "2010-06-01")

--- a/src/AWSServices.jl
+++ b/src/AWSServices.jl
@@ -96,7 +96,7 @@ const forecastquery = AWS.JSONService("forecastquery", "2018-06-26", "1.1", "Ama
 const frauddetector = AWS.JSONService("frauddetector", "2019-11-15", "1.1", "AWSHawksNestServiceFacade")
 const fsx = AWS.JSONService("fsx", "2018-03-01", "1.1", "AWSSimbaAPIService_v20180301")
 const gamelift = AWS.JSONService("gamelift", "2015-10-01", "1.1", "GameLift")
-const glacier = AWS.RestJSONService("glacier", "2012-06-01", LittleDict("headers" => LittleDict("x-amz-glacier-version" => "2012-06-01")))
+const glacier = AWS.RestJSONService("glacier", "2012-06-01", LittleDict("x-amz-glacier-version" => "2012-06-01"))
 const global_accelerator = AWS.JSONService("globalaccelerator", "2018-08-08", "1.1", "GlobalAccelerator_V20180706")
 const glue = AWS.JSONService("glue", "2017-03-31", "1.1", "AWSGlue")
 const greengrass = AWS.RestJSONService("greengrass", "2017-06-07")

--- a/test/AWS.jl
+++ b/test/AWS.jl
@@ -383,15 +383,15 @@ end
     end
 
     @testset "POST - w/ Params" begin
-        AWSServices.s3("POST", "/$bucket_name?delete", Dict("body"=>
-        """
+        body = """
             <Delete xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
                 <Object>
                     <Key>$file_name</Key>
                 </Object>
             </Delete>
-        """
-        ))
+            """
+
+        AWSServices.s3("POST", "/$bucket_name?delete", Dict("body"=>body))
 
         try
             AWSServices.s3("GET", "/$bucket_name/$file_name")

--- a/test/AWS.jl
+++ b/test/AWS.jl
@@ -422,7 +422,7 @@ end
     end
 
     @testset "POST" begin
-        tags = Dict("Tags"=> Dict("Tag-01"=>"Tag-01", "Tag-02"=>"Tag-02"))
+        tags = Dict("Tags"=> LittleDict("Tag-01"=>"Tag-01", "Tag-02"=>"Tag-02"))
 
         for vault in vault_names
             AWSServices.glacier("POST", "/-/vaults/$vault/tags?operation=add", tags)
@@ -439,7 +439,8 @@ end
         # If this is an Integer AWS Coral cannot convert it to a String
         # "class com.amazon.coral.value.json.numbers.TruncatingBigNumber can not be converted to an String"
         limit = "1"
-        result = AWSServices.glacier("GET", "/-/vaults/", ("limit"=>limit))
+        params = LittleDict("limit" => limit)
+        result = AWSServices.glacier("GET", "/-/vaults/", params)
 
         @test length(result["VaultList"]) == parse(Int, limit)
     end

--- a/test/AWS.jl
+++ b/test/AWS.jl
@@ -236,15 +236,6 @@ end
         end
 
         @testset "JSON" begin
-            aws = AWS.AWSConfig()
-
-            request = LittleDict{Symbol, Union{String, Dict{<:Any, <:Any}}}(
-                :content => "",
-                :request_method => "GET",
-                :service => "s3",
-                :url => "https://s3.us-east-1.amazonaws.com/sample-bucket"
-            )
-
             json_headers = ["Content-Type"=>"application/json"]
             json_body = """{"Marker":null,"VaultList":[{"CreationDate":"2020-06-22T03:14:41.754Z","LastInventoryDate":null,"NumberOfArchives":0,"SizeInBytes":0,"VaultARN":"arn:aws:glacier:us-east-1:000:vaults/test","VaultName":"test"}]}"""
 

--- a/test/AWS.jl
+++ b/test/AWS.jl
@@ -365,7 +365,7 @@ end
 
     @testset "PUT - w/ Params" begin
         body = "sample-file-body"
-        AWSServices.s3("PUT", "/$bucket_name/$file_name", Dict("body"=>body))
+        AWSServices.s3("PUT", "/$bucket_name/$file_name", Dict("body" => body))
 
         @test !isempty(AWSServices.s3("GET", "/$bucket_name/$file_name"))
     end
@@ -377,7 +377,7 @@ end
 
     @testset "GET - w/ Params" begin
         max_keys = 1
-        result = AWSServices.s3("GET", "/$bucket_name", Dict("max_keys"=>max_keys))
+        result = AWSServices.s3("GET", "/$bucket_name", Dict("max_keys" => max_keys))
 
         @test max_keys == length([result["ListBucketResult"]["Contents"]])
     end
@@ -391,7 +391,7 @@ end
             </Delete>
             """
 
-        AWSServices.s3("POST", "/$bucket_name?delete", Dict("body"=>body))
+        AWSServices.s3("POST", "/$bucket_name?delete", Dict("body" => body))
 
         try
             AWSServices.s3("GET", "/$bucket_name/$file_name")
@@ -424,7 +424,7 @@ end
     end
 
     @testset "POST" begin
-        tags = Dict("Tags"=> LittleDict("Tag-01"=>"Tag-01", "Tag-02"=>"Tag-02"))
+        tags = Dict("Tags"=> LittleDict("Tag-01" => "Tag-01", "Tag-02" => "Tag-02"))
 
         for vault in vault_names
             AWSServices.glacier("POST", "/-/vaults/$vault/tags?operation=add", tags)

--- a/test/patch.jl
+++ b/test/patch.jl
@@ -61,7 +61,7 @@ function _response!(; version::VersionNumber=version, status::Int64=status, head
     return response
 end
 
-_http_request_patch = @patch function AWS._http_request(aws::AWSConfig, request::LittleDict)
+_http_request_patch = @patch function AWS._http_request(aws::AWSConfig, request::Request)
     return response
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,7 +14,6 @@ using OrderedCollections: LittleDict, OrderedDict
 using MbedTLS: digest, MD_SHA256, MD_MD5
 using Mocking
 using Retry
-using SymDict
 using Test
 using UUIDs
 using XMLDict


### PR DESCRIPTION
## TODO Before merge
- [x] Don't hard-code the glacier API version, instead pull it from the `aws-sdk-js`

## Notes
- This is merging into `v1` feature branch not `master`
- I am not including high/low level generated API definitions as I feel this is overwhelming for people reviewing the code

## Changes
This PR ports over the `REST JSON` request functionality. The other main change is to `RestJSONService` structs now have an additional field called `service_specifics`. This has been added in because certain AWS services require special casing, using AWS Glacier we have a few options on how to handle these cases.

### Problem
AWS Glacier requires the `x-amz-glacier-version=2012-06-01` in every request header.

### Solutions

1) Do nothing, the end user will always need to make a request passing along these custom headers with every request.

Easy for us since we don't have to do anything. But the users experience is quite poor having to handle these cases themselves.

2) Write `if` checks when making a `REST-XML` call, and append these headers.

Better than the first solution, however as this list of special cases grow our functor grows in complexity with `if` checks, e.g.

```julia
function (service::RestJSONService)(...)
    ...
    if service == "glacier"
        # append specific headers
    elseif service == "foo"
        # append specific headers
    end
end
```

We can do things a bit better than that.

3) Have a `service_specifics` field on the `struct`

This allows us to handle our special cases when generating the low-level API definitions so we can end up with something clean like:

```julia
const glacier = AWS.RestJSONService("glacier", "2012-06-01", Dict(:headers => Dict("x-amz-glacier-version" => "2012-06-01")))
```

And then in our functor, we just merge the `service_specifics[:headers]` to handle this special case. Or whatever else it might be.