### PR TITLE
Add webtoken auth to precedence list

### DIFF
--- a/src/AWSCredentials.jl
+++ b/src/AWSCredentials.jl
@@ -152,6 +152,7 @@ function AWSCredentials(; profile=nothing)
         env_var_credentials,
         () -> dot_aws_credentials(profile),
         () -> dot_aws_config(profile),
+        credentials_from_webtoken,
         ecs_instance_credentials,
         ec2_instance_credentials
     ]
@@ -453,7 +454,7 @@ function dot_aws_config(profile=nothing)
 end
 
 
-function credentials_from_webtoken(profile=nothing)
+function credentials_from_webtoken()
     token_role_arn = "AWS_ROLE_ARN"
     token_role_session = "AWS_ROLE_SESSION_NAME"
     token_web_identity = "AWS_WEB_IDENTITY_TOKEN_FILE"
@@ -464,9 +465,7 @@ function credentials_from_webtoken(profile=nothing)
         haskey(ENV, token_web_identity)
 
     if !has_all_keys
-        throw(WebIdentityVarsNotSet(
-            "You need to set $(token_role_arn), $(token_role_session), $(token_web_identity) environment variables"
-        ))
+        return nothing
     end
 
     role_arn = ENV[token_role_arn]
@@ -480,7 +479,7 @@ function credentials_from_webtoken(profile=nothing)
             "RoleSessionName" => role_session,
             "WebIdentityToken" => web_identity
         );
-        aws_config=AWSConfig(profile=profile)
+        aws_config=AWSConfig(creds=nothing)
     )
 
     role_creds = resp["AssumeRoleWithWebIdentityResult"]["Credentials"]

--- a/src/AWSCredentials.jl
+++ b/src/AWSCredentials.jl
@@ -472,7 +472,7 @@ function credentials_from_webtoken()
     role_session = ENV[token_role_session]
     web_identity = read(ENV["AWS_WEB_IDENTITY_TOKEN_FILE"], String)
 
-    resp = AWSServices.sts(
+    resp = @mock AWSServices.sts(
         "AssumeRoleWithWebIdentity",
         Dict(
             "RoleArn" => role_arn, 

--- a/src/AWSExceptions.jl
+++ b/src/AWSExceptions.jl
@@ -5,7 +5,7 @@ using JSON
 using XMLDict
 using XMLDict: XMLDictElement
 
-export AWSException, ProtocolNotDefined, InvalidFileName, NoCredentials, WebIdentityVarsNotSet
+export AWSException, ProtocolNotDefined, InvalidFileName, NoCredentials
 
 struct ProtocolNotDefined <: Exception
     message::String

--- a/src/AWSExceptions.jl
+++ b/src/AWSExceptions.jl
@@ -22,11 +22,6 @@ struct NoCredentials <: Exception
 end
 Base.show(io::IO, e::NoCredentials) = println(io, e.message)
 
-struct WebIdentityVarsNotSet <: Exception
-    message::String
-end
-Base.show(io::IO, e::WebIdentityVarsNotSet) = println(io, e.message)
-
 struct AWSException <: Exception
     code::String
     message::String

--- a/test/AWSCredentials.jl
+++ b/test/AWSCredentials.jl
@@ -463,6 +463,8 @@ end
     end
 
     @testset "Web Identity File" begin
+        @test credentials_from_webtoken() == nothing
+
         mktempdir() do dir
             web_identity_file = joinpath(dir, "web_identity")
             write(web_identity_file, "foobar")
@@ -479,13 +481,18 @@ end
                     @test result.secret_key == Patches.web_secret_key
                     @test result.token == Patches.web_sesh_token
                     @test result.renew == credentials_from_webtoken
+                    expiry = result.expiry
+
+                    result = check_credentials(result)
+
+                    @test result.access_key_id == Patches.web_access_key
+                    @test result.secret_key == Patches.web_secret_key
+                    @test result.token == Patches.web_sesh_token
+                    @test result.renew == credentials_from_webtoken
+                    @test expiry != result.expiry
                 end
             end
         end
-    end
-
-    @testset "Web Identity File -- Exception" begin
-        @test_throws WebIdentityVarsNotSet credentials_from_webtoken()
     end
 
     @testset "Credentials Not Found" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,7 @@
 using AWS
 using AWS: AWSCredentials
 using AWS: AWSServices
-using AWS.AWSExceptions: AWSException, NoCredentials, WebIdentityVarsNotSet
+using AWS.AWSExceptions: AWSException, NoCredentials
 using AWS.AWSMetadataUtilities: _clean_documentation, _filter_latest_service_version,
     _generate_low_level_definition, _generate_high_level_definition, _generate_high_level_definitions,
     _get_aws_sdk_js_files, _get_service_and_version, _get_function_parameters, _clean_uri, _format_function_name,


### PR DESCRIPTION
This should fix the issues we're still having from #244.

Also:

- removes `profile` from the webtoken parameters since it's not really used. I can add this back in if necessary, I was just following the convention from the EC2 and ECS credential functions.
- returns `nothing` if the keys don't exist, since we want it to continue down the precedence list.
- explicitly passes `nothing` in for `creds`. This caused an infinite loop as `credentials_from_webtoken` called `AWSConfig` which would call `AWSCredentials`, etc.

There's probably a cleaner way to handle that last point, if anyone has opinions!