### PR TITLE
Use create-pull-request@v3

### DIFF
--- a/.github/workflows/update_apis.yml
+++ b/.github/workflows/update_apis.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: julia-actions/julia-buildpkg@latest
       - name: UpdateAPI
         # Run against the latest version, since everything merged into master will be tagged.
-        run: sudo julia --project -e 'using AWS; AWS.AWSMetadata.parse_aws_metadata();'
+        run: julia --project -e 'using AWS; AWS.AWSMetadata.parse_aws_metadata();'
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3
         with:

--- a/.github/workflows/update_apis.yml
+++ b/.github/workflows/update_apis.yml
@@ -13,8 +13,6 @@ jobs:
         os: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v2
-        with:
-          repository: JuliaCloud/AWS.jl
       - uses: julia-actions/setup-julia@latest
         with:
           version: ${{ matrix.julia-version }}
@@ -25,7 +23,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3
         with:
-         commit-message: AWS API Definitions Updated
-         reviewers: mattBrzezinski
-         title: AWS API Definitions Updated
-         token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: AWS API Definitions Updated
+          reviewers: mattBrzezinski
+          title: AWS API Definitions Updated
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update_apis.yml
+++ b/.github/workflows/update_apis.yml
@@ -17,9 +17,9 @@ jobs:
           version: ${{ matrix.julia-version }}
       - name: UpdateAPI
         # Run against the latest version, since everything merged into master will be tagged.
-        run: julia -e 'import Pkg; Pkg.add(Pkg.PackageSpec(url="https://github.com/JuliaCloud/AWS.jl.git", rev="master")); using AWS; AWS.AWSMetadata.parse_aws_metadata();'
+        run: sudo julia -e 'import Pkg; Pkg.add(Pkg.PackageSpec(url="https://github.com/JuliaCloud/AWS.jl.git", rev="master")); using AWS; AWS.AWSMetadata.parse_aws_metadata();'
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v2
+        uses: peter-evans/create-pull-request@v3
         with:
          path: "~/.julia/dev/AWS/"
          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update_apis.yml
+++ b/.github/workflows/update_apis.yml
@@ -12,14 +12,20 @@ jobs:
         julia-arch: [x86]
         os: [ubuntu-latest]
     steps:
+      - uses: actions/checkout@v2
+        with:
+          repository: JuliaCloud/AWS.jl
       - uses: julia-actions/setup-julia@latest
         with:
           version: ${{ matrix.julia-version }}
+      - uses: julia-actions/julia-buildpkg@latest
       - name: UpdateAPI
         # Run against the latest version, since everything merged into master will be tagged.
-        run: sudo julia -e 'import Pkg; Pkg.add(Pkg.PackageSpec(url="https://github.com/JuliaCloud/AWS.jl.git", rev="master")); using AWS; AWS.AWSMetadata.parse_aws_metadata();'
+        run: sudo julia --project -e 'using AWS; AWS.AWSMetadata.parse_aws_metadata();'
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3
         with:
-         path: "~/.julia/dev/AWS/"
+         commit-message: AWS API Definitions Updated
+         reviewers: mattBrzezinski
+         title: AWS API Definitions Updated
          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Attempting to test the GH Action to auto generate files from a different repository as to not spam this one with merge requests. It's however running into some issues, which I've logged https://github.com/peter-evans/create-pull-request/issues/534.

It seems like Peter is in Tokyo and it's currently sleeping time there, so I'll check in on the issue later on in the evening. In the meantime these seem to be two useful things to changed:

- Update to `create-pull-request@v3` and use the latest version
