### PR TITLE
AssumeRole parse response properly

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AWS"
 uuid = "fbe9abb3-538b-5e4e-ba9e-bc94f4f92ebc"
 license = "MIT"
-version = "1.25.0"
+version = "1.25.1"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/AWSCredentials.jl
+++ b/src/AWSCredentials.jl
@@ -459,7 +459,7 @@ function credentials_from_webtoken()
     token_role_session = "AWS_ROLE_SESSION_NAME"
     token_web_identity = "AWS_WEB_IDENTITY_TOKEN_FILE"
 
-    has_all_keys = 
+    has_all_keys =
         haskey(ENV, token_role_arn) &&
         haskey(ENV, token_role_session) &&
         haskey(ENV, token_web_identity)
@@ -475,7 +475,7 @@ function credentials_from_webtoken()
     resp = @mock AWSServices.sts(
         "AssumeRoleWithWebIdentity",
         Dict(
-            "RoleArn" => role_arn, 
+            "RoleArn" => role_arn,
             "RoleSessionName" => role_session,
             "WebIdentityToken" => web_identity
         );
@@ -562,13 +562,13 @@ function _aws_get_role(role::AbstractString, ini::Inifile)
         aws_config=config
     )
 
-    role_creds = role["Credentials"]
+    role_creds = role["AssumeRoleResult"]["Credentials"]
 
     return AWSCredentials(
         role_creds["AccessKeyId"],
         role_creds["SecretAccessKey"],
         role_creds["SessionToken"];
-        expiry=unix2datetime(role_creds["Expiration"])
+        expiry=DateTime(rstrip(role_creds["Expiration"], 'Z'))
     )
 end
 


### PR DESCRIPTION
# Problem
We are seeing the following error on our CI machines:

```julia
ERROR: LoadError: InitError: KeyError: key "Credentials" not found
Stacktrace:
 [1] getindex(::OrderedCollections.LittleDict{Union{String, Symbol},Any,Array{Union{String, Symbol},1},Array{Any,1}}, ::String) at ./abstractdict.jl:492
 [2] _aws_get_role(::String, ::IniFile.Inifile) at /Users/admin/builds/f75a2375/0/invenia/{REDACTED}.jl.tmp/depot/packages/AWS/SALZq/src/AWSCredentials.jl:565
 [3] dot_aws_config(::Nothing) at /Users/admin/builds/f75a2375/0/invenia/{REDACTED}.jl.tmp/depot/packages/AWS/SALZq/src/AWSCredentials.jl:449
 [4] (::AWS.var"#12#15")() at /Users/admin/builds/f75a2375/0/invenia/{REDACTED}.jl.tmp/depot/packages/AWS/SALZq/src/AWSCredentials.jl:154
 [5] AWS.AWSCredentials(; profile::Nothing) at /Users/admin/builds/f75a2375/0/invenia/{REDACTED}.jl.tmp/depot/packages/AWS/SALZq/src/AWSCredentials.jl:163
 [6] AWS.AWSConfig() at /Users/admin/builds/f75a2375/0/invenia/{REDACTED}.jl.tmp/depot/packages/AWS/SALZq/src/AWSConfig.jl:18
 [7] #global_aws_config#21 at /Users/admin/builds/f75a2375/0/invenia/{REDACTED}.jl.tmp/depot/packages/AWS/SALZq/src/AWS.jl:47 [inlined]
 [8] global_aws_config at /Users/admin/builds/f75a2375/0/invenia/{REDACTED}.jl.tmp/depot/packages/AWS/SALZq/src/AWS.jl:46 [inlined]
 [9] AWSS3.S3Path(::String) at /Users/admin/builds/f75a2375/0/invenia/{REDACTED}.jl.tmp/depot/packages/AWSS3/H9WJU/src/s3path.jl:83
 [10] init(::Type{{REDACTED}.{REDACTED}}) at /Users/admin/builds/f75a2375/0/invenia/{REDACTED}.jl.tmp/depot/packages/{REDACTED}/p9Xwj/src/{REDACTED}.jl:74
 [11] __init__() at /Users/admin/builds/f75a2375/0/invenia/{REDACTED}.jl.tmp/depot/packages/{REDACTED}/p9Xwj/src/{REDACTED}.jl:24
 [12] _include_from_serialized(::String, ::Array{Any,1}) at ./loading.jl:697
 [13] _require_from_serialized(::String) at ./loading.jl:749
 [14] _require(::Base.PkgId) at ./loading.jl:1040
 [15] require(::Base.PkgId) at ./loading.jl:928
 [16] require(::Module, ::Symbol) at ./loading.jl:923
 [17] include(::String) at ./client.jl:457
 [18] top-level scope at none:6
during initialization of module {REDACTED}
```

# Solution
AWS does not return the credentials when assuming a role at the top-level, but instead it's nested in the `AssumeRoleResult` key.