### PR TITLE
Fixed some JSON specifications for operations

### DIFF
--- a/test/resources/aws_jl_test.yaml
+++ b/test/resources/aws_jl_test.yaml
@@ -147,11 +147,11 @@ Resources:
       PolicyDocument:
         Version: 2012-10-17
         Statement:
-        - Effect: Allow
-          Action:
-          - dynamodb:CreateTable
-          - dynamodb:PutItem
-          - dynamodb:DescribeTable
-          - dynamodb:Scan
+          - Effect: Allow
+            Action:
+              - dynamodb:CreateTable
+              - dynamodb:PutItem
+              - dynamodb:DescribeTable
+              - dynamodb:Scan
           - dynamodb:DeleteTable
           Resource: arn:aws:dynamodb:*:351396300852:table/aws-jl-test-*

--- a/test/resources/aws_jl_test.yaml
+++ b/test/resources/aws_jl_test.yaml
@@ -23,9 +23,9 @@ Resources:
             Resource: !Sub arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/${AWS::StackName}/*
 
   IAMPolicy:
-    Type: AWS::IAM::Policy
+    Type: AWS::IAM::ManagedPolicy
     Properties:
-      PolicyName: IAMPolicy
+      ManagedPolicyName: IAMPolicy
       Users:
         - !Ref PublicCIUser
       PolicyDocument:
@@ -39,9 +39,9 @@ Resources:
             Resource:
               - !Sub arn:aws:iam::${AWS::AccountId}:policy/aws-jl-test-*
   SecretsManagerPolicy:
-    Type: AWS::IAM::Policy
+    Type: AWS::IAM::ManagedPolicy
     Properties:
-      PolicyName: SecretsManagerTestPolicy
+      ManagedPolicyName: SecretsManagerTestPolicy
       Users:
         - !Ref PublicCIUser
       PolicyDocument:
@@ -56,9 +56,9 @@ Resources:
             Action: secretsmanager:CreateSecret
             Resource: "*"
   GlacierTestPolicy:
-    Type: AWS::IAM::Policy
+    Type: AWS::IAM::ManagedPolicy
     Properties:
-      PolicyName: GlacierTestPolicy
+      ManagedPolicyName: GlacierTestPolicy
       Users:
         - !Ref PublicCIUser
       PolicyDocument:
@@ -69,15 +69,15 @@ Resources:
               - glacier:AddTagsToVault
               - glacier:CreateVault
               - glacier:DeleteVault
-              - ListTagsForVault
+              - glacier:ListTagsForVault
             Resource: !Sub arn:aws:glacier:*:${AWS::AccountId}:vaults/aws-jl-test-*
           - Effect: Allow
             Action: glacier:ListVaults
             Resource: "*"
   S3TestPolicy:
-    Type: AWS::IAM::Policy
+    Type: AWS::IAM::ManagedPolicy
     Properties:
-      PolicyName: S3TestPolicy
+      ManagedPolicyName: S3TestPolicy
       Users:
         - !Ref PublicCIUser
       PolicyDocument:
@@ -114,9 +114,9 @@ Resources:
               - s3:GetObjectVersion
             Resource: arn:aws:s3:::aws-jl-test-*/*
   SQSTestPolicy:
-    Type: AWS::IAM::Policy
+    Type: AWS::IAM::ManagedPolicy
     Properties:
-      PolicyName: SQSTestPolicy
+      ManagedPolicyName: SQSTestPolicy
       Users:
         - !Ref PublicCIUser
       PolicyDocument:
@@ -138,3 +138,20 @@ Resources:
               - sqs:SendMessageBatch
               - sqs:SetQueueAttributes
             Resource: !Sub arn:aws:sqs:*:${AWS::AccountId}:aws-jl-test-*
+  DynamoDBTestPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      ManagedPolicyName: DynamoDBTestPolicy
+      Users:
+        - !Ref PublicCIUser
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+        - Effect: Allow
+          Action:
+          - dynamodb:CreateTable
+          - dynamodb:PutItem
+          - dynamodb:DescribeTable
+          - dynamodb:Scan
+          - dynamodb:DeleteTable
+          Resource: arn:aws:dynamodb:*:351396300852:table/aws-jl-test-*


### PR DESCRIPTION
## Problem
Currently working on some tooling that needs to write to a DyanmoDB table. This operation is failing with an error:

```
AWS.AWSExceptions.AWSException("SerializationException", "Unrecognized collection type java.util.Map<java.lang.String, com.amazonaws.dynamodb.v20120810.AttributeValue>", Dict{String,Any}
```

This is due to the specification of JSON that we're using. In an example of the `content` that we send to AWS when attempting to put an object:

`“{\“TableName\“:\“table\“,\“Item\“:[{\“pk\“:[{\“S\“:\“sample\“}]}]}”`

However, AWS expects this to be:

`“{\“TableName\“:\“table\“,\“Item\“:{\“pk\“:{\“S\“:\“sample\“}}}”`

## Solution
This implements a `_children_to_dict` function from [AWSCore.jl](https://github.com/JuliaCloud/AWSCore.jl/blob/0b1057e648d21eeb5ec044dec690dc4c8eb934c6/src/AWSCore.jl#L142).

This however is not a proper solution, in testing this I found that doing a `CreateTable` operation fails. This is because AWS expects the content for this operations `AttributeDefinitions` and `KeySchema` to be an array.

What we're sending now:
> "{\"BillingMode\": \"PAY_PER_REQUEST\",\"AttributeDefinitions\":{\"AttributeName\":\"$(partition_key)\",\"AttributeType\":\"S\"},\"TableName\":\"$(table_name)\",\"KeySchema\":{\"AttributeName\":\"$(partition_key)\",\"KeyType\":\"HASH\"}}"

What AWS expects:
> "{\"BillingMode\": \"PAY_PER_REQUEST\",\"AttributeDefinitions\":[{\"AttributeName\":\"$(partition_key)\",\"AttributeType\":\"S\"}],\"TableName\":\"$(table_name)\",\"KeySchema\":[{\"AttributeName\":\"$(partition_key)\",\"KeyType\":\"HASH\"}]}"

This is a very much intermediate step to unblock the work I'm doing, and will need to be properly addressed in the future https://github.com/JuliaCloud/AWS.jl/issues/246. It's much easier to have a hard-coded string for creating a table than it is to hard-code larger put_item requests.