### PR TITLE
Minor fixes

### DIFF
--- a/src/AWS.jl
+++ b/src/AWS.jl
@@ -500,8 +500,7 @@ function (service::RestXMLService)(
     )
 
     if haskey(args, "response_dict_type")
-        request.response_dict_type = args["response_dict_type"]
-        delete!(args, "response_dict_type")
+        request.response_dict_type = pop!(args, "response_dict_type")
     end
 
     delete!(args, "headers")
@@ -564,8 +563,7 @@ function (service::QueryService)(
     )
 
     if haskey(args, "response_dict_type")
-        request.response_dict_type = args["response_dict_type"]
-        delete!(args, "response_dict_type")
+        request.response_dict_type = pop!(args, "response_dict_type")
     end
 
     request.headers["Content-Type"] = "application/x-www-form-urlencoded; charset=utf-8"
@@ -617,8 +615,7 @@ function (service::JSONService)(
     )
 
     if haskey(args, "response_dict_type")
-        request.response_dict_type = args["response_dict_type"]
-        delete!(args, "response_dict_type")
+        request.response_dict_type = pop!(args, "response_dict_type")
     end
 
     request.headers["Content-Type"] = "application/x-amz-json-$(service.json_version)"
@@ -665,8 +662,7 @@ function (service::RestJSONService)(
     )
 
     if haskey(args, "response_dict_type")
-        request.response_dict_type = args["response_dict_type"]
-        delete!(args, "response_dict_type")
+        request.response_dict_type = pop!(args, "response_dict_type")
     end
 
     request.url = _generate_service_url(aws_config.region, request.service, request.resource)

--- a/src/AWS.jl
+++ b/src/AWS.jl
@@ -485,7 +485,7 @@ Perform a RestXML request to AWS.
 """
 function (service::RestXMLService)(
     request_method::String, request_uri::String, args::AbstractDict{String, <:Any}=Dict{String, Any}(); 
-    aws_config::AWSConfig=aws_config[],
+    aws_config::AWSConfig=global_aws_config(),
 )
     request = Request(
         service=service.name,
@@ -501,6 +501,7 @@ function (service::RestXMLService)(
 
     if haskey(args, "response_dict_type")
         request.response_dict_type = args["response_dict_type"]
+        delete!(args, "response_dict_type")
     end
 
     delete!(args, "headers")
@@ -544,7 +545,7 @@ Perform a Query request to AWS.
 """
 function (service::QueryService)(
     operation::String, args::AbstractDict{String, <:Any}=Dict{String, Any}(); 
-    aws_config::AWSConfig=aws_config[],
+    aws_config::AWSConfig=global_aws_config(),
 )
     POST_RESOURCE = "/"
     return_headers = _return_headers(args)
@@ -561,6 +562,11 @@ function (service::QueryService)(
         response_stream=get(args, "response_stream", nothing),
         return_raw=get(args, "return_raw", false),
     )
+
+    if haskey(args, "response_dict_type")
+        request.response_dict_type = args["response_dict_type"]
+        delete!(args, "response_dict_type")
+    end
 
     request.headers["Content-Type"] = "application/x-www-form-urlencoded; charset=utf-8"
 
@@ -591,7 +597,7 @@ Perform a JSON request to AWS.
 """
 function (service::JSONService)(
     operation::String, args::AbstractDict{String, <:Any}=Dict{String, Any}();
-    aws_config::AWSConfig=aws_config[],
+    aws_config::AWSConfig=global_aws_config(),
 )
     POST_RESOURCE = "/"
     return_headers = _return_headers(args)
@@ -609,6 +615,11 @@ function (service::JSONService)(
         response_stream=get(args, "response_stream", nothing),
         return_raw=get(args, "return_raw", false),
     )
+
+    if haskey(args, "response_dict_type")
+        request.response_dict_type = args["response_dict_type"]
+        delete!(args, "response_dict_type")
+    end
 
     request.headers["Content-Type"] = "application/x-amz-json-$(service.json_version)"
     request.headers["X-Amz-Target"] = "$(service.target).$(operation)"
@@ -637,7 +648,7 @@ Perform a RestJSON request to AWS.
 """
 function (service::RestJSONService)(
     request_method::String, request_uri::String, args::AbstractDict{String, <:Any}=Dict{String, String}();
-    aws_config::AWSConfig=aws_config[],
+    aws_config::AWSConfig=global_aws_config(),
 )
     return_headers = _return_headers(args)
 
@@ -655,6 +666,7 @@ function (service::RestJSONService)(
 
     if haskey(args, "response_dict_type")
         request.response_dict_type = args["response_dict_type"]
+        delete!(args, "response_dict_type")
     end
 
     request.url = _generate_service_url(aws_config.region, request.service, request.resource)


### PR DESCRIPTION
1. Properly reference the global AWSConfig, in each protocol function
With the changes to the default `AWSConfig`, if you do not call `AWS.global_aws_config()`, and you perform a low-level request you will get an error that the Reference is not assigned.

1.  Remove response_dict_type from args if it's available
If you pass in a specified `response_dict_type` in a REST protocol function it will attempt to iterate over this type which will error. We just need to `delete!` it from `args` after we assign it to the `Request`.

1. Use response_dict_type in Query and JSON services
Missed adding this `Request` parameter for Query and JSON protocol requests.