### PR TITLE
Bors deletes merged branches

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,0 +1,4 @@
+status = [
+  "continuous-integration/travis-ci/push"
+]
+delete-merged-branches = true


### PR DESCRIPTION
Bors is configured globally for the `JuliaCloud` organization, this just allows it to delete merged branches.