### PR TITLE
RFC: Fix error handling if HTTP.StatusError occurs

### DIFF
--- a/src/AWSExceptions.jl
+++ b/src/AWSExceptions.jl
@@ -36,6 +36,7 @@ end
 http_message(e::HTTP.StatusError) = String(copy(e.response.body))
 http_status(e::HTTP.StatusError) = e.status
 content_type(e::HTTP.StatusError) = HTTP.header(e.response, "Content-Type")
+is_valid_xml_string(str) = startswith(str, '<')
 
 function AWSException(e::HTTP.StatusError)
     code = string(http_status(e))
@@ -57,7 +58,7 @@ function AWSException(e::HTTP.StatusError)
 
     # Extract API error code from XML error message...
     error_content_types = ["", "application/xml", "text/xml"]
-    if content_type(e) in error_content_types && length(http_message(e)) > 0 && !isa(e, HTTP.StatusError)
+    if content_type(e) in error_content_types && is_valid_xml_string(http_message(e))
         info = parse_xml(http_message(e))
     end
 

--- a/src/AWSExceptions.jl
+++ b/src/AWSExceptions.jl
@@ -57,7 +57,7 @@ function AWSException(e::HTTP.StatusError)
 
     # Extract API error code from XML error message...
     error_content_types = ["", "application/xml", "text/xml"]
-    if content_type(e) in error_content_types && length(http_message(e)) > 0
+    if content_type(e) in error_content_types && length(http_message(e)) > 0 && !isa(e, HTTP.StatusError)
         info = parse_xml(http_message(e))
     end
 

--- a/test/AWSExceptions.jl
+++ b/test/AWSExceptions.jl
@@ -49,6 +49,19 @@
         @test ex.info["RequestId"] == expected["requestId"]
     end
 
+    @testset "XMLRequest - Invalid XML" begin
+        expected = Dict(
+            "body"=>"InvalidXML",
+            "headers"=>["Content-Type" => "application/xml"],
+            "status_code"=>404,
+        )
+        req = HTTP.Request("GET", "https://amazon.ca", expected["headers"], expected["body"])
+        resp = HTTP.Response(expected["status_code"], expected["headers"]; body=expected["body"], request=req)
+        ex = AWSException(HTTP.StatusError(expected["status_code"], resp))
+
+        @test ex.code == "404"
+    end
+
     @testset "JSON Request -- $msg" for msg in ["message", "Message"]
         expected = Dict(
             "code" => "InvalidSignatureException",


### PR DESCRIPTION
This is a simple (possible too simple) fix.

Before PR:

```Julia
julia> s3_get_file(config, bucket, "//a//", "temp")
ERROR: XMLError: Start tag expected, '<' not found from XML parser (code: 4, line: 1)
Stacktrace:
 [1] throw_xml_error() at /Users/user/.julia/packages/EzXML/ZNwhK/src/error.jl:87
 [2] macro expansion at /Users/user/.julia/packages/EzXML/ZNwhK/src/error.jl:52 [inlined]
 [3] parsexml(::String) at /Users/user/.julia/packages/EzXML/ZNwhK/src/document.jl:80
 [4] parse_xml at /Users/user/.julia/packages/XMLDict/vlQGP/src/XMLDict.jl:60 [inlined]
 [5] AWS.AWSExceptions.AWSException(::HTTP.ExceptionRequest.StatusError) at /Users/user/.julia/dev/AWS/src/AWSExceptions.jl:63
 [6] macro expansion at /Users/user/.julia/dev/AWS/src/AWS.jl:378 [inlined]
 [7] macro expansion at /Users/user/.julia/packages/Retry/vS1bg/src/repeat_try.jl:377 [inlined]
 [8] submit_request(::AWSConfig, ::Request; return_headers::Bool) at /Users/user/.julia/dev/AWS/src/AWS.jl:369
 [9] (::RestXMLService)(::String, ::String, ::Dict{String,Bool}; aws_config::AWSConfig) at /Users/user/.julia/dev/AWS/src/AWS.jl:594
 [10] #get_object#90 at /Users/user/.julia/dev/AWS/src/services/s3.jl:1736 [inlined]
 [11] s3_get_file(::AWSConfig, ::String, ::String, ::String; version::String, kwargs::Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}) at /Users/user/.julia/packages/AWSS3/lhRVu/src/AWSS3.jl:103
 [12] s3_get_file(::AWSConfig, ::String, ::String, ::String) at /Users/user/.julia/packages/AWSS3/lhRVu/src/AWSS3.jl:103
 [13] top-level scope at REPL[21]:1
```

After PR:

```Julia
julia> s3_get_file(config, bucket, "//a//", "temp")
ERROR: AWS.AWSExceptions.AWSException("404", "AWSException", Dict{String,Dict}(), HTTP.ExceptionRequest.StatusError(404, "GET", "/bucket//a/?return_stream=true", HTTP.Messages.Response:
"""
HTTP/1.1 404 Not Found
x-amz-request-id: D2989F4D92B7559B
x-amz-id-2: K5oH5uih5SnpX9Lrt+QFS82v14292CH2dagoSEF4nE2vHMNNaGSJe36Sw3KCaZlsYmlhdddQ4ZY=
Content-Type: application/xml
Transfer-Encoding: chunked
Date: Thu, 04 Mar 2021 05:15:04 GMT
Server: AmazonS3

[Message Body was streamed]"""))
Stacktrace:
 [1] request(::Type{HTTP.ExceptionRequest.ExceptionLayer{HTTP.ConnectionRequest.ConnectionPoolLayer{HTTP.StreamRequest.StreamLayer{Union{}}}}}, ::URIs.URI, ::Vararg{Any,N} where N; kw::Base.Iterators.Pairs{Symbol,Any,Tuple{Symbol,Symbol,Symbol},NamedTuple{(:iofunction, :require_ssl_verification, :response_stream),Tuple{Nothing,Bool,Base.BufferStream}}}) at /Users/user/.julia/packages/HTTP/hbs7O/src/ExceptionRequest.jl:22
 [2] request(::Type{HTTP.MessageRequest.MessageLayer{HTTP.ExceptionRequest.ExceptionLayer{HTTP.ConnectionRequest.ConnectionPoolLayer{HTTP.StreamRequest.StreamLayer{Union{}}}}}}, ::String, ::URIs.URI, ::Array{Pair{SubString{String},SubString{String}},1}, ::String; http_version::VersionNumber, target::String, parent::Nothing, iofunction::Nothing, kw::Base.Iterators.Pairs{Symbol,Any,Tuple{Symbol,Symbol},NamedTuple{(:require_ssl_verification, :response_stream),Tuple{Bool,Base.BufferStream}}}) at /Users/user/.julia/packages/HTTP/hbs7O/src/MessageRequest.jl:58
 [3] request(::Type{HTTP.BasicAuthRequest.BasicAuthLayer{HTTP.MessageRequest.MessageLayer{HTTP.ExceptionRequest.ExceptionLayer{HTTP.ConnectionRequest.ConnectionPoolLayer{HTTP.StreamRequest.StreamLayer{Union{}}}}}}}, ::String, ::URIs.URI, ::Array{Pair{SubString{String},SubString{String}},1}, ::String; kw::Base.Iterators.Pairs{Symbol,Any,Tuple{Symbol,Symbol},NamedTuple{(:require_ssl_verification, :response_stream),Tuple{Bool,Base.BufferStream}}}) at /Users/user/.julia/packages/HTTP/hbs7O/src/BasicAuthRequest.jl:28
 [4] macro expansion at /Users/user/.julia/dev/AWS/src/AWS.jl:310 [inlined]
 [5] macro expansion at /Users/user/.julia/packages/Retry/vS1bg/src/repeat_try.jl:192 [inlined]
 [6] _http_request(::Request) at /Users/user/.julia/dev/AWS/src/AWS.jl:303
 [7] macro expansion at /Users/user/.julia/packages/Mocking/U41JO/src/mock.jl:29 [inlined]
 [8] macro expansion at /Users/user/.julia/dev/AWS/src/AWS.jl:371 [inlined]
 [9] macro expansion at /Users/user/.julia/packages/Retry/vS1bg/src/repeat_try.jl:192 [inlined]
 [10] submit_request(::AWSConfig, ::Request; return_headers::Bool) at /Users/user/.julia/dev/AWS/src/AWS.jl:369
 [11] (::RestXMLService)(::String, ::String, ::Dict{String,Bool}; aws_config::AWSConfig) at /Users/user/.julia/dev/AWS/src/AWS.jl:594
 [12] #get_object#90 at /Users/user/.julia/dev/AWS/src/services/s3.jl:1736 [inlined]
 [13] s3_get_file(::AWSConfig, ::String, ::String, ::String; version::String, kwargs::Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}) at /Users/user/.julia/packages/AWSS3/lhRVu/src/AWSS3.jl:103
 [14] s3_get_file(::AWSConfig, ::String, ::String, ::String) at /Users/user/.julia/packages/AWSS3/lhRVu/src/AWSS3.jl:103
 [15] top-level scope at REPL[21]:1
```

This is a quick fix, but wanted to get thoughts on whether this is applicable for all `HTTP.StatusError`s? Another option would be to `try` `catch` the xml parsing, or actually check that the response information is a valid xml. 

Will close #303 