### PR TITLE
Pass along kwargs for global_aws_config; set_global_aws_config()

### DIFF
--- a/src/AWS.jl
+++ b/src/AWS.jl
@@ -13,7 +13,7 @@ using UUIDs: UUIDs
 using XMLDict
 
 export @service
-export _merge, AWSConfig, AWSExceptions, AWSServices, Request, global_aws_config, set_global_aws_config, set_user_agent
+export _merge, AWSConfig, AWSExceptions, AWSServices, Request, global_aws_config, set_user_agent
 export JSONService, RestJSONService, RestXMLService, QueryService
 
 include("utilities.jl")

--- a/src/AWS.jl
+++ b/src/AWS.jl
@@ -42,7 +42,7 @@ If one is not set, create one with default configuration options.
 - `AWSConfig`: The global AWS configuration
 """
 function global_aws_config(; kwargs...)
-    if !isassigned(aws_config)
+    if !isassigned(aws_config) || !isempty(kwargs)
         aws_config[] = AWSConfig(; kwargs...)
     end
 
@@ -61,7 +61,7 @@ Set the global AWSConfig.
 # Returns
 - `AWSConfig`: Global AWSConfig
 """
-function set_global_aws_config(config::AWSConfig)
+function global_aws_config(config::AWSConfig)
     return aws_config[] = config
 end
 

--- a/src/AWS.jl
+++ b/src/AWS.jl
@@ -51,7 +51,7 @@ end
 
 
 """
-    set_global_aws_config(config::AWSConfig)
+    global_aws_config(config::AWSConfig)
 
 Set the global AWSConfig.
 

--- a/src/AWS.jl
+++ b/src/AWS.jl
@@ -13,7 +13,7 @@ using UUIDs: UUIDs
 using XMLDict
 
 export @service
-export _merge, AWSConfig, AWSExceptions, AWSServices, Request, global_aws_config, set_user_agent
+export _merge, AWSConfig, AWSExceptions, AWSServices, Request, global_aws_config, set_global_aws_config, set_user_agent
 export JSONService, RestJSONService, RestXMLService, QueryService
 
 include("utilities.jl")
@@ -33,6 +33,10 @@ aws_config = Ref{AWSConfig}()
     global_aws_config()
 
 Retrieve the global AWS configuration.
+If one is not set, create one with default configuration options.
+
+# Keywords
+- `kwargs...`: AWSConfig kwargs to be passed along if the global configuration is not already set
 
 # Returns
 - `AWSConfig`: The global AWS configuration
@@ -43,6 +47,22 @@ function global_aws_config(; kwargs...)
     end
 
     return aws_config[]
+end
+
+
+"""
+    set_global_aws_config(config::AWSConfig)
+
+Set the global AWSConfig.
+
+# Arguments
+- `config::AWSConfig`: The AWSConfig to set in the global state
+
+# Returns
+- `AWSConfig`: Global AWSConfig
+"""
+function set_global_aws_config(config::AWSConfig)
+    return aws_config[] = config
 end
 
 

--- a/src/AWS.jl
+++ b/src/AWS.jl
@@ -37,9 +37,9 @@ Retrieve the global AWS configuration.
 # Returns
 - `AWSConfig`: The global AWS configuration
 """
-function global_aws_config()
+function global_aws_config(; kwargs...)
     if !isassigned(aws_config)
-        aws_config[] = AWSConfig()
+        aws_config[] = AWSConfig(; kwargs...)
     end
 
     return aws_config[]

--- a/test/AWS.jl
+++ b/test/AWS.jl
@@ -7,6 +7,17 @@ end
     @test :S3 in names(Main)
 end
 
+@testset "set global config region" begin
+    try
+        region = "us-east-2"
+        AWS.global_aws_config(; region=region)
+
+        @test AWS.global_aws_config().region == region
+    finally
+        AWS.aws_config[] = AWSConfig()
+    end
+end
+
 @testset "set user agent" begin
     new_user_agent = "new user agent"
 

--- a/test/AWS.jl
+++ b/test/AWS.jl
@@ -7,7 +7,7 @@ end
     @test :S3 in names(Main)
 end
 
-@testset "set global config region" begin
+@testset "global config, kwargs" begin
     try
         region = "us-east-2"
         AWS.global_aws_config(; region=region)
@@ -15,6 +15,20 @@ end
         @test AWS.global_aws_config().region == region
     finally
         AWS.aws_config[] = AWSConfig()
+    end
+end
+
+@testset "set global aws config" begin
+    test_region = "test region"
+    expected = AWSConfig(region=test_region)
+
+    try
+        AWS.set_global_aws_config(expected)
+        result = AWS.global_aws_config()
+
+        @test result.region == test_region
+    finally
+        AWS.set_global_aws_config(AWSConfig())
     end
 end
 

--- a/test/AWS.jl
+++ b/test/AWS.jl
@@ -23,12 +23,12 @@ end
     expected = AWSConfig(region=test_region)
 
     try
-        AWS.set_global_aws_config(expected)
+        AWS.global_aws_config(expected)
         result = AWS.global_aws_config()
 
         @test result.region == test_region
     finally
-        AWS.set_global_aws_config(AWSConfig())
+        AWS.global_aws_config(AWSConfig())
     end
 end
 


### PR DESCRIPTION
## Resolves: #177 

## Overview
By default we are always setting the `AWSConfig.region` to `us-east-1`. Some people don't use this region, we should give them the option to set the default region by passing `kwargs...` along to the underlying `AWSConfig()` call.

Also included a function `set_global_aws_config(config::AWSConfig)` to set the global configuration.