### PR TITLE
Do not set AWSConfig() on package load

### DIFF
--- a/src/AWS.jl
+++ b/src/AWS.jl
@@ -24,7 +24,7 @@ using ..AWSExceptions
 using ..AWSExceptions: AWSException
 
 user_agent = Ref("AWS.jl/1.0.0")
-aws_config = Ref(AWSConfig())
+aws_config = Ref{AWSConfig}()
 
 """
     global_aws_config()
@@ -34,7 +34,13 @@ Retrieve the global AWS configuration.
 # Returns
 - `AWSConfig`: The global AWS configuration
 """
-global_aws_config() = aws_config[]
+function global_aws_config()
+    if !isassigned(aws_config)
+        aws_config[] = AWSConfig()
+    end
+
+    return aws_config[]
+end
 
 
 """


### PR DESCRIPTION
# Overview
When attempting to add this package to the General Registry, the `AutoMerge` feature [fails](https://github.com/JuliaRegistries/General/runs/1048331805?check_suite_focus=true#step:6:278).

This is because the RegistryCI instance does not have any valid AWS Credentials on it. The package can be added to the general registry, however it would be a manual process and someone would continuously need to approve it. This would get tiresome really quickly.

# Solution
Instead of retrieving credentials when the package loads, instead retrieve them when the reference is called.