### PR TITLE
S3: really call version 2 in `list_objects_v2`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,6 +16,7 @@ Mocking = "78c3b35d-d492-501b-9361-3d52fe80e533"
 OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 Retry = "20febd7b-183b-5ae2-ac4a-720e7ce64774"
 Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
+URIs = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 XMLDict = "228000da-037f-5747-90a9-8195ccbf91a5"
 
@@ -31,6 +32,7 @@ OrderedCollections = "1"
 Retry = "0.3, 0.4"
 XMLDict = "0.3, 0.4"
 julia = "1"
+URIs = "1"
 
 [extras]
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"

--- a/src/AWS.jl
+++ b/src/AWS.jl
@@ -11,6 +11,7 @@ using Retry
 using Sockets
 using UUIDs: UUIDs
 using XMLDict
+import URIs
 
 export @service
 export _merge, AbstractAWSConfig, AWSConfig, AWSExceptions, AWSServices, Request
@@ -576,7 +577,9 @@ function (service::RestXMLService)(
     return_headers = _return_headers(args)
 
     if request.service == "s3"
-        request_uri = _clean_s3_uri(request_uri)
+        u = URIs.URI(request_uri)
+        cleaned_uri = URIs.URI(u;path=_clean_s3_uri(u.path))
+        request_uri = string(cleaned_uri)
     end
     request.resource = _generate_rest_resource(request_uri, args)
     query_str = HTTP.escapeuri(args)

--- a/test/minio.jl
+++ b/test/minio.jl
@@ -36,6 +36,12 @@ S3.put_object("anewbucket","foo/baz",Dict("body"=>"a secondnested object"))
 objs = S3.list_objects_v2("anewbucket")
 @test length(objs["Contents"]) == 4
 
+# Test api version 2 of list-objects
+objs_truncated = S3.list_objects_v2("anewbucket", Dict("max-keys"=>2))
+@test length(objs_truncated["Contents"]) == 2
+@test objs_truncated["IsTruncated"]
+@test haskey(objs_truncated,"NextContinuationToken")
+
 # Test listing with prefixes
 objs_prefix = S3.list_objects_v2("anewbucket", Dict("prefix"=>"", "delimiter"=>"/"))
 @test length(objs_prefix["Contents"]) == 2


### PR DESCRIPTION
Fixes #316 by only using S3 escape rules for the path.

- With this I can properly use the continuation token for paginated results.
- I don't know enough about minio to know if the added tests are suitable to detect a regression. 
- URIs.jl has been added as an dependency, but I feel that this will sooner or later be the case anyway.