### PR TITLE
Cleaned up RestXML and Query responses

### DIFF
--- a/src/AWS.jl
+++ b/src/AWS.jl
@@ -390,7 +390,10 @@ function submit_request(aws::AWSConfig, request::Request; return_headers::Bool=f
 
     if occursin(r"/xml", mime)
         xml_dict_type = response_dict_type{Union{Symbol, String}, Any}
-        return (return_headers ? (xml_dict(body, xml_dict_type), response_dict_type(response.headers)) : xml_dict(body, xml_dict_type))
+        body = parse_xml(body)
+        root = XMLDict.root(body.x)
+
+        return (return_headers ? (xml_dict(root, xml_dict_type), response_dict_type(response.headers)) : xml_dict(root, xml_dict_type))
     elseif occursin(r"/x-amz-json-1.[01]$", mime) || endswith(mime, "json")
         info = isempty(response.body) ? nothing : JSON.parse(body, dicttype=response_dict_type)
         return (return_headers ? (info, response_dict_type(response.headers)) : info)

--- a/src/AWSConfig.jl
+++ b/src/AWSConfig.jl
@@ -53,7 +53,7 @@ end
 
 function _update_creds!(aws_config::AWSConfig)
     r = AWSServices.sts("GetCallerIdentity"; aws_config=aws_config)
-    r = r["GetCallerIdentityResponse"]["GetCallerIdentityResult"]
+    r = r["GetCallerIdentityResult"]
     creds = aws_config.credentials
 
     creds.user_arn = r["Arn"]

--- a/test/AWS.jl
+++ b/test/AWS.jl
@@ -506,7 +506,7 @@ end
         expected_policy_document = JSON.json(expected_policy_document)
 
         response = IAM.create_policy(expected_policy_document, expected_policy_name)
-        policy_arn = policy_arn = response["CreatePolicyResult"]["Policy"]["Arn"]
+        policy_arn = response["CreatePolicyResult"]["Policy"]["Arn"]
 
         try
             response_policy_version = IAM.get_policy_version(policy_arn, "v1")


### PR DESCRIPTION
## Overview
While re-writing the code for this package we wanted to make responses back be Dictionaries.
We currently use `XMLDict.xml_dict()`, which appends two metadata pieces of information back, the XML `version` and `encoding`.

```julia
EC2.describe_volume_status()
OrderedCollections.LittleDict{Union{String, Symbol},Any,Array{Union{String, Symbol},1},Array{Any,1}} with 3 entries:
  :version                       => "1.0"
  :encoding                      => "UTF-8"
  "DescribeVolumeStatusResponse" => OrderedCollections.LittleDict{…]
```

This adds an unnecessary level of abstraction as the user would then need to do `result["DescribeVolumeStatusResponse"]` to get the actual AWS information.
This also means that you cannot directly replace `AWSCore.jl` with `AWS.jl` and have a smooth transition over.

## Solution
Replicate what `XMLDict` does and only return back the important information.

```julia
EC2.describe_volume_status()
OrderedCollections.LittleDict{Union{String, Symbol},Any,Array{Union{String, Symbol},1},Array{Any,1}} with 2 entries:
  "requestId"       => "19c981b2-8701-4972-aa53-100272d7cc0a"
  "volumeStatusSet" => OrderedCollections.LittleDict{Union{String, Symbol},Any,Array{Union{String, Symbol},1},Array{Any,1}}("item"=>OrderedCollections.LittleDict{Union{String, Symbol},Any,Array{Union{String, Symbol},…
```