### PR TITLE
make AWS_ROLE_SESSION_NAME optional

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -36,9 +36,10 @@ julia = "1"
 
 [extras]
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Suppressor = "fd094767-a336-5f1f-9728-57cf17d0bbfb"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [targets]
-test = ["Pkg", "Suppressor", "Test", "UUIDs"]
+test = ["Pkg", "Random", "Suppressor", "Test", "UUIDs"]

--- a/src/AWSCredentials.jl
+++ b/src/AWSCredentials.jl
@@ -478,7 +478,8 @@ function credentials_from_webtoken()
 
     role_arn = ENV[token_role_arn]
     role_session = get(ENV, token_role_session) do
-        default_role_session = replace("default-AWS.jl-role-session-$(now())", ":" => "-")
+        timestamp = Dates.format(now(UTC), dateformat"yyyymmdd\THHMMSS\Z")
+        default_role_session = "default-AWS.jl-role-session-$timestamp" 
         @warn "Consider setting (optional) AWS_ROLE_SESSION_NAME environment variable, defaulting to $default_role_session"
         return default_role_session
     end

--- a/src/AWSCredentials.jl
+++ b/src/AWSCredentials.jl
@@ -477,7 +477,7 @@ function credentials_from_webtoken()
     end
 
     role_arn = ENV[token_role_arn]
-    role_session = get!(ENV, token_role_session) do
+    role_session = get(ENV, token_role_session) do
         default_role_session = replace("default-AWS.jl-role-session-$(now())", ":" => "-")
         @warn "Consider setting (optional) AWS_ROLE_SESSION_NAME environment variable, defaulting to $default_role_session"
         return default_role_session

--- a/src/AWSCredentials.jl
+++ b/src/AWSCredentials.jl
@@ -470,7 +470,6 @@ function credentials_from_webtoken()
 
     has_all_keys =
         haskey(ENV, token_role_arn) &&
-        haskey(ENV, token_role_session) &&
         haskey(ENV, token_web_identity)
 
     if !has_all_keys
@@ -478,7 +477,11 @@ function credentials_from_webtoken()
     end
 
     role_arn = ENV[token_role_arn]
-    role_session = ENV[token_role_session]
+    role_session = get!(ENV, token_role_session) do
+        default_role_session = replace("default-AWS.jl-role-session-$(now())", ":" => "-")
+        @warn "Consider setting (optional) AWS_ROLE_SESSION_NAME environment variable, defaulting to $default_role_session"
+        return default_role_session
+    end
     web_identity = read(ENV["AWS_WEB_IDENTITY_TOKEN_FILE"], String)
 
     resp = @mock AWSServices.sts(

--- a/src/AWSCredentials.jl
+++ b/src/AWSCredentials.jl
@@ -494,12 +494,13 @@ function credentials_from_webtoken()
     )
 
     role_creds = resp["AssumeRoleWithWebIdentityResult"]["Credentials"]
+    assumed_role_user = resp["AssumeRoleWithWebIdentityResult"]["AssumedRoleUser"]
 
     return AWSCredentials(
         role_creds["AccessKeyId"],
         role_creds["SecretAccessKey"],
         role_creds["SessionToken"],
-        role_creds["AssumedRoleUser"]["Arn"];
+        assumed_role_user["Arn"];
         expiry=DateTime(rstrip(role_creds["Expiration"], 'Z')),
         renew=credentials_from_webtoken
     )

--- a/test/AWSCredentials.jl
+++ b/test/AWSCredentials.jl
@@ -492,6 +492,27 @@ end
                     @test expiry != result.expiry
                 end
             end
+
+            withenv(
+                "AWS_ROLE_ARN" => "foobar",
+                "AWS_WEB_IDENTITY_TOKEN_FILE" => web_identity_file,
+            ) do
+                apply(Patches._web_identity_patch) do
+                    result = credentials_from_webtoken()
+
+                    @test result.access_key_id == Patches.web_access_key
+                    @test result.secret_key == Patches.web_secret_key
+                    @test result.renew == credentials_from_webtoken
+                    expiry = result.expiry
+
+                    result = check_credentials(result)
+
+                    @test result.access_key_id == Patches.web_access_key
+                    @test result.secret_key == Patches.web_secret_key
+                    @test result.renew == credentials_from_webtoken
+                    @test expiry != result.expiry
+                end
+            end
         end
     end
 

--- a/test/patch.jl
+++ b/test/patch.jl
@@ -78,10 +78,16 @@ _web_identity_patch = function (;
             "SecretAccessKey" => secret_key,
             "SessionToken" => session_token,
             "Expiration" => string(now(UTC)),
-            "AssumedRoleUser" => Dict("Arn" => role_arn * "/" * params["RoleSessionName"]),
         )
 
-        result = Dict("AssumeRoleWithWebIdentityResult" => Dict("Credentials" => creds))
+        result = Dict(
+            "AssumeRoleWithWebIdentityResult" => Dict(
+                "Credentials" => creds,
+                "AssumedRoleUser" => Dict(
+                    "Arn" => role_arn * "/" * params["RoleSessionName"],
+                ),
+            ),
+        )
 
         return HTTP.Response(200, ["Content-Type" => "text/json", "charset" => "utf-8"], body=json(result))
     end

--- a/test/patch.jl
+++ b/test/patch.jl
@@ -44,10 +44,6 @@ body = """
 
 response = HTTP.Messages.Response()
 
-web_access_key = "web_identity_access_key"
-web_secret_key = "web_identity_secret_key"
-web_sesh_token = "web_session_token"
-
 function _response!(; version::VersionNumber=version, status::Int64=status, headers::Array=headers, body::String=body)
     response.version = version
     response.status = status
@@ -69,17 +65,26 @@ _config_file_patch = @patch function dot_aws_config_file()
     return ""
 end
 
-_web_identity_patch = @patch function AWS._http_request(request)
-    creds = Dict(
-        "AccessKeyId" => web_access_key, 
-        "SecretAccessKey" => web_secret_key,
-        "SessionToken" => web_sesh_token, 
-        "Expiration" => string(now(UTC))
-    )
+_web_identity_patch = function (;
+    access_key="web_identity_access_key",
+    secret_key="web_identity_secret_key",
+    session_token="web_session_token",
+    role_arn="arn:aws:sts:::assumed-role/role-name",
+)
+    @patch function AWS._http_request(request)
+        params = Dict(split.(split(request.content, '&'), '='))
+        creds = Dict(
+            "AccessKeyId" => access_key,
+            "SecretAccessKey" => secret_key,
+            "SessionToken" => session_token,
+            "Expiration" => string(now(UTC)),
+            "AssumedRoleUser" => Dict("Arn" => role_arn * "/" * params["RoleSessionName"]),
+        )
 
-    result = Dict("AssumeRoleWithWebIdentityResult" => Dict("Credentials" => creds))
+        result = Dict("AssumeRoleWithWebIdentityResult" => Dict("Credentials" => creds))
 
-    return HTTP.Response(200, ["Content-Type" => "text/json", "charset" => "utf-8"], body=json(result))
+        return HTTP.Response(200, ["Content-Type" => "text/json", "charset" => "utf-8"], body=json(result))
+    end
 end
 
 _github_tree_patch = @patch function tree(repo, tree_obj; kwargs...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,6 +16,7 @@ using OrderedCollections: LittleDict, OrderedDict
 using MbedTLS: digest, MD_SHA256, MD_MD5
 using Mocking
 using Pkg
+using Random
 using Retry
 using Suppressor
 using Test


### PR DESCRIPTION
AWS docs indicate that it should be optional.
If unspecified, a default is set and warning logged.