### PR TITLE
Handle '=' in S3 filenames

### DIFF
--- a/src/AWS.jl
+++ b/src/AWS.jl
@@ -332,37 +332,6 @@ end
 
 
 """
-    _clean_s3_uri(uri::AbstractString)
-
-Escape special AWS S3 characters properly.
-
-AWS S3 allows for various special characters in file names, these characters are not being
-properly escaped before we make the requests.
-
-We cannot call `HTTP.escapeuri(request.uri)` because this will escape `/` characters which
-are used in the filepathing for sub-directories.
-
-# Arguments
-- `uri::AbstractString`: URI to to cleaned
-
-# Returns
-- `String`: URI with characters escaped
-"""
-function _clean_s3_uri(uri::AbstractString)
-    chars_to_clean = (
-        ' ' => "%20",
-        '!' => "%21",
-        ''' => "%27",
-        '(' => "%28",
-        ')' => "%29",
-        '*' => "%2A",
-        '=' => "%3D"
-    )
-    return reduce(replace, chars_to_clean, init=uri)
-end
-
-
-"""
     submit_request(aws::AbstractAWSConfig, request::Request; return_headers::Bool=false)
 
 Submit the request to AWS.
@@ -396,9 +365,6 @@ function submit_request(aws::AbstractAWSConfig, request::Request; return_headers
 
     request.headers["User-Agent"] = user_agent[]
     request.headers["Host"] = HTTP.URI(request.url).host
-    if request.service == "s3"
-        request.url = _clean_s3_uri(request.url)
-    end
 
     @repeat 3 try
         credentials(aws) === nothing || sign!(aws, request)
@@ -558,6 +524,36 @@ function (service::RestXMLService)(
     request_method::String, request_uri::String, args::AbstractDict{String, <:Any}=Dict{String, Any}();
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
+    """
+        _clean_s3_uri(uri::AbstractString)
+
+    Escape special AWS S3 characters properly.
+
+    AWS S3 allows for various special characters in file names, these characters are not being
+    properly escaped before we make the requests.
+
+    We cannot call `HTTP.escapeuri(request.uri)` because this will escape `/` characters which
+    are used in the filepathing for sub-directories.
+
+    # Arguments
+    - `uri::AbstractString`: URI to to cleaned
+
+    # Returns
+    - `String`: URI with characters escaped
+    """
+    function _clean_s3_uri(uri::AbstractString)
+        chars_to_clean = (
+            ' ' => "%20",
+            '!' => "%21",
+            ''' => "%27",
+            '(' => "%28",
+            ')' => "%29",
+            '*' => "%2A",
+            '=' => "%3D"
+        )
+        return reduce(replace, chars_to_clean, init=uri)
+    end
+
     request = Request(
         service=service.name,
         api_version=service.api_version,
@@ -578,6 +574,9 @@ function (service::RestXMLService)(
     delete!(args, "body")
     return_headers = _return_headers(args)
 
+    if request.service == "s3"
+        request_uri = _clean_s3_uri(request_uri)
+    end
     request.resource = _generate_rest_resource(request_uri, args)
     query_str = HTTP.escapeuri(args)
 

--- a/src/AWS.jl
+++ b/src/AWS.jl
@@ -332,7 +332,7 @@ end
 
 
 """
-    _clean_uri(uri::AbstractString)
+    _clean_s3_uri(uri::AbstractString)
 
 Escape special AWS S3 characters properly.
 
@@ -348,17 +348,16 @@ are used in the filepathing for sub-directories.
 # Returns
 - `String`: URI with characters escaped
 """
-function _clean_uri(uri::AbstractString)
-    chars_to_clean = [
+function _clean_s3_uri(uri::AbstractString)
+    chars_to_clean = (
         ' ' => "%20",
         '!' => "%21",
         ''' => "%27",
         '(' => "%28",
         ')' => "%29",
         '*' => "%2A",
-        '=' => "%3D",
-    ]
-
+        '=' => "%3D"
+    )
     return reduce(replace, chars_to_clean, init=uri)
 end
 
@@ -397,7 +396,9 @@ function submit_request(aws::AbstractAWSConfig, request::Request; return_headers
 
     request.headers["User-Agent"] = user_agent[]
     request.headers["Host"] = HTTP.URI(request.url).host
-    request.url = _clean_uri(request.url)
+    if request.service == "s3"
+        request.url = _clean_s3_uri(request.url)
+    end
 
     @repeat 3 try
         credentials(aws) === nothing || sign!(aws, request)

--- a/src/AWS.jl
+++ b/src/AWS.jl
@@ -355,7 +355,8 @@ function _clean_uri(uri::AbstractString)
         ''' => "%27",
         '(' => "%28",
         ')' => "%29",
-        '*' => "%2A"
+        '*' => "%2A",
+        '=' => "%3D",
     ]
 
     return reduce(replace, chars_to_clean, init=uri)

--- a/test/AWS.jl
+++ b/test/AWS.jl
@@ -743,7 +743,7 @@ end
 
     @testset "low-level s3" begin
         bucket_name = "aws-jl-test---" * _now_formatted()
-        file_name = "*)('! .txt"  # Special characters which S3 allows
+        file_name = "*)=('! .txt"  # Special characters which S3 allows
 
         function _bucket_exists(bucket_name)
             try


### PR DESCRIPTION
- Same as https://github.com/JuliaCloud/AWS.jl/pull/285 but adds `'='` to the list, as this is a valid character in S3 filenames, but if unescaped interferes with the GET / PUT request syntax