### PR TITLE
Escape plus character (+) in S3 URIs

### DIFF
--- a/src/AWS.jl
+++ b/src/AWS.jl
@@ -549,7 +549,8 @@ function (service::RestXMLService)(
             '(' => "%28",
             ')' => "%29",
             '*' => "%2A",
-            '=' => "%3D"
+            '+' => "%2B",
+            '=' => "%3D",
         )
         return reduce(replace, chars_to_clean, init=uri)
     end

--- a/test/AWS.jl
+++ b/test/AWS.jl
@@ -743,7 +743,7 @@ end
 
     @testset "low-level s3" begin
         bucket_name = "aws-jl-test---" * _now_formatted()
-        file_name = "*)=('! .txt"  # Special characters which S3 allows
+        file_name = "*)=('! +.txt"  # Special characters which S3 allows
 
         function _bucket_exists(bucket_name)
             try


### PR DESCRIPTION
This is a narrower, partial fix for #297, which adds an extra special case for
escaping `+` in S3 URIs.  There are still characters on the list of "probably
work but require special handling" that are not escaped but it at least fixes my
specific problem (accessing existing objects with `+` in their keys).

Alternative to #298 