### PR TITLE
Properly throw errors if credentials are not found

### DIFF
--- a/src/AWSCredentials.jl
+++ b/src/AWSCredentials.jl
@@ -295,7 +295,7 @@ function _ec2_metadata(metadata_endpoint::String)
     try
         request = @mock HTTP.request("GET", "http://169.254.169.254/latest/meta-data/$metadata_endpoint")
 
-        return String(request.body)
+        return request isa Nothing ? nothing : String(request.body)
     catch e
         e isa HTTP.IOError || rethrow(e)
     end
@@ -311,6 +311,11 @@ Parse the EC2 metadata to retrieve AWSCredentials.
 """
 function ec2_instance_credentials()
     info = _ec2_metadata("iam/info")
+
+    if info isa Nothing
+        return nothing
+    end
+
     info = JSON.parse(info)
 
     name = _ec2_metadata("iam/security-credentials/")
@@ -427,7 +432,7 @@ If this fails try to retrieve credentials from `_aws_get_role()`, otherwise retu
 - `profile`: Specific profile used to get AWSCredentials, default is `nothing`
 """
 function dot_aws_config(profile=nothing)
-    config_file = dot_aws_config_file()
+    config_file = @mock dot_aws_config_file()
 
     if isfile(config_file)
         ini = read(Inifile(), config_file)

--- a/src/AWSCredentials.jl
+++ b/src/AWSCredentials.jl
@@ -295,7 +295,7 @@ function _ec2_metadata(metadata_endpoint::String)
     try
         request = @mock HTTP.request("GET", "http://169.254.169.254/latest/meta-data/$metadata_endpoint")
 
-        return request isa Nothing ? nothing : String(request.body)
+        return request === nothing ? nothing : String(request.body)
     catch e
         e isa HTTP.IOError || rethrow(e)
     end
@@ -312,7 +312,7 @@ Parse the EC2 metadata to retrieve AWSCredentials.
 function ec2_instance_credentials()
     info = _ec2_metadata("iam/info")
 
-    if info isa Nothing
+    if info === nothing
         return nothing
     end
 


### PR DESCRIPTION
# Overview
One overlooked thing which I hadn't considered is if users attempt to use this package without having any AWS Credentials configured on their machine.

An example of this is in my attempt to add this package to the [General Julia Registry](https://github.com/JuliaRegistries/General/pull/20506). The AutoMerge step for the registrator uses Microsoft Azure instances, these internally use the IP address `169.254.169.254`. When looking for AWS Credentials, our last attempt is to use the [instance metadata](https://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/instancedata-data-retrieval.html). We expect that if you're not on an AWS instance you will receive a `TimeoutError`. However, running this on an Azure instance will return back a 404 error.

# Solution
Check the returned value from attempting to get instance metadata if it's `nothing`.

# Notes
Added a test to replicate a "clean" instance, one without:

- Environment Variables for AWS Credentials
- No `config` or `credential` files
- Returns back `nothing` when querying the instance metadata endpoints