### PR TITLE
Mock getting AWS SDK JS files

### DIFF
--- a/src/AWSMetadataUtilities.jl
+++ b/src/AWSMetadataUtilities.jl
@@ -6,6 +6,7 @@ using .AWSExceptions
 using OrderedCollections: OrderedDict, LittleDict
 using HTTP
 using JSON
+using Mocking
 
 
 """
@@ -20,7 +21,7 @@ function _get_aws_sdk_js_files()
     headers = ["User-Agent" => "JuliaCloud/AWS.jl"]
     url = "https://api.github.com/repos/aws/aws-sdk-js/contents/apis"
 
-    req = HTTP.get(url, headers)
+    req = @mock HTTP.get(url, headers)
     files = JSON.parse(String(req.body), dicttype=OrderedDict)
     filter!(f -> endswith(f["name"], ".normal.json"), files)  # Only get ${Service}.normal.json files
     files = _filter_latest_service_version(files)

--- a/test/AWS.jl
+++ b/test/AWS.jl
@@ -104,7 +104,7 @@ end
             url="https://s3.us-east-1.amazonaws.com/sample-bucket"
         )
 
-        apply(Patches._http_request_patch) do
+        apply(Patches._aws_http_request_patch) do
             Patches._response!()
             result = AWS.do_request(aws, request)
 
@@ -123,7 +123,7 @@ end
             url="https://s3.us-east-1.amazonaws.com/sample-bucket"
         )
 
-        apply(Patches._http_request_patch) do
+        apply(Patches._aws_http_request_patch) do
             Patches._response!()
             result = AWS.do_request(aws, request)
 
@@ -141,7 +141,7 @@ end
         )
 
         @testset "body" begin
-            apply(Patches._http_request_patch) do
+            apply(Patches._aws_http_request_patch) do
                 Patches._response!()
                 result = AWS.do_request(aws, request)
 
@@ -150,7 +150,7 @@ end
         end
 
         @testset "body and headers" begin
-            apply(Patches._http_request_patch) do
+            apply(Patches._aws_http_request_patch) do
                 Patches._response!()
                 body, headers = AWS.do_request(aws, request; return_headers=true)
 
@@ -169,7 +169,7 @@ end
         )
 
         @testset "empty" begin
-            apply(Patches._http_request_patch) do
+            apply(Patches._aws_http_request_patch) do
                 @testset "default" begin
                     expected_body = ""
                     expected_headers = Pair["Content-Type"=>"",]
@@ -231,7 +231,7 @@ end
             expected_body = xml_dict((Patches.body), expected_body_type)
             expected_headers = Pair["Content-Type"=>"application/xml",]
 
-            apply(Patches._http_request_patch) do
+            apply(Patches._aws_http_request_patch) do
                 Patches._response!(headers=expected_headers,)
 
                 @testset "body" begin
@@ -260,7 +260,7 @@ end
             expected_body_type = LittleDict{String, Any}
             expected_body = JSON.parse(json_body, dicttype=LittleDict)
 
-            apply(Patches._http_request_patch) do
+            apply(Patches._aws_http_request_patch) do
                 Patches._response!(body=json_body, headers=json_headers,)
 
                 @testset "body" begin
@@ -290,7 +290,7 @@ end
                 url="https://s3.us-east-1.amazonaws.com/sample-bucket",
             )
 
-            apply(Patches._http_request_patch) do
+            apply(Patches._aws_http_request_patch) do
                 expected_headers = ["Content-Type" => "text/html"]
                 expected_body = Patches.body
                 expected_header_type = LittleDict{SubString{String}, SubString{String}}

--- a/test/AWSMetadataUtilities.jl
+++ b/test/AWSMetadataUtilities.jl
@@ -7,8 +7,12 @@ function _clean_high_level_definition(definition::String)
 end
 
 @testset "_get_aws_sdk_js_files" begin
-    files = _get_aws_sdk_js_files()
-    @test !isempty(files)
+    apply(Patches._http_get_patch) do
+        files = _get_aws_sdk_js_files()
+
+        @test length(files) == 1
+        @test files[1] == OrderedDict("name" => "test-2020-01-01.normal.json")
+    end
 end
 
 @testset "_filter_latest_service_version" begin

--- a/test/patch.jl
+++ b/test/patch.jl
@@ -50,8 +50,23 @@ function _response!(; version::VersionNumber=version, status::Int64=status, head
     return response
 end
 
-_http_request_patch = @patch function AWS._http_request(request::Request)
+_aws_http_request_patch = @patch function AWS._http_request(request::Request)
     return response
+end
+
+
+aws_sdk_files =
+    """
+    [
+        {"name": "test-2020-01-01.normal.json"},
+        {"name": "test-2020-01-01.min.json"},
+        {"name": "test-2020-01-01.paginators.json"},
+        {"name": "test-2020-01-01.examples.json"}
+    ]
+    """
+
+_http_get_patch = @patch function HTTP.get(url::String, headers)
+    return HTTP.Response(200, aws_sdk_files)
 end
 
 end


### PR DESCRIPTION
## Problem
Currently we are making unauthorized requests to GitHub when retrieving the [AWS SDK JS]() for generating our Julia definitions off of. Unauthenticated requests are limited to 60 requests per hour, I've run into the rate limitation personally and we are now seeing that with Travis CI.

## Solutions
There are two solutions to this problem, the first is creating authenticated requests. I attempted to configure an OAuth application on GitHub to make authorized requests, it was very simple. The problem comes how do we make the request in Julia.

I first attempted to do run an external command to do `curl -u id:secret https://github.com/aws/aws-sdk-js/tree/master/apis`, this was fine. Except that running this command prints the output into the terminal and causes it to hang. I then looked into using [LibCURL.jl](https://github.com/JuliaWeb/LibCURL.jl), however this seems like overkill for one test.

The other solution is in this merge request, just simply mock the response back from GitHub and continue onwards with testing.