### PR TITLE
Enable non-AWS S3 service providers

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AWS"
 uuid = "fbe9abb3-538b-5e4e-ba9e-bc94f4f92ebc"
 license = "MIT"
-version = "1.15.0"
+version = "1.13.0"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/test/AWS.jl
+++ b/test/AWS.jl
@@ -391,6 +391,15 @@ end
         @test result == expected_result
     end
 
+    @testset "service host" begin
+        endpoint = "sdb"
+        request.service = endpoint
+        service_host = "test_host"
+        expected_result = "https://$endpoint.$region.$service_host$resource"
+        result = AWS._generate_service_url(region, request.service, request.resource; service_host=service_host)
+
+        @test result == expected_result
+    end
 
     @testset "sdb -- us-east-1 region exception" begin
         endpoint = "sdb"


### PR DESCRIPTION
Resolves: #111 

## Problem
One thing which I overlooked when creating this package was using different S3 service providers for backed storage. If you currently use a different service provider, the S3 functionality will not work.

## Solution
Pass in an arg when making an `S3` request called `service_host` to generate the URL properly.

```julia
args = Dict("service_host"=>"my_user_host")
result = s3("GET", "my-bucket", args)
```