### PR TITLE
Set response_stream to Base.BufferStream if none provided when returning stream

### DIFF
--- a/src/AWS.jl
+++ b/src/AWS.jl
@@ -289,6 +289,10 @@ function _http_request(request::Request)
     @repeat 4 try
         http_stack = HTTP.stack(redirect=false, retry=false, aws_authorization=false)
 
+        if request.return_stream && request.response_stream === nothing
+            request.response_stream = Base.BufferStream()
+        end
+
         return HTTP.request(
             http_stack,
             request.request_method,


### PR DESCRIPTION
If you set the `return_stream` option to `True`, but do not provide a `response_stream` you'll be reading `nothing` since that's the default value.