### PR TITLE
Fix bors callback

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,6 +1,6 @@
 status = [
     "Julia 1.0.5 - ubuntu-latest - x64",
-    "Julia 1.3 - ubuntu-latest - x64",
+    "Julia 1.5 - ubuntu-latest - x64",
     "Julia 1 - macOS-latest - x64",
     "Julia 1 - ubuntu-latest - x64",
 ]


### PR DESCRIPTION
In [this](https://github.com/JuliaCloud/AWS.jl/commit/a2cb76ac61a866f71b39530adbebdd53c6999009#diff-3ab46ee209a127470fce3c2cf106b1a1dbadbb929a4b5b13656a4bc4ce19c0b8R34) commit we changed from `Julia1.3 -> Julia1.5` but didn't update the `bors.toml` file.

I believe this is what is failing the call back when doing merges and tries.