### PR TITLE
Implemented Query Requests

### DIFF
--- a/src/AWS.jl
+++ b/src/AWS.jl
@@ -444,7 +444,7 @@ function (service::RestXMLService)(aws::AWSConfig, request_method::String, reque
 end
 (service::RestXMLService)(request_method::String, request_uri::String, args::AbstractDict{String, <:Any}=Dict{String, Any}()) = service(AWSConfig(), request_method, request_uri, args)
 
-function (service::QueryService)(aws::AWS.AWSConfig, operation::String, args::AbstractDict{String, <:Any})
+function (service::QueryService)(aws::AWS.AWSConfig, operation::String, args::AbstractDict{String, <:Any}=Dict{String, Any}())
     POST_RESOURCE = "/"
     return_headers = _return_headers(args)
 

--- a/src/AWS.jl
+++ b/src/AWS.jl
@@ -463,15 +463,9 @@ function (service::QueryService)(aws::AWS.AWSConfig, operation::String, args::Ab
 
     request.headers["Content-Type"] = "application/x-www-form-urlencoded; charset=utf-8"
 
-    if service.name == "iam"
-        aws.region = "us-east-1"
-    end
-
-    if isempty(request.content)
-        args["Action"] = operation
-        args["Version"] = service.api_version
-        request.content = HTTP.escapeuri(_flatten_query(service.name, args))
-    end
+    args["Action"] = operation
+    args["Version"] = service.api_version
+    request.content = HTTP.escapeuri(_flatten_query(service.name, args))
 
     do_request(aws, request; return_headers=return_headers)
 end

--- a/src/AWS.jl
+++ b/src/AWS.jl
@@ -361,17 +361,21 @@ function _return_headers(args::AbstractDict{String, <:Any})
     return return_headers
 end
 
-function _flatten_query(service::String, query::AbstractDict{String, <:Any}, result::Vector{Pair{String, String}}=Vector{Pair{String, String}}(), prefix::String="")
+function _flatten_query(service::String, query::AbstractDict{String, <: Any})
+    return _flatten_query!(Pair{String, String}[], service, query)
+end
+
+function _flatten_query!(result::Vector{Pair{String, String}}, service::String, query::AbstractDict{String, <:Any}, prefix::String="")
     for (k, v) in query
         if typeof(v) <: AbstractDict
-            _flatten_query(service, v, result, string(prefix, k, "."))
+            _flatten_query!(result, service, v, string(prefix, k, "."))
         elseif typeof(v) <: AbstractArray
             for (i, j) in enumerate(v)
                 suffix = service in ("ec2", "sqs") ? "" : ".member"
                 prefix_key = string(prefix, k, suffix, ".", i)
 
                 if typeof(j) <: AbstractDict
-                    _flatten_query(service, j, result, string(prefix_key, "."))
+                    _flatten_query!(result, service, j, string(prefix_key, "."))
                 else
                     push!(result, Pair(prefix_key, string(j)))
                 end

--- a/src/AWSCredentials.jl
+++ b/src/AWSCredentials.jl
@@ -486,7 +486,7 @@ function _aws_get_role(role::AbstractString, ini::Inifile)
     source_profile === nothing && return nothing
     credentials = nothing
 
-    for f in [dot_aws_credentials, dot_aws_config]
+    for f in (dot_aws_credentials, dot_aws_config)
         credentials = f(source_profile)
         credentials === nothing || break
     end

--- a/src/AWSMetadataUtilities.jl
+++ b/src/AWSMetadataUtilities.jl
@@ -142,7 +142,7 @@ function _generate_low_level_definition(service::Dict)
 
     if protocol == "rest-xml"
         return "const $service_id = AWS.RestXMLService(\"$service_name\", \"$api_version\")"
-    elseif protocol in ["ec2", "query"]
+    elseif protocol in ("ec2", "query")
         return "const $service_id = AWS.QueryService(\"$service_name\", \"$api_version\")"
     elseif protocol == "rest-json"
          if haskey(service_specifics, service_id)
@@ -349,7 +349,7 @@ function _generate_high_level_definition(
     operation_definition *= repeat('"', 3)
 
     # Depending on the protocol type of the operation we need to generate a different definition
-    if protocol in ["json", "query", "ec2"]
+    if protocol in ("json", "query", "ec2")
         if !isempty(required_parameters)
             operation_definition *= "\n$name(args) = $service_name(\"$name\", args)\n"
         else
@@ -358,7 +358,7 @@ function _generate_high_level_definition(
                 $name(args) = $service_name(\"$name\", args)
                 """
         end
-    elseif protocol in ["rest-json", "rest-xml"]
+    elseif protocol in ("rest-json", "rest-xml")
         if !isempty(required_parameters)
             request_uri = replace(request_uri, '{'=>"\$(")  # Replace { with $(
             request_uri = replace(request_uri, '}'=>')')  # Replace } with )

--- a/test/AWS.jl
+++ b/test/AWS.jl
@@ -400,13 +400,15 @@ end
         policy_arn = response["CreatePolicyResponse"]["CreatePolicyResult"]["Policy"]["Arn"]
 
         # Get Policy
-        response_policy_version = AWSServices.iam("GetPolicyVersion", LittleDict("PolicyArn"=>policy_arn, "VersionId"=>"v1"))
-        response_document = response_policy_version["GetPolicyVersionResponse"]["GetPolicyVersionResult"]["PolicyVersion"]["Document"]
-        @test HTTP.unescapeuri(response_document) == expected_policy_document
-
-        # Delete Policy
-        AWSServices.iam("DeletePolicy", LittleDict("PolicyArn"=>policy_arn))
-        @test_throws AWSException AWSServices.iam("GetPolicy", LittleDict("PolicyArn"=>policy_arn))
+        try
+            response_policy_version = AWSServices.iam("GetPolicyVersion", LittleDict("PolicyArn"=>policy_arn, "VersionId"=>"v1"))
+            response_document = response_policy_version["GetPolicyVersionResponse"]["GetPolicyVersionResult"]["PolicyVersion"]["Document"]
+            @test HTTP.unescapeuri(response_document) == expected_policy_document
+        finally
+            # Delete Policy
+            AWSServices.iam("DeletePolicy", LittleDict("PolicyArn"=>policy_arn))
+            @test_throws AWSException AWSServices.iam("GetPolicy", LittleDict("PolicyArn"=>policy_arn))
+        end
     end
 
     @testset "sqs" begin

--- a/test/AWS.jl
+++ b/test/AWS.jl
@@ -387,23 +387,18 @@ end
         )
         expected_policy_document = JSON.json(expected_policy_document)
 
-        @testset "Create Policy" begin
-            response = AWSServices.iam("CreatePolicy", LittleDict("PolicyName"=>expected_policy_name, "PolicyDocument"=>expected_policy_document))
-            policy_arn = response["CreatePolicyResponse"]["CreatePolicyResult"]["Policy"]["Arn"]
-        end
+        # Create Policy
+        response = AWSServices.iam("CreatePolicy", LittleDict("PolicyName"=>expected_policy_name, "PolicyDocument"=>expected_policy_document))
+        policy_arn = response["CreatePolicyResponse"]["CreatePolicyResult"]["Policy"]["Arn"]
 
-        @testset "Get Policy" begin
-            response_policy_version = AWSServices.iam("GetPolicyVersion", LittleDict("PolicyArn"=>policy_arn, "VersionId"=>"v1"))
-            response_document = response_policy_version["GetPolicyVersionResponse"]["GetPolicyVersionResult"]["PolicyVersion"]["Document"]
+        # Get Policy
+        response_policy_version = AWSServices.iam("GetPolicyVersion", LittleDict("PolicyArn"=>policy_arn, "VersionId"=>"v1"))
+        response_document = response_policy_version["GetPolicyVersionResponse"]["GetPolicyVersionResult"]["PolicyVersion"]["Document"]
+        @test HTTP.unescapeuri(response_document) == expected_policy_document
 
-            @test HTTP.unescapeuri(response_document) == expected_policy_document
-        end
-
-        @testset "Delete Policy" begin
-            AWSServices.iam("DeletePolicy", LittleDict("PolicyArn"=>policy_arn))
-
-            @test_throws AWSException AWSServices.iam("GetPolicy", LittleDict("PolicyArn"=>policy_arn))
-        end
+        # Delete Policy
+        AWSServices.iam("DeletePolicy", LittleDict("PolicyArn"=>policy_arn))
+        @test_throws AWSException AWSServices.iam("GetPolicy", LittleDict("PolicyArn"=>policy_arn))
     end
 
     @testset "sqs" begin
@@ -416,69 +411,54 @@ end
             return result["GetQueueUrlResponse"]["GetQueueUrlResult"]["QueueUrl"]
         end
 
-        @testset "Create Queue" begin
-            AWSServices.sqs("CreateQueue", LittleDict("QueueName"=>queue_name))
-        end
+        # Create Queue
+        AWSServices.sqs("CreateQueue", LittleDict("QueueName"=>queue_name))
 
-        @testset "Get Queues" begin
-            @test _get_queue_url(queue_name) isa String
-        end
+        # Get Queues
+        queue_url = _get_queue_url(queue_name)
+        @test !isempty(queue_url)
 
-        @testset "Change Message Visibility Batch Request" begin
-            queue_url = _get_queue_url(queue_name)
-            expected_message_id = "aws-jl-test"
+        # Change Message Visibility Batch Request
+        expected_message_id = "aws-jl-test"
 
-            AWSServices.sqs("SendMessage", LittleDict(
-                    "QueueUrl"=>queue_url,
-                    "MessageBody"=>expected_message
-                )
+        AWSServices.sqs("SendMessage", LittleDict(
+                "QueueUrl"=>queue_url,
+                "MessageBody"=>expected_message
             )
+        )
 
-            response = AWSServices.sqs("ReceiveMessage", LittleDict("QueueUrl"=>queue_url,))
-            receipt_handle = response["ReceiveMessageResponse"]["ReceiveMessageResult"]["Message"]["ReceiptHandle"]
+        response = AWSServices.sqs("ReceiveMessage", LittleDict("QueueUrl"=>queue_url,))
+        receipt_handle = response["ReceiveMessageResponse"]["ReceiveMessageResult"]["Message"]["ReceiptHandle"]
 
-            response = AWSServices.sqs("DeleteMessageBatch", LittleDict(
-                    "QueueUrl"=>queue_url,
-                    "DeleteMessageBatchRequestEntry"=>[
-                        LittleDict(
-                            "Id"=>expected_message_id,
-                            "ReceiptHandle"=>receipt_handle,
-                        )
-                    ]
-                )
+        response = AWSServices.sqs("DeleteMessageBatch", LittleDict(
+                "QueueUrl"=>queue_url,
+                "DeleteMessageBatchRequestEntry"=>[
+                    LittleDict(
+                        "Id"=>expected_message_id,
+                        "ReceiptHandle"=>receipt_handle,
+                    )
+                ]
             )
+        )
 
-            message_id = response["DeleteMessageBatchResponse"]["DeleteMessageBatchResult"]["DeleteMessageBatchResultEntry"]["Id"]
+        message_id = response["DeleteMessageBatchResponse"]["DeleteMessageBatchResult"]["DeleteMessageBatchResultEntry"]["Id"]
+        @test message_id == expected_message_id
 
-            @test message_id == expected_message_id
-        end
-
-        @testset "Send Message" begin
-            queue_url = _get_queue_url(queue_name)
-
-            AWSServices.sqs("SendMessage", LittleDict(
-                    "QueueUrl"=>queue_url,
-                    "MessageBody"=>expected_message
-                )
+        # Send message
+        AWSServices.sqs("SendMessage", LittleDict(
+                "QueueUrl"=>queue_url,
+                "MessageBody"=>expected_message
             )
-        end
+        )
 
-        @testset "Receive Message" begin
-            queue_url = _get_queue_url(queue_name)
+        # Receive Message
+        result = AWSServices.sqs("ReceiveMessage", LittleDict("QueueUrl"=>queue_url))
+        message = result["ReceiveMessageResponse"]["ReceiveMessageResult"]["Message"]["Body"]
+        @test message == expected_message
 
-            result = AWSServices.sqs("ReceiveMessage", LittleDict("QueueUrl"=>queue_url))
-            message = result["ReceiveMessageResponse"]["ReceiveMessageResult"]["Message"]["Body"]
-
-            @test message == expected_message
-        end
-
-        @testset "Delete Queue" begin
-            queue_url = _get_queue_url(queue_name)
-
-            AWSServices.sqs("DeleteQueue", LittleDict("QueueUrl"=>queue_url))
-
-            @test_throws AWSException _get_queue_url(queue_name)
-        end
+        # Delete Queue
+        AWSServices.sqs("DeleteQueue", LittleDict("QueueUrl"=>queue_url))
+        @test_throws AWSException _get_queue_url(queue_name)
     end
 end
 

--- a/test/AWS.jl
+++ b/test/AWS.jl
@@ -352,22 +352,30 @@ end
         service = "sts"
         result = AWS._flatten_query(service, args)
 
-        @test result["high_level_key"] == high_level_value
-        @test result["high_level_array.member.1.low_level_key_1"] == entry_1["low_level_key_1"]
-        @test result["high_level_array.member.1.low_level_key_2"] == entry_1["low_level_key_2"]
-        @test result["high_level_array.member.2.low_level_key_3"] == entry_2["low_level_key_3"]
-        @test result["high_level_array.member.2.low_level_key_4"] == entry_2["low_level_key_4"]
+        expected = Pair{String,String}[
+            "high_level_key" => "high_level_value",
+            "high_level_array.member.1.low_level_key_1" => "low_level_value_1",
+            "high_level_array.member.1.low_level_key_2" => "low_level_value_2",
+            "high_level_array.member.2.low_level_key_3" => "low_level_value_3",
+            "high_level_array.member.2.low_level_key_4" => "low_level_value_4"
+        ]
+
+        @test result == expected
     end
 
     @testset "sqs - special casing suffix" begin
         service = "sqs"
         result = AWS._flatten_query(service, args)
 
-        @test result["high_level_key"] == high_level_value
-        @test result["high_level_array.1.low_level_key_1"] == entry_1["low_level_key_1"]
-        @test result["high_level_array.1.low_level_key_2"] == entry_1["low_level_key_2"]
-        @test result["high_level_array.2.low_level_key_3"] == entry_2["low_level_key_3"]
-        @test result["high_level_array.2.low_level_key_4"] == entry_2["low_level_key_4"]
+        expected = Pair{String,String}[
+            "high_level_key" => "high_level_value",
+            "high_level_array.1.low_level_key_1" => "low_level_value_1",
+            "high_level_array.1.low_level_key_2" => "low_level_value_2",
+            "high_level_array.2.low_level_key_3" => "low_level_value_3",
+            "high_level_array.2.low_level_key_4" => "low_level_value_4"
+        ]
+
+        @test result == expected
     end
 end
 

--- a/test/AWS.jl
+++ b/test/AWS.jl
@@ -374,7 +374,7 @@ end
 @testset "query" begin
     @testset "iam" begin
         policy_arn = ""
-        expected_policy_name = "AWS.jl-Test-Policy"
+        expected_policy_name = "AWS.jl-Test-Policy" * lowercase(Dates.format(now(Dates.UTC), "yyyymmddTHHMMSSZ"))
         expected_policy_document = LittleDict(
             "Version"=> "2012-10-17",
             "Statement"=> [

--- a/test/AWS.jl
+++ b/test/AWS.jl
@@ -350,7 +350,6 @@ end
 
     @testset "non-special case suffix" begin
         service = "sts"
-
         result = AWS._flatten_query(service, args)
 
         @test result["high_level_key"] == high_level_value
@@ -362,7 +361,6 @@ end
 
     @testset "sqs - special casing suffix" begin
         service = "sqs"
-
         result = AWS._flatten_query(service, args)
 
         @test result["high_level_key"] == high_level_value
@@ -430,26 +428,15 @@ end
             queue_url = _get_queue_url(queue_name)
             expected_message_id = "aws-jl-test"
 
-            # Send a message
             AWSServices.sqs("SendMessage", LittleDict(
                     "QueueUrl"=>queue_url,
                     "MessageBody"=>expected_message
                 )
             )
 
-            # Get the receipt handle
             response = AWSServices.sqs("ReceiveMessage", LittleDict("QueueUrl"=>queue_url,))
             receipt_handle = response["ReceiveMessageResponse"]["ReceiveMessageResult"]["Message"]["ReceiptHandle"]
 
-            # Change the message visibility
-            response = AWSServices.sqs("ChangeMessageVisibility", LittleDict(
-                    "QueueUrl"=>queue_url,
-                    "ReceiptHandle"=>receipt_handle,
-                    "VisibilityTimeout"=>300  # 5 minutes
-                )
-            )
-
-            # Delete the message
             response = AWSServices.sqs("DeleteMessageBatch", LittleDict(
                     "QueueUrl"=>queue_url,
                     "DeleteMessageBatchRequestEntry"=>[

--- a/test/AWSCredentials.jl
+++ b/test/AWSCredentials.jl
@@ -5,7 +5,7 @@ macro test_ecode(error_codes, expr)
             @test false
         catch e
             if e isa AWSException
-                @test ecode(e) in ($error_codes;)
+                @test ecode(e) in [$error_codes;]
             else
                 rethrow(e)
             end

--- a/test/AWSCredentials.jl
+++ b/test/AWSCredentials.jl
@@ -5,7 +5,7 @@ macro test_ecode(error_codes, expr)
             @test false
         catch e
             if e isa AWSException
-                @test ecode(e) in [$error_codes;]
+                @test ecode(e) in ($error_codes;)
             else
                 rethrow(e)
             end


### PR DESCRIPTION
## Overview
This merge request contains the implementation of Query Service requests. I have also modified the `if x in y` statements to use `Tuple` instead of `Array` for a very, very minor performance benefit as pointed out by @iamed2 in a previous PR.

There was a discussion in a previous PR about the default usage of `OrderedDict` for IAM, [here](https://github.com/JuliaCloud/AWS.jl/pull/126#issuecomment-655096785). Which leads to the original PR which introduce this change, https://github.com/JuliaCloud/AWSCore.jl/pull/25)

Looking into this further, I am not understanding the necessity for the change. When the response is returned back from AWS your IAM policy is a string. When you modify an IAM policy document you are creating a new version of it, not replacing the existing one. Even so, if you are passing in this policy document as a `Dict` your request would fail. It must come through as a `String`. Maybe I am missing something here @omus but I believe that this is still safe. Using the example from  https://github.com/JuliaCloud/AWSCore.jl/pull/25, you would pull down the policy version (as a String), you could parse it into some sort of `Dict`, modify it, then would need to stringify it and make the request.

## Design Decision
In `AWSCore.jl` for `IAM, STS, SQS, SNS` services we had set the request content `ContentType` to `JSON`. I have decided to not implement this feature, as it does not accurately reflect what the AWS docs specify as a response, [see Sample Response](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_DeleteMessageBatch.html).

This results in a small, but important change in responses. Here is an example for a `SQS DeleteMessageBatch` request.

### ContentType=JSON
```julia
{
  "DeleteMessageBatchResponse": {
    "DeleteMessageBatchResult": {
      "Failed": null,
      "Successful": [
        {
          "Id": "msg1"
        },
        {
          "Id": "msg2"
        }
      ]
    },
    "ResponseMetadata": {
      "RequestId": "redacted"
    }
  }
}
```

### ContentType not set
```julia
{
  "version": "1.0",
  "DeleteMessageBatchResponse": {
    "DeleteMessageBatchResult": {
      "DeleteMessageBatchResultEntry": [
        {
          "Id": "msg1"
        },
        {
          "Id": "msg2"
        }
      ]
    },
    "ResponseMetadata": {
      "RequestId": "redacted"
    }
  }
}
```

There are other cases of odd behaviour with using `ContentType=JSON` such as `SQS ReceiveMessage`. This request returns only one message, yet with JSON it comes back as an array. It also does not include important information such as `ReceiptHandle`, and again does not reflect what the documentation states as a [response](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_ReceiveMessage.html).

### JSON
```julia
"messages": [
  {
    "Attributes": null,
    "Body": "Hello for AWS.jl",
    "MD5OfBody": "9f501028c282e05583de12e3bfd4ca8b",
    "MD5OfMessageAttributes": null,
    "MessageAttributes": null,
    "MessageId": "6495bfc8-e726-4370-8e89-743436ddcb32",
  }
]
```

### ContentType not set
```julia
"Message": {
  "MessageId": "64ae707c-a354-45d4-9271-f58260fe4928",
  "ReceiptHandle": "redacted",
  "MD5OfBody": "9f501028c282e05583de12e3bfd4ca8b",
  "Body": "Hello for AWS.jl"
}
```

## Future Work
There are only a handful of tasks left for the completion of the `v1` re-write:
- RestJSON functionality
- Removal of `AWSCore.jl` wrappings in the package
- GitHub Actions for auto-generation of code
- Various small cleanups
- Merge `v1->master`, and have a beer 🎉 