### PR TITLE
Improve AWSException show

### DIFF
--- a/src/AWSExceptions.jl
+++ b/src/AWSExceptions.jl
@@ -28,9 +28,9 @@ struct AWSException <: Exception
     info::Union{XMLDictElement, Dict, String, Nothing}
     cause::HTTP.StatusError
 end
-function show(io::IO, e::AWSException)
+function Base.show(io::IO, e::AWSException)
     message = isempty(e.message) ? "" : (" -- " * e.message)
-    println(io, string(e.code, message, "\n", e.cause))
+    println(io, "AWSException: ", string(e.code, message, "\n", e.cause))
 end
 
 http_message(e::HTTP.StatusError) = String(copy(e.response.body))


### PR DESCRIPTION
- Extend `Base.show` so used when thrown (think this was a typo before?)
- Add "AWSException" to `show` as per other exception types

Before this PR:

```Julia
julia> s3_get(config, bucket "//a//")
ERROR: AWS.AWSExceptions.AWSException("NoSuchKey", "The specified key does not exist.", EzXML.Document(EzXML.Node(<DOCUMENT_NODE@0x00007fd892859ad0>)), HTTP.ExceptionRequest.StatusError(404, "GET", "/bucket///a//?return_raw=false", HTTP.Messages.Response:
"""
HTTP/1.1 404 Not Found
x-amz-request-id:
x-amz-id-2:=
Content-Type: application/xml
Transfer-Encoding: chunked
Date: Wed, 10 Mar 2021 03:58:07 GMT
Server: AmazonS3

<?xml version="1.0" encoding="UTF-8"?>
<Error><Code>NoSuchKey</Code><Message>The specified key does not exist.</Message><Key>//a//</Key><RequestId></RequestId><HostId>=</HostId></Error>"""))
```

With this PR:
```
ERROR: AWSException: NoSuchKey -- The specified key does not exist.
HTTP.ExceptionRequest.StatusError(404, "GET", "/bucket///a//?return_raw=false", HTTP.Messages.Response:
"""
julia> s3_get(config, bucket, "//a//")
HTTP/1.1 404 Not Found
x-amz-request-id:
x-amz-id-2: 
Content-Type: application/xml
Transfer-Encoding: chunked
Date: Wed, 10 Mar 2021 03:56:22 GMT
Server: AmazonS3

<?xml version="1.0" encoding="UTF-8"?>
<Error><Code>NoSuchKey</Code><Message>The specified key does not exist.</Message><Key>//a//</Key><RequestId></RequestId><HostId>=</HostId></Error>""")
```