### PR TITLE
make URL's a little more hackable

### DIFF
--- a/src/AWSConfig.jl
+++ b/src/AWSConfig.jl
@@ -2,6 +2,7 @@ mutable struct AWSConfig
     credentials::Union{AWSCredentials, Nothing}
     region::String
     output::String
+    host::String
 end
 
 function AWSConfig(;
@@ -9,8 +10,9 @@ function AWSConfig(;
     creds=AWSCredentials(profile=profile),
     region=get(ENV, "AWS_DEFAULT_REGION", "us-east-1"),
     output="json",
+    endpoint="",
 )
-    return AWSConfig(creds, region, output)
+    return AWSConfig(creds, region, output, endpoint)
 end
 
 """


### PR DESCRIPTION
This adds the `host` field to `AWSConfig` which allows users to override the generated host URL for all services.  This is crucial for software that provides API's that mimic AWS services such as min.io.

I used the extremely awkward name `endpoint` as the keyword argument.  This is to maintain consistency with the AWS CLI which allows overriding this argument with `--endpoint-url`.  Of course this name makes no sense because it only gives the host typically, I'd be happy to change it but I'm not sure what the best convention is here.  It's already a bit obscure.

I still have to add some unit tests, in the meantime, let me know what you think.