### PR TITLE
Update Git URI when updating API definitions

### DIFF
--- a/.github/workflows/update_apis.yml
+++ b/.github/workflows/update_apis.yml
@@ -17,7 +17,7 @@ jobs:
           version: ${{ matrix.julia-version }}
       - name: UpdateAPI
         # Run against the latest version, since everything merged into master will be tagged.
-        run: julia -e 'import Pkg; Pkg.develop(Pkg.PackageSpec(url="https://github.com/JuliaCloud/AWS.git", rev="master")); using AWS; AWS.AWSMetadata.parse_aws_metadata();'
+        run: julia -e 'import Pkg; Pkg.develop(Pkg.PackageSpec(url="https://github.com/JuliaCloud/AWS.git")); using AWS; AWS.AWSMetadata.parse_aws_metadata();'
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v2
         with:

--- a/.github/workflows/update_apis.yml
+++ b/.github/workflows/update_apis.yml
@@ -17,7 +17,7 @@ jobs:
           version: ${{ matrix.julia-version }}
       - name: UpdateAPI
         # Run against the latest version, since everything merged into master will be tagged.
-        run: julia -e 'import Pkg; Pkg.develop(url="https://github.com/JuliaCloud/AWS.jl.git"); using AWS; AWS.AWSMetadata.parse_aws_metadata();'
+        run: julia -e 'import Pkg; Pkg.add(Pkg.PackageSpec(url="https://github.com/JuliaCloud/AWS.jl.git", rev="master")); using AWS; AWS.AWSMetadata.parse_aws_metadata();'
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v2
         with:

--- a/.github/workflows/update_apis.yml
+++ b/.github/workflows/update_apis.yml
@@ -17,7 +17,7 @@ jobs:
           version: ${{ matrix.julia-version }}
       - name: UpdateAPI
         # Run against the latest version, since everything merged into master will be tagged.
-        run: julia -e 'import Pkg; Pkg.develop(Pkg.PackageSpec(url="https://github.com/JuliaCloud/AWS.git")); using AWS; AWS.AWSMetadata.parse_aws_metadata();'
+        run: julia -e 'import Pkg; Pkg.develop(url="https://github.com/JuliaCloud/AWS.jl.git"); using AWS; AWS.AWSMetadata.parse_aws_metadata();'
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v2
         with:


### PR DESCRIPTION
The GitHub Action to automatically update the API definitions is [failing](https://github.com/JuliaCloud/AWS.jl/runs/1046951497?check_suite_focus=true).

````
Run julia -e 'import Pkg; Pkg.develop(Pkg.PackageSpec(url="https://github.com/JuliaCloud/AWS.git", rev="master")); using AWS; AWS.AWSMetadata.parse_aws_metadata();'
ERROR: git revision specification invalid when calling `develop`: `master` specified for package `https://github.com/JuliaCloud/AWS.git`
Stacktrace:
 [1] pkgerror(::String, ::Vararg{String,N} where N) at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.5/Pkg/src/Types.jl:52
 [2] develop(::Pkg.Types.Context, ::Array{Pkg.Types.PackageSpec,1}; shared::Bool, preserve::Pkg.Types.PreserveLevel, platform::Pkg.BinaryPlatforms.Linux, kwargs::Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}) at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.5/Pkg/src/API.jl:107
 [3] develop(::Pkg.Types.Context, ::Array{Pkg.Types.PackageSpec,1}) at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.5/Pkg/src/API.jl:93
 [4] #develop#13 at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.5/Pkg/src/API.jl:67 [inlined]
 [5] develop at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.5/Pkg/src/API.jl:67 [inlined]
 [6] #develop#11 at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.5/Pkg/src/API.jl:65 [inlined]
 [7] develop(::Pkg.Types.PackageSpec) at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.5/Pkg/src/API.jl:65
 [8] top-level scope at none:1
````