### PR TITLE
updated HTTP compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -22,7 +22,7 @@ XMLDict = "228000da-037f-5747-90a9-8195ccbf91a5"
 [compat]
 Compat = "3"
 GitHub = "5"
-HTTP = "0.8"
+HTTP = "0.8, 0.9"
 IniFile = "0.5"
 JSON = "0.18, 0.19, 0.20, 0.21"
 MbedTLS = "0.6, 0.7, 1"


### PR DESCRIPTION
This package was causing HTTP to be held back.

HTTP 0.9 seems unlikely to break anything, but I don't really have a way of testing this.