### PR TITLE
Regenerate AWS API definitions automatically

### DIFF
--- a/.github/workflows/update_apis.yml
+++ b/.github/workflows/update_apis.yml
@@ -1,5 +1,5 @@
 name: AWS
- on:
+on:
   schedule:
     - cron: '0 6 * * *'  # Daily at 6 a.m.
 

--- a/.github/workflows/update_apis.yml
+++ b/.github/workflows/update_apis.yml
@@ -1,0 +1,24 @@
+name: AWS
+ on:
+  schedule:
+    - cron: '0 6 * * *'  # Daily at 6 a.m.
+
+jobs:
+  AWS:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        julia-version: [1.4.0]
+        julia-arch: [x86]
+        os: [ubuntu-latest]
+    steps:
+      - uses: julia-actions/setup-julia@latest
+        with:
+          version: ${{ matrix.julia-version }}
+      - name: UpdateAPI
+        run: julia -e 'import Pkg; Pkg.develop(Pkg.PackageSpec(url="https://github.com/JuliaCloud/AWS.git")); using AWS; AWS.AWSMetadata.parse_aws_metadata();'
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v2
+        with:
+         path: "~/.julia/dev/AWS/"
+         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update_apis.yml
+++ b/.github/workflows/update_apis.yml
@@ -1,7 +1,7 @@
 name: AWS
 on:
   schedule:
-    - cron: '0 6 * * *'  # Daily at 6 a.m.
+    - cron: '0 6 * * *'  # Daily at 6 a.m. UTC 
 
 jobs:
   AWS:

--- a/.github/workflows/update_apis.yml
+++ b/.github/workflows/update_apis.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        julia-version: [1.4.0]
+        julia-version: [1] 
         julia-arch: [x86]
         os: [ubuntu-latest]
     steps:


### PR DESCRIPTION
## Overview
This merge request creates a GitHub action to regenerate AWS API definitions every day at 6a.m., if there are changes it will create a subsequent merge request with the changes.

This should be one of the last merge requests to go in.