### PR TITLE
Use WebIdentityTokens to create credentials

### DIFF
--- a/src/AWSExceptions.jl
+++ b/src/AWSExceptions.jl
@@ -5,7 +5,7 @@ using JSON
 using XMLDict
 using XMLDict: XMLDictElement
 
-export AWSException, ProtocolNotDefined, InvalidFileName, NoCredentials
+export AWSException, ProtocolNotDefined, InvalidFileName, NoCredentials, WebIdentityVarsNotSet
 
 struct ProtocolNotDefined <: Exception
     message::String
@@ -21,6 +21,11 @@ struct NoCredentials <: Exception
     message::String
 end
 Base.show(io::IO, e::NoCredentials) = println(io, e.message)
+
+struct WebIdentityVarsNotSet <: Exception
+    message::String
+end
+Base.show(io::IO, e::WebIdentityVarsNotSet) = println(io, e.message)
 
 struct AWSException <: Exception
     code::String

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,7 @@
 using AWS
 using AWS: AWSCredentials
 using AWS: AWSServices
-using AWS.AWSExceptions: AWSException, NoCredentials
+using AWS.AWSExceptions: AWSException, NoCredentials, WebIdentityVarsNotSet
 using AWS.AWSMetadataUtilities: _clean_documentation, _filter_latest_service_version,
     _generate_low_level_definition, _generate_high_level_definition, _generate_high_level_definitions,
     _get_aws_sdk_js_files, _get_service_and_version, _get_function_parameters, _clean_uri, _format_function_name,


### PR DESCRIPTION
### Resolves #244 

These changes use existing credentials to assume temporary credentials via a [Web Identity File](https://docs.aws.amazon.com/credref/latest/refdocs/setting-global-web_identity_token_file.html) using [AssumeRoleWithWebIdentity](https://github.com/JuliaCloud/AWS.jl/blob/master/src/services/sts.jl#L48).

The code was taken from the issue itself, with a slight modification to ensure that the appropriate env vars are set before proceeding.