### PR TITLE
Fix special characters in S3 filenames

### DIFF
--- a/test/AWS.jl
+++ b/test/AWS.jl
@@ -743,7 +743,7 @@ end
 
     @testset "low-level s3" begin
         bucket_name = "aws-jl-test---" * _now_formatted()
-        file_name = string(uuid4())
+        file_name = "*)('! .txt"  # Special characters which S3 allows
 
         function _bucket_exists(bucket_name)
             try


### PR DESCRIPTION
# Problem
AWS S3 allows for a lot of characters in file names. These aren't always limited to `a-z A-Z 0-9`, but also some special characters like `-` and `_`. Or more problematic ones, like `*`, `(`, `'`.

I've already handled one special casing previous (a space), however starting to see a few more appearing. This PR will handle a few more, but not all.

# Solution
The fix here is to replace known problematic characters. In [AWSCore](https://github.com/JuliaCloud/AWSCore.jl/blob/1eb00b46ceac09712429ff923bc1a8cfcf21c1e2/src/AWSCore.jl#L333) this was a bit easier, because the file path was provided as an extra argument. However, in this iteration we are just providing the `request_uri`.

So simply doing `HTTP.escapeuri(request_uri)` would work, except that it will replace `/` with `%2F`, and it will completely break S3 usage. There are a few ways to handle these situations outside of this proposed change:

1) Ignore it, users can manually escape URIs themselves (not nice)
2) Call `HTTP.escapeuri(request_uri)` then replace all instances of `%2F` with `/` (seems more dangerous)
3) Completely re-work `AWS.jl` and create a new major version release (I don't have time for this, nor the want)

# Notes
- [Relevant Stackoverflow Post](https://stackoverflow.com/questions/7116450/what-are-valid-s3-key-names-that-can-be-accessed-via-the-s3-rest-api)