### PR TITLE
use URIs.escapepath instead of custom S3 escaping

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,6 +16,7 @@ Mocking = "78c3b35d-d492-501b-9361-3d52fe80e533"
 OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 Retry = "20febd7b-183b-5ae2-ac4a-720e7ce64774"
 Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
+URIs = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 XMLDict = "228000da-037f-5747-90a9-8195ccbf91a5"
 

--- a/Project.toml
+++ b/Project.toml
@@ -30,6 +30,7 @@ MbedTLS = "0.6, 0.7, 1"
 Mocking = "0.7"
 OrderedCollections = "1"
 Retry = "0.3, 0.4"
+URIs = "1"
 XMLDict = "0.3, 0.4"
 julia = "1"
 

--- a/test/AWS.jl
+++ b/test/AWS.jl
@@ -743,7 +743,10 @@ end
 
     @testset "low-level s3" begin
         bucket_name = "aws-jl-test---" * _now_formatted()
-        file_name = "*)=('! .txt"  # Special characters which S3 allows
+        # Special characters which S3 explicitly allows or does not explicitly
+        # suggest avoiding "might require special handling"
+        # https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html
+        file_name = "!/-_.*'()&\$@=;:+ ,?.txt"
 
         function _bucket_exists(bucket_name)
             try


### PR DESCRIPTION
Fixes #297

The current custom implementation of URI escaping misses many characters that
are valid in S3 keys
https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html

URIs.jl now includes an `escapepath` function that leaves `/` characters
un-escaped and is suitable for escaping S3 keys.  This PR replaces the custom
escaping function with that one, and changes the "weird filename" in the tests
to use all the characters that are either explicitly allowed or "might require
special handling in code" according to the current AWS docs (linked above).