### PR TITLE
Handle spacing in S3 files

### DIFF
--- a/src/AWS.jl
+++ b/src/AWS.jl
@@ -350,6 +350,7 @@ function submit_request(aws::AWSConfig, request::Request; return_headers::Bool=f
 
     request.headers["User-Agent"] = user_agent[]
     request.headers["Host"] = HTTP.URI(request.url).host
+    request.url = replace(request.url, " " => "%20")
 
     @repeat 3 try
         _sign!(aws, request)

--- a/test/AWS.jl
+++ b/test/AWS.jl
@@ -1,7 +1,3 @@
-function _now_formatted()
-    return lowercase(Dates.format(now(Dates.UTC), dateformat"yyyymmdd\THHMMSSsss\Z"))
-end
-
 @testset "service module" begin
     @service S3
     @test :S3 in names(Main)

--- a/test/issues.jl
+++ b/test/issues.jl
@@ -7,9 +7,9 @@ S3.create_bucket(bucket_name)
     # https://github.com/JuliaCloud/AWS.jl/issues/223
     body = "Hello World!"
     file_name = "contains spaces"
-    S3.put_object(bucket_name, file_name, Dict("body" => body))
 
     try
+        S3.put_object(bucket_name, file_name, Dict("body" => body))
         resp = S3.get_object(bucket_name, file_name)
 
         @test String(resp) == body

--- a/test/issues.jl
+++ b/test/issues.jl
@@ -1,0 +1,15 @@
+@service S3
+
+bucket_name = "aws-jl-test-issues---" * _now_formatted()
+S3.create_bucket(bucket_name)
+
+@testset "issue 223" begin
+    # https://github.com/JuliaCloud/AWS.jl/issues/223
+    body = "Hello World!"
+    file_name = "contains spaces"
+    S3.put_object(bucket_name, file_name, Dict("body" => body))
+
+    resp = S3.get_object(bucket_name, file_name)
+
+    @test String(resp) == body
+end

--- a/test/issues.jl
+++ b/test/issues.jl
@@ -9,7 +9,11 @@ S3.create_bucket(bucket_name)
     file_name = "contains spaces"
     S3.put_object(bucket_name, file_name, Dict("body" => body))
 
-    resp = S3.get_object(bucket_name, file_name)
+    try
+        resp = S3.get_object(bucket_name, file_name)
 
-    @test String(resp) == body
+        @test String(resp) == body
+    finally
+        S3.delete_bucket(bucket_name)
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,11 +28,16 @@ include("patch.jl")
 
 aws = AWSConfig()
 
+function _now_formatted()
+    return lowercase(Dates.format(now(Dates.UTC), dateformat"yyyymmdd\THHMMSSsss\Z"))
+end
+
 @testset "AWS.jl" begin
-    include("utilities.jl")
     include("AWS.jl")
     include("AWSCredentials.jl")
     include("AWSExceptions.jl")
     include("AWSMetadataUtilities.jl")
+    include("issues.jl")
     include("test_pkg.jl")
+    include("utilities.jl")
 end


### PR DESCRIPTION
## Problem
This is also a problem in [AWSCore.jl](https://github.com/JuliaCloud/AWSCore.jl), I'll port a fix for that some time soon. But currently you cannot get an object with a space in its name.

The issue roots itself in the URL not being encoded.

```julia
using AWS
@service S3

S3.get_object("/mattbr-test-bucket", "hello world")

> ERROR: AWS.AWSExceptions.AWSException("HttpVersionNotSupported", "The HTTP version specified is not supported."
```

## Solution
Resolves: #223 

We cannot do an `HTTP.escapeuri()` call because we do not want to escape `/` characters. This is a bit problematic since in the high-level wrapper we have,

https://github.com/JuliaCloud/AWS.jl/blob/6dcae89cc64f93d8135c7c50a98771bd7b70d535/src/services/s3.jl#L760-L761

Which passes in `/$(Bucket)/$(Key)` as the URI. Instead what we can do is replace the space character with `%20` to encode it.