### PR TITLE
Fixed XRay & hault auto-generation

### DIFF
--- a/.github/workflows/update_apis.yml
+++ b/.github/workflows/update_apis.yml
@@ -1,7 +1,7 @@
 name: AWS
-on:
-  schedule:
-    - cron: '0 6 * * *'  # Daily at 6 a.m. UTC 
+# on:
+#   schedule:
+#     - cron: '0 6 * * *'  # Daily at 6 a.m. UTC 
 
 jobs:
   AWS:

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AWS"
 uuid = "fbe9abb3-538b-5e4e-ba9e-bc94f4f92ebc"
 license = "MIT"
-version = "1.14.0"
+version = "1.15.0"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/AWSServices.jl
+++ b/src/AWSServices.jl
@@ -237,5 +237,6 @@ const worklink = AWS.RestJSONService("worklink", "2018-09-25")
 const workmail = AWS.JSONService("workmail", "2017-10-01", "1.1", "WorkMailService")
 const workmailmessageflow = AWS.RestJSONService("workmailmessageflow", "2019-05-01")
 const workspaces = AWS.JSONService("workspaces", "2015-04-08", "1.1", "WorkspacesService")
+const xray = AWS.RestJSONService("xray", "2016-04-12")
 
 end


### PR DESCRIPTION
There is an issue with GitHub API limits, this is being attempted to be resolved in #208. However as a temporary bandage I'm putting the `XRay` low-level definition back in while I think of a better solution to resolve this issue.

Also temporary disabling auto-generation for definitions.