### PR TITLE
isa Any

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AWS"
 uuid = "fbe9abb3-538b-5e4e-ba9e-bc94f4f92ebc"
 license = "MIT"
-version = "1.34.0"
+version = "1.34.1"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/AWSMetadataUtilities.jl
+++ b/src/AWSMetadataUtilities.jl
@@ -479,27 +479,27 @@ function _generate_high_level_definition(
         if required_keys && (idempotent || headers)
             return """
                 $formatted_function_name($(join(req_keys, ", ")); aws_config::AbstractAWSConfig=global_aws_config()) = $service_name(\"$method\", \"$request_uri\", $params_headers_str; aws_config=aws_config)
-                $formatted_function_name($(join(req_keys, ", ")), params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = $service_name(\"$method\", \"$request_uri\", Dict{String, Any}(mergewith(_merge, $params_headers_str, params)); aws_config=aws_config)
+                $formatted_function_name($(join(req_keys, ", ")), params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()) = $service_name(\"$method\", \"$request_uri\", Dict{String, Any}(mergewith(_merge, $params_headers_str, params)); aws_config=aws_config)
                 """
         elseif !required_keys && (idempotent || headers)
             return """
                 $formatted_function_name(; aws_config::AbstractAWSConfig=global_aws_config()) = $service_name(\"$method\", \"$request_uri\", $params_headers_str; aws_config=aws_config)
-                $formatted_function_name(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = $service_name(\"$method\", \"$request_uri\", Dict{String, Any}(mergewith(_merge, $params_headers_str, params)); aws_config=aws_config)
+                $formatted_function_name(params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()) = $service_name(\"$method\", \"$request_uri\", Dict{String, Any}(mergewith(_merge, $params_headers_str, params)); aws_config=aws_config)
                 """
         elseif required_keys && !isempty(req_kv)
             return """
                 $formatted_function_name($(join(req_keys, ", ")); aws_config::AbstractAWSConfig=global_aws_config()) = $service_name(\"$method\", \"$request_uri\", $req_str); aws_config=aws_config)
-                $formatted_function_name($(join(req_keys, ", ")), params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = $service_name(\"$method\", \"$request_uri\", Dict{String, Any}(mergewith(_merge, $req_str), params)); aws_config=aws_config)
+                $formatted_function_name($(join(req_keys, ", ")), params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()) = $service_name(\"$method\", \"$request_uri\", Dict{String, Any}(mergewith(_merge, $req_str), params)); aws_config=aws_config)
                 """
         elseif required_keys
             return """
                 $formatted_function_name($(join(req_keys, ", ")); aws_config::AbstractAWSConfig=global_aws_config()) = $service_name(\"$method\", \"$request_uri\"; aws_config=aws_config)
-                $formatted_function_name($(join(req_keys, ", ")), params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = $service_name(\"$method\", \"$request_uri\", params; aws_config=aws_config)
+                $formatted_function_name($(join(req_keys, ", ")), params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()) = $service_name(\"$method\", \"$request_uri\", params; aws_config=aws_config)
                 """
         else
             return """
                 $formatted_function_name(; aws_config::AbstractAWSConfig=global_aws_config()) = $service_name(\"$method\", \"$request_uri\"; aws_config=aws_config)
-                $formatted_function_name(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = $service_name(\"$method\", \"$request_uri\", params; aws_config=aws_config)
+                $formatted_function_name(params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()) = $service_name(\"$method\", \"$request_uri\", params; aws_config=aws_config)
                 """
         end
     end
@@ -534,22 +534,22 @@ function _generate_high_level_definition(
         if required && idempotent
             return """
                 $formatted_function_name($(join(req_keys, ", ")); aws_config::AbstractAWSConfig=global_aws_config()) = $service_name(\"$function_name\", Dict{String, Any}($(join(req_kv, ", ")), $(join(idempotent_kv, ", "))); aws_config=aws_config)
-                $formatted_function_name($(join(req_keys, ", ")), params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = $service_name(\"$function_name\", Dict{String, Any}(mergewith(_merge, Dict{String, Any}($(join(req_kv, ", ")), $(join(idempotent_kv, ", "))), params)); aws_config=aws_config)
+                $formatted_function_name($(join(req_keys, ", ")), params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()) = $service_name(\"$function_name\", Dict{String, Any}(mergewith(_merge, Dict{String, Any}($(join(req_kv, ", ")), $(join(idempotent_kv, ", "))), params)); aws_config=aws_config)
                 """
         elseif required
             return """
                 $formatted_function_name($(join(req_keys, ", ")); aws_config::AbstractAWSConfig=global_aws_config()) = $service_name(\"$function_name\", Dict{String, Any}($(join(req_kv, ", "))); aws_config=aws_config)
-                $formatted_function_name($(join(req_keys, ", ")), params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = $service_name(\"$function_name\", Dict{String, Any}(mergewith(_merge, Dict{String, Any}($(join(req_kv, ", "))), params)); aws_config=aws_config)
+                $formatted_function_name($(join(req_keys, ", ")), params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()) = $service_name(\"$function_name\", Dict{String, Any}(mergewith(_merge, Dict{String, Any}($(join(req_kv, ", "))), params)); aws_config=aws_config)
                 """
         elseif idempotent
             return """
                 $formatted_function_name(; aws_config::AbstractAWSConfig=global_aws_config()) = $service_name(\"$function_name\", Dict{String, Any}($(join(idempotent_kv, ", "))); aws_config=aws_config)
-                $formatted_function_name(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = $service_name(\"$function_name\", Dict{String, Any}(mergewith(_merge, Dict{String, Any}($(join(idempotent_kv, ", "))), params)); aws_config=aws_config)
+                $formatted_function_name(params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()) = $service_name(\"$function_name\", Dict{String, Any}(mergewith(_merge, Dict{String, Any}($(join(idempotent_kv, ", "))), params)); aws_config=aws_config)
                 """
         else
             return """
                 $formatted_function_name(; aws_config::AbstractAWSConfig=global_aws_config()) = $service_name(\"$function_name\"; aws_config=aws_config)
-                $formatted_function_name(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = $service_name(\"$function_name\", params; aws_config=aws_config)
+                $formatted_function_name(params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()) = $service_name(\"$function_name\", params; aws_config=aws_config)
                 """
         end
     end

--- a/src/services/accessanalyzer.jl
+++ b/src/services/accessanalyzer.jl
@@ -301,7 +301,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"type"`: The type of analyzer.
 """
 list_analyzers(; aws_config::AbstractAWSConfig=global_aws_config()) = accessanalyzer("GET", "/analyzer"; aws_config=aws_config)
-list_analyzers(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = accessanalyzer("GET", "/analyzer", params; aws_config=aws_config)
+list_analyzers(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = accessanalyzer("GET", "/analyzer", params; aws_config=aws_config)
 
 """
     list_archive_rules(analyzer_name)
@@ -356,7 +356,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   for a specific principal.
 """
 list_policy_generations(; aws_config::AbstractAWSConfig=global_aws_config()) = accessanalyzer("GET", "/policy/generation"; aws_config=aws_config)
-list_policy_generations(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = accessanalyzer("GET", "/policy/generation", params; aws_config=aws_config)
+list_policy_generations(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = accessanalyzer("GET", "/policy/generation", params; aws_config=aws_config)
 
 """
     list_tags_for_resource(resource_arn)

--- a/src/services/amp.jl
+++ b/src/services/amp.jl
@@ -65,7 +65,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   is obtained from the output of the previous ListWorkspaces request.
 """
 list_workspaces(; aws_config::AbstractAWSConfig=global_aws_config()) = amp("GET", "/workspaces"; aws_config=aws_config)
-list_workspaces(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = amp("GET", "/workspaces", params; aws_config=aws_config)
+list_workspaces(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = amp("GET", "/workspaces", params; aws_config=aws_config)
 
 """
     update_workspace_alias(workspace_id)

--- a/src/services/amplify.jl
+++ b/src/services/amplify.jl
@@ -374,7 +374,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   result. Pass its value in another request to retrieve more entries.
 """
 list_apps(; aws_config::AbstractAWSConfig=global_aws_config()) = amplify("GET", "/apps"; aws_config=aws_config)
-list_apps(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = amplify("GET", "/apps", params; aws_config=aws_config)
+list_apps(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = amplify("GET", "/apps", params; aws_config=aws_config)
 
 """
     list_artifacts(app_id, branch_name, job_id)

--- a/src/services/api_gateway.jl
+++ b/src/services/api_gateway.jl
@@ -27,7 +27,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"value"`: Specifies a value of the API key.
 """
 create_api_key(; aws_config::AbstractAWSConfig=global_aws_config()) = api_gateway("POST", "/apikeys"; aws_config=aws_config)
-create_api_key(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = api_gateway("POST", "/apikeys", params; aws_config=aws_config)
+create_api_key(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = api_gateway("POST", "/apikeys", params; aws_config=aws_config)
 
 """
     create_authorizer(name, restapi_id, type)
@@ -761,7 +761,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   to 256 characters.
 """
 generate_client_certificate(; aws_config::AbstractAWSConfig=global_aws_config()) = api_gateway("POST", "/clientcertificates"; aws_config=aws_config)
-generate_client_certificate(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = api_gateway("POST", "/clientcertificates", params; aws_config=aws_config)
+generate_client_certificate(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = api_gateway("POST", "/clientcertificates", params; aws_config=aws_config)
 
 """
     get_account()
@@ -771,7 +771,7 @@ Gets information about the current Account resource.
 
 """
 get_account(; aws_config::AbstractAWSConfig=global_aws_config()) = api_gateway("GET", "/account"; aws_config=aws_config)
-get_account(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = api_gateway("GET", "/account", params; aws_config=aws_config)
+get_account(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = api_gateway("GET", "/account", params; aws_config=aws_config)
 
 """
     get_api_key(api__key)
@@ -808,7 +808,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"position"`: The current pagination position in the paged result set.
 """
 get_api_keys(; aws_config::AbstractAWSConfig=global_aws_config()) = api_gateway("GET", "/apikeys"; aws_config=aws_config)
-get_api_keys(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = api_gateway("GET", "/apikeys", params; aws_config=aws_config)
+get_api_keys(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = api_gateway("GET", "/apikeys", params; aws_config=aws_config)
 
 """
     get_authorizer(authorizer_id, restapi_id)
@@ -904,7 +904,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"position"`: The current pagination position in the paged result set.
 """
 get_client_certificates(; aws_config::AbstractAWSConfig=global_aws_config()) = api_gateway("GET", "/clientcertificates"; aws_config=aws_config)
-get_client_certificates(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = api_gateway("GET", "/clientcertificates", params; aws_config=aws_config)
+get_client_certificates(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = api_gateway("GET", "/clientcertificates", params; aws_config=aws_config)
 
 """
     get_deployment(deployment_id, restapi_id)
@@ -1047,7 +1047,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"position"`: The current pagination position in the paged result set.
 """
 get_domain_names(; aws_config::AbstractAWSConfig=global_aws_config()) = api_gateway("GET", "/domainnames"; aws_config=aws_config)
-get_domain_names(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = api_gateway("GET", "/domainnames", params; aws_config=aws_config)
+get_domain_names(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = api_gateway("GET", "/domainnames", params; aws_config=aws_config)
 
 """
     get_export(export_type, restapi_id, stage_name)
@@ -1337,7 +1337,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"position"`: The current pagination position in the paged result set.
 """
 get_rest_apis(; aws_config::AbstractAWSConfig=global_aws_config()) = api_gateway("GET", "/restapis"; aws_config=aws_config)
-get_rest_apis(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = api_gateway("GET", "/restapis", params; aws_config=aws_config)
+get_rest_apis(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = api_gateway("GET", "/restapis", params; aws_config=aws_config)
 
 """
     get_sdk(restapi_id, sdk_type, stage_name)
@@ -1388,7 +1388,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"position"`: The current pagination position in the paged result set.
 """
 get_sdk_types(; aws_config::AbstractAWSConfig=global_aws_config()) = api_gateway("GET", "/sdktypes"; aws_config=aws_config)
-get_sdk_types(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = api_gateway("GET", "/sdktypes", params; aws_config=aws_config)
+get_sdk_types(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = api_gateway("GET", "/sdktypes", params; aws_config=aws_config)
 
 """
     get_stage(restapi_id, stage_name)
@@ -1523,7 +1523,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"position"`: The current pagination position in the paged result set.
 """
 get_usage_plans(; aws_config::AbstractAWSConfig=global_aws_config()) = api_gateway("GET", "/usageplans"; aws_config=aws_config)
-get_usage_plans(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = api_gateway("GET", "/usageplans", params; aws_config=aws_config)
+get_usage_plans(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = api_gateway("GET", "/usageplans", params; aws_config=aws_config)
 
 """
     get_vpc_link(vpclink_id)
@@ -1552,7 +1552,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"position"`: The current pagination position in the paged result set.
 """
 get_vpc_links(; aws_config::AbstractAWSConfig=global_aws_config()) = api_gateway("GET", "/vpclinks"; aws_config=aws_config)
-get_vpc_links(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = api_gateway("GET", "/vpclinks", params; aws_config=aws_config)
+get_vpc_links(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = api_gateway("GET", "/vpclinks", params; aws_config=aws_config)
 
 """
     import_api_keys(body, format)
@@ -1980,7 +1980,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   and in the order specified in this list.
 """
 update_account(; aws_config::AbstractAWSConfig=global_aws_config()) = api_gateway("PATCH", "/account"; aws_config=aws_config)
-update_account(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = api_gateway("PATCH", "/account", params; aws_config=aws_config)
+update_account(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = api_gateway("PATCH", "/account", params; aws_config=aws_config)
 
 """
     update_api_key(api__key)

--- a/src/services/apigatewayv2.jl
+++ b/src/services/apigatewayv2.jl
@@ -753,7 +753,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   element of the collection.
 """
 get_apis(; aws_config::AbstractAWSConfig=global_aws_config()) = apigatewayv2("GET", "/v2/apis"; aws_config=aws_config)
-get_apis(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = apigatewayv2("GET", "/v2/apis", params; aws_config=aws_config)
+get_apis(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = apigatewayv2("GET", "/v2/apis", params; aws_config=aws_config)
 
 """
     get_authorizer(api_id, authorizer_id)
@@ -845,7 +845,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   element of the collection.
 """
 get_domain_names(; aws_config::AbstractAWSConfig=global_aws_config()) = apigatewayv2("GET", "/v2/domainnames"; aws_config=aws_config)
-get_domain_names(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = apigatewayv2("GET", "/v2/domainnames", params; aws_config=aws_config)
+get_domain_names(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = apigatewayv2("GET", "/v2/domainnames", params; aws_config=aws_config)
 
 """
     get_integration(api_id, integration_id)
@@ -1097,7 +1097,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   element of the collection.
 """
 get_vpc_links(; aws_config::AbstractAWSConfig=global_aws_config()) = apigatewayv2("GET", "/v2/vpclinks"; aws_config=aws_config)
-get_vpc_links(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = apigatewayv2("GET", "/v2/vpclinks", params; aws_config=aws_config)
+get_vpc_links(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = apigatewayv2("GET", "/v2/vpclinks", params; aws_config=aws_config)
 
 """
     import_api(body)

--- a/src/services/app_mesh.jl
+++ b/src/services/app_mesh.jl
@@ -553,7 +553,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   items in a list and not for other programmatic purposes.
 """
 list_meshes(; aws_config::AbstractAWSConfig=global_aws_config()) = app_mesh("GET", "/v20190125/meshes"; aws_config=aws_config)
-list_meshes(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = app_mesh("GET", "/v20190125/meshes", params; aws_config=aws_config)
+list_meshes(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = app_mesh("GET", "/v20190125/meshes", params; aws_config=aws_config)
 
 """
     list_routes(mesh_name, virtual_router_name)

--- a/src/services/appconfig.jl
+++ b/src/services/appconfig.jl
@@ -373,7 +373,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"next_token"`: A token to start the list. Use this token to get the next set of results.
 """
 list_applications(; aws_config::AbstractAWSConfig=global_aws_config()) = appconfig("GET", "/applications"; aws_config=aws_config)
-list_applications(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = appconfig("GET", "/applications", params; aws_config=aws_config)
+list_applications(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = appconfig("GET", "/applications", params; aws_config=aws_config)
 
 """
     list_configuration_profiles(application_id)
@@ -406,7 +406,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"next_token"`: A token to start the list. Use this token to get the next set of results.
 """
 list_deployment_strategies(; aws_config::AbstractAWSConfig=global_aws_config()) = appconfig("GET", "/deploymentstrategies"; aws_config=aws_config)
-list_deployment_strategies(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = appconfig("GET", "/deploymentstrategies", params; aws_config=aws_config)
+list_deployment_strategies(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = appconfig("GET", "/deploymentstrategies", params; aws_config=aws_config)
 
 """
     list_deployments(application_id, environment_id)

--- a/src/services/appflow.jl
+++ b/src/services/appflow.jl
@@ -143,7 +143,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`:  The pagination token for the next page of data.
 """
 describe_connector_profiles(; aws_config::AbstractAWSConfig=global_aws_config()) = appflow("POST", "/describe-connector-profiles"; aws_config=aws_config)
-describe_connector_profiles(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = appflow("POST", "/describe-connector-profiles", params; aws_config=aws_config)
+describe_connector_profiles(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = appflow("POST", "/describe-connector-profiles", params; aws_config=aws_config)
 
 """
     describe_connectors()
@@ -161,7 +161,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`:  The pagination token for the next page of data.
 """
 describe_connectors(; aws_config::AbstractAWSConfig=global_aws_config()) = appflow("POST", "/describe-connectors"; aws_config=aws_config)
-describe_connectors(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = appflow("POST", "/describe-connectors", params; aws_config=aws_config)
+describe_connectors(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = appflow("POST", "/describe-connectors", params; aws_config=aws_config)
 
 """
     describe_flow(flow_name)
@@ -216,7 +216,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   roots. Otherwise, this request returns all entities supported by the provider.
 """
 list_connector_entities(; aws_config::AbstractAWSConfig=global_aws_config()) = appflow("POST", "/list-connector-entities"; aws_config=aws_config)
-list_connector_entities(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = appflow("POST", "/list-connector-entities", params; aws_config=aws_config)
+list_connector_entities(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = appflow("POST", "/list-connector-entities", params; aws_config=aws_config)
 
 """
     list_flows()
@@ -231,7 +231,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`:  The pagination token for next page of data.
 """
 list_flows(; aws_config::AbstractAWSConfig=global_aws_config()) = appflow("POST", "/list-flows"; aws_config=aws_config)
-list_flows(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = appflow("POST", "/list-flows", params; aws_config=aws_config)
+list_flows(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = appflow("POST", "/list-flows", params; aws_config=aws_config)
 
 """
     list_tags_for_resource(resource_arn)

--- a/src/services/appintegrations.jl
+++ b/src/services/appintegrations.jl
@@ -91,7 +91,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   previous response in the next request to retrieve the next set of results.
 """
 list_event_integrations(; aws_config::AbstractAWSConfig=global_aws_config()) = appintegrations("GET", "/eventIntegrations"; aws_config=aws_config)
-list_event_integrations(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = appintegrations("GET", "/eventIntegrations", params; aws_config=aws_config)
+list_event_integrations(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = appintegrations("GET", "/eventIntegrations", params; aws_config=aws_config)
 
 """
     list_tags_for_resource(resource_arn)

--- a/src/services/appsync.jl
+++ b/src/services/appsync.jl
@@ -472,7 +472,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   which can be used to return the next set of items in the list.
 """
 list_graphql_apis(; aws_config::AbstractAWSConfig=global_aws_config()) = appsync("GET", "/v1/apis"; aws_config=aws_config)
-list_graphql_apis(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = appsync("GET", "/v1/apis", params; aws_config=aws_config)
+list_graphql_apis(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = appsync("GET", "/v1/apis", params; aws_config=aws_config)
 
 """
     list_resolvers(api_id, type_name)

--- a/src/services/auditmanager.jl
+++ b/src/services/auditmanager.jl
@@ -238,7 +238,7 @@ delete_control(controlId, params::AbstractDict{String, <:Any}; aws_config::Abstr
 
 """
 deregister_account(; aws_config::AbstractAWSConfig=global_aws_config()) = auditmanager("POST", "/account/deregisterAccount"; aws_config=aws_config)
-deregister_account(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = auditmanager("POST", "/account/deregisterAccount", params; aws_config=aws_config)
+deregister_account(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = auditmanager("POST", "/account/deregisterAccount", params; aws_config=aws_config)
 
 """
     deregister_organization_admin_account()
@@ -251,7 +251,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"adminAccountId"`:  The identifier for the specified administrator account.
 """
 deregister_organization_admin_account(; aws_config::AbstractAWSConfig=global_aws_config()) = auditmanager("POST", "/account/deregisterOrganizationAdminAccount"; aws_config=aws_config)
-deregister_organization_admin_account(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = auditmanager("POST", "/account/deregisterOrganizationAdminAccount", params; aws_config=aws_config)
+deregister_organization_admin_account(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = auditmanager("POST", "/account/deregisterOrganizationAdminAccount", params; aws_config=aws_config)
 
 """
     disassociate_assessment_report_evidence_folder(assessment_id, evidence_folder_id)
@@ -276,7 +276,7 @@ disassociate_assessment_report_evidence_folder(assessmentId, evidenceFolderId, p
 
 """
 get_account_status(; aws_config::AbstractAWSConfig=global_aws_config()) = auditmanager("GET", "/account/status"; aws_config=aws_config)
-get_account_status(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = auditmanager("GET", "/account/status", params; aws_config=aws_config)
+get_account_status(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = auditmanager("GET", "/account/status", params; aws_config=aws_config)
 
 """
     get_assessment(assessment_id)
@@ -364,7 +364,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`:  The pagination token used to fetch the next set of results.
 """
 get_delegations(; aws_config::AbstractAWSConfig=global_aws_config()) = auditmanager("GET", "/delegations"; aws_config=aws_config)
-get_delegations(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = auditmanager("GET", "/delegations", params; aws_config=aws_config)
+get_delegations(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = auditmanager("GET", "/delegations", params; aws_config=aws_config)
 
 """
     get_evidence(assessment_id, control_set_id, evidence_folder_id, evidence_id)
@@ -465,7 +465,7 @@ get_evidence_folders_by_assessment_control(assessmentId, controlId, controlSetId
 
 """
 get_organization_admin_account(; aws_config::AbstractAWSConfig=global_aws_config()) = auditmanager("GET", "/account/organizationAdminAccount"; aws_config=aws_config)
-get_organization_admin_account(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = auditmanager("GET", "/account/organizationAdminAccount", params; aws_config=aws_config)
+get_organization_admin_account(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = auditmanager("GET", "/account/organizationAdminAccount", params; aws_config=aws_config)
 
 """
     get_services_in_scope()
@@ -475,7 +475,7 @@ get_organization_admin_account(params::AbstractDict{String, Any}; aws_config::Ab
 
 """
 get_services_in_scope(; aws_config::AbstractAWSConfig=global_aws_config()) = auditmanager("GET", "/services"; aws_config=aws_config)
-get_services_in_scope(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = auditmanager("GET", "/services", params; aws_config=aws_config)
+get_services_in_scope(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = auditmanager("GET", "/services", params; aws_config=aws_config)
 
 """
     get_settings(attribute)
@@ -521,7 +521,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`:  The pagination token used to fetch the next set of results.
 """
 list_assessment_reports(; aws_config::AbstractAWSConfig=global_aws_config()) = auditmanager("GET", "/assessmentReports"; aws_config=aws_config)
-list_assessment_reports(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = auditmanager("GET", "/assessmentReports", params; aws_config=aws_config)
+list_assessment_reports(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = auditmanager("GET", "/assessmentReports", params; aws_config=aws_config)
 
 """
     list_assessments()
@@ -536,7 +536,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`:  The pagination token used to fetch the next set of results.
 """
 list_assessments(; aws_config::AbstractAWSConfig=global_aws_config()) = auditmanager("GET", "/assessments"; aws_config=aws_config)
-list_assessments(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = auditmanager("GET", "/assessments", params; aws_config=aws_config)
+list_assessments(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = auditmanager("GET", "/assessments", params; aws_config=aws_config)
 
 """
     list_controls(control_type)
@@ -587,7 +587,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`:  The pagination token used to fetch the next set of results.
 """
 list_notifications(; aws_config::AbstractAWSConfig=global_aws_config()) = auditmanager("GET", "/notifications"; aws_config=aws_config)
-list_notifications(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = auditmanager("GET", "/notifications", params; aws_config=aws_config)
+list_notifications(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = auditmanager("GET", "/notifications", params; aws_config=aws_config)
 
 """
     list_tags_for_resource(resource_arn)
@@ -614,7 +614,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"kmsKey"`:  The AWS KMS key details.
 """
 register_account(; aws_config::AbstractAWSConfig=global_aws_config()) = auditmanager("POST", "/account/registerAccount"; aws_config=aws_config)
-register_account(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = auditmanager("POST", "/account/registerAccount", params; aws_config=aws_config)
+register_account(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = auditmanager("POST", "/account/registerAccount", params; aws_config=aws_config)
 
 """
     register_organization_admin_account(admin_account_id)
@@ -787,7 +787,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Audit Manager sends notifications.
 """
 update_settings(; aws_config::AbstractAWSConfig=global_aws_config()) = auditmanager("PUT", "/settings"; aws_config=aws_config)
-update_settings(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = auditmanager("PUT", "/settings", params; aws_config=aws_config)
+update_settings(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = auditmanager("PUT", "/settings", params; aws_config=aws_config)
 
 """
     validate_assessment_report_integrity(s3_relative_path)

--- a/src/services/backup.jl
+++ b/src/services/backup.jl
@@ -233,7 +233,7 @@ cross-account backup.
 
 """
 describe_global_settings(; aws_config::AbstractAWSConfig=global_aws_config()) = backup("GET", "/global-settings"; aws_config=aws_config)
-describe_global_settings(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = backup("GET", "/global-settings", params; aws_config=aws_config)
+describe_global_settings(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = backup("GET", "/global-settings", params; aws_config=aws_config)
 
 """
     describe_protected_resource(resource_arn)
@@ -281,7 +281,7 @@ try to protect that service's resources in this Region.
 
 """
 describe_region_settings(; aws_config::AbstractAWSConfig=global_aws_config()) = backup("GET", "/account-settings"; aws_config=aws_config)
-describe_region_settings(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = backup("GET", "/account-settings", params; aws_config=aws_config)
+describe_region_settings(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = backup("GET", "/account-settings", params; aws_config=aws_config)
 
 """
     describe_restore_job(restore_job_id)
@@ -443,7 +443,7 @@ Returns the AWS resource types supported by AWS Backup.
 
 """
 get_supported_resource_types(; aws_config::AbstractAWSConfig=global_aws_config()) = backup("GET", "/supported-resource-types"; aws_config=aws_config)
-get_supported_resource_types(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = backup("GET", "/supported-resource-types", params; aws_config=aws_config)
+get_supported_resource_types(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = backup("GET", "/supported-resource-types", params; aws_config=aws_config)
 
 """
     list_backup_jobs()
@@ -476,7 +476,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"state"`: Returns only backup jobs that are in the specified state.
 """
 list_backup_jobs(; aws_config::AbstractAWSConfig=global_aws_config()) = backup("GET", "/backup-jobs/"; aws_config=aws_config)
-list_backup_jobs(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = backup("GET", "/backup-jobs/", params; aws_config=aws_config)
+list_backup_jobs(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = backup("GET", "/backup-jobs/", params; aws_config=aws_config)
 
 """
     list_backup_plan_templates()
@@ -493,7 +493,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   items in your list starting at the location pointed to by the next token.
 """
 list_backup_plan_templates(; aws_config::AbstractAWSConfig=global_aws_config()) = backup("GET", "/backup/template/plans"; aws_config=aws_config)
-list_backup_plan_templates(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = backup("GET", "/backup/template/plans", params; aws_config=aws_config)
+list_backup_plan_templates(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = backup("GET", "/backup/template/plans", params; aws_config=aws_config)
 
 """
     list_backup_plan_versions(backup_plan_id)
@@ -534,7 +534,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   items in your list starting at the location pointed to by the next token.
 """
 list_backup_plans(; aws_config::AbstractAWSConfig=global_aws_config()) = backup("GET", "/backup/plans/"; aws_config=aws_config)
-list_backup_plans(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = backup("GET", "/backup/plans/", params; aws_config=aws_config)
+list_backup_plans(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = backup("GET", "/backup/plans/", params; aws_config=aws_config)
 
 """
     list_backup_selections(backup_plan_id)
@@ -570,7 +570,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   items in your list starting at the location pointed to by the next token.
 """
 list_backup_vaults(; aws_config::AbstractAWSConfig=global_aws_config()) = backup("GET", "/backup-vaults/"; aws_config=aws_config)
-list_backup_vaults(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = backup("GET", "/backup-vaults/", params; aws_config=aws_config)
+list_backup_vaults(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = backup("GET", "/backup-vaults/", params; aws_config=aws_config)
 
 """
     list_copy_jobs()
@@ -600,7 +600,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"state"`: Returns only copy jobs that are in the specified state.
 """
 list_copy_jobs(; aws_config::AbstractAWSConfig=global_aws_config()) = backup("GET", "/copy-jobs/"; aws_config=aws_config)
-list_copy_jobs(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = backup("GET", "/copy-jobs/", params; aws_config=aws_config)
+list_copy_jobs(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = backup("GET", "/copy-jobs/", params; aws_config=aws_config)
 
 """
     list_protected_resources()
@@ -617,7 +617,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   items in your list starting at the location pointed to by the next token.
 """
 list_protected_resources(; aws_config::AbstractAWSConfig=global_aws_config()) = backup("GET", "/resources/"; aws_config=aws_config)
-list_protected_resources(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = backup("GET", "/resources/", params; aws_config=aws_config)
+list_protected_resources(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = backup("GET", "/resources/", params; aws_config=aws_config)
 
 """
     list_recovery_points_by_backup_vault(backup_vault_name)
@@ -689,7 +689,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"status"`: Returns only restore jobs associated with the specified job status.
 """
 list_restore_jobs(; aws_config::AbstractAWSConfig=global_aws_config()) = backup("GET", "/restore-jobs/"; aws_config=aws_config)
-list_restore_jobs(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = backup("GET", "/restore-jobs/", params; aws_config=aws_config)
+list_restore_jobs(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = backup("GET", "/restore-jobs/", params; aws_config=aws_config)
 
 """
     list_tags(resource_arn)
@@ -944,7 +944,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"GlobalSettings"`: A list of resources along with the opt-in preferences for the account.
 """
 update_global_settings(; aws_config::AbstractAWSConfig=global_aws_config()) = backup("PUT", "/global-settings"; aws_config=aws_config)
-update_global_settings(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = backup("PUT", "/global-settings", params; aws_config=aws_config)
+update_global_settings(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = backup("PUT", "/global-settings", params; aws_config=aws_config)
 
 """
     update_recovery_point_lifecycle(backup_vault_name, recovery_point_arn)
@@ -997,4 +997,4 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   preferences for the Region.
 """
 update_region_settings(; aws_config::AbstractAWSConfig=global_aws_config()) = backup("PUT", "/account-settings"; aws_config=aws_config)
-update_region_settings(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = backup("PUT", "/account-settings", params; aws_config=aws_config)
+update_region_settings(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = backup("PUT", "/account-settings", params; aws_config=aws_config)

--- a/src/services/batch.jl
+++ b/src/services/batch.jl
@@ -219,7 +219,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   items in a list and not for other programmatic purposes.
 """
 describe_compute_environments(; aws_config::AbstractAWSConfig=global_aws_config()) = batch("POST", "/v1/describecomputeenvironments"; aws_config=aws_config)
-describe_compute_environments(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = batch("POST", "/v1/describecomputeenvironments", params; aws_config=aws_config)
+describe_compute_environments(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = batch("POST", "/v1/describecomputeenvironments", params; aws_config=aws_config)
 
 """
     describe_job_definitions()
@@ -249,7 +249,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"status"`: The status used to filter job definitions.
 """
 describe_job_definitions(; aws_config::AbstractAWSConfig=global_aws_config()) = batch("POST", "/v1/describejobdefinitions"; aws_config=aws_config)
-describe_job_definitions(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = batch("POST", "/v1/describejobdefinitions", params; aws_config=aws_config)
+describe_job_definitions(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = batch("POST", "/v1/describejobdefinitions", params; aws_config=aws_config)
 
 """
     describe_job_queues()
@@ -275,7 +275,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   not for other programmatic purposes.
 """
 describe_job_queues(; aws_config::AbstractAWSConfig=global_aws_config()) = batch("POST", "/v1/describejobqueues"; aws_config=aws_config)
-describe_job_queues(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = batch("POST", "/v1/describejobqueues", params; aws_config=aws_config)
+describe_job_queues(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = batch("POST", "/v1/describejobqueues", params; aws_config=aws_config)
 
 """
     describe_jobs(jobs)
@@ -325,7 +325,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   programmatic purposes.
 """
 list_jobs(; aws_config::AbstractAWSConfig=global_aws_config()) = batch("POST", "/v1/listjobs"; aws_config=aws_config)
-list_jobs(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = batch("POST", "/v1/listjobs", params; aws_config=aws_config)
+list_jobs(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = batch("POST", "/v1/listjobs", params; aws_config=aws_config)
 
 """
     list_tags_for_resource(resource_arn)

--- a/src/services/chime.jl
+++ b/src/services/chime.jl
@@ -1432,7 +1432,7 @@ Business Calling and Amazon Chime Voice Connector settings.
 
 """
 get_global_settings(; aws_config::AbstractAWSConfig=global_aws_config()) = chime("GET", "/settings"; aws_config=aws_config)
-get_global_settings(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = chime("GET", "/settings", params; aws_config=aws_config)
+get_global_settings(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = chime("GET", "/settings", params; aws_config=aws_config)
 
 """
     get_meeting(meeting_id)
@@ -1457,7 +1457,7 @@ The details of the endpoint for the messaging session.
 
 """
 get_messaging_session_endpoint(; aws_config::AbstractAWSConfig=global_aws_config()) = chime("GET", "/endpoints/messaging-session"; aws_config=aws_config)
-get_messaging_session_endpoint(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = chime("GET", "/endpoints/messaging-session", params; aws_config=aws_config)
+get_messaging_session_endpoint(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = chime("GET", "/endpoints/messaging-session", params; aws_config=aws_config)
 
 """
     get_phone_number(phone_number_id)
@@ -1496,7 +1496,7 @@ default outbound calling name.
 
 """
 get_phone_number_settings(; aws_config::AbstractAWSConfig=global_aws_config()) = chime("GET", "/settings/phone-number"; aws_config=aws_config)
-get_phone_number_settings(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = chime("GET", "/settings/phone-number", params; aws_config=aws_config)
+get_phone_number_settings(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = chime("GET", "/settings/phone-number", params; aws_config=aws_config)
 
 """
     get_proxy_session(proxy_session_id, voice_connector_id)
@@ -1772,7 +1772,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"user-email"`: User email address with which to filter results.
 """
 list_accounts(; aws_config::AbstractAWSConfig=global_aws_config()) = chime("GET", "/accounts"; aws_config=aws_config)
-list_accounts(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = chime("GET", "/accounts", params; aws_config=aws_config)
+list_accounts(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = chime("GET", "/accounts", params; aws_config=aws_config)
 
 """
     list_app_instance_admins(app_instance_arn)
@@ -1823,7 +1823,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   number of AppInstances.
 """
 list_app_instances(; aws_config::AbstractAWSConfig=global_aws_config()) = chime("GET", "/app-instances"; aws_config=aws_config)
-list_app_instances(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = chime("GET", "/app-instances", params; aws_config=aws_config)
+list_app_instances(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = chime("GET", "/app-instances", params; aws_config=aws_config)
 
 """
     list_attendee_tags(attendee_id, meeting_id)
@@ -1938,7 +1938,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"x-amz-chime-bearer"`: The AppInstanceUserArn of the user that makes the API call.
 """
 list_channel_memberships_for_app_instance_user(; aws_config::AbstractAWSConfig=global_aws_config()) = chime("GET", "/channels?scope=app-instance-user-memberships"; aws_config=aws_config)
-list_channel_memberships_for_app_instance_user(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = chime("GET", "/channels?scope=app-instance-user-memberships", params; aws_config=aws_config)
+list_channel_memberships_for_app_instance_user(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = chime("GET", "/channels?scope=app-instance-user-memberships", params; aws_config=aws_config)
 
 """
     list_channel_messages(channel_arn)
@@ -2032,7 +2032,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"x-amz-chime-bearer"`: The AppInstanceUserArn of the user that makes the API call.
 """
 list_channels_moderated_by_app_instance_user(; aws_config::AbstractAWSConfig=global_aws_config()) = chime("GET", "/channels?scope=app-instance-user-moderated-channels"; aws_config=aws_config)
-list_channels_moderated_by_app_instance_user(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = chime("GET", "/channels?scope=app-instance-user-moderated-channels", params; aws_config=aws_config)
+list_channels_moderated_by_app_instance_user(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = chime("GET", "/channels?scope=app-instance-user-moderated-channels", params; aws_config=aws_config)
 
 """
     list_meeting_tags(meeting_id)
@@ -2060,7 +2060,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"next-token"`: The token to use to retrieve the next page of results.
 """
 list_meetings(; aws_config::AbstractAWSConfig=global_aws_config()) = chime("GET", "/meetings"; aws_config=aws_config)
-list_meetings(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = chime("GET", "/meetings", params; aws_config=aws_config)
+list_meetings(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = chime("GET", "/meetings", params; aws_config=aws_config)
 
 """
     list_phone_number_orders()
@@ -2074,7 +2074,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"next-token"`: The token to use to retrieve the next page of results.
 """
 list_phone_number_orders(; aws_config::AbstractAWSConfig=global_aws_config()) = chime("GET", "/phone-number-orders"; aws_config=aws_config)
-list_phone_number_orders(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = chime("GET", "/phone-number-orders", params; aws_config=aws_config)
+list_phone_number_orders(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = chime("GET", "/phone-number-orders", params; aws_config=aws_config)
 
 """
     list_phone_numbers()
@@ -2093,7 +2093,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"status"`: The phone number status.
 """
 list_phone_numbers(; aws_config::AbstractAWSConfig=global_aws_config()) = chime("GET", "/phone-numbers"; aws_config=aws_config)
-list_phone_numbers(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = chime("GET", "/phone-numbers", params; aws_config=aws_config)
+list_phone_numbers(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = chime("GET", "/phone-numbers", params; aws_config=aws_config)
 
 """
     list_proxy_sessions(voice_connector_id)
@@ -2165,7 +2165,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"next-token"`: The token to use to retrieve the next page of results.
 """
 list_sip_media_applications(; aws_config::AbstractAWSConfig=global_aws_config()) = chime("GET", "/sip-media-applications"; aws_config=aws_config)
-list_sip_media_applications(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = chime("GET", "/sip-media-applications", params; aws_config=aws_config)
+list_sip_media_applications(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = chime("GET", "/sip-media-applications", params; aws_config=aws_config)
 
 """
     list_sip_rules()
@@ -2181,7 +2181,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"sip-media-application"`: The SIP media application ID.
 """
 list_sip_rules(; aws_config::AbstractAWSConfig=global_aws_config()) = chime("GET", "/sip-rules"; aws_config=aws_config)
-list_sip_rules(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = chime("GET", "/sip-rules", params; aws_config=aws_config)
+list_sip_rules(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = chime("GET", "/sip-rules", params; aws_config=aws_config)
 
 """
     list_tags_for_resource(arn)
@@ -2229,7 +2229,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"next-token"`: The token to use to retrieve the next page of results.
 """
 list_voice_connector_groups(; aws_config::AbstractAWSConfig=global_aws_config()) = chime("GET", "/voice-connector-groups"; aws_config=aws_config)
-list_voice_connector_groups(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = chime("GET", "/voice-connector-groups", params; aws_config=aws_config)
+list_voice_connector_groups(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = chime("GET", "/voice-connector-groups", params; aws_config=aws_config)
 
 """
     list_voice_connector_termination_credentials(voice_connector_id)
@@ -2256,7 +2256,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"next-token"`: The token to use to retrieve the next page of results.
 """
 list_voice_connectors(; aws_config::AbstractAWSConfig=global_aws_config()) = chime("GET", "/voice-connectors"; aws_config=aws_config)
-list_voice_connectors(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = chime("GET", "/voice-connectors", params; aws_config=aws_config)
+list_voice_connectors(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = chime("GET", "/voice-connectors", params; aws_config=aws_config)
 
 """
     logout_user(account_id, user_id)
@@ -2585,7 +2585,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"toll-free-prefix"`: The toll-free prefix that you use to filter results.
 """
 search_available_phone_numbers(; aws_config::AbstractAWSConfig=global_aws_config()) = chime("GET", "/search?type=phone-numbers"; aws_config=aws_config)
-search_available_phone_numbers(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = chime("GET", "/search?type=phone-numbers", params; aws_config=aws_config)
+search_available_phone_numbers(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = chime("GET", "/search?type=phone-numbers", params; aws_config=aws_config)
 
 """
     send_channel_message(client_request_token, content, persistence, type, channel_arn)

--- a/src/services/clouddirectory.jl
+++ b/src/services/clouddirectory.jl
@@ -631,7 +631,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`: The pagination token.
 """
 list_development_schema_arns(; aws_config::AbstractAWSConfig=global_aws_config()) = clouddirectory("POST", "/amazonclouddirectory/2017-01-11/schema/development"; aws_config=aws_config)
-list_development_schema_arns(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = clouddirectory("POST", "/amazonclouddirectory/2017-01-11/schema/development", params; aws_config=aws_config)
+list_development_schema_arns(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = clouddirectory("POST", "/amazonclouddirectory/2017-01-11/schema/development", params; aws_config=aws_config)
 
 """
     list_directories()
@@ -647,7 +647,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Deleted.
 """
 list_directories(; aws_config::AbstractAWSConfig=global_aws_config()) = clouddirectory("POST", "/amazonclouddirectory/2017-01-11/directory/list"; aws_config=aws_config)
-list_directories(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = clouddirectory("POST", "/amazonclouddirectory/2017-01-11/directory/list", params; aws_config=aws_config)
+list_directories(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = clouddirectory("POST", "/amazonclouddirectory/2017-01-11/directory/list", params; aws_config=aws_config)
 
 """
     list_facet_attributes(name, x-amz-data-partition)
@@ -747,7 +747,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   minor version ARNs for a major version are listed.
 """
 list_managed_schema_arns(; aws_config::AbstractAWSConfig=global_aws_config()) = clouddirectory("POST", "/amazonclouddirectory/2017-01-11/schema/managed"; aws_config=aws_config)
-list_managed_schema_arns(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = clouddirectory("POST", "/amazonclouddirectory/2017-01-11/schema/managed", params; aws_config=aws_config)
+list_managed_schema_arns(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = clouddirectory("POST", "/amazonclouddirectory/2017-01-11/schema/managed", params; aws_config=aws_config)
 
 """
     list_object_attributes(object_reference, x-amz-data-partition)
@@ -943,7 +943,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   list all minor version ARNs for a major version.
 """
 list_published_schema_arns(; aws_config::AbstractAWSConfig=global_aws_config()) = clouddirectory("POST", "/amazonclouddirectory/2017-01-11/schema/published"; aws_config=aws_config)
-list_published_schema_arns(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = clouddirectory("POST", "/amazonclouddirectory/2017-01-11/schema/published", params; aws_config=aws_config)
+list_published_schema_arns(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = clouddirectory("POST", "/amazonclouddirectory/2017-01-11/schema/published", params; aws_config=aws_config)
 
 """
     list_tags_for_resource(resource_arn)

--- a/src/services/cloudfront.jl
+++ b/src/services/cloudfront.jl
@@ -443,7 +443,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"Name"`: The name of the real-time log configuration to delete.
 """
 delete_realtime_log_config2020_05_31(; aws_config::AbstractAWSConfig=global_aws_config()) = cloudfront("POST", "/2020-05-31/delete-realtime-log-config/"; aws_config=aws_config)
-delete_realtime_log_config2020_05_31(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = cloudfront("POST", "/2020-05-31/delete-realtime-log-config/", params; aws_config=aws_config)
+delete_realtime_log_config2020_05_31(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = cloudfront("POST", "/2020-05-31/delete-realtime-log-config/", params; aws_config=aws_config)
 
 """
     delete_streaming_distribution2020_05_31(id)
@@ -774,7 +774,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"Name"`: The name of the real-time log configuration to get.
 """
 get_realtime_log_config2020_05_31(; aws_config::AbstractAWSConfig=global_aws_config()) = cloudfront("POST", "/2020-05-31/get-realtime-log-config/"; aws_config=aws_config)
-get_realtime_log_config2020_05_31(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = cloudfront("POST", "/2020-05-31/get-realtime-log-config/", params; aws_config=aws_config)
+get_realtime_log_config2020_05_31(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = cloudfront("POST", "/2020-05-31/get-realtime-log-config/", params; aws_config=aws_config)
 
 """
     get_streaming_distribution2020_05_31(id)
@@ -827,7 +827,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   only the custom policies created in your AWS account.
 """
 list_cache_policies2020_05_31(; aws_config::AbstractAWSConfig=global_aws_config()) = cloudfront("GET", "/2020-05-31/cache-policy"; aws_config=aws_config)
-list_cache_policies2020_05_31(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = cloudfront("GET", "/2020-05-31/cache-policy", params; aws_config=aws_config)
+list_cache_policies2020_05_31(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = cloudfront("GET", "/2020-05-31/cache-policy", params; aws_config=aws_config)
 
 """
     list_cloud_front_origin_access_identities2020_05_31()
@@ -845,7 +845,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   body.
 """
 list_cloud_front_origin_access_identities2020_05_31(; aws_config::AbstractAWSConfig=global_aws_config()) = cloudfront("GET", "/2020-05-31/origin-access-identity/cloudfront"; aws_config=aws_config)
-list_cloud_front_origin_access_identities2020_05_31(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = cloudfront("GET", "/2020-05-31/origin-access-identity/cloudfront", params; aws_config=aws_config)
+list_cloud_front_origin_access_identities2020_05_31(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = cloudfront("GET", "/2020-05-31/origin-access-identity/cloudfront", params; aws_config=aws_config)
 
 """
     list_distributions2020_05_31()
@@ -862,7 +862,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"MaxItems"`: The maximum number of distributions you want in the response body.
 """
 list_distributions2020_05_31(; aws_config::AbstractAWSConfig=global_aws_config()) = cloudfront("GET", "/2020-05-31/distribution"; aws_config=aws_config)
-list_distributions2020_05_31(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = cloudfront("GET", "/2020-05-31/distribution", params; aws_config=aws_config)
+list_distributions2020_05_31(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = cloudfront("GET", "/2020-05-31/distribution", params; aws_config=aws_config)
 
 """
     list_distributions_by_cache_policy_id2020_05_31(cache_policy_id)
@@ -968,7 +968,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   distributions you want to list.
 """
 list_distributions_by_realtime_log_config2020_05_31(; aws_config::AbstractAWSConfig=global_aws_config()) = cloudfront("POST", "/2020-05-31/distributionsByRealtimeLogConfig/"; aws_config=aws_config)
-list_distributions_by_realtime_log_config2020_05_31(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = cloudfront("POST", "/2020-05-31/distributionsByRealtimeLogConfig/", params; aws_config=aws_config)
+list_distributions_by_realtime_log_config2020_05_31(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = cloudfront("POST", "/2020-05-31/distributionsByRealtimeLogConfig/", params; aws_config=aws_config)
 
 """
     list_distributions_by_web_aclid2020_05_31(web_aclid)
@@ -1011,7 +1011,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   response body.
 """
 list_field_level_encryption_configs2020_05_31(; aws_config::AbstractAWSConfig=global_aws_config()) = cloudfront("GET", "/2020-05-31/field-level-encryption"; aws_config=aws_config)
-list_field_level_encryption_configs2020_05_31(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = cloudfront("GET", "/2020-05-31/field-level-encryption", params; aws_config=aws_config)
+list_field_level_encryption_configs2020_05_31(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = cloudfront("GET", "/2020-05-31/field-level-encryption", params; aws_config=aws_config)
 
 """
     list_field_level_encryption_profiles2020_05_31()
@@ -1030,7 +1030,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   response body.
 """
 list_field_level_encryption_profiles2020_05_31(; aws_config::AbstractAWSConfig=global_aws_config()) = cloudfront("GET", "/2020-05-31/field-level-encryption-profile"; aws_config=aws_config)
-list_field_level_encryption_profiles2020_05_31(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = cloudfront("GET", "/2020-05-31/field-level-encryption-profile", params; aws_config=aws_config)
+list_field_level_encryption_profiles2020_05_31(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = cloudfront("GET", "/2020-05-31/field-level-encryption-profile", params; aws_config=aws_config)
 
 """
     list_invalidations2020_05_31(distribution_id)
@@ -1074,7 +1074,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"MaxItems"`: The maximum number of key groups that you want in the response.
 """
 list_key_groups2020_05_31(; aws_config::AbstractAWSConfig=global_aws_config()) = cloudfront("GET", "/2020-05-31/key-group"; aws_config=aws_config)
-list_key_groups2020_05_31(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = cloudfront("GET", "/2020-05-31/key-group", params; aws_config=aws_config)
+list_key_groups2020_05_31(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = cloudfront("GET", "/2020-05-31/key-group", params; aws_config=aws_config)
 
 """
     list_origin_request_policies2020_05_31()
@@ -1100,7 +1100,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Returns only the custom policies created in your AWS account.
 """
 list_origin_request_policies2020_05_31(; aws_config::AbstractAWSConfig=global_aws_config()) = cloudfront("GET", "/2020-05-31/origin-request-policy"; aws_config=aws_config)
-list_origin_request_policies2020_05_31(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = cloudfront("GET", "/2020-05-31/origin-request-policy", params; aws_config=aws_config)
+list_origin_request_policies2020_05_31(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = cloudfront("GET", "/2020-05-31/origin-request-policy", params; aws_config=aws_config)
 
 """
     list_public_keys2020_05_31()
@@ -1117,7 +1117,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"MaxItems"`: The maximum number of public keys you want in the response body.
 """
 list_public_keys2020_05_31(; aws_config::AbstractAWSConfig=global_aws_config()) = cloudfront("GET", "/2020-05-31/public-key"; aws_config=aws_config)
-list_public_keys2020_05_31(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = cloudfront("GET", "/2020-05-31/public-key", params; aws_config=aws_config)
+list_public_keys2020_05_31(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = cloudfront("GET", "/2020-05-31/public-key", params; aws_config=aws_config)
 
 """
     list_realtime_log_configs2020_05_31()
@@ -1139,7 +1139,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   response.
 """
 list_realtime_log_configs2020_05_31(; aws_config::AbstractAWSConfig=global_aws_config()) = cloudfront("GET", "/2020-05-31/realtime-log-config"; aws_config=aws_config)
-list_realtime_log_configs2020_05_31(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = cloudfront("GET", "/2020-05-31/realtime-log-config", params; aws_config=aws_config)
+list_realtime_log_configs2020_05_31(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = cloudfront("GET", "/2020-05-31/realtime-log-config", params; aws_config=aws_config)
 
 """
     list_streaming_distributions2020_05_31()
@@ -1153,7 +1153,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"MaxItems"`: The value that you provided for the MaxItems request parameter.
 """
 list_streaming_distributions2020_05_31(; aws_config::AbstractAWSConfig=global_aws_config()) = cloudfront("GET", "/2020-05-31/streaming-distribution"; aws_config=aws_config)
-list_streaming_distributions2020_05_31(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = cloudfront("GET", "/2020-05-31/streaming-distribution", params; aws_config=aws_config)
+list_streaming_distributions2020_05_31(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = cloudfront("GET", "/2020-05-31/streaming-distribution", params; aws_config=aws_config)
 
 """
     list_tags_for_resource2020_05_31(resource)
@@ -1423,7 +1423,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   data. You must provide an integer between 1 and 100, inclusive.
 """
 update_realtime_log_config2020_05_31(; aws_config::AbstractAWSConfig=global_aws_config()) = cloudfront("PUT", "/2020-05-31/realtime-log-config/"; aws_config=aws_config)
-update_realtime_log_config2020_05_31(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = cloudfront("PUT", "/2020-05-31/realtime-log-config/", params; aws_config=aws_config)
+update_realtime_log_config2020_05_31(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = cloudfront("PUT", "/2020-05-31/realtime-log-config/", params; aws_config=aws_config)
 
 """
     update_streaming_distribution2020_05_31(id, streaming_distribution_config)

--- a/src/services/codeartifact.jl
+++ b/src/services/codeartifact.jl
@@ -540,7 +540,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   previous response in the next request to retrieve the next set of results.
 """
 list_domains(; aws_config::AbstractAWSConfig=global_aws_config()) = codeartifact("POST", "/v1/domains"; aws_config=aws_config)
-list_domains(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = codeartifact("POST", "/v1/domains", params; aws_config=aws_config)
+list_domains(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = codeartifact("POST", "/v1/domains", params; aws_config=aws_config)
 
 """
     list_package_version_assets(domain, format, package, repository, version)
@@ -696,7 +696,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   with names that start with repositoryPrefix are returned.
 """
 list_repositories(; aws_config::AbstractAWSConfig=global_aws_config()) = codeartifact("POST", "/v1/repositories"; aws_config=aws_config)
-list_repositories(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = codeartifact("POST", "/v1/repositories", params; aws_config=aws_config)
+list_repositories(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = codeartifact("POST", "/v1/repositories", params; aws_config=aws_config)
 
 """
     list_repositories_in_domain(domain)

--- a/src/services/codeguru_reviewer.jl
+++ b/src/services/codeguru_reviewer.jl
@@ -249,7 +249,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   to control access to associated repositories in the Amazon CodeGuru Reviewer User Guide.
 """
 list_repository_associations(; aws_config::AbstractAWSConfig=global_aws_config()) = codeguru_reviewer("GET", "/associations"; aws_config=aws_config)
-list_repository_associations(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = codeguru_reviewer("GET", "/associations", params; aws_config=aws_config)
+list_repository_associations(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = codeguru_reviewer("GET", "/associations", params; aws_config=aws_config)
 
 """
     list_tags_for_resource(resource_arn)

--- a/src/services/codeguruprofiler.jl
+++ b/src/services/codeguruprofiler.jl
@@ -161,7 +161,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   is only used to retrieve the next items in a list and not for other programmatic purposes.
 """
 get_findings_report_account_summary(; aws_config::AbstractAWSConfig=global_aws_config()) = codeguruprofiler("GET", "/internal/findingsReports"; aws_config=aws_config)
-get_findings_report_account_summary(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = codeguruprofiler("GET", "/internal/findingsReports", params; aws_config=aws_config)
+get_findings_report_account_summary(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = codeguruprofiler("GET", "/internal/findingsReports", params; aws_config=aws_config)
 
 """
     get_notification_configuration(profiling_group_name)
@@ -385,7 +385,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   the next items in a list and not for other programmatic purposes.
 """
 list_profiling_groups(; aws_config::AbstractAWSConfig=global_aws_config()) = codeguruprofiler("GET", "/profilingGroups"; aws_config=aws_config)
-list_profiling_groups(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = codeguruprofiler("GET", "/profilingGroups", params; aws_config=aws_config)
+list_profiling_groups(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = codeguruprofiler("GET", "/profilingGroups", params; aws_config=aws_config)
 
 """
     list_tags_for_resource(resource_arn)

--- a/src/services/codestar_connections.jl
+++ b/src/services/codestar_connections.jl
@@ -48,6 +48,7 @@ default. You can make its status `AVAILABLE` by setting up the host in the conso
 
 # Optional Parameters
 Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys are:
+- `"Tags"`:
 - `"VpcConfiguration"`: The VPC configuration to be provisioned for the host. A VPC must be
   configured and the infrastructure to be represented by the host must already be connected
   to the VPC.

--- a/src/services/codestar_notifications.jl
+++ b/src/services/codestar_notifications.jl
@@ -101,7 +101,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   batch of the results.
 """
 list_event_types(; aws_config::AbstractAWSConfig=global_aws_config()) = codestar_notifications("POST", "/listEventTypes"; aws_config=aws_config)
-list_event_types(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = codestar_notifications("POST", "/listEventTypes", params; aws_config=aws_config)
+list_event_types(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = codestar_notifications("POST", "/listEventTypes", params; aws_config=aws_config)
 
 """
     list_notification_rules()
@@ -121,7 +121,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   batch of the results.
 """
 list_notification_rules(; aws_config::AbstractAWSConfig=global_aws_config()) = codestar_notifications("POST", "/listNotificationRules"; aws_config=aws_config)
-list_notification_rules(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = codestar_notifications("POST", "/listNotificationRules", params; aws_config=aws_config)
+list_notification_rules(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = codestar_notifications("POST", "/listNotificationRules", params; aws_config=aws_config)
 
 """
     list_tags_for_resource(arn)
@@ -154,7 +154,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   batch of the results.
 """
 list_targets(; aws_config::AbstractAWSConfig=global_aws_config()) = codestar_notifications("POST", "/listTargets"; aws_config=aws_config)
-list_targets(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = codestar_notifications("POST", "/listTargets", params; aws_config=aws_config)
+list_targets(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = codestar_notifications("POST", "/listTargets", params; aws_config=aws_config)
 
 """
     subscribe(arn, target)

--- a/src/services/cognito_sync.jl
+++ b/src/services/cognito_sync.jl
@@ -197,7 +197,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: A pagination token for obtaining the next page of results.
 """
 list_identity_pool_usage(; aws_config::AbstractAWSConfig=global_aws_config()) = cognito_sync("GET", "/identitypools"; aws_config=aws_config)
-list_identity_pool_usage(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = cognito_sync("GET", "/identitypools", params; aws_config=aws_config)
+list_identity_pool_usage(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = cognito_sync("GET", "/identitypools", params; aws_config=aws_config)
 
 """
     list_records(dataset_name, identity_id, identity_pool_id)

--- a/src/services/comprehendmedical.jl
+++ b/src/services/comprehendmedical.jl
@@ -141,7 +141,8 @@ infer_icd10_cm(Text, params::AbstractDict{String, <:Any}; aws_config::AbstractAW
 
 InferRxNorm detects medications as entities listed in a patient record and links to the
 normalized concept identifiers in the RxNorm database from the National Library of
-Medicine. Amazon Comprehend Medical only detects medical entities in English language texts.
+Medicine. Amazon Comprehend Medical only detects medical entities in English language
+texts.
 
 # Arguments
 - `text`: The input text used for analysis. The input for InferRxNorm is a string from 1 to

--- a/src/services/config_service.jl
+++ b/src/services/config_service.jl
@@ -333,9 +333,10 @@ describe_aggregate_compliance_by_config_rules(ConfigurationAggregatorName, param
     describe_aggregate_compliance_by_conformance_packs(configuration_aggregator_name, params::Dict{String,<:Any})
 
 Returns a list of the conformance packs and their associated compliance status with the
-count of compliant and noncompliant AWS Config rules within each conformance pack.  The
-results can return an empty result page, but if you have a nextToken, the results are
-displayed on the next page.
+count of compliant and noncompliant AWS Config rules within each conformance pack. Also
+returns the total rule count which includes compliant rules, noncompliant rules, and rules
+that cannot be evaluated due to insufficient data.  The results can return an empty result
+page, but if you have a nextToken, the results are displayed on the next page.
 
 # Arguments
 - `configuration_aggregator_name`: The name of the configuration aggregator.
@@ -343,8 +344,8 @@ displayed on the next page.
 # Optional Parameters
 Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys are:
 - `"Filters"`: Filters the result by AggregateConformancePackComplianceFilters object.
-- `"Limit"`: The maximum number of conformance packs details returned on each page. The
-  default is maximum. If you specify 0, AWS Config uses the default.
+- `"Limit"`: The maximum number of conformance packs compliance details returned on each
+  page. The default is maximum. If you specify 0, AWS Config uses the default.
 - `"NextToken"`: The nextToken string returned on a previous page that you use to get the
   next page of results in a paginated response.
 """
@@ -895,9 +896,9 @@ get_aggregate_config_rule_compliance_summary(ConfigurationAggregatorName, params
     get_aggregate_conformance_pack_compliance_summary(configuration_aggregator_name, params::Dict{String,<:Any})
 
 Returns the count of compliant and noncompliant conformance packs across all AWS Accounts
-and AWS Regions. You can filter based on AWS Account ID or AWS Region.  The results can
-return an empty result page, but if you have a nextToken, the results are displayed on the
-next page.
+and AWS Regions in an aggregator. You can filter based on AWS Account ID or AWS Region.
+The results can return an empty result page, but if you have a nextToken, the results are
+displayed on the next page.
 
 # Arguments
 - `configuration_aggregator_name`: The name of the configuration aggregator.

--- a/src/services/connect.jl
+++ b/src/services/connect.jl
@@ -936,7 +936,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   previous response in the next request to retrieve the next set of results.
 """
 list_instances(; aws_config::AbstractAWSConfig=global_aws_config()) = connect("GET", "/instance"; aws_config=aws_config)
-list_instances(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = connect("GET", "/instance", params; aws_config=aws_config)
+list_instances(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = connect("GET", "/instance", params; aws_config=aws_config)
 
 """
     list_integration_associations(instance_id)

--- a/src/services/customer_profiles.jl
+++ b/src/services/customer_profiles.jl
@@ -269,7 +269,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"next-token"`: The pagination token from the previous ListDomain API call.
 """
 list_domains(; aws_config::AbstractAWSConfig=global_aws_config()) = customer_profiles("GET", "/domains"; aws_config=aws_config)
-list_domains(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = customer_profiles("GET", "/domains", params; aws_config=aws_config)
+list_domains(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = customer_profiles("GET", "/domains", params; aws_config=aws_config)
 
 """
     list_integrations(domain_name)
@@ -300,7 +300,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"next-token"`: The pagination token from the previous ListObjectTypeTemplates API call.
 """
 list_profile_object_type_templates(; aws_config::AbstractAWSConfig=global_aws_config()) = customer_profiles("GET", "/templates"; aws_config=aws_config)
-list_profile_object_type_templates(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = customer_profiles("GET", "/templates", params; aws_config=aws_config)
+list_profile_object_type_templates(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = customer_profiles("GET", "/templates", params; aws_config=aws_config)
 
 """
     list_profile_object_types(domain_name)

--- a/src/services/database_migration_service.jl
+++ b/src/services/database_migration_service.jl
@@ -579,6 +579,28 @@ describe_connections(; aws_config::AbstractAWSConfig=global_aws_config()) = data
 describe_connections(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = database_migration_service("DescribeConnections", params; aws_config=aws_config)
 
 """
+    describe_endpoint_settings(engine_name)
+    describe_endpoint_settings(engine_name, params::Dict{String,<:Any})
+
+Returns information about the possible endpoint settings available when you create an
+endpoint for a specific database engine.
+
+# Arguments
+- `engine_name`: The databse engine used for your source or target endpoint.
+
+# Optional Parameters
+Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys are:
+- `"Marker"`: An optional pagination token provided by a previous request. If this
+  parameter is specified, the response includes only records beyond the marker, up to the
+  value specified by MaxRecords.
+- `"MaxRecords"`: The maximum number of records to include in the response. If more records
+  exist than the specified MaxRecords value, a pagination token called a marker is included
+  in the response so that the remaining results can be retrieved.
+"""
+describe_endpoint_settings(EngineName; aws_config::AbstractAWSConfig=global_aws_config()) = database_migration_service("DescribeEndpointSettings", Dict{String, Any}("EngineName"=>EngineName); aws_config=aws_config)
+describe_endpoint_settings(EngineName, params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = database_migration_service("DescribeEndpointSettings", Dict{String, Any}(mergewith(_merge, Dict{String, Any}("EngineName"=>EngineName), params)); aws_config=aws_config)
+
+"""
     describe_endpoint_types()
     describe_endpoint_types(params::Dict{String,<:Any})
 
@@ -1230,9 +1252,9 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"ReplicationTaskSettings"`: JSON file that contains settings for the task, such as task
   metadata settings.
 - `"TableMappings"`: When using the AWS CLI or boto3, provide the path of the JSON file
-  that contains the table mappings. Precede the path with file://. When working with the DMS
-  API, provide the JSON as the parameter value, for example: --table-mappings
-  file://mappingfile.json
+  that contains the table mappings. Precede the path with file://. For example,
+  --table-mappings file://mappingfile.json. When working with the DMS API, provide the JSON
+  as the parameter value.
 - `"TaskData"`: Supplemental information that the task requires to migrate the data for
   certain source and target endpoints. For more information, see Specifying Supplemental Data
   for Task Settings in the AWS Database Migration Service User Guide.

--- a/src/services/databrew.jl
+++ b/src/services/databrew.jl
@@ -349,7 +349,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: The token returned by a previous call to retrieve the next set of results.
 """
 list_datasets(; aws_config::AbstractAWSConfig=global_aws_config()) = databrew("GET", "/datasets"; aws_config=aws_config)
-list_datasets(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = databrew("GET", "/datasets", params; aws_config=aws_config)
+list_datasets(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = databrew("GET", "/datasets", params; aws_config=aws_config)
 
 """
     list_job_runs(name)
@@ -386,7 +386,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   those jobs that are associated with the specified project.
 """
 list_jobs(; aws_config::AbstractAWSConfig=global_aws_config()) = databrew("GET", "/jobs"; aws_config=aws_config)
-list_jobs(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = databrew("GET", "/jobs", params; aws_config=aws_config)
+list_jobs(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = databrew("GET", "/jobs", params; aws_config=aws_config)
 
 """
     list_projects()
@@ -400,7 +400,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: The token returned by a previous call to retrieve the next set of results.
 """
 list_projects(; aws_config::AbstractAWSConfig=global_aws_config()) = databrew("GET", "/projects"; aws_config=aws_config)
-list_projects(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = databrew("GET", "/projects", params; aws_config=aws_config)
+list_projects(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = databrew("GET", "/projects", params; aws_config=aws_config)
 
 """
     list_recipe_versions(name)
@@ -434,7 +434,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   LATEST_PUBLISHED recipe versions. Valid values: LATEST_WORKING | LATEST_PUBLISHED
 """
 list_recipes(; aws_config::AbstractAWSConfig=global_aws_config()) = databrew("GET", "/recipes"; aws_config=aws_config)
-list_recipes(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = databrew("GET", "/recipes", params; aws_config=aws_config)
+list_recipes(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = databrew("GET", "/recipes", params; aws_config=aws_config)
 
 """
     list_schedules()
@@ -449,7 +449,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: The token returned by a previous call to retrieve the next set of results.
 """
 list_schedules(; aws_config::AbstractAWSConfig=global_aws_config()) = databrew("GET", "/schedules"; aws_config=aws_config)
-list_schedules(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = databrew("GET", "/schedules", params; aws_config=aws_config)
+list_schedules(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = databrew("GET", "/schedules", params; aws_config=aws_config)
 
 """
     list_tags_for_resource(resource_arn)

--- a/src/services/dataexchange.jl
+++ b/src/services/dataexchange.jl
@@ -206,7 +206,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   or ENTITLED to the account (for subscribers).
 """
 list_data_sets(; aws_config::AbstractAWSConfig=global_aws_config()) = dataexchange("GET", "/v1/data-sets"; aws_config=aws_config)
-list_data_sets(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = dataexchange("GET", "/v1/data-sets", params; aws_config=aws_config)
+list_data_sets(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = dataexchange("GET", "/v1/data-sets", params; aws_config=aws_config)
 
 """
     list_jobs()
@@ -223,7 +223,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"revisionId"`: The unique identifier for a revision.
 """
 list_jobs(; aws_config::AbstractAWSConfig=global_aws_config()) = dataexchange("GET", "/v1/jobs"; aws_config=aws_config)
-list_jobs(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = dataexchange("GET", "/v1/jobs", params; aws_config=aws_config)
+list_jobs(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = dataexchange("GET", "/v1/jobs", params; aws_config=aws_config)
 
 """
     list_revision_assets(data_set_id, revision_id)

--- a/src/services/detective.jl
+++ b/src/services/detective.jl
@@ -44,7 +44,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   key and the tag value.
 """
 create_graph(; aws_config::AbstractAWSConfig=global_aws_config()) = detective("POST", "/graph"; aws_config=aws_config)
-create_graph(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = detective("POST", "/graph", params; aws_config=aws_config)
+create_graph(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = detective("POST", "/graph", params; aws_config=aws_config)
 
 """
     create_members(accounts, graph_arn)
@@ -162,7 +162,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   pagination token.
 """
 list_graphs(; aws_config::AbstractAWSConfig=global_aws_config()) = detective("POST", "/graphs/list"; aws_config=aws_config)
-list_graphs(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = detective("POST", "/graphs/list", params; aws_config=aws_config)
+list_graphs(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = detective("POST", "/graphs/list", params; aws_config=aws_config)
 
 """
     list_invitations()
@@ -184,7 +184,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   pagination token.
 """
 list_invitations(; aws_config::AbstractAWSConfig=global_aws_config()) = detective("POST", "/invitations/list"; aws_config=aws_config)
-list_invitations(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = detective("POST", "/invitations/list", params; aws_config=aws_config)
+list_invitations(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = detective("POST", "/invitations/list", params; aws_config=aws_config)
 
 """
     list_members(graph_arn)

--- a/src/services/devops_guru.jl
+++ b/src/services/devops_guru.jl
@@ -36,7 +36,7 @@ of operations in your AWS account.
 
 """
 describe_account_health(; aws_config::AbstractAWSConfig=global_aws_config()) = devops_guru("GET", "/accounts/health"; aws_config=aws_config)
-describe_account_health(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = devops_guru("GET", "/accounts/health", params; aws_config=aws_config)
+describe_account_health(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = devops_guru("GET", "/accounts/health", params; aws_config=aws_config)
 
 """
     describe_account_overview(from_time)
@@ -84,7 +84,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"InsightId"`:  The ID of the insight for which the feedback was provided.
 """
 describe_feedback(; aws_config::AbstractAWSConfig=global_aws_config()) = devops_guru("POST", "/feedback"; aws_config=aws_config)
-describe_feedback(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = devops_guru("POST", "/feedback", params; aws_config=aws_config)
+describe_feedback(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = devops_guru("POST", "/feedback", params; aws_config=aws_config)
 
 """
     describe_insight(id)
@@ -133,7 +133,7 @@ to create an OpsItem for each generated insight.
 
 """
 describe_service_integration(; aws_config::AbstractAWSConfig=global_aws_config()) = devops_guru("GET", "/service-integrations"; aws_config=aws_config)
-describe_service_integration(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = devops_guru("GET", "/service-integrations", params; aws_config=aws_config)
+describe_service_integration(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = devops_guru("GET", "/service-integrations", params; aws_config=aws_config)
 
 """
     get_resource_collection(resource_collection_type)
@@ -232,7 +232,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   operation. If this value is null, it retrieves the first page.
 """
 list_notification_channels(; aws_config::AbstractAWSConfig=global_aws_config()) = devops_guru("POST", "/channels"; aws_config=aws_config)
-list_notification_channels(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = devops_guru("POST", "/channels", params; aws_config=aws_config)
+list_notification_channels(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = devops_guru("POST", "/channels", params; aws_config=aws_config)
 
 """
     list_recommendations(insight_id)
@@ -264,7 +264,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   insight.
 """
 put_feedback(; aws_config::AbstractAWSConfig=global_aws_config()) = devops_guru("PUT", "/feedback"; aws_config=aws_config)
-put_feedback(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = devops_guru("PUT", "/feedback", params; aws_config=aws_config)
+put_feedback(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = devops_guru("PUT", "/feedback", params; aws_config=aws_config)
 
 """
     remove_notification_channel(id)

--- a/src/services/dlm.jl
+++ b/src/services/dlm.jl
@@ -58,7 +58,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"targetTags"`: The target tag for a policy. Tags are strings in the format key=value.
 """
 get_lifecycle_policies(; aws_config::AbstractAWSConfig=global_aws_config()) = dlm("GET", "/policies"; aws_config=aws_config)
-get_lifecycle_policies(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = dlm("GET", "/policies", params; aws_config=aws_config)
+get_lifecycle_policies(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = dlm("GET", "/policies", params; aws_config=aws_config)
 
 """
     get_lifecycle_policy(policy_id)

--- a/src/services/efs.jl
+++ b/src/services/efs.jl
@@ -350,7 +350,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   in the subsequent request to fetch the next page of access point descriptions.
 """
 describe_access_points(; aws_config::AbstractAWSConfig=global_aws_config()) = efs("GET", "/2015-02-01/access-points"; aws_config=aws_config)
-describe_access_points(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = efs("GET", "/2015-02-01/access-points", params; aws_config=aws_config)
+describe_access_points(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = efs("GET", "/2015-02-01/access-points", params; aws_config=aws_config)
 
 """
     describe_backup_policy(file_system_id)
@@ -413,7 +413,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   100 per page if you have more than 100 file systems.
 """
 describe_file_systems(; aws_config::AbstractAWSConfig=global_aws_config()) = efs("GET", "/2015-02-01/file-systems"; aws_config=aws_config)
-describe_file_systems(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = efs("GET", "/2015-02-01/file-systems", params; aws_config=aws_config)
+describe_file_systems(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = efs("GET", "/2015-02-01/file-systems", params; aws_config=aws_config)
 
 """
     describe_lifecycle_configuration(file_system_id)
@@ -482,7 +482,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   either a mount target ID or ARN as input.
 """
 describe_mount_targets(; aws_config::AbstractAWSConfig=global_aws_config()) = efs("GET", "/2015-02-01/mount-targets"; aws_config=aws_config)
-describe_mount_targets(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = efs("GET", "/2015-02-01/mount-targets", params; aws_config=aws_config)
+describe_mount_targets(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = efs("GET", "/2015-02-01/mount-targets", params; aws_config=aws_config)
 
 """
     describe_tags(file_system_id)

--- a/src/services/eks.jl
+++ b/src/services/eks.jl
@@ -383,7 +383,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   only to retrieve the next items in a list and not for other programmatic purposes.
 """
 describe_addon_versions(; aws_config::AbstractAWSConfig=global_aws_config()) = eks("GET", "/addons/supported-versions"; aws_config=aws_config)
-describe_addon_versions(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = eks("GET", "/addons/supported-versions", params; aws_config=aws_config)
+describe_addon_versions(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = eks("GET", "/addons/supported-versions", params; aws_config=aws_config)
 
 """
     describe_cluster(name)
@@ -533,7 +533,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   the next items in a list and not for other programmatic purposes.
 """
 list_clusters(; aws_config::AbstractAWSConfig=global_aws_config()) = eks("GET", "/clusters"; aws_config=aws_config)
-list_clusters(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = eks("GET", "/clusters", params; aws_config=aws_config)
+list_clusters(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = eks("GET", "/clusters", params; aws_config=aws_config)
 
 """
     list_fargate_profiles(name)

--- a/src/services/elastic_inference.jl
+++ b/src/services/elastic_inference.jl
@@ -34,7 +34,7 @@ characteristics, such as memory and throughput.
 
 """
 describe_accelerator_types(; aws_config::AbstractAWSConfig=global_aws_config()) = elastic_inference("GET", "/describe-accelerator-types"; aws_config=aws_config)
-describe_accelerator_types(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = elastic_inference("GET", "/describe-accelerator-types", params; aws_config=aws_config)
+describe_accelerator_types(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = elastic_inference("GET", "/describe-accelerator-types", params; aws_config=aws_config)
 
 """
     describe_accelerators()
@@ -57,7 +57,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   a previously truncated response.
 """
 describe_accelerators(; aws_config::AbstractAWSConfig=global_aws_config()) = elastic_inference("POST", "/describe-accelerators"; aws_config=aws_config)
-describe_accelerators(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = elastic_inference("POST", "/describe-accelerators", params; aws_config=aws_config)
+describe_accelerators(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = elastic_inference("POST", "/describe-accelerators", params; aws_config=aws_config)
 
 """
     list_tags_for_resource(resource_arn)

--- a/src/services/elastic_transcoder.jl
+++ b/src/services/elastic_transcoder.jl
@@ -305,7 +305,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   pageToken in subsequent GET requests to get each successive page of results.
 """
 list_pipelines(; aws_config::AbstractAWSConfig=global_aws_config()) = elastic_transcoder("GET", "/2012-09-25/pipelines"; aws_config=aws_config)
-list_pipelines(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = elastic_transcoder("GET", "/2012-09-25/pipelines", params; aws_config=aws_config)
+list_pipelines(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = elastic_transcoder("GET", "/2012-09-25/pipelines", params; aws_config=aws_config)
 
 """
     list_presets()
@@ -322,7 +322,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   pageToken in subsequent GET requests to get each successive page of results.
 """
 list_presets(; aws_config::AbstractAWSConfig=global_aws_config()) = elastic_transcoder("GET", "/2012-09-25/presets"; aws_config=aws_config)
-list_presets(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = elastic_transcoder("GET", "/2012-09-25/presets", params; aws_config=aws_config)
+list_presets(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = elastic_transcoder("GET", "/2012-09-25/presets", params; aws_config=aws_config)
 
 """
     read_job(id)

--- a/src/services/elasticsearch_service.jl
+++ b/src/services/elasticsearch_service.jl
@@ -171,7 +171,7 @@ Role in VPC Endpoints for Amazon Elasticsearch Service Domains.
 
 """
 delete_elasticsearch_service_role(; aws_config::AbstractAWSConfig=global_aws_config()) = elasticsearch_service("DELETE", "/2015-01-01/es/role"; aws_config=aws_config)
-delete_elasticsearch_service_role(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = elasticsearch_service("DELETE", "/2015-01-01/es/role", params; aws_config=aws_config)
+delete_elasticsearch_service_role(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = elasticsearch_service("DELETE", "/2015-01-01/es/role", params; aws_config=aws_config)
 
 """
     delete_inbound_cross_cluster_search_connection(connection_id)
@@ -317,7 +317,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   NextToken. It is used for pagination.
 """
 describe_inbound_cross_cluster_search_connections(; aws_config::AbstractAWSConfig=global_aws_config()) = elasticsearch_service("POST", "/2015-01-01/es/ccs/inboundConnection/search"; aws_config=aws_config)
-describe_inbound_cross_cluster_search_connections(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = elasticsearch_service("POST", "/2015-01-01/es/ccs/inboundConnection/search", params; aws_config=aws_config)
+describe_inbound_cross_cluster_search_connections(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = elasticsearch_service("POST", "/2015-01-01/es/ccs/inboundConnection/search", params; aws_config=aws_config)
 
 """
     describe_outbound_cross_cluster_search_connections()
@@ -338,7 +338,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   NextToken. It is used for pagination.
 """
 describe_outbound_cross_cluster_search_connections(; aws_config::AbstractAWSConfig=global_aws_config()) = elasticsearch_service("POST", "/2015-01-01/es/ccs/outboundConnection/search"; aws_config=aws_config)
-describe_outbound_cross_cluster_search_connections(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = elasticsearch_service("POST", "/2015-01-01/es/ccs/outboundConnection/search", params; aws_config=aws_config)
+describe_outbound_cross_cluster_search_connections(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = elasticsearch_service("POST", "/2015-01-01/es/ccs/outboundConnection/search", params; aws_config=aws_config)
 
 """
     describe_packages()
@@ -355,7 +355,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   non-null NextToken value. If provided, returns results for the next page.
 """
 describe_packages(; aws_config::AbstractAWSConfig=global_aws_config()) = elasticsearch_service("POST", "/2015-01-01/packages/describe"; aws_config=aws_config)
-describe_packages(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = elasticsearch_service("POST", "/2015-01-01/packages/describe", params; aws_config=aws_config)
+describe_packages(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = elasticsearch_service("POST", "/2015-01-01/packages/describe", params; aws_config=aws_config)
 
 """
     describe_reserved_elasticsearch_instance_offerings()
@@ -373,7 +373,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   available offering that matches the specified reservation identifier.
 """
 describe_reserved_elasticsearch_instance_offerings(; aws_config::AbstractAWSConfig=global_aws_config()) = elasticsearch_service("GET", "/2015-01-01/es/reservedInstanceOfferings"; aws_config=aws_config)
-describe_reserved_elasticsearch_instance_offerings(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = elasticsearch_service("GET", "/2015-01-01/es/reservedInstanceOfferings", params; aws_config=aws_config)
+describe_reserved_elasticsearch_instance_offerings(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = elasticsearch_service("GET", "/2015-01-01/es/reservedInstanceOfferings", params; aws_config=aws_config)
 
 """
     describe_reserved_elasticsearch_instances()
@@ -391,7 +391,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   show only the reservation that matches the specified reserved Elasticsearch instance ID.
 """
 describe_reserved_elasticsearch_instances(; aws_config::AbstractAWSConfig=global_aws_config()) = elasticsearch_service("GET", "/2015-01-01/es/reservedInstances"; aws_config=aws_config)
-describe_reserved_elasticsearch_instances(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = elasticsearch_service("GET", "/2015-01-01/es/reservedInstances", params; aws_config=aws_config)
+describe_reserved_elasticsearch_instances(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = elasticsearch_service("GET", "/2015-01-01/es/reservedInstances", params; aws_config=aws_config)
 
 """
     dissociate_package(domain_name, package_id)
@@ -420,7 +420,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"domainName"`:
 """
 get_compatible_elasticsearch_versions(; aws_config::AbstractAWSConfig=global_aws_config()) = elasticsearch_service("GET", "/2015-01-01/es/compatibleVersions"; aws_config=aws_config)
-get_compatible_elasticsearch_versions(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = elasticsearch_service("GET", "/2015-01-01/es/compatibleVersions", params; aws_config=aws_config)
+get_compatible_elasticsearch_versions(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = elasticsearch_service("GET", "/2015-01-01/es/compatibleVersions", params; aws_config=aws_config)
 
 """
     get_package_version_history(package_id)
@@ -480,7 +480,7 @@ Returns the name of all Elasticsearch domains owned by the current user's accoun
 
 """
 list_domain_names(; aws_config::AbstractAWSConfig=global_aws_config()) = elasticsearch_service("GET", "/2015-01-01/domain"; aws_config=aws_config)
-list_domain_names(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = elasticsearch_service("GET", "/2015-01-01/domain", params; aws_config=aws_config)
+list_domain_names(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = elasticsearch_service("GET", "/2015-01-01/domain", params; aws_config=aws_config)
 
 """
     list_domains_for_package(package_id)
@@ -536,7 +536,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`:
 """
 list_elasticsearch_versions(; aws_config::AbstractAWSConfig=global_aws_config()) = elasticsearch_service("GET", "/2015-01-01/es/versions"; aws_config=aws_config)
-list_elasticsearch_versions(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = elasticsearch_service("GET", "/2015-01-01/es/versions", params; aws_config=aws_config)
+list_elasticsearch_versions(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = elasticsearch_service("GET", "/2015-01-01/es/versions", params; aws_config=aws_config)
 
 """
     list_packages_for_domain(domain_name)

--- a/src/services/emr_containers.jl
+++ b/src/services/emr_containers.jl
@@ -228,7 +228,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"states"`: The states of the requested virtual clusters.
 """
 list_virtual_clusters(; aws_config::AbstractAWSConfig=global_aws_config()) = emr_containers("GET", "/virtualclusters"; aws_config=aws_config)
-list_virtual_clusters(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = emr_containers("GET", "/virtualclusters", params; aws_config=aws_config)
+list_virtual_clusters(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = emr_containers("GET", "/virtualclusters", params; aws_config=aws_config)
 
 """
     start_job_run(client_token, execution_role_arn, job_driver, release_label, virtual_cluster_id)

--- a/src/services/fis.jl
+++ b/src/services/fis.jl
@@ -100,7 +100,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: The token for the next page of results.
 """
 list_actions(; aws_config::AbstractAWSConfig=global_aws_config()) = fis("GET", "/actions"; aws_config=aws_config)
-list_actions(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = fis("GET", "/actions", params; aws_config=aws_config)
+list_actions(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = fis("GET", "/actions", params; aws_config=aws_config)
 
 """
     list_experiment_templates()
@@ -115,7 +115,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: The token for the next page of results.
 """
 list_experiment_templates(; aws_config::AbstractAWSConfig=global_aws_config()) = fis("GET", "/experimentTemplates"; aws_config=aws_config)
-list_experiment_templates(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = fis("GET", "/experimentTemplates", params; aws_config=aws_config)
+list_experiment_templates(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = fis("GET", "/experimentTemplates", params; aws_config=aws_config)
 
 """
     list_experiments()
@@ -130,7 +130,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: The token for the next page of results.
 """
 list_experiments(; aws_config::AbstractAWSConfig=global_aws_config()) = fis("GET", "/experiments"; aws_config=aws_config)
-list_experiments(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = fis("GET", "/experiments", params; aws_config=aws_config)
+list_experiments(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = fis("GET", "/experiments", params; aws_config=aws_config)
 
 """
     list_tags_for_resource(resource_arn)

--- a/src/services/fsx.jl
+++ b/src/services/fsx.jl
@@ -55,6 +55,49 @@ cancel_data_repository_task(TaskId; aws_config::AbstractAWSConfig=global_aws_con
 cancel_data_repository_task(TaskId, params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = fsx("CancelDataRepositoryTask", Dict{String, Any}(mergewith(_merge, Dict{String, Any}("TaskId"=>TaskId), params)); aws_config=aws_config)
 
 """
+    copy_backup(source_backup_id)
+    copy_backup(source_backup_id, params::Dict{String,<:Any})
+
+Copies an existing backup within the same AWS account to another Region (cross-Region copy)
+or within the same Region (in-Region copy). You can have up to five backup copy requests in
+progress to a single destination Region per account. You can use cross-Region backup copies
+for cross-region disaster recovery. You periodically take backups and copy them to another
+Region so that in the event of a disaster in the primary Region, you can restore from
+backup and recover availability quickly in the other Region. You can make cross-Region
+copies only within your AWS partition.  You can also use backup copies to clone your file
+data set to another Region or within the same Region. You can use the SourceRegion
+parameter to specify the AWS Region from which the backup will be copied. For example, if
+you make the call from the us-west-1 Region and want to copy a backup from the us-east-2
+Region, you specify us-east-2 in the SourceRegion parameter to make a cross-Region copy. If
+you don't specify a Region, the backup copy is created in the same Region where the request
+is sent from (in-Region copy). For more information on creating backup copies, see  Copying
+backups in the Amazon FSx for Windows User Guide and Copying backups in the Amazon FSx for
+Lustre User Guide.
+
+# Arguments
+- `source_backup_id`: The ID of the source backup. Specifies the ID of the backup that is
+  being copied.
+
+# Optional Parameters
+Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys are:
+- `"ClientRequestToken"`:
+- `"CopyTags"`: A boolean flag indicating whether tags from the source backup should be
+  copied to the backup copy. This value defaults to false. If you set CopyTags to true and
+  the source backup has existing tags, you can use the Tags parameter to create new tags,
+  provided that the sum of the source backup tags and the new tags doesn't exceed 50. Both
+  sets of tags are merged. If there are tag conflicts (for example, two tags with the same
+  key but different values), the tags created with the Tags parameter take precedence.
+- `"KmsKeyId"`:
+- `"SourceRegion"`: The source AWS Region of the backup. Specifies the AWS Region from
+  which the backup is being copied. The source and destination Regions must be in the same
+  AWS partition. If you don't specify a Region, it defaults to the Region where the request
+  is sent from (in-Region copy).
+- `"Tags"`:
+"""
+copy_backup(SourceBackupId; aws_config::AbstractAWSConfig=global_aws_config()) = fsx("CopyBackup", Dict{String, Any}("SourceBackupId"=>SourceBackupId, "ClientRequestToken"=>string(uuid4())); aws_config=aws_config)
+copy_backup(SourceBackupId, params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = fsx("CopyBackup", Dict{String, Any}(mergewith(_merge, Dict{String, Any}("SourceBackupId"=>SourceBackupId, "ClientRequestToken"=>string(uuid4())), params)); aws_config=aws_config)
+
+"""
     create_backup(file_system_id)
     create_backup(file_system_id, params::Dict{String,<:Any})
 
@@ -169,9 +212,10 @@ state along with other information.
   from. For Windows MULTI_AZ_1 file system deployment types, provide exactly two subnet IDs,
   one for the preferred file server and one for the standby file server. You specify one of
   these subnets as the preferred subnet using the WindowsConfiguration &gt; PreferredSubnetID
-  property. For Windows SINGLE_AZ_1 and SINGLE_AZ_2 file system deployment types and Lustre
-  file systems, provide exactly one subnet ID. The file server is launched in that subnet's
-  Availability Zone.
+  property. For more information, see  Availability and durability: Single-AZ and Multi-AZ
+  file systems. For Windows SINGLE_AZ_1 and SINGLE_AZ_2 file system deployment types and
+  Lustre file systems, provide exactly one subnet ID. The file server is launched in that
+  subnet's Availability Zone.
 
 # Optional Parameters
 Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys are:
@@ -236,6 +280,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"ClientRequestToken"`: A string of up to 64 ASCII characters that Amazon FSx uses to
   ensure idempotent creation. This string is automatically filled on your behalf when you use
   the AWS Command Line Interface (AWS CLI) or an AWS SDK.
+- `"KmsKeyId"`:
 - `"LustreConfiguration"`:
 - `"SecurityGroupIds"`: A list of IDs for the security groups that apply to the specified
   network interfaces created for file system access. These security groups apply to all

--- a/src/services/greengrass.jl
+++ b/src/services/greengrass.jl
@@ -52,7 +52,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"tags"`: Tag(s) to add to the new resource.
 """
 create_connector_definition(; aws_config::AbstractAWSConfig=global_aws_config()) = greengrass("POST", "/greengrass/definition/connectors"; aws_config=aws_config)
-create_connector_definition(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = greengrass("POST", "/greengrass/definition/connectors", params; aws_config=aws_config)
+create_connector_definition(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = greengrass("POST", "/greengrass/definition/connectors", params; aws_config=aws_config)
 
 """
     create_connector_definition_version(connector_definition_id)
@@ -88,7 +88,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"tags"`: Tag(s) to add to the new resource.
 """
 create_core_definition(; aws_config::AbstractAWSConfig=global_aws_config()) = greengrass("POST", "/greengrass/definition/cores"; aws_config=aws_config)
-create_core_definition(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = greengrass("POST", "/greengrass/definition/cores", params; aws_config=aws_config)
+create_core_definition(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = greengrass("POST", "/greengrass/definition/cores", params; aws_config=aws_config)
 
 """
     create_core_definition_version(core_definition_id)
@@ -144,7 +144,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"tags"`: Tag(s) to add to the new resource.
 """
 create_device_definition(; aws_config::AbstractAWSConfig=global_aws_config()) = greengrass("POST", "/greengrass/definition/devices"; aws_config=aws_config)
-create_device_definition(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = greengrass("POST", "/greengrass/definition/devices", params; aws_config=aws_config)
+create_device_definition(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = greengrass("POST", "/greengrass/definition/devices", params; aws_config=aws_config)
 
 """
     create_device_definition_version(device_definition_id)
@@ -180,7 +180,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"tags"`: Tag(s) to add to the new resource.
 """
 create_function_definition(; aws_config::AbstractAWSConfig=global_aws_config()) = greengrass("POST", "/greengrass/definition/functions"; aws_config=aws_config)
-create_function_definition(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = greengrass("POST", "/greengrass/definition/functions", params; aws_config=aws_config)
+create_function_definition(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = greengrass("POST", "/greengrass/definition/functions", params; aws_config=aws_config)
 
 """
     create_function_definition_version(function_definition_id)
@@ -280,7 +280,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"tags"`: Tag(s) to add to the new resource.
 """
 create_logger_definition(; aws_config::AbstractAWSConfig=global_aws_config()) = greengrass("POST", "/greengrass/definition/loggers"; aws_config=aws_config)
-create_logger_definition(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = greengrass("POST", "/greengrass/definition/loggers", params; aws_config=aws_config)
+create_logger_definition(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = greengrass("POST", "/greengrass/definition/loggers", params; aws_config=aws_config)
 
 """
     create_logger_definition_version(logger_definition_id)
@@ -315,7 +315,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"tags"`: Tag(s) to add to the new resource.
 """
 create_resource_definition(; aws_config::AbstractAWSConfig=global_aws_config()) = greengrass("POST", "/greengrass/definition/resources"; aws_config=aws_config)
-create_resource_definition(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = greengrass("POST", "/greengrass/definition/resources", params; aws_config=aws_config)
+create_resource_definition(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = greengrass("POST", "/greengrass/definition/resources", params; aws_config=aws_config)
 
 """
     create_resource_definition_version(resource_definition_id)
@@ -373,7 +373,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"tags"`: Tag(s) to add to the new resource.
 """
 create_subscription_definition(; aws_config::AbstractAWSConfig=global_aws_config()) = greengrass("POST", "/greengrass/definition/subscriptions"; aws_config=aws_config)
-create_subscription_definition(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = greengrass("POST", "/greengrass/definition/subscriptions", params; aws_config=aws_config)
+create_subscription_definition(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = greengrass("POST", "/greengrass/definition/subscriptions", params; aws_config=aws_config)
 
 """
     create_subscription_definition_version(subscription_definition_id)
@@ -518,7 +518,7 @@ not work.
 
 """
 disassociate_service_role_from_account(; aws_config::AbstractAWSConfig=global_aws_config()) = greengrass("DELETE", "/greengrass/servicerole"; aws_config=aws_config)
-disassociate_service_role_from_account(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = greengrass("DELETE", "/greengrass/servicerole", params; aws_config=aws_config)
+disassociate_service_role_from_account(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = greengrass("DELETE", "/greengrass/servicerole", params; aws_config=aws_config)
 
 """
     get_associated_role(group_id)
@@ -847,7 +847,7 @@ Retrieves the service role that is attached to your account.
 
 """
 get_service_role_for_account(; aws_config::AbstractAWSConfig=global_aws_config()) = greengrass("GET", "/greengrass/servicerole"; aws_config=aws_config)
-get_service_role_for_account(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = greengrass("GET", "/greengrass/servicerole", params; aws_config=aws_config)
+get_service_role_for_account(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = greengrass("GET", "/greengrass/servicerole", params; aws_config=aws_config)
 
 """
     get_subscription_definition(subscription_definition_id)
@@ -929,7 +929,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   additional results.
 """
 list_bulk_deployments(; aws_config::AbstractAWSConfig=global_aws_config()) = greengrass("GET", "/greengrass/bulk/deployments"; aws_config=aws_config)
-list_bulk_deployments(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = greengrass("GET", "/greengrass/bulk/deployments", params; aws_config=aws_config)
+list_bulk_deployments(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = greengrass("GET", "/greengrass/bulk/deployments", params; aws_config=aws_config)
 
 """
     list_connector_definition_versions(connector_definition_id)
@@ -964,7 +964,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   additional results.
 """
 list_connector_definitions(; aws_config::AbstractAWSConfig=global_aws_config()) = greengrass("GET", "/greengrass/definition/connectors"; aws_config=aws_config)
-list_connector_definitions(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = greengrass("GET", "/greengrass/definition/connectors", params; aws_config=aws_config)
+list_connector_definitions(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = greengrass("GET", "/greengrass/definition/connectors", params; aws_config=aws_config)
 
 """
     list_core_definition_versions(core_definition_id)
@@ -997,7 +997,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   additional results.
 """
 list_core_definitions(; aws_config::AbstractAWSConfig=global_aws_config()) = greengrass("GET", "/greengrass/definition/cores"; aws_config=aws_config)
-list_core_definitions(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = greengrass("GET", "/greengrass/definition/cores", params; aws_config=aws_config)
+list_core_definitions(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = greengrass("GET", "/greengrass/definition/cores", params; aws_config=aws_config)
 
 """
     list_deployments(group_id)
@@ -1048,7 +1048,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   additional results.
 """
 list_device_definitions(; aws_config::AbstractAWSConfig=global_aws_config()) = greengrass("GET", "/greengrass/definition/devices"; aws_config=aws_config)
-list_device_definitions(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = greengrass("GET", "/greengrass/definition/devices", params; aws_config=aws_config)
+list_device_definitions(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = greengrass("GET", "/greengrass/definition/devices", params; aws_config=aws_config)
 
 """
     list_function_definition_versions(function_definition_id)
@@ -1081,7 +1081,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   additional results.
 """
 list_function_definitions(; aws_config::AbstractAWSConfig=global_aws_config()) = greengrass("GET", "/greengrass/definition/functions"; aws_config=aws_config)
-list_function_definitions(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = greengrass("GET", "/greengrass/definition/functions", params; aws_config=aws_config)
+list_function_definitions(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = greengrass("GET", "/greengrass/definition/functions", params; aws_config=aws_config)
 
 """
     list_group_certificate_authorities(group_id)
@@ -1127,7 +1127,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   additional results.
 """
 list_groups(; aws_config::AbstractAWSConfig=global_aws_config()) = greengrass("GET", "/greengrass/groups"; aws_config=aws_config)
-list_groups(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = greengrass("GET", "/greengrass/groups", params; aws_config=aws_config)
+list_groups(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = greengrass("GET", "/greengrass/groups", params; aws_config=aws_config)
 
 """
     list_logger_definition_versions(logger_definition_id)
@@ -1160,7 +1160,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   additional results.
 """
 list_logger_definitions(; aws_config::AbstractAWSConfig=global_aws_config()) = greengrass("GET", "/greengrass/definition/loggers"; aws_config=aws_config)
-list_logger_definitions(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = greengrass("GET", "/greengrass/definition/loggers", params; aws_config=aws_config)
+list_logger_definitions(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = greengrass("GET", "/greengrass/definition/loggers", params; aws_config=aws_config)
 
 """
     list_resource_definition_versions(resource_definition_id)
@@ -1193,7 +1193,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   additional results.
 """
 list_resource_definitions(; aws_config::AbstractAWSConfig=global_aws_config()) = greengrass("GET", "/greengrass/definition/resources"; aws_config=aws_config)
-list_resource_definitions(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = greengrass("GET", "/greengrass/definition/resources", params; aws_config=aws_config)
+list_resource_definitions(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = greengrass("GET", "/greengrass/definition/resources", params; aws_config=aws_config)
 
 """
     list_subscription_definition_versions(subscription_definition_id)
@@ -1226,7 +1226,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   additional results.
 """
 list_subscription_definitions(; aws_config::AbstractAWSConfig=global_aws_config()) = greengrass("GET", "/greengrass/definition/subscriptions"; aws_config=aws_config)
-list_subscription_definitions(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = greengrass("GET", "/greengrass/definition/subscriptions", params; aws_config=aws_config)
+list_subscription_definitions(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = greengrass("GET", "/greengrass/definition/subscriptions", params; aws_config=aws_config)
 
 """
     list_tags_for_resource(resource-arn)

--- a/src/services/greengrassv2.jl
+++ b/src/services/greengrassv2.jl
@@ -51,7 +51,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   information, see Tag your resources in the AWS IoT Greengrass V2 Developer Guide.
 """
 create_component_version(; aws_config::AbstractAWSConfig=global_aws_config()) = greengrassv2("POST", "/greengrass/v2/createComponentVersion"; aws_config=aws_config)
-create_component_version(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = greengrassv2("POST", "/greengrass/v2/createComponentVersion", params; aws_config=aws_config)
+create_component_version(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = greengrassv2("POST", "/greengrass/v2/createComponentVersion", params; aws_config=aws_config)
 
 """
     create_deployment(target_arn)
@@ -231,7 +231,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"scope"`: The scope of the components to list. Default: PRIVATE
 """
 list_components(; aws_config::AbstractAWSConfig=global_aws_config()) = greengrassv2("GET", "/greengrass/v2/components"; aws_config=aws_config)
-list_components(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = greengrassv2("GET", "/greengrass/v2/components", params; aws_config=aws_config)
+list_components(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = greengrassv2("GET", "/greengrass/v2/components", params; aws_config=aws_config)
 
 """
     list_core_devices()
@@ -252,7 +252,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   this parameter, the list includes only core devices that are members of this thing group.
 """
 list_core_devices(; aws_config::AbstractAWSConfig=global_aws_config()) = greengrassv2("GET", "/greengrass/v2/coreDevices"; aws_config=aws_config)
-list_core_devices(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = greengrassv2("GET", "/greengrass/v2/coreDevices", params; aws_config=aws_config)
+list_core_devices(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = greengrassv2("GET", "/greengrass/v2/coreDevices", params; aws_config=aws_config)
 
 """
     list_deployments()
@@ -270,7 +270,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"targetArn"`: The ARN of the target AWS IoT thing or thing group.
 """
 list_deployments(; aws_config::AbstractAWSConfig=global_aws_config()) = greengrassv2("GET", "/greengrass/v2/deployments"; aws_config=aws_config)
-list_deployments(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = greengrassv2("GET", "/greengrass/v2/deployments", params; aws_config=aws_config)
+list_deployments(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = greengrassv2("GET", "/greengrass/v2/deployments", params; aws_config=aws_config)
 
 """
     list_effective_deployments(core_device_thing_name)

--- a/src/services/groundstation.jl
+++ b/src/services/groundstation.jl
@@ -214,7 +214,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   get the next page of results.
 """
 list_configs(; aws_config::AbstractAWSConfig=global_aws_config()) = groundstation("GET", "/config"; aws_config=aws_config)
-list_configs(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = groundstation("GET", "/config", params; aws_config=aws_config)
+list_configs(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = groundstation("GET", "/config", params; aws_config=aws_config)
 
 """
     list_contacts(end_time, start_time, status_list)
@@ -253,7 +253,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   ListDataflowEndpointGroups call. Used to get the next page of results.
 """
 list_dataflow_endpoint_groups(; aws_config::AbstractAWSConfig=global_aws_config()) = groundstation("GET", "/dataflowEndpointGroup"; aws_config=aws_config)
-list_dataflow_endpoint_groups(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = groundstation("GET", "/dataflowEndpointGroup", params; aws_config=aws_config)
+list_dataflow_endpoint_groups(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = groundstation("GET", "/dataflowEndpointGroup", params; aws_config=aws_config)
 
 """
     list_ground_stations()
@@ -269,7 +269,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"satelliteId"`: Satellite ID to retrieve on-boarded ground stations.
 """
 list_ground_stations(; aws_config::AbstractAWSConfig=global_aws_config()) = groundstation("GET", "/groundstation"; aws_config=aws_config)
-list_ground_stations(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = groundstation("GET", "/groundstation", params; aws_config=aws_config)
+list_ground_stations(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = groundstation("GET", "/groundstation", params; aws_config=aws_config)
 
 """
     list_mission_profiles()
@@ -284,7 +284,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Used to get the next page of results.
 """
 list_mission_profiles(; aws_config::AbstractAWSConfig=global_aws_config()) = groundstation("GET", "/missionprofile"; aws_config=aws_config)
-list_mission_profiles(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = groundstation("GET", "/missionprofile", params; aws_config=aws_config)
+list_mission_profiles(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = groundstation("GET", "/missionprofile", params; aws_config=aws_config)
 
 """
     list_satellites()
@@ -299,7 +299,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   satellites.
 """
 list_satellites(; aws_config::AbstractAWSConfig=global_aws_config()) = groundstation("GET", "/satellite"; aws_config=aws_config)
-list_satellites(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = groundstation("GET", "/satellite", params; aws_config=aws_config)
+list_satellites(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = groundstation("GET", "/satellite", params; aws_config=aws_config)
 
 """
     list_tags_for_resource(resource_arn)

--- a/src/services/guardduty.jl
+++ b/src/services/guardduty.jl
@@ -524,7 +524,7 @@ member account except the currently accepted invitation.
 
 """
 get_invitations_count(; aws_config::AbstractAWSConfig=global_aws_config()) = guardduty("GET", "/invitation/count"; aws_config=aws_config)
-get_invitations_count(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = guardduty("GET", "/invitation/count", params; aws_config=aws_config)
+get_invitations_count(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = guardduty("GET", "/invitation/count", params; aws_config=aws_config)
 
 """
     get_ipset(detector_id, ip_set_id)
@@ -668,7 +668,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   response to continue listing data.
 """
 list_detectors(; aws_config::AbstractAWSConfig=global_aws_config()) = guardduty("GET", "/detector"; aws_config=aws_config)
-list_detectors(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = guardduty("GET", "/detector", params; aws_config=aws_config)
+list_detectors(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = guardduty("GET", "/detector", params; aws_config=aws_config)
 
 """
     list_filters(detector_id)
@@ -767,7 +767,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   response to continue listing data.
 """
 list_invitations(; aws_config::AbstractAWSConfig=global_aws_config()) = guardduty("GET", "/invitation"; aws_config=aws_config)
-list_invitations(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = guardduty("GET", "/invitation", params; aws_config=aws_config)
+list_invitations(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = guardduty("GET", "/invitation", params; aws_config=aws_config)
 
 """
     list_ipsets(detector_id)
@@ -830,7 +830,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   listing results after the first page.
 """
 list_organization_admin_accounts(; aws_config::AbstractAWSConfig=global_aws_config()) = guardduty("GET", "/admin"; aws_config=aws_config)
-list_organization_admin_accounts(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = guardduty("GET", "/admin", params; aws_config=aws_config)
+list_organization_admin_accounts(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = guardduty("GET", "/admin", params; aws_config=aws_config)
 
 """
     list_publishing_destinations(detector_id)

--- a/src/services/imagebuilder.jl
+++ b/src/services/imagebuilder.jl
@@ -560,7 +560,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   shared with you by other customers.
 """
 list_components(; aws_config::AbstractAWSConfig=global_aws_config()) = imagebuilder("POST", "/ListComponents"; aws_config=aws_config)
-list_components(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = imagebuilder("POST", "/ListComponents", params; aws_config=aws_config)
+list_components(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = imagebuilder("POST", "/ListComponents", params; aws_config=aws_config)
 
 """
     list_container_recipes()
@@ -580,7 +580,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   account.
 """
 list_container_recipes(; aws_config::AbstractAWSConfig=global_aws_config()) = imagebuilder("POST", "/ListContainerRecipes"; aws_config=aws_config)
-list_container_recipes(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = imagebuilder("POST", "/ListContainerRecipes", params; aws_config=aws_config)
+list_container_recipes(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = imagebuilder("POST", "/ListContainerRecipes", params; aws_config=aws_config)
 
 """
     list_distribution_configurations()
@@ -596,7 +596,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   previously truncated response.
 """
 list_distribution_configurations(; aws_config::AbstractAWSConfig=global_aws_config()) = imagebuilder("POST", "/ListDistributionConfigurations"; aws_config=aws_config)
-list_distribution_configurations(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = imagebuilder("POST", "/ListDistributionConfigurations", params; aws_config=aws_config)
+list_distribution_configurations(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = imagebuilder("POST", "/ListDistributionConfigurations", params; aws_config=aws_config)
 
 """
     list_image_build_versions(image_version_arn)
@@ -673,7 +673,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   previously truncated response.
 """
 list_image_pipelines(; aws_config::AbstractAWSConfig=global_aws_config()) = imagebuilder("POST", "/ListImagePipelines"; aws_config=aws_config)
-list_image_pipelines(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = imagebuilder("POST", "/ListImagePipelines", params; aws_config=aws_config)
+list_image_pipelines(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = imagebuilder("POST", "/ListImagePipelines", params; aws_config=aws_config)
 
 """
     list_image_recipes()
@@ -693,7 +693,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   recipes that have been shared with you by other customers.
 """
 list_image_recipes(; aws_config::AbstractAWSConfig=global_aws_config()) = imagebuilder("POST", "/ListImageRecipes"; aws_config=aws_config)
-list_image_recipes(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = imagebuilder("POST", "/ListImageRecipes", params; aws_config=aws_config)
+list_image_recipes(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = imagebuilder("POST", "/ListImageRecipes", params; aws_config=aws_config)
 
 """
     list_images()
@@ -715,7 +715,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   other customers.
 """
 list_images(; aws_config::AbstractAWSConfig=global_aws_config()) = imagebuilder("POST", "/ListImages"; aws_config=aws_config)
-list_images(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = imagebuilder("POST", "/ListImages", params; aws_config=aws_config)
+list_images(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = imagebuilder("POST", "/ListImages", params; aws_config=aws_config)
 
 """
     list_infrastructure_configurations()
@@ -731,7 +731,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   previously truncated response.
 """
 list_infrastructure_configurations(; aws_config::AbstractAWSConfig=global_aws_config()) = imagebuilder("POST", "/ListInfrastructureConfigurations"; aws_config=aws_config)
-list_infrastructure_configurations(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = imagebuilder("POST", "/ListInfrastructureConfigurations", params; aws_config=aws_config)
+list_infrastructure_configurations(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = imagebuilder("POST", "/ListInfrastructureConfigurations", params; aws_config=aws_config)
 
 """
     list_tags_for_resource(resource_arn)

--- a/src/services/iot.jl
+++ b/src/services/iot.jl
@@ -37,7 +37,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"thingName"`: The name of the thing to be added to the billing group.
 """
 add_thing_to_billing_group(; aws_config::AbstractAWSConfig=global_aws_config()) = iot("PUT", "/billing-groups/addThingToBillingGroup"; aws_config=aws_config)
-add_thing_to_billing_group(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("PUT", "/billing-groups/addThingToBillingGroup", params; aws_config=aws_config)
+add_thing_to_billing_group(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("PUT", "/billing-groups/addThingToBillingGroup", params; aws_config=aws_config)
 
 """
     add_thing_to_thing_group()
@@ -57,7 +57,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"thingName"`: The name of the thing to add to a group.
 """
 add_thing_to_thing_group(; aws_config::AbstractAWSConfig=global_aws_config()) = iot("PUT", "/thing-groups/addThingToThingGroup"; aws_config=aws_config)
-add_thing_to_thing_group(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("PUT", "/thing-groups/addThingToThingGroup", params; aws_config=aws_config)
+add_thing_to_thing_group(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("PUT", "/thing-groups/addThingToThingGroup", params; aws_config=aws_config)
 
 """
     associate_targets_with_job(job_id, targets)
@@ -271,7 +271,7 @@ Clears the default authorizer.
 
 """
 clear_default_authorizer(; aws_config::AbstractAWSConfig=global_aws_config()) = iot("DELETE", "/default-authorizer"; aws_config=aws_config)
-clear_default_authorizer(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("DELETE", "/default-authorizer", params; aws_config=aws_config)
+clear_default_authorizer(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("DELETE", "/default-authorizer", params; aws_config=aws_config)
 
 """
     confirm_topic_rule_destination(confirmation_token)
@@ -555,7 +555,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"setAsActive"`: Specifies whether the certificate is active.
 """
 create_keys_and_certificate(; aws_config::AbstractAWSConfig=global_aws_config()) = iot("POST", "/keys-and-certificate"; aws_config=aws_config)
-create_keys_and_certificate(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("POST", "/keys-and-certificate", params; aws_config=aws_config)
+create_keys_and_certificate(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("POST", "/keys-and-certificate", params; aws_config=aws_config)
 
 """
     create_mitigation_action(action_name, action_params, role_arn)
@@ -933,7 +933,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"deleteScheduledAudits"`: If true, all scheduled audits are deleted.
 """
 delete_account_audit_configuration(; aws_config::AbstractAWSConfig=global_aws_config()) = iot("DELETE", "/audit/configuration"; aws_config=aws_config)
-delete_account_audit_configuration(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("DELETE", "/audit/configuration", params; aws_config=aws_config)
+delete_account_audit_configuration(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("DELETE", "/audit/configuration", params; aws_config=aws_config)
 
 """
     delete_audit_suppression(check_name, resource_identifier)
@@ -1241,7 +1241,7 @@ Deletes a CA certificate registration code.
 
 """
 delete_registration_code(; aws_config::AbstractAWSConfig=global_aws_config()) = iot("DELETE", "/registrationcode"; aws_config=aws_config)
-delete_registration_code(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("DELETE", "/registrationcode", params; aws_config=aws_config)
+delete_registration_code(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("DELETE", "/registrationcode", params; aws_config=aws_config)
 
 """
     delete_role_alias(role_alias)
@@ -1419,7 +1419,7 @@ include how audit notifications are sent and which audit checks are enabled or d
 
 """
 describe_account_audit_configuration(; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/audit/configuration"; aws_config=aws_config)
-describe_account_audit_configuration(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/audit/configuration", params; aws_config=aws_config)
+describe_account_audit_configuration(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/audit/configuration", params; aws_config=aws_config)
 
 """
     describe_audit_finding(finding_id)
@@ -1553,7 +1553,7 @@ Describes the default authorizer.
 
 """
 describe_default_authorizer(; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/default-authorizer"; aws_config=aws_config)
-describe_default_authorizer(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/default-authorizer", params; aws_config=aws_config)
+describe_default_authorizer(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/default-authorizer", params; aws_config=aws_config)
 
 """
     describe_detect_mitigation_actions_task(task_id)
@@ -1611,7 +1611,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   widespread distrust of Symantec certificate authorities.
 """
 describe_endpoint(; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/endpoint"; aws_config=aws_config)
-describe_endpoint(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/endpoint", params; aws_config=aws_config)
+describe_endpoint(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/endpoint", params; aws_config=aws_config)
 
 """
     describe_event_configurations()
@@ -1621,7 +1621,7 @@ Describes event configurations.
 
 """
 describe_event_configurations(; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/event-configurations"; aws_config=aws_config)
-describe_event_configurations(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/event-configurations", params; aws_config=aws_config)
+describe_event_configurations(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/event-configurations", params; aws_config=aws_config)
 
 """
     describe_index(index_name)
@@ -1916,7 +1916,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"securityProfileName"`:  The name of the security profile.
 """
 get_behavior_model_training_summaries(; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/behavior-model-training/summaries"; aws_config=aws_config)
-get_behavior_model_training_summaries(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/behavior-model-training/summaries", params; aws_config=aws_config)
+get_behavior_model_training_summaries(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/behavior-model-training/summaries", params; aws_config=aws_config)
 
 """
     get_cardinality(query_string)
@@ -1952,7 +1952,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"thingName"`: The thing name.
 """
 get_effective_policies(; aws_config::AbstractAWSConfig=global_aws_config()) = iot("POST", "/effective-policies"; aws_config=aws_config)
-get_effective_policies(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("POST", "/effective-policies", params; aws_config=aws_config)
+get_effective_policies(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("POST", "/effective-policies", params; aws_config=aws_config)
 
 """
     get_indexing_configuration()
@@ -1962,7 +1962,7 @@ Gets the indexing configuration.
 
 """
 get_indexing_configuration(; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/indexing/config"; aws_config=aws_config)
-get_indexing_configuration(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/indexing/config", params; aws_config=aws_config)
+get_indexing_configuration(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/indexing/config", params; aws_config=aws_config)
 
 """
     get_job_document(job_id)
@@ -1986,7 +1986,7 @@ GetV2LoggingOptions instead.
 
 """
 get_logging_options(; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/loggingOptions"; aws_config=aws_config)
-get_logging_options(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/loggingOptions", params; aws_config=aws_config)
+get_logging_options(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/loggingOptions", params; aws_config=aws_config)
 
 """
     get_otaupdate(ota_update_id)
@@ -2062,7 +2062,7 @@ Gets a registration code used to register a CA certificate with AWS IoT.
 
 """
 get_registration_code(; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/registrationcode"; aws_config=aws_config)
-get_registration_code(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/registrationcode", params; aws_config=aws_config)
+get_registration_code(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/registrationcode", params; aws_config=aws_config)
 
 """
     get_statistics(query_string)
@@ -2119,7 +2119,7 @@ Gets the fine grained logging options.
 
 """
 get_v2_logging_options(; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/v2LoggingOptions"; aws_config=aws_config)
-get_v2_logging_options(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/v2LoggingOptions", params; aws_config=aws_config)
+get_v2_logging_options(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/v2LoggingOptions", params; aws_config=aws_config)
 
 """
     list_active_violations()
@@ -2138,7 +2138,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"thingName"`: The name of the thing whose active violations are listed.
 """
 list_active_violations(; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/active-violations"; aws_config=aws_config)
-list_active_violations(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/active-violations", params; aws_config=aws_config)
+list_active_violations(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/active-violations", params; aws_config=aws_config)
 
 """
     list_attached_policies(target)
@@ -2184,7 +2184,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   specify either the taskId or the startTime and endTime, but not both.
 """
 list_audit_findings(; aws_config::AbstractAWSConfig=global_aws_config()) = iot("POST", "/audit/findings"; aws_config=aws_config)
-list_audit_findings(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("POST", "/audit/findings", params; aws_config=aws_config)
+list_audit_findings(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("POST", "/audit/findings", params; aws_config=aws_config)
 
 """
     list_audit_mitigation_actions_executions(finding_id, task_id)
@@ -2249,7 +2249,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"resourceIdentifier"`:
 """
 list_audit_suppressions(; aws_config::AbstractAWSConfig=global_aws_config()) = iot("POST", "/audit/suppressions/list"; aws_config=aws_config)
-list_audit_suppressions(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("POST", "/audit/suppressions/list", params; aws_config=aws_config)
+list_audit_suppressions(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("POST", "/audit/suppressions/list", params; aws_config=aws_config)
 
 """
     list_audit_tasks(end_time, start_time)
@@ -2289,7 +2289,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"status"`: The status of the list authorizers request.
 """
 list_authorizers(; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/authorizers/"; aws_config=aws_config)
-list_authorizers(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/authorizers/", params; aws_config=aws_config)
+list_authorizers(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/authorizers/", params; aws_config=aws_config)
 
 """
     list_billing_groups()
@@ -2306,7 +2306,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   response; otherwise null to receive the first set of results.
 """
 list_billing_groups(; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/billing-groups"; aws_config=aws_config)
-list_billing_groups(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/billing-groups", params; aws_config=aws_config)
+list_billing_groups(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/billing-groups", params; aws_config=aws_config)
 
 """
     list_cacertificates()
@@ -2322,7 +2322,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"pageSize"`: The result page size.
 """
 list_cacertificates(; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/cacertificates"; aws_config=aws_config)
-list_cacertificates(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/cacertificates", params; aws_config=aws_config)
+list_cacertificates(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/cacertificates", params; aws_config=aws_config)
 
 """
     list_certificates()
@@ -2339,7 +2339,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"pageSize"`: The result page size.
 """
 list_certificates(; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/certificates"; aws_config=aws_config)
-list_certificates(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/certificates", params; aws_config=aws_config)
+list_certificates(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/certificates", params; aws_config=aws_config)
 
 """
     list_certificates_by_ca(ca_certificate_id)
@@ -2373,7 +2373,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`:  The token for the next set of results.
 """
 list_custom_metrics(; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/custom-metrics"; aws_config=aws_config)
-list_custom_metrics(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/custom-metrics", params; aws_config=aws_config)
+list_custom_metrics(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/custom-metrics", params; aws_config=aws_config)
 
 """
     list_detect_mitigation_actions_executions()
@@ -2394,7 +2394,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"violationId"`:  The unique identifier of the violation.
 """
 list_detect_mitigation_actions_executions(; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/detect/mitigationactions/executions"; aws_config=aws_config)
-list_detect_mitigation_actions_executions(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/detect/mitigationactions/executions", params; aws_config=aws_config)
+list_detect_mitigation_actions_executions(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/detect/mitigationactions/executions", params; aws_config=aws_config)
 
 """
     list_detect_mitigation_actions_tasks(end_time, start_time)
@@ -2428,7 +2428,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: The token for the next set of results.
 """
 list_dimensions(; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/dimensions"; aws_config=aws_config)
-list_dimensions(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/dimensions", params; aws_config=aws_config)
+list_dimensions(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/dimensions", params; aws_config=aws_config)
 
 """
     list_domain_configurations()
@@ -2445,7 +2445,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"serviceType"`: The type of service delivered by the endpoint.
 """
 list_domain_configurations(; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/domainConfigurations"; aws_config=aws_config)
-list_domain_configurations(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/domainConfigurations", params; aws_config=aws_config)
+list_domain_configurations(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/domainConfigurations", params; aws_config=aws_config)
 
 """
     list_indices()
@@ -2460,7 +2460,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   additional results.
 """
 list_indices(; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/indices"; aws_config=aws_config)
-list_indices(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/indices", params; aws_config=aws_config)
+list_indices(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/indices", params; aws_config=aws_config)
 
 """
     list_job_executions_for_job(job_id)
@@ -2531,7 +2531,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   group.
 """
 list_jobs(; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/jobs"; aws_config=aws_config)
-list_jobs(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/jobs", params; aws_config=aws_config)
+list_jobs(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/jobs", params; aws_config=aws_config)
 
 """
     list_mitigation_actions()
@@ -2547,7 +2547,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: The token for the next set of results.
 """
 list_mitigation_actions(; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/mitigationactions/actions"; aws_config=aws_config)
-list_mitigation_actions(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/mitigationactions/actions", params; aws_config=aws_config)
+list_mitigation_actions(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/mitigationactions/actions", params; aws_config=aws_config)
 
 """
     list_otaupdates()
@@ -2562,7 +2562,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"otaUpdateStatus"`: The OTA update job status.
 """
 list_otaupdates(; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/otaUpdates"; aws_config=aws_config)
-list_otaupdates(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/otaUpdates", params; aws_config=aws_config)
+list_otaupdates(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/otaUpdates", params; aws_config=aws_config)
 
 """
     list_outgoing_certificates()
@@ -2578,7 +2578,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"pageSize"`: The result page size.
 """
 list_outgoing_certificates(; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/certificates-out-going"; aws_config=aws_config)
-list_outgoing_certificates(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/certificates-out-going", params; aws_config=aws_config)
+list_outgoing_certificates(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/certificates-out-going", params; aws_config=aws_config)
 
 """
     list_policies()
@@ -2594,7 +2594,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"pageSize"`: The result page size.
 """
 list_policies(; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/policies"; aws_config=aws_config)
-list_policies(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/policies", params; aws_config=aws_config)
+list_policies(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/policies", params; aws_config=aws_config)
 
 """
     list_policy_principals(x-amzn-iot-policy)
@@ -2701,7 +2701,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: A token to retrieve the next set of results.
 """
 list_provisioning_templates(; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/provisioning-templates"; aws_config=aws_config)
-list_provisioning_templates(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/provisioning-templates", params; aws_config=aws_config)
+list_provisioning_templates(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/provisioning-templates", params; aws_config=aws_config)
 
 """
     list_role_aliases()
@@ -2716,7 +2716,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"pageSize"`: The maximum number of results to return at one time.
 """
 list_role_aliases(; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/role-aliases"; aws_config=aws_config)
-list_role_aliases(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/role-aliases", params; aws_config=aws_config)
+list_role_aliases(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/role-aliases", params; aws_config=aws_config)
 
 """
     list_scheduled_audits()
@@ -2730,7 +2730,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: The token for the next set of results.
 """
 list_scheduled_audits(; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/audit/scheduledaudits"; aws_config=aws_config)
-list_scheduled_audits(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/audit/scheduledaudits", params; aws_config=aws_config)
+list_scheduled_audits(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/audit/scheduledaudits", params; aws_config=aws_config)
 
 """
     list_security_profiles()
@@ -2749,7 +2749,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: The token for the next set of results.
 """
 list_security_profiles(; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/security-profiles"; aws_config=aws_config)
-list_security_profiles(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/security-profiles", params; aws_config=aws_config)
+list_security_profiles(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/security-profiles", params; aws_config=aws_config)
 
 """
     list_security_profiles_for_target(security_profile_target_arn)
@@ -2783,7 +2783,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: A token used to get the next set of results.
 """
 list_streams(; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/streams"; aws_config=aws_config)
-list_streams(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/streams", params; aws_config=aws_config)
+list_streams(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/streams", params; aws_config=aws_config)
 
 """
     list_tags_for_resource(resource_arn)
@@ -2854,7 +2854,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"recursive"`: If true, return child groups as well.
 """
 list_thing_groups(; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/thing-groups"; aws_config=aws_config)
-list_thing_groups(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/thing-groups", params; aws_config=aws_config)
+list_thing_groups(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/thing-groups", params; aws_config=aws_config)
 
 """
     list_thing_groups_for_thing(thing_name)
@@ -2927,7 +2927,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"status"`: The status of the bulk thing provisioning task.
 """
 list_thing_registration_tasks(; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/thing-registration-tasks"; aws_config=aws_config)
-list_thing_registration_tasks(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/thing-registration-tasks", params; aws_config=aws_config)
+list_thing_registration_tasks(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/thing-registration-tasks", params; aws_config=aws_config)
 
 """
     list_thing_types()
@@ -2943,7 +2943,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"thingTypeName"`: The name of the thing type.
 """
 list_thing_types(; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/thing-types"; aws_config=aws_config)
-list_thing_types(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/thing-types", params; aws_config=aws_config)
+list_thing_types(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/thing-types", params; aws_config=aws_config)
 
 """
     list_things()
@@ -2970,7 +2970,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   attributeValue provided.
 """
 list_things(; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/things"; aws_config=aws_config)
-list_things(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/things", params; aws_config=aws_config)
+list_things(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/things", params; aws_config=aws_config)
 
 """
     list_things_in_billing_group(billing_group_name)
@@ -3022,7 +3022,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   response; otherwise null to receive the first set of results.
 """
 list_topic_rule_destinations(; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/destinations"; aws_config=aws_config)
-list_topic_rule_destinations(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/destinations", params; aws_config=aws_config)
+list_topic_rule_destinations(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/destinations", params; aws_config=aws_config)
 
 """
     list_topic_rules()
@@ -3039,7 +3039,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"topic"`: The topic.
 """
 list_topic_rules(; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/rules"; aws_config=aws_config)
-list_topic_rules(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/rules", params; aws_config=aws_config)
+list_topic_rules(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/rules", params; aws_config=aws_config)
 
 """
     list_v2_logging_levels()
@@ -3056,7 +3056,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   THING_Group.
 """
 list_v2_logging_levels(; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/v2LoggingLevel"; aws_config=aws_config)
-list_v2_logging_levels(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/v2LoggingLevel", params; aws_config=aws_config)
+list_v2_logging_levels(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("GET", "/v2LoggingLevel", params; aws_config=aws_config)
 
 """
     list_violation_events(end_time, start_time)
@@ -3205,7 +3205,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"thingName"`: The name of the thing to be removed from the billing group.
 """
 remove_thing_from_billing_group(; aws_config::AbstractAWSConfig=global_aws_config()) = iot("PUT", "/billing-groups/removeThingFromBillingGroup"; aws_config=aws_config)
-remove_thing_from_billing_group(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("PUT", "/billing-groups/removeThingFromBillingGroup", params; aws_config=aws_config)
+remove_thing_from_billing_group(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("PUT", "/billing-groups/removeThingFromBillingGroup", params; aws_config=aws_config)
 
 """
     remove_thing_from_thing_group()
@@ -3223,7 +3223,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"thingName"`: The name of the thing to remove from the group.
 """
 remove_thing_from_thing_group(; aws_config::AbstractAWSConfig=global_aws_config()) = iot("PUT", "/thing-groups/removeThingFromThingGroup"; aws_config=aws_config)
-remove_thing_from_thing_group(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("PUT", "/thing-groups/removeThingFromThingGroup", params; aws_config=aws_config)
+remove_thing_from_thing_group(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("PUT", "/thing-groups/removeThingFromThingGroup", params; aws_config=aws_config)
 
 """
     replace_topic_rule(rule_name, topic_rule_payload)
@@ -3332,7 +3332,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"roleArn"`: The ARN of the role that allows IoT to write to Cloudwatch logs.
 """
 set_v2_logging_options(; aws_config::AbstractAWSConfig=global_aws_config()) = iot("POST", "/v2LoggingOptions"; aws_config=aws_config)
-set_v2_logging_options(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("POST", "/v2LoggingOptions", params; aws_config=aws_config)
+set_v2_logging_options(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("POST", "/v2LoggingOptions", params; aws_config=aws_config)
 
 """
     start_audit_mitigation_actions_task(audit_check_to_actions_mapping, client_request_token, target, task_id)
@@ -3555,7 +3555,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   required when performing an audit.
 """
 update_account_audit_configuration(; aws_config::AbstractAWSConfig=global_aws_config()) = iot("PATCH", "/audit/configuration"; aws_config=aws_config)
-update_account_audit_configuration(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("PATCH", "/audit/configuration", params; aws_config=aws_config)
+update_account_audit_configuration(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("PATCH", "/audit/configuration", params; aws_config=aws_config)
 
 """
     update_audit_suppression(check_name, resource_identifier)
@@ -3749,7 +3749,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"eventConfigurations"`: The new event configuration values.
 """
 update_event_configurations(; aws_config::AbstractAWSConfig=global_aws_config()) = iot("PATCH", "/event-configurations"; aws_config=aws_config)
-update_event_configurations(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("PATCH", "/event-configurations", params; aws_config=aws_config)
+update_event_configurations(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("PATCH", "/event-configurations", params; aws_config=aws_config)
 
 """
     update_indexing_configuration()
@@ -3763,7 +3763,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"thingIndexingConfiguration"`: Thing indexing configuration.
 """
 update_indexing_configuration(; aws_config::AbstractAWSConfig=global_aws_config()) = iot("POST", "/indexing/config"; aws_config=aws_config)
-update_indexing_configuration(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("POST", "/indexing/config", params; aws_config=aws_config)
+update_indexing_configuration(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("POST", "/indexing/config", params; aws_config=aws_config)
 
 """
     update_job(job_id)
@@ -3997,7 +3997,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"thingName"`: The thing whose group memberships will be updated.
 """
 update_thing_groups_for_thing(; aws_config::AbstractAWSConfig=global_aws_config()) = iot("PUT", "/thing-groups/updateThingGroupsForThing"; aws_config=aws_config)
-update_thing_groups_for_thing(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("PUT", "/thing-groups/updateThingGroupsForThing", params; aws_config=aws_config)
+update_thing_groups_for_thing(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot("PUT", "/thing-groups/updateThingGroupsForThing", params; aws_config=aws_config)
 
 """
     update_topic_rule_destination(arn, status)

--- a/src/services/iot_1click_devices_service.jl
+++ b/src/services/iot_1click_devices_service.jl
@@ -151,7 +151,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: The token to retrieve the next set of results.
 """
 list_devices(; aws_config::AbstractAWSConfig=global_aws_config()) = iot_1click_devices_service("GET", "/devices"; aws_config=aws_config)
-list_devices(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot_1click_devices_service("GET", "/devices", params; aws_config=aws_config)
+list_devices(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot_1click_devices_service("GET", "/devices", params; aws_config=aws_config)
 
 """
     list_tags_for_resource(resource-arn)

--- a/src/services/iot_1click_projects.jl
+++ b/src/services/iot_1click_projects.jl
@@ -180,7 +180,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: The token to retrieve the next set of results.
 """
 list_projects(; aws_config::AbstractAWSConfig=global_aws_config()) = iot_1click_projects("GET", "/projects"; aws_config=aws_config)
-list_projects(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot_1click_projects("GET", "/projects", params; aws_config=aws_config)
+list_projects(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot_1click_projects("GET", "/projects", params; aws_config=aws_config)
 
 """
     list_tags_for_resource(resource_arn)

--- a/src/services/iot_events.jl
+++ b/src/services/iot_events.jl
@@ -126,7 +126,7 @@ Retrieves the current settings of the AWS IoT Events logging options.
 
 """
 describe_logging_options(; aws_config::AbstractAWSConfig=global_aws_config()) = iot_events("GET", "/logging"; aws_config=aws_config)
-describe_logging_options(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot_events("GET", "/logging", params; aws_config=aws_config)
+describe_logging_options(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot_events("GET", "/logging", params; aws_config=aws_config)
 
 """
     get_detector_model_analysis_results(analysis_id)
@@ -176,7 +176,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: The token that you can use to return the next set of results.
 """
 list_detector_models(; aws_config::AbstractAWSConfig=global_aws_config()) = iot_events("GET", "/detector-models"; aws_config=aws_config)
-list_detector_models(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot_events("GET", "/detector-models", params; aws_config=aws_config)
+list_detector_models(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot_events("GET", "/detector-models", params; aws_config=aws_config)
 
 """
     list_inputs()
@@ -190,7 +190,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: The token that you can use to return the next set of results.
 """
 list_inputs(; aws_config::AbstractAWSConfig=global_aws_config()) = iot_events("GET", "/inputs"; aws_config=aws_config)
-list_inputs(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot_events("GET", "/inputs", params; aws_config=aws_config)
+list_inputs(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot_events("GET", "/inputs", params; aws_config=aws_config)
 
 """
     list_tags_for_resource(resource_arn)

--- a/src/services/iot_wireless.jl
+++ b/src/services/iot_wireless.jl
@@ -420,7 +420,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Server endpoint.
 """
 get_service_endpoint(; aws_config::AbstractAWSConfig=global_aws_config()) = iot_wireless("GET", "/service-endpoint"; aws_config=aws_config)
-get_service_endpoint(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot_wireless("GET", "/service-endpoint", params; aws_config=aws_config)
+get_service_endpoint(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot_wireless("GET", "/service-endpoint", params; aws_config=aws_config)
 
 """
     get_service_profile(id)
@@ -554,7 +554,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   response; otherwise null to receive the first set of results.
 """
 list_destinations(; aws_config::AbstractAWSConfig=global_aws_config()) = iot_wireless("GET", "/destinations"; aws_config=aws_config)
-list_destinations(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot_wireless("GET", "/destinations", params; aws_config=aws_config)
+list_destinations(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot_wireless("GET", "/destinations", params; aws_config=aws_config)
 
 """
     list_device_profiles()
@@ -569,7 +569,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   response; otherwise null to receive the first set of results.
 """
 list_device_profiles(; aws_config::AbstractAWSConfig=global_aws_config()) = iot_wireless("GET", "/device-profiles"; aws_config=aws_config)
-list_device_profiles(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot_wireless("GET", "/device-profiles", params; aws_config=aws_config)
+list_device_profiles(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot_wireless("GET", "/device-profiles", params; aws_config=aws_config)
 
 """
     list_partner_accounts()
@@ -584,7 +584,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   response; otherwise null to receive the first set of results.
 """
 list_partner_accounts(; aws_config::AbstractAWSConfig=global_aws_config()) = iot_wireless("GET", "/partner-accounts"; aws_config=aws_config)
-list_partner_accounts(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot_wireless("GET", "/partner-accounts", params; aws_config=aws_config)
+list_partner_accounts(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot_wireless("GET", "/partner-accounts", params; aws_config=aws_config)
 
 """
     list_service_profiles()
@@ -599,7 +599,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   response; otherwise null to receive the first set of results.
 """
 list_service_profiles(; aws_config::AbstractAWSConfig=global_aws_config()) = iot_wireless("GET", "/service-profiles"; aws_config=aws_config)
-list_service_profiles(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot_wireless("GET", "/service-profiles", params; aws_config=aws_config)
+list_service_profiles(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot_wireless("GET", "/service-profiles", params; aws_config=aws_config)
 
 """
     list_tags_for_resource(resource_arn)
@@ -634,7 +634,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   device type.
 """
 list_wireless_devices(; aws_config::AbstractAWSConfig=global_aws_config()) = iot_wireless("GET", "/wireless-devices"; aws_config=aws_config)
-list_wireless_devices(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot_wireless("GET", "/wireless-devices", params; aws_config=aws_config)
+list_wireless_devices(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot_wireless("GET", "/wireless-devices", params; aws_config=aws_config)
 
 """
     list_wireless_gateway_task_definitions()
@@ -651,7 +651,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   use this task definition type.
 """
 list_wireless_gateway_task_definitions(; aws_config::AbstractAWSConfig=global_aws_config()) = iot_wireless("GET", "/wireless-gateway-task-definitions"; aws_config=aws_config)
-list_wireless_gateway_task_definitions(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot_wireless("GET", "/wireless-gateway-task-definitions", params; aws_config=aws_config)
+list_wireless_gateway_task_definitions(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot_wireless("GET", "/wireless-gateway-task-definitions", params; aws_config=aws_config)
 
 """
     list_wireless_gateways()
@@ -666,7 +666,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   response; otherwise null to receive the first set of results.
 """
 list_wireless_gateways(; aws_config::AbstractAWSConfig=global_aws_config()) = iot_wireless("GET", "/wireless-gateways"; aws_config=aws_config)
-list_wireless_gateways(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot_wireless("GET", "/wireless-gateways", params; aws_config=aws_config)
+list_wireless_gateways(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iot_wireless("GET", "/wireless-gateways", params; aws_config=aws_config)
 
 """
     send_data_to_wireless_device(id, payload_data, transmit_mode)

--- a/src/services/iotanalytics.jl
+++ b/src/services/iotanalytics.jl
@@ -298,7 +298,7 @@ Retrieves the current settings of the AWS IoT Analytics logging options.
 
 """
 describe_logging_options(; aws_config::AbstractAWSConfig=global_aws_config()) = iotanalytics("GET", "/logging"; aws_config=aws_config)
-describe_logging_options(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iotanalytics("GET", "/logging", params; aws_config=aws_config)
+describe_logging_options(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iotanalytics("GET", "/logging", params; aws_config=aws_config)
 
 """
     describe_pipeline(pipeline_name)
@@ -345,7 +345,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: The token for the next set of results.
 """
 list_channels(; aws_config::AbstractAWSConfig=global_aws_config()) = iotanalytics("GET", "/channels"; aws_config=aws_config)
-list_channels(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iotanalytics("GET", "/channels", params; aws_config=aws_config)
+list_channels(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iotanalytics("GET", "/channels", params; aws_config=aws_config)
 
 """
     list_dataset_contents(dataset_name)
@@ -383,7 +383,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: The token for the next set of results.
 """
 list_datasets(; aws_config::AbstractAWSConfig=global_aws_config()) = iotanalytics("GET", "/datasets"; aws_config=aws_config)
-list_datasets(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iotanalytics("GET", "/datasets", params; aws_config=aws_config)
+list_datasets(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iotanalytics("GET", "/datasets", params; aws_config=aws_config)
 
 """
     list_datastores()
@@ -398,7 +398,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: The token for the next set of results.
 """
 list_datastores(; aws_config::AbstractAWSConfig=global_aws_config()) = iotanalytics("GET", "/datastores"; aws_config=aws_config)
-list_datastores(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iotanalytics("GET", "/datastores", params; aws_config=aws_config)
+list_datastores(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iotanalytics("GET", "/datastores", params; aws_config=aws_config)
 
 """
     list_pipelines()
@@ -413,7 +413,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: The token for the next set of results.
 """
 list_pipelines(; aws_config::AbstractAWSConfig=global_aws_config()) = iotanalytics("GET", "/pipelines"; aws_config=aws_config)
-list_pipelines(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iotanalytics("GET", "/pipelines", params; aws_config=aws_config)
+list_pipelines(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iotanalytics("GET", "/pipelines", params; aws_config=aws_config)
 
 """
     list_tags_for_resource(resource_arn)

--- a/src/services/iotdeviceadvisor.jl
+++ b/src/services/iotdeviceadvisor.jl
@@ -17,7 +17,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"tags"`: The tags to be attached to the suite definition.
 """
 create_suite_definition(; aws_config::AbstractAWSConfig=global_aws_config()) = iotdeviceadvisor("POST", "/suiteDefinitions"; aws_config=aws_config)
-create_suite_definition(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iotdeviceadvisor("POST", "/suiteDefinitions", params; aws_config=aws_config)
+create_suite_definition(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iotdeviceadvisor("POST", "/suiteDefinitions", params; aws_config=aws_config)
 
 """
     delete_suite_definition(suite_definition_id)
@@ -90,7 +90,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: Requests the Device Advisor test suites next token.
 """
 list_suite_definitions(; aws_config::AbstractAWSConfig=global_aws_config()) = iotdeviceadvisor("GET", "/suiteDefinitions"; aws_config=aws_config)
-list_suite_definitions(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iotdeviceadvisor("GET", "/suiteDefinitions", params; aws_config=aws_config)
+list_suite_definitions(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iotdeviceadvisor("GET", "/suiteDefinitions", params; aws_config=aws_config)
 
 """
     list_suite_runs()
@@ -109,7 +109,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   based on suite definition version.
 """
 list_suite_runs(; aws_config::AbstractAWSConfig=global_aws_config()) = iotdeviceadvisor("GET", "/suiteRuns"; aws_config=aws_config)
-list_suite_runs(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iotdeviceadvisor("GET", "/suiteRuns", params; aws_config=aws_config)
+list_suite_runs(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iotdeviceadvisor("GET", "/suiteRuns", params; aws_config=aws_config)
 
 """
     list_tags_for_resource(resource_arn)
@@ -137,7 +137,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: Requests the test cases next token.
 """
 list_test_cases(; aws_config::AbstractAWSConfig=global_aws_config()) = iotdeviceadvisor("GET", "/testCases"; aws_config=aws_config)
-list_test_cases(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iotdeviceadvisor("GET", "/testCases", params; aws_config=aws_config)
+list_test_cases(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iotdeviceadvisor("GET", "/testCases", params; aws_config=aws_config)
 
 """
     start_suite_run(suite_definition_id)

--- a/src/services/iotfleethub.jl
+++ b/src/services/iotfleethub.jl
@@ -74,7 +74,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: A token used to get the next set of results.
 """
 list_applications(; aws_config::AbstractAWSConfig=global_aws_config()) = iotfleethub("GET", "/applications"; aws_config=aws_config)
-list_applications(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iotfleethub("GET", "/applications", params; aws_config=aws_config)
+list_applications(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iotfleethub("GET", "/applications", params; aws_config=aws_config)
 
 """
     list_tags_for_resource(resource_arn)

--- a/src/services/iotsitewise.jl
+++ b/src/services/iotsitewise.jl
@@ -497,7 +497,7 @@ SiteWise User Guide.
 
 """
 describe_default_encryption_configuration(; aws_config::AbstractAWSConfig=global_aws_config()) = iotsitewise("GET", "/configuration/account/encryption"; aws_config=aws_config)
-describe_default_encryption_configuration(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iotsitewise("GET", "/configuration/account/encryption", params; aws_config=aws_config)
+describe_default_encryption_configuration(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iotsitewise("GET", "/configuration/account/encryption", params; aws_config=aws_config)
 
 """
     describe_gateway(gateway_id)
@@ -541,7 +541,7 @@ Retrieves the current AWS IoT SiteWise logging options.
 
 """
 describe_logging_options(; aws_config::AbstractAWSConfig=global_aws_config()) = iotsitewise("GET", "/logging"; aws_config=aws_config)
-describe_logging_options(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iotsitewise("GET", "/logging", params; aws_config=aws_config)
+describe_logging_options(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iotsitewise("GET", "/logging", params; aws_config=aws_config)
 
 """
     describe_portal(portal_id)
@@ -649,7 +649,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"propertyId"`: The ID of the asset property.
 """
 get_asset_property_value(; aws_config::AbstractAWSConfig=global_aws_config()) = iotsitewise("GET", "/properties/latest"; aws_config=aws_config)
-get_asset_property_value(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iotsitewise("GET", "/properties/latest", params; aws_config=aws_config)
+get_asset_property_value(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iotsitewise("GET", "/properties/latest", params; aws_config=aws_config)
 
 """
     get_asset_property_value_history()
@@ -682,7 +682,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   ASCENDING
 """
 get_asset_property_value_history(; aws_config::AbstractAWSConfig=global_aws_config()) = iotsitewise("GET", "/properties/history"; aws_config=aws_config)
-get_asset_property_value_history(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iotsitewise("GET", "/properties/history", params; aws_config=aws_config)
+get_asset_property_value_history(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iotsitewise("GET", "/properties/history", params; aws_config=aws_config)
 
 """
     list_access_policies()
@@ -708,7 +708,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   you specify resourceId.
 """
 list_access_policies(; aws_config::AbstractAWSConfig=global_aws_config()) = iotsitewise("GET", "/access-policies"; aws_config=aws_config)
-list_access_policies(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iotsitewise("GET", "/access-policies", params; aws_config=aws_config)
+list_access_policies(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iotsitewise("GET", "/access-policies", params; aws_config=aws_config)
 
 """
     list_asset_models()
@@ -723,7 +723,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: The token to be used for the next set of paginated results.
 """
 list_asset_models(; aws_config::AbstractAWSConfig=global_aws_config()) = iotsitewise("GET", "/asset-models"; aws_config=aws_config)
-list_asset_models(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iotsitewise("GET", "/asset-models", params; aws_config=aws_config)
+list_asset_models(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iotsitewise("GET", "/asset-models", params; aws_config=aws_config)
 
 """
     list_asset_relationships(asset_id, traversal_type)
@@ -770,7 +770,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: The token to be used for the next set of paginated results.
 """
 list_assets(; aws_config::AbstractAWSConfig=global_aws_config()) = iotsitewise("GET", "/assets"; aws_config=aws_config)
-list_assets(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iotsitewise("GET", "/assets", params; aws_config=aws_config)
+list_assets(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iotsitewise("GET", "/assets", params; aws_config=aws_config)
 
 """
     list_associated_assets(asset_id)
@@ -831,7 +831,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: The token to be used for the next set of paginated results.
 """
 list_gateways(; aws_config::AbstractAWSConfig=global_aws_config()) = iotsitewise("GET", "/20200301/gateways"; aws_config=aws_config)
-list_gateways(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iotsitewise("GET", "/20200301/gateways", params; aws_config=aws_config)
+list_gateways(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iotsitewise("GET", "/20200301/gateways", params; aws_config=aws_config)
 
 """
     list_portals()
@@ -846,7 +846,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: The token to be used for the next set of paginated results.
 """
 list_portals(; aws_config::AbstractAWSConfig=global_aws_config()) = iotsitewise("GET", "/portals"; aws_config=aws_config)
-list_portals(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iotsitewise("GET", "/portals", params; aws_config=aws_config)
+list_portals(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = iotsitewise("GET", "/portals", params; aws_config=aws_config)
 
 """
     list_project_assets(project_id)

--- a/src/services/ivs.jl
+++ b/src/services/ivs.jl
@@ -57,7 +57,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   and bitrate can be up to 1.5 Mbps.
 """
 create_channel(; aws_config::AbstractAWSConfig=global_aws_config()) = ivs("POST", "/CreateChannel"; aws_config=aws_config)
-create_channel(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = ivs("POST", "/CreateChannel", params; aws_config=aws_config)
+create_channel(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = ivs("POST", "/CreateChannel", params; aws_config=aws_config)
 
 """
     create_recording_configuration(destination_configuration)
@@ -275,7 +275,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   nextToken response field.
 """
 list_channels(; aws_config::AbstractAWSConfig=global_aws_config()) = ivs("POST", "/ListChannels"; aws_config=aws_config)
-list_channels(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = ivs("POST", "/ListChannels", params; aws_config=aws_config)
+list_channels(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = ivs("POST", "/ListChannels", params; aws_config=aws_config)
 
 """
     list_playback_key_pairs()
@@ -291,7 +291,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: Maximum number of key pairs to return.
 """
 list_playback_key_pairs(; aws_config::AbstractAWSConfig=global_aws_config()) = ivs("POST", "/ListPlaybackKeyPairs"; aws_config=aws_config)
-list_playback_key_pairs(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = ivs("POST", "/ListPlaybackKeyPairs", params; aws_config=aws_config)
+list_playback_key_pairs(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = ivs("POST", "/ListPlaybackKeyPairs", params; aws_config=aws_config)
 
 """
     list_recording_configurations()
@@ -307,7 +307,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   pagination; see the nextToken response field.
 """
 list_recording_configurations(; aws_config::AbstractAWSConfig=global_aws_config()) = ivs("POST", "/ListRecordingConfigurations"; aws_config=aws_config)
-list_recording_configurations(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = ivs("POST", "/ListRecordingConfigurations", params; aws_config=aws_config)
+list_recording_configurations(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = ivs("POST", "/ListRecordingConfigurations", params; aws_config=aws_config)
 
 """
     list_stream_keys(channel_arn)
@@ -341,7 +341,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   nextToken response field.
 """
 list_streams(; aws_config::AbstractAWSConfig=global_aws_config()) = ivs("POST", "/ListStreams"; aws_config=aws_config)
-list_streams(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = ivs("POST", "/ListStreams", params; aws_config=aws_config)
+list_streams(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = ivs("POST", "/ListStreams", params; aws_config=aws_config)
 
 """
     list_tags_for_resource(resource_arn)

--- a/src/services/kafka.jl
+++ b/src/services/kafka.jl
@@ -246,7 +246,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   
 """
 get_compatible_kafka_versions(; aws_config::AbstractAWSConfig=global_aws_config()) = kafka("GET", "/v1/compatible-kafka-versions"; aws_config=aws_config)
-get_compatible_kafka_versions(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = kafka("GET", "/v1/compatible-kafka-versions", params; aws_config=aws_config)
+get_compatible_kafka_versions(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = kafka("GET", "/v1/compatible-kafka-versions", params; aws_config=aws_config)
 
 """
     list_cluster_operations(cluster_arn)
@@ -298,7 +298,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   next batch, provide this token in your next request.
 """
 list_clusters(; aws_config::AbstractAWSConfig=global_aws_config()) = kafka("GET", "/v1/clusters"; aws_config=aws_config)
-list_clusters(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = kafka("GET", "/v1/clusters", params; aws_config=aws_config)
+list_clusters(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = kafka("GET", "/v1/clusters", params; aws_config=aws_config)
 
 """
     list_configuration_revisions(arn)
@@ -345,7 +345,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   next batch, provide this token in your next request.
 """
 list_configurations(; aws_config::AbstractAWSConfig=global_aws_config()) = kafka("GET", "/v1/configurations"; aws_config=aws_config)
-list_configurations(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = kafka("GET", "/v1/configurations", params; aws_config=aws_config)
+list_configurations(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = kafka("GET", "/v1/configurations", params; aws_config=aws_config)
 
 """
     list_kafka_versions()
@@ -365,7 +365,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   provide this token in your next request.
 """
 list_kafka_versions(; aws_config::AbstractAWSConfig=global_aws_config()) = kafka("GET", "/v1/kafka-versions"; aws_config=aws_config)
-list_kafka_versions(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = kafka("GET", "/v1/kafka-versions", params; aws_config=aws_config)
+list_kafka_versions(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = kafka("GET", "/v1/kafka-versions", params; aws_config=aws_config)
 
 """
     list_nodes(cluster_arn)

--- a/src/services/kinesis_video.jl
+++ b/src/services/kinesis_video.jl
@@ -122,7 +122,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"ChannelName"`: The name of the signaling channel that you want to describe.
 """
 describe_signaling_channel(; aws_config::AbstractAWSConfig=global_aws_config()) = kinesis_video("POST", "/describeSignalingChannel"; aws_config=aws_config)
-describe_signaling_channel(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = kinesis_video("POST", "/describeSignalingChannel", params; aws_config=aws_config)
+describe_signaling_channel(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = kinesis_video("POST", "/describeSignalingChannel", params; aws_config=aws_config)
 
 """
     describe_stream()
@@ -137,7 +137,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"StreamName"`: The name of the stream.
 """
 describe_stream(; aws_config::AbstractAWSConfig=global_aws_config()) = kinesis_video("POST", "/describeStream"; aws_config=aws_config)
-describe_stream(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = kinesis_video("POST", "/describeStream", params; aws_config=aws_config)
+describe_stream(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = kinesis_video("POST", "/describeStream", params; aws_config=aws_config)
 
 """
     get_data_endpoint(apiname)
@@ -208,7 +208,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   batch of channels, provide this token in your next request.
 """
 list_signaling_channels(; aws_config::AbstractAWSConfig=global_aws_config()) = kinesis_video("POST", "/listSignalingChannels"; aws_config=aws_config)
-list_signaling_channels(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = kinesis_video("POST", "/listSignalingChannels", params; aws_config=aws_config)
+list_signaling_channels(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = kinesis_video("POST", "/listSignalingChannels", params; aws_config=aws_config)
 
 """
     list_streams()
@@ -228,7 +228,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   condition. Currently, you can specify only the prefix of a stream name as a condition.
 """
 list_streams(; aws_config::AbstractAWSConfig=global_aws_config()) = kinesis_video("POST", "/listStreams"; aws_config=aws_config)
-list_streams(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = kinesis_video("POST", "/listStreams", params; aws_config=aws_config)
+list_streams(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = kinesis_video("POST", "/listStreams", params; aws_config=aws_config)
 
 """
     list_tags_for_resource(resource_arn)
@@ -266,7 +266,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"StreamName"`: The name of the stream that you want to list tags for.
 """
 list_tags_for_stream(; aws_config::AbstractAWSConfig=global_aws_config()) = kinesis_video("POST", "/listTagsForStream"; aws_config=aws_config)
-list_tags_for_stream(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = kinesis_video("POST", "/listTagsForStream", params; aws_config=aws_config)
+list_tags_for_stream(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = kinesis_video("POST", "/listTagsForStream", params; aws_config=aws_config)
 
 """
     tag_resource(resource_arn, tags)

--- a/src/services/kinesis_video_archived_media.jl
+++ b/src/services/kinesis_video_archived_media.jl
@@ -189,7 +189,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   You must specify either the StreamName or the StreamARN.
 """
 get_dashstreaming_session_url(; aws_config::AbstractAWSConfig=global_aws_config()) = kinesis_video_archived_media("POST", "/getDASHStreamingSessionURL"; aws_config=aws_config)
-get_dashstreaming_session_url(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = kinesis_video_archived_media("POST", "/getDASHStreamingSessionURL", params; aws_config=aws_config)
+get_dashstreaming_session_url(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = kinesis_video_archived_media("POST", "/getDASHStreamingSessionURL", params; aws_config=aws_config)
 
 """
     get_hlsstreaming_session_url()
@@ -372,7 +372,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   You must specify either the StreamName or the StreamARN.
 """
 get_hlsstreaming_session_url(; aws_config::AbstractAWSConfig=global_aws_config()) = kinesis_video_archived_media("POST", "/getHLSStreamingSessionURL"; aws_config=aws_config)
-get_hlsstreaming_session_url(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = kinesis_video_archived_media("POST", "/getHLSStreamingSessionURL", params; aws_config=aws_config)
+get_hlsstreaming_session_url(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = kinesis_video_archived_media("POST", "/getHLSStreamingSessionURL", params; aws_config=aws_config)
 
 """
     get_media_for_fragment_list(fragments)
@@ -444,4 +444,4 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   either this parameter or the StreamARN parameter.
 """
 list_fragments(; aws_config::AbstractAWSConfig=global_aws_config()) = kinesis_video_archived_media("POST", "/listFragments"; aws_config=aws_config)
-list_fragments(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = kinesis_video_archived_media("POST", "/listFragments", params; aws_config=aws_config)
+list_fragments(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = kinesis_video_archived_media("POST", "/listFragments", params; aws_config=aws_config)

--- a/src/services/lambda.jl
+++ b/src/services/lambda.jl
@@ -452,7 +452,7 @@ Retrieves details about your account's limits and usage in an AWS Region.
 
 """
 get_account_settings(; aws_config::AbstractAWSConfig=global_aws_config()) = lambda("GET", "/2016-08-19/account-settings/"; aws_config=aws_config)
-get_account_settings(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = lambda("GET", "/2016-08-19/account-settings/", params; aws_config=aws_config)
+get_account_settings(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = lambda("GET", "/2016-08-19/account-settings/", params; aws_config=aws_config)
 
 """
     get_alias(function_name, name)
@@ -797,7 +797,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"MaxItems"`: Maximum number of items to return.
 """
 list_code_signing_configs(; aws_config::AbstractAWSConfig=global_aws_config()) = lambda("GET", "/2020-04-22/code-signing-configs/"; aws_config=aws_config)
-list_code_signing_configs(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = lambda("GET", "/2020-04-22/code-signing-configs/", params; aws_config=aws_config)
+list_code_signing_configs(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = lambda("GET", "/2020-04-22/code-signing-configs/", params; aws_config=aws_config)
 
 """
     list_event_source_mappings()
@@ -821,7 +821,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"MaxItems"`: The maximum number of event source mappings to return.
 """
 list_event_source_mappings(; aws_config::AbstractAWSConfig=global_aws_config()) = lambda("GET", "/2015-03-31/event-source-mappings/"; aws_config=aws_config)
-list_event_source_mappings(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = lambda("GET", "/2015-03-31/event-source-mappings/", params; aws_config=aws_config)
+list_event_source_mappings(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = lambda("GET", "/2015-03-31/event-source-mappings/", params; aws_config=aws_config)
 
 """
     list_function_event_invoke_configs(function_name)
@@ -872,7 +872,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   higher.
 """
 list_functions(; aws_config::AbstractAWSConfig=global_aws_config()) = lambda("GET", "/2015-03-31/functions/"; aws_config=aws_config)
-list_functions(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = lambda("GET", "/2015-03-31/functions/", params; aws_config=aws_config)
+list_functions(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = lambda("GET", "/2015-03-31/functions/", params; aws_config=aws_config)
 
 """
     list_functions_by_code_signing_config(code_signing_config_arn)
@@ -930,7 +930,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"MaxItems"`: The maximum number of layers to return.
 """
 list_layers(; aws_config::AbstractAWSConfig=global_aws_config()) = lambda("GET", "/2018-10-31/layers"; aws_config=aws_config)
-list_layers(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = lambda("GET", "/2018-10-31/layers", params; aws_config=aws_config)
+list_layers(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = lambda("GET", "/2018-10-31/layers", params; aws_config=aws_config)
 
 """
     list_provisioned_concurrency_configs(function_name)

--- a/src/services/lex_model_building_service.jl
+++ b/src/services/lex_model_building_service.jl
@@ -406,7 +406,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   next page of bots, specify the pagination token in the next request.
 """
 get_bots(; aws_config::AbstractAWSConfig=global_aws_config()) = lex_model_building_service("GET", "/bots/"; aws_config=aws_config)
-get_bots(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = lex_model_building_service("GET", "/bots/", params; aws_config=aws_config)
+get_bots(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = lex_model_building_service("GET", "/bots/", params; aws_config=aws_config)
 
 """
     get_builtin_intent(signature)
@@ -444,7 +444,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Built-in Intents in the Alexa Skills Kit.
 """
 get_builtin_intents(; aws_config::AbstractAWSConfig=global_aws_config()) = lex_model_building_service("GET", "/builtins/intents/"; aws_config=aws_config)
-get_builtin_intents(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = lex_model_building_service("GET", "/builtins/intents/", params; aws_config=aws_config)
+get_builtin_intents(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = lex_model_building_service("GET", "/builtins/intents/", params; aws_config=aws_config)
 
 """
     get_builtin_slot_types()
@@ -468,7 +468,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   matches both \"xyzabc\" and \"abcxyz.\"
 """
 get_builtin_slot_types(; aws_config::AbstractAWSConfig=global_aws_config()) = lex_model_building_service("GET", "/builtins/slottypes/"; aws_config=aws_config)
-get_builtin_slot_types(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = lex_model_building_service("GET", "/builtins/slottypes/", params; aws_config=aws_config)
+get_builtin_slot_types(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = lex_model_building_service("GET", "/builtins/slottypes/", params; aws_config=aws_config)
 
 """
     get_export(export_type, name, resource_type, version)
@@ -560,7 +560,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   fetch the next page of intents, specify the pagination token in the next request.
 """
 get_intents(; aws_config::AbstractAWSConfig=global_aws_config()) = lex_model_building_service("GET", "/intents/"; aws_config=aws_config)
-get_intents(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = lex_model_building_service("GET", "/intents/", params; aws_config=aws_config)
+get_intents(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = lex_model_building_service("GET", "/intents/", params; aws_config=aws_config)
 
 """
     get_slot_type(name, version)
@@ -626,7 +626,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   request.
 """
 get_slot_types(; aws_config::AbstractAWSConfig=global_aws_config()) = lex_model_building_service("GET", "/slottypes/"; aws_config=aws_config)
-get_slot_types(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = lex_model_building_service("GET", "/slottypes/", params; aws_config=aws_config)
+get_slot_types(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = lex_model_building_service("GET", "/slottypes/", params; aws_config=aws_config)
 
 """
     get_utterances_view(bot_versions, botname, status_type)

--- a/src/services/lex_models_v2.jl
+++ b/src/services/lex_models_v2.jl
@@ -649,7 +649,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   list be sorted by bot name in ascending or descending order.
 """
 list_bots(; aws_config::AbstractAWSConfig=global_aws_config()) = lex_models_v2("POST", "/bots/"; aws_config=aws_config)
-list_bots(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = lex_models_v2("POST", "/bots/", params; aws_config=aws_config)
+list_bots(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = lex_models_v2("POST", "/bots/", params; aws_config=aws_config)
 
 """
     list_built_in_intents(locale_id)

--- a/src/services/lightsail.jl
+++ b/src/services/lightsail.jl
@@ -778,14 +778,29 @@ supports tag-based access control via request tags. For more information, see th
 Dev Guide.
 
 # Arguments
-- `master_database_name`: The name of the master database created when the Lightsail
-  database resource is created. Constraints:   Must contain from 1 to 64 alphanumeric
-  characters.   Cannot be a word reserved by the specified database engine
-- `master_username`: The master user name for your new database. Constraints:   Master user
-  name is required.   Must contain from 1 to 16 alphanumeric characters.   The first
-  character must be a letter.   Cannot be a reserved word for the database engine you choose.
-  For more information about reserved words in MySQL 5.6 or 5.7, see the Keywords and
-  Reserved Words articles for MySQL 5.6 or MySQL 5.7 respectively.
+- `master_database_name`: The meaning of this parameter differs according to the database
+  engine you use.  MySQL  The name of the database to create when the Lightsail database
+  resource is created. If this parameter isn't specified, no database is created in the
+  database resource. Constraints:   Must contain 1 to 64 letters or numbers.   Must begin
+  with a letter. Subsequent characters can be letters, underscores, or digits (0- 9).   Can't
+  be a word reserved by the specified database engine. For more information about reserved
+  words in MySQL, see the Keywords and Reserved Words articles for MySQL 5.6, MySQL 5.7, and
+  MySQL 8.0.    PostgreSQL  The name of the database to create when the Lightsail database
+  resource is created. If this parameter isn't specified, a database named postgres is
+  created in the database resource. Constraints:   Must contain 1 to 63 letters or numbers.
+  Must begin with a letter. Subsequent characters can be letters, underscores, or digits (0-
+  9).   Can't be a word reserved by the specified database engine. For more information about
+  reserved words in PostgreSQL, see the SQL Key Words articles for PostgreSQL 9.6, PostgreSQL
+  10, PostgreSQL 11, and PostgreSQL 12.
+- `master_username`: The name for the master user.  MySQL  Constraints:   Required for
+  MySQL.   Must be 1 to 16 letters or numbers. Can contain underscores.   First character
+  must be a letter.   Can't be a reserved word for the chosen database engine. For more
+  information about reserved words in MySQL 5.6 or 5.7, see the Keywords and Reserved Words
+  articles for MySQL 5.6, MySQL 5.7, or MySQL 8.0.    PostgreSQL  Constraints:   Required for
+  PostgreSQL.   Must be 1 to 63 letters or numbers. Can contain underscores.   First
+  character must be a letter.   Can't be a reserved word for the chosen database engine. For
+  more information about reserved words in MySQL 5.6 or 5.7, see the Keywords and Reserved
+  Words articles for PostgreSQL 9.6, PostgreSQL 10, PostgreSQL 11, and PostgreSQL 12.
 - `relational_database_blueprint_id`: The blueprint ID for your new database. A blueprint
   describes the major engine version of a database. You can get a list of database blueprints
   IDs by using the get relational database blueprints operation.
@@ -802,9 +817,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   us-east-2a case-sensitive format. You can get a list of Availability Zones by using the get
   regions operation. Be sure to add the include relational database Availability Zones
   parameter to your request.
-- `"masterUserPassword"`: The password for the master user of your new database. The
-  password can include any printable ASCII character except \"/\", \"\"\", or \"@\".
-  Constraints: Must contain 8 to 41 characters.
+- `"masterUserPassword"`: The password for the master user. The password can include any
+  printable ASCII character except \"/\", \"\"\", or \"@\". It cannot contain spaces.  MySQL
+  Constraints: Must contain from 8 to 41 characters.  PostgreSQL  Constraints: Must contain
+  from 8 to 128 characters.
 - `"preferredBackupWindow"`: The daily time range during which automated backups are
   created for your new database if automated backups are enabled. The default is a 30-minute
   window selected at random from an 8-hour block of time for each AWS Region. For more
@@ -841,9 +857,9 @@ control via request tags and resource tags applied to the resource identified by
 relationalDatabaseSnapshotName. For more information, see the Lightsail Dev Guide.
 
 # Arguments
-- `relational_database_name`: The name to use for your new database. Constraints:   Must
-  contain from 2 to 255 alphanumeric characters, or hyphens.   The first and last character
-  must be a letter or number.
+- `relational_database_name`: The name to use for your new Lightsail database resource.
+  Constraints:   Must contain from 2 to 255 alphanumeric characters, or hyphens.   The first
+  and last character must be a letter or number.
 
 # Optional Parameters
 Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys are:
@@ -3187,7 +3203,7 @@ operation supports tag-based access control via resource tags applied to the res
 identified by relationalDatabaseName. For more information, see the Lightsail Dev Guide.
 
 # Arguments
-- `relational_database_name`: The name of your database to update.
+- `relational_database_name`: The name of your Lightsail database resource to update.
 
 # Optional Parameters
 Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys are:
@@ -3203,9 +3219,9 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"enableBackupRetention"`: When true, enables automated backup retention for your
   database. Updates are applied during the next maintenance window because this can result in
   an outage.
-- `"masterUserPassword"`: The password for the master user of your database. The password
-  can include any printable ASCII character except \"/\", \"\"\", or \"@\". Constraints: Must
-  contain 8 to 41 characters.
+- `"masterUserPassword"`: The password for the master user. The password can include any
+  printable ASCII character except \"/\", \"\"\", or \"@\". MySQL  Constraints: Must contain
+  from 8 to 41 characters.  PostgreSQL  Constraints: Must contain from 8 to 128 characters.
 - `"preferredBackupWindow"`: The daily time range during which automated backups are
   created for your database if automated backups are enabled. Constraints:   Must be in the
   hh24:mi-hh24:mi format. Example: 16:00-16:30    Specified in Coordinated Universal Time

--- a/src/services/location.jl
+++ b/src/services/location.jl
@@ -491,7 +491,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   response. If no token is provided, the default page is the first page.  Default value: null
 """
 list_geofence_collections(; aws_config::AbstractAWSConfig=global_aws_config()) = location("POST", "/geofencing/v0/list-collections"; aws_config=aws_config)
-list_geofence_collections(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = location("POST", "/geofencing/v0/list-collections", params; aws_config=aws_config)
+list_geofence_collections(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = location("POST", "/geofencing/v0/list-collections", params; aws_config=aws_config)
 
 """
     list_geofences(collection_name)
@@ -524,7 +524,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   response. If no token is provided, the default page is the first page. Default value: null
 """
 list_maps(; aws_config::AbstractAWSConfig=global_aws_config()) = location("POST", "/maps/v0/list-maps"; aws_config=aws_config)
-list_maps(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = location("POST", "/maps/v0/list-maps", params; aws_config=aws_config)
+list_maps(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = location("POST", "/maps/v0/list-maps", params; aws_config=aws_config)
 
 """
     list_place_indexes()
@@ -540,7 +540,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   response. If no token is provided, the default page is the first page. Default value: null
 """
 list_place_indexes(; aws_config::AbstractAWSConfig=global_aws_config()) = location("POST", "/places/v0/list-indexes"; aws_config=aws_config)
-list_place_indexes(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = location("POST", "/places/v0/list-indexes", params; aws_config=aws_config)
+list_place_indexes(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = location("POST", "/places/v0/list-indexes", params; aws_config=aws_config)
 
 """
     list_tracker_consumers(tracker_name)
@@ -576,7 +576,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   response. If no token is provided, the default page is the first page.  Default value: null
 """
 list_trackers(; aws_config::AbstractAWSConfig=global_aws_config()) = location("POST", "/tracking/v0/list-trackers"; aws_config=aws_config)
-list_trackers(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = location("POST", "/tracking/v0/list-trackers", params; aws_config=aws_config)
+list_trackers(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = location("POST", "/tracking/v0/list-trackers", params; aws_config=aws_config)
 
 """
     put_geofence(collection_name, geofence_id, geometry)

--- a/src/services/lookoutmetrics.jl
+++ b/src/services/lookoutmetrics.jl
@@ -228,7 +228,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"S3SourceConfig"`: A datasource bucket in Amazon S3.
 """
 get_sample_data(; aws_config::AbstractAWSConfig=global_aws_config()) = lookoutmetrics("POST", "/GetSampleData"; aws_config=aws_config)
-get_sample_data(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = lookoutmetrics("POST", "/GetSampleData", params; aws_config=aws_config)
+get_sample_data(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = lookoutmetrics("POST", "/GetSampleData", params; aws_config=aws_config)
 
 """
     list_alerts()
@@ -245,7 +245,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   expire after 24 hours.
 """
 list_alerts(; aws_config::AbstractAWSConfig=global_aws_config()) = lookoutmetrics("POST", "/ListAlerts"; aws_config=aws_config)
-list_alerts(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = lookoutmetrics("POST", "/ListAlerts", params; aws_config=aws_config)
+list_alerts(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = lookoutmetrics("POST", "/ListAlerts", params; aws_config=aws_config)
 
 """
     list_anomaly_detectors()
@@ -261,7 +261,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   expire after 24 hours.
 """
 list_anomaly_detectors(; aws_config::AbstractAWSConfig=global_aws_config()) = lookoutmetrics("POST", "/ListAnomalyDetectors"; aws_config=aws_config)
-list_anomaly_detectors(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = lookoutmetrics("POST", "/ListAnomalyDetectors", params; aws_config=aws_config)
+list_anomaly_detectors(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = lookoutmetrics("POST", "/ListAnomalyDetectors", params; aws_config=aws_config)
 
 """
     list_anomaly_group_summaries(anomaly_detector_arn, sensitivity_threshold)
@@ -318,7 +318,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   expire after 24 hours.
 """
 list_metric_sets(; aws_config::AbstractAWSConfig=global_aws_config()) = lookoutmetrics("POST", "/ListMetricSets"; aws_config=aws_config)
-list_metric_sets(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = lookoutmetrics("POST", "/ListMetricSets", params; aws_config=aws_config)
+list_metric_sets(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = lookoutmetrics("POST", "/ListMetricSets", params; aws_config=aws_config)
 
 """
     list_tags_for_resource(resource_arn)

--- a/src/services/lookoutvision.jl
+++ b/src/services/lookoutvision.jl
@@ -340,7 +340,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   use this pagination token to retrieve the next set of projects.
 """
 list_projects(; aws_config::AbstractAWSConfig=global_aws_config()) = lookoutvision("GET", "/2020-11-20/projects"; aws_config=aws_config)
-list_projects(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = lookoutvision("GET", "/2020-11-20/projects", params; aws_config=aws_config)
+list_projects(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = lookoutvision("GET", "/2020-11-20/projects", params; aws_config=aws_config)
 
 """
     list_tags_for_resource(resource_arn)

--- a/src/services/macie2.jl
+++ b/src/services/macie2.jl
@@ -35,7 +35,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   identifiers to retrieve information about.
 """
 batch_get_custom_data_identifiers(; aws_config::AbstractAWSConfig=global_aws_config()) = macie2("POST", "/custom-data-identifiers/get"; aws_config=aws_config)
-batch_get_custom_data_identifiers(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = macie2("POST", "/custom-data-identifiers/get", params; aws_config=aws_config)
+batch_get_custom_data_identifiers(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = macie2("POST", "/custom-data-identifiers/get", params; aws_config=aws_config)
 
 """
     create_classification_job(client_token, job_type, name, s3_job_definition)
@@ -207,7 +207,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Policy:IAMUser/S3BucketEncryptionDisabled.
 """
 create_sample_findings(; aws_config::AbstractAWSConfig=global_aws_config()) = macie2("POST", "/findings/sample"; aws_config=aws_config)
-create_sample_findings(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = macie2("POST", "/findings/sample", params; aws_config=aws_config)
+create_sample_findings(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = macie2("POST", "/findings/sample", params; aws_config=aws_config)
 
 """
     decline_invitations(account_ids)
@@ -296,7 +296,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"sortCriteria"`: The criteria to use to sort the query results.
 """
 describe_buckets(; aws_config::AbstractAWSConfig=global_aws_config()) = macie2("POST", "/datasources/s3"; aws_config=aws_config)
-describe_buckets(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = macie2("POST", "/datasources/s3", params; aws_config=aws_config)
+describe_buckets(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = macie2("POST", "/datasources/s3", params; aws_config=aws_config)
 
 """
     describe_classification_job(job_id)
@@ -319,7 +319,7 @@ Retrieves the Amazon Macie configuration settings for an AWS organization.
 
 """
 describe_organization_configuration(; aws_config::AbstractAWSConfig=global_aws_config()) = macie2("GET", "/admin/configuration"; aws_config=aws_config)
-describe_organization_configuration(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = macie2("GET", "/admin/configuration", params; aws_config=aws_config)
+describe_organization_configuration(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = macie2("GET", "/admin/configuration", params; aws_config=aws_config)
 
 """
     disable_macie()
@@ -329,7 +329,7 @@ Disables an Amazon Macie account and deletes Macie resources for the account.
 
 """
 disable_macie(; aws_config::AbstractAWSConfig=global_aws_config()) = macie2("DELETE", "/macie"; aws_config=aws_config)
-disable_macie(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = macie2("DELETE", "/macie", params; aws_config=aws_config)
+disable_macie(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = macie2("DELETE", "/macie", params; aws_config=aws_config)
 
 """
     disable_organization_admin_account(admin_account_id)
@@ -354,7 +354,7 @@ Disassociates a member account from its Amazon Macie administrator account.
 
 """
 disassociate_from_administrator_account(; aws_config::AbstractAWSConfig=global_aws_config()) = macie2("POST", "/administrator/disassociate"; aws_config=aws_config)
-disassociate_from_administrator_account(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = macie2("POST", "/administrator/disassociate", params; aws_config=aws_config)
+disassociate_from_administrator_account(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = macie2("POST", "/administrator/disassociate", params; aws_config=aws_config)
 
 """
     disassociate_from_master_account()
@@ -365,7 +365,7 @@ This operation has been replaced by the DisassociateFromAdministratorAccount ope
 
 """
 disassociate_from_master_account(; aws_config::AbstractAWSConfig=global_aws_config()) = macie2("POST", "/master/disassociate"; aws_config=aws_config)
-disassociate_from_master_account(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = macie2("POST", "/master/disassociate", params; aws_config=aws_config)
+disassociate_from_master_account(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = macie2("POST", "/master/disassociate", params; aws_config=aws_config)
 
 """
     disassociate_member(id)
@@ -427,7 +427,7 @@ Retrieves information about the Amazon Macie administrator account for an accoun
 
 """
 get_administrator_account(; aws_config::AbstractAWSConfig=global_aws_config()) = macie2("GET", "/administrator"; aws_config=aws_config)
-get_administrator_account(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = macie2("GET", "/administrator", params; aws_config=aws_config)
+get_administrator_account(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = macie2("GET", "/administrator", params; aws_config=aws_config)
 
 """
     get_bucket_statistics()
@@ -441,7 +441,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"accountId"`: The unique identifier for the AWS account.
 """
 get_bucket_statistics(; aws_config::AbstractAWSConfig=global_aws_config()) = macie2("POST", "/datasources/s3/statistics"; aws_config=aws_config)
-get_bucket_statistics(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = macie2("POST", "/datasources/s3/statistics", params; aws_config=aws_config)
+get_bucket_statistics(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = macie2("POST", "/datasources/s3/statistics", params; aws_config=aws_config)
 
 """
     get_classification_export_configuration()
@@ -451,7 +451,7 @@ Retrieves the configuration settings for storing data classification results.
 
 """
 get_classification_export_configuration(; aws_config::AbstractAWSConfig=global_aws_config()) = macie2("GET", "/classification-export-configuration"; aws_config=aws_config)
-get_classification_export_configuration(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = macie2("GET", "/classification-export-configuration", params; aws_config=aws_config)
+get_classification_export_configuration(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = macie2("GET", "/classification-export-configuration", params; aws_config=aws_config)
 
 """
     get_custom_data_identifier(id)
@@ -529,7 +529,7 @@ Retrieves the configuration settings for publishing findings to AWS Security Hub
 
 """
 get_findings_publication_configuration(; aws_config::AbstractAWSConfig=global_aws_config()) = macie2("GET", "/findings-publication-configuration"; aws_config=aws_config)
-get_findings_publication_configuration(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = macie2("GET", "/findings-publication-configuration", params; aws_config=aws_config)
+get_findings_publication_configuration(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = macie2("GET", "/findings-publication-configuration", params; aws_config=aws_config)
 
 """
     get_invitations_count()
@@ -539,7 +539,7 @@ Retrieves the count of Amazon Macie membership invitations that were received by
 
 """
 get_invitations_count(; aws_config::AbstractAWSConfig=global_aws_config()) = macie2("GET", "/invitations/count"; aws_config=aws_config)
-get_invitations_count(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = macie2("GET", "/invitations/count", params; aws_config=aws_config)
+get_invitations_count(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = macie2("GET", "/invitations/count", params; aws_config=aws_config)
 
 """
     get_macie_session()
@@ -549,7 +549,7 @@ Retrieves the current status and configuration settings for an Amazon Macie acco
 
 """
 get_macie_session(; aws_config::AbstractAWSConfig=global_aws_config()) = macie2("GET", "/macie"; aws_config=aws_config)
-get_macie_session(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = macie2("GET", "/macie", params; aws_config=aws_config)
+get_macie_session(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = macie2("GET", "/macie", params; aws_config=aws_config)
 
 """
     get_master_account()
@@ -560,7 +560,7 @@ account. This operation has been replaced by the GetAdministratorAccount operati
 
 """
 get_master_account(; aws_config::AbstractAWSConfig=global_aws_config()) = macie2("GET", "/master"; aws_config=aws_config)
-get_master_account(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = macie2("GET", "/master", params; aws_config=aws_config)
+get_master_account(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = macie2("GET", "/master", params; aws_config=aws_config)
 
 """
     get_member(id)
@@ -598,7 +598,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   30 days.
 """
 get_usage_statistics(; aws_config::AbstractAWSConfig=global_aws_config()) = macie2("POST", "/usage/statistics"; aws_config=aws_config)
-get_usage_statistics(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = macie2("POST", "/usage/statistics", params; aws_config=aws_config)
+get_usage_statistics(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = macie2("POST", "/usage/statistics", params; aws_config=aws_config)
 
 """
     get_usage_totals()
@@ -614,7 +614,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   usage data for the preceding 30 days.
 """
 get_usage_totals(; aws_config::AbstractAWSConfig=global_aws_config()) = macie2("GET", "/usage"; aws_config=aws_config)
-get_usage_totals(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = macie2("GET", "/usage", params; aws_config=aws_config)
+get_usage_totals(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = macie2("GET", "/usage", params; aws_config=aws_config)
 
 """
     list_classification_jobs()
@@ -631,7 +631,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"sortCriteria"`: The criteria to use to sort the results.
 """
 list_classification_jobs(; aws_config::AbstractAWSConfig=global_aws_config()) = macie2("POST", "/jobs/list"; aws_config=aws_config)
-list_classification_jobs(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = macie2("POST", "/jobs/list", params; aws_config=aws_config)
+list_classification_jobs(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = macie2("POST", "/jobs/list", params; aws_config=aws_config)
 
 """
     list_custom_data_identifiers()
@@ -646,7 +646,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   paginated response.
 """
 list_custom_data_identifiers(; aws_config::AbstractAWSConfig=global_aws_config()) = macie2("POST", "/custom-data-identifiers/list"; aws_config=aws_config)
-list_custom_data_identifiers(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = macie2("POST", "/custom-data-identifiers/list", params; aws_config=aws_config)
+list_custom_data_identifiers(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = macie2("POST", "/custom-data-identifiers/list", params; aws_config=aws_config)
 
 """
     list_findings()
@@ -663,7 +663,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"sortCriteria"`: The criteria to use to sort the results.
 """
 list_findings(; aws_config::AbstractAWSConfig=global_aws_config()) = macie2("POST", "/findings"; aws_config=aws_config)
-list_findings(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = macie2("POST", "/findings", params; aws_config=aws_config)
+list_findings(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = macie2("POST", "/findings", params; aws_config=aws_config)
 
 """
     list_findings_filters()
@@ -679,7 +679,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   paginated response.
 """
 list_findings_filters(; aws_config::AbstractAWSConfig=global_aws_config()) = macie2("GET", "/findingsfilters"; aws_config=aws_config)
-list_findings_filters(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = macie2("GET", "/findingsfilters", params; aws_config=aws_config)
+list_findings_filters(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = macie2("GET", "/findingsfilters", params; aws_config=aws_config)
 
 """
     list_invitations()
@@ -696,7 +696,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   paginated response.
 """
 list_invitations(; aws_config::AbstractAWSConfig=global_aws_config()) = macie2("GET", "/invitations"; aws_config=aws_config)
-list_invitations(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = macie2("GET", "/invitations", params; aws_config=aws_config)
+list_invitations(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = macie2("GET", "/invitations", params; aws_config=aws_config)
 
 """
     list_members()
@@ -717,7 +717,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   false.
 """
 list_members(; aws_config::AbstractAWSConfig=global_aws_config()) = macie2("GET", "/members"; aws_config=aws_config)
-list_members(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = macie2("GET", "/members", params; aws_config=aws_config)
+list_members(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = macie2("GET", "/members", params; aws_config=aws_config)
 
 """
     list_organization_admin_accounts()
@@ -734,7 +734,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   paginated response.
 """
 list_organization_admin_accounts(; aws_config::AbstractAWSConfig=global_aws_config()) = macie2("GET", "/admin"; aws_config=aws_config)
-list_organization_admin_accounts(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = macie2("GET", "/admin", params; aws_config=aws_config)
+list_organization_admin_accounts(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = macie2("GET", "/admin", params; aws_config=aws_config)
 
 """
     list_tags_for_resource(resource_arn)
@@ -925,7 +925,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   account.
 """
 update_macie_session(; aws_config::AbstractAWSConfig=global_aws_config()) = macie2("PATCH", "/macie"; aws_config=aws_config)
-update_macie_session(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = macie2("PATCH", "/macie", params; aws_config=aws_config)
+update_macie_session(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = macie2("PATCH", "/macie", params; aws_config=aws_config)
 
 """
     update_member_session(id, status)

--- a/src/services/managedblockchain.jl
+++ b/src/services/managedblockchain.jl
@@ -237,7 +237,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: The pagination token that indicates the next set of results to retrieve.
 """
 list_invitations(; aws_config::AbstractAWSConfig=global_aws_config()) = managedblockchain("GET", "/invitations"; aws_config=aws_config)
-list_invitations(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = managedblockchain("GET", "/invitations", params; aws_config=aws_config)
+list_invitations(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = managedblockchain("GET", "/invitations", params; aws_config=aws_config)
 
 """
     list_members(network_id)
@@ -281,7 +281,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   status are listed. Applies only to Hyperledger Fabric.
 """
 list_networks(; aws_config::AbstractAWSConfig=global_aws_config()) = managedblockchain("GET", "/networks"; aws_config=aws_config)
-list_networks(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = managedblockchain("GET", "/networks", params; aws_config=aws_config)
+list_networks(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = managedblockchain("GET", "/networks", params; aws_config=aws_config)
 
 """
     list_nodes(network_id)

--- a/src/services/mediaconnect.jl
+++ b/src/services/mediaconnect.jl
@@ -162,7 +162,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   NextToken value.
 """
 list_entitlements(; aws_config::AbstractAWSConfig=global_aws_config()) = mediaconnect("GET", "/v1/entitlements"; aws_config=aws_config)
-list_entitlements(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = mediaconnect("GET", "/v1/entitlements", params; aws_config=aws_config)
+list_entitlements(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = mediaconnect("GET", "/v1/entitlements", params; aws_config=aws_config)
 
 """
     list_flows()
@@ -185,7 +185,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   you can submit the ListFlows request a second time and specify the NextToken value.
 """
 list_flows(; aws_config::AbstractAWSConfig=global_aws_config()) = mediaconnect("GET", "/v1/flows"; aws_config=aws_config)
-list_flows(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = mediaconnect("GET", "/v1/flows", params; aws_config=aws_config)
+list_flows(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = mediaconnect("GET", "/v1/flows", params; aws_config=aws_config)
 
 """
     list_offerings()
@@ -211,7 +211,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   value.
 """
 list_offerings(; aws_config::AbstractAWSConfig=global_aws_config()) = mediaconnect("GET", "/v1/offerings"; aws_config=aws_config)
-list_offerings(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = mediaconnect("GET", "/v1/offerings", params; aws_config=aws_config)
+list_offerings(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = mediaconnect("GET", "/v1/offerings", params; aws_config=aws_config)
 
 """
     list_reservations()
@@ -235,7 +235,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   NextToken value.
 """
 list_reservations(; aws_config::AbstractAWSConfig=global_aws_config()) = mediaconnect("GET", "/v1/reservations"; aws_config=aws_config)
-list_reservations(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = mediaconnect("GET", "/v1/reservations", params; aws_config=aws_config)
+list_reservations(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = mediaconnect("GET", "/v1/reservations", params; aws_config=aws_config)
 
 """
     list_tags_for_resource(resource_arn)

--- a/src/services/mediaconvert.jl
+++ b/src/services/mediaconvert.jl
@@ -236,7 +236,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   request the next batch of endpoints.
 """
 describe_endpoints(; aws_config::AbstractAWSConfig=global_aws_config()) = mediaconvert("POST", "/2017-08-29/endpoints"; aws_config=aws_config)
-describe_endpoints(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = mediaconvert("POST", "/2017-08-29/endpoints", params; aws_config=aws_config)
+describe_endpoints(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = mediaconvert("POST", "/2017-08-29/endpoints", params; aws_config=aws_config)
 
 """
     disassociate_certificate(arn)
@@ -328,7 +328,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   are sorted in ASCENDING or DESCENDING order. Default varies by resource.
 """
 list_job_templates(; aws_config::AbstractAWSConfig=global_aws_config()) = mediaconvert("GET", "/2017-08-29/jobTemplates"; aws_config=aws_config)
-list_job_templates(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = mediaconvert("GET", "/2017-08-29/jobTemplates", params; aws_config=aws_config)
+list_job_templates(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = mediaconvert("GET", "/2017-08-29/jobTemplates", params; aws_config=aws_config)
 
 """
     list_jobs()
@@ -351,7 +351,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   or ERROR.
 """
 list_jobs(; aws_config::AbstractAWSConfig=global_aws_config()) = mediaconvert("GET", "/2017-08-29/jobs"; aws_config=aws_config)
-list_jobs(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = mediaconvert("GET", "/2017-08-29/jobs", params; aws_config=aws_config)
+list_jobs(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = mediaconvert("GET", "/2017-08-29/jobs", params; aws_config=aws_config)
 
 """
     list_presets()
@@ -376,7 +376,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   are sorted in ASCENDING or DESCENDING order. Default varies by resource.
 """
 list_presets(; aws_config::AbstractAWSConfig=global_aws_config()) = mediaconvert("GET", "/2017-08-29/presets"; aws_config=aws_config)
-list_presets(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = mediaconvert("GET", "/2017-08-29/presets", params; aws_config=aws_config)
+list_presets(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = mediaconvert("GET", "/2017-08-29/presets", params; aws_config=aws_config)
 
 """
     list_queues()
@@ -399,7 +399,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   are sorted in ASCENDING or DESCENDING order. Default varies by resource.
 """
 list_queues(; aws_config::AbstractAWSConfig=global_aws_config()) = mediaconvert("GET", "/2017-08-29/queues"; aws_config=aws_config)
-list_queues(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = mediaconvert("GET", "/2017-08-29/queues", params; aws_config=aws_config)
+list_queues(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = mediaconvert("GET", "/2017-08-29/queues", params; aws_config=aws_config)
 
 """
     list_tags_for_resource(arn)

--- a/src/services/medialive.jl
+++ b/src/services/medialive.jl
@@ -33,7 +33,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"multiplexIds"`: List of multiplex IDs
 """
 batch_delete(; aws_config::AbstractAWSConfig=global_aws_config()) = medialive("POST", "/prod/batch/delete"; aws_config=aws_config)
-batch_delete(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = medialive("POST", "/prod/batch/delete", params; aws_config=aws_config)
+batch_delete(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = medialive("POST", "/prod/batch/delete", params; aws_config=aws_config)
 
 """
     batch_start()
@@ -47,7 +47,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"multiplexIds"`: List of multiplex IDs
 """
 batch_start(; aws_config::AbstractAWSConfig=global_aws_config()) = medialive("POST", "/prod/batch/start"; aws_config=aws_config)
-batch_start(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = medialive("POST", "/prod/batch/start", params; aws_config=aws_config)
+batch_start(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = medialive("POST", "/prod/batch/start", params; aws_config=aws_config)
 
 """
     batch_stop()
@@ -61,7 +61,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"multiplexIds"`: List of multiplex IDs
 """
 batch_stop(; aws_config::AbstractAWSConfig=global_aws_config()) = medialive("POST", "/prod/batch/stop"; aws_config=aws_config)
-batch_stop(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = medialive("POST", "/prod/batch/stop", params; aws_config=aws_config)
+batch_stop(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = medialive("POST", "/prod/batch/stop", params; aws_config=aws_config)
 
 """
     batch_update_schedule(channel_id)
@@ -171,7 +171,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"whitelistRules"`: List of IPv4 CIDR addresses to whitelist
 """
 create_input_security_group(; aws_config::AbstractAWSConfig=global_aws_config()) = medialive("POST", "/prod/inputSecurityGroups"; aws_config=aws_config)
-create_input_security_group(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = medialive("POST", "/prod/inputSecurityGroups", params; aws_config=aws_config)
+create_input_security_group(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = medialive("POST", "/prod/inputSecurityGroups", params; aws_config=aws_config)
 
 """
     create_multiplex(availability_zones, multiplex_settings, name, request_id)
@@ -500,7 +500,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`:
 """
 list_channels(; aws_config::AbstractAWSConfig=global_aws_config()) = medialive("GET", "/prod/channels"; aws_config=aws_config)
-list_channels(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = medialive("GET", "/prod/channels", params; aws_config=aws_config)
+list_channels(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = medialive("GET", "/prod/channels", params; aws_config=aws_config)
 
 """
     list_input_device_transfers(transfer_type)
@@ -533,7 +533,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`:
 """
 list_input_devices(; aws_config::AbstractAWSConfig=global_aws_config()) = medialive("GET", "/prod/inputDevices"; aws_config=aws_config)
-list_input_devices(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = medialive("GET", "/prod/inputDevices", params; aws_config=aws_config)
+list_input_devices(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = medialive("GET", "/prod/inputDevices", params; aws_config=aws_config)
 
 """
     list_input_security_groups()
@@ -547,7 +547,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`:
 """
 list_input_security_groups(; aws_config::AbstractAWSConfig=global_aws_config()) = medialive("GET", "/prod/inputSecurityGroups"; aws_config=aws_config)
-list_input_security_groups(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = medialive("GET", "/prod/inputSecurityGroups", params; aws_config=aws_config)
+list_input_security_groups(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = medialive("GET", "/prod/inputSecurityGroups", params; aws_config=aws_config)
 
 """
     list_inputs()
@@ -561,7 +561,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`:
 """
 list_inputs(; aws_config::AbstractAWSConfig=global_aws_config()) = medialive("GET", "/prod/inputs"; aws_config=aws_config)
-list_inputs(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = medialive("GET", "/prod/inputs", params; aws_config=aws_config)
+list_inputs(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = medialive("GET", "/prod/inputs", params; aws_config=aws_config)
 
 """
     list_multiplex_programs(multiplex_id)
@@ -592,7 +592,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: The token to retrieve the next page of results.
 """
 list_multiplexes(; aws_config::AbstractAWSConfig=global_aws_config()) = medialive("GET", "/prod/multiplexes"; aws_config=aws_config)
-list_multiplexes(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = medialive("GET", "/prod/multiplexes", params; aws_config=aws_config)
+list_multiplexes(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = medialive("GET", "/prod/multiplexes", params; aws_config=aws_config)
 
 """
     list_offerings()
@@ -617,7 +617,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"videoQuality"`: Filter by video quality, 'STANDARD', 'ENHANCED', or 'PREMIUM'
 """
 list_offerings(; aws_config::AbstractAWSConfig=global_aws_config()) = medialive("GET", "/prod/offerings"; aws_config=aws_config)
-list_offerings(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = medialive("GET", "/prod/offerings", params; aws_config=aws_config)
+list_offerings(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = medialive("GET", "/prod/offerings", params; aws_config=aws_config)
 
 """
     list_reservations()
@@ -639,7 +639,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"videoQuality"`: Filter by video quality, 'STANDARD', 'ENHANCED', or 'PREMIUM'
 """
 list_reservations(; aws_config::AbstractAWSConfig=global_aws_config()) = medialive("GET", "/prod/reservations"; aws_config=aws_config)
-list_reservations(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = medialive("GET", "/prod/reservations", params; aws_config=aws_config)
+list_reservations(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = medialive("GET", "/prod/reservations", params; aws_config=aws_config)
 
 """
     list_tags_for_resource(resource-arn)

--- a/src/services/mediapackage.jl
+++ b/src/services/mediapackage.jl
@@ -181,7 +181,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: A token used to resume pagination from the end of a previous request.
 """
 list_channels(; aws_config::AbstractAWSConfig=global_aws_config()) = mediapackage("GET", "/channels"; aws_config=aws_config)
-list_channels(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = mediapackage("GET", "/channels", params; aws_config=aws_config)
+list_channels(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = mediapackage("GET", "/channels", params; aws_config=aws_config)
 
 """
     list_harvest_jobs()
@@ -199,7 +199,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: A token used to resume pagination from the end of a previous request.
 """
 list_harvest_jobs(; aws_config::AbstractAWSConfig=global_aws_config()) = mediapackage("GET", "/harvest_jobs"; aws_config=aws_config)
-list_harvest_jobs(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = mediapackage("GET", "/harvest_jobs", params; aws_config=aws_config)
+list_harvest_jobs(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = mediapackage("GET", "/harvest_jobs", params; aws_config=aws_config)
 
 """
     list_origin_endpoints()
@@ -215,7 +215,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: A token used to resume pagination from the end of a previous request.
 """
 list_origin_endpoints(; aws_config::AbstractAWSConfig=global_aws_config()) = mediapackage("GET", "/origin_endpoints"; aws_config=aws_config)
-list_origin_endpoints(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = mediapackage("GET", "/origin_endpoints", params; aws_config=aws_config)
+list_origin_endpoints(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = mediapackage("GET", "/origin_endpoints", params; aws_config=aws_config)
 
 """
     list_tags_for_resource(resource-arn)

--- a/src/services/mediapackage_vod.jl
+++ b/src/services/mediapackage_vod.jl
@@ -170,7 +170,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"packagingGroupId"`: Returns Assets associated with the specified PackagingGroup.
 """
 list_assets(; aws_config::AbstractAWSConfig=global_aws_config()) = mediapackage_vod("GET", "/assets"; aws_config=aws_config)
-list_assets(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = mediapackage_vod("GET", "/assets", params; aws_config=aws_config)
+list_assets(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = mediapackage_vod("GET", "/assets", params; aws_config=aws_config)
 
 """
     list_packaging_configurations()
@@ -186,7 +186,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   the specified PackagingGroup.
 """
 list_packaging_configurations(; aws_config::AbstractAWSConfig=global_aws_config()) = mediapackage_vod("GET", "/packaging_configurations"; aws_config=aws_config)
-list_packaging_configurations(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = mediapackage_vod("GET", "/packaging_configurations", params; aws_config=aws_config)
+list_packaging_configurations(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = mediapackage_vod("GET", "/packaging_configurations", params; aws_config=aws_config)
 
 """
     list_packaging_groups()
@@ -200,7 +200,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: A token used to resume pagination from the end of a previous request.
 """
 list_packaging_groups(; aws_config::AbstractAWSConfig=global_aws_config()) = mediapackage_vod("GET", "/packaging_groups"; aws_config=aws_config)
-list_packaging_groups(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = mediapackage_vod("GET", "/packaging_groups", params; aws_config=aws_config)
+list_packaging_groups(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = mediapackage_vod("GET", "/packaging_groups", params; aws_config=aws_config)
 
 """
     list_tags_for_resource(resource-arn)

--- a/src/services/mediastore_data.jl
+++ b/src/services/mediastore_data.jl
@@ -88,7 +88,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   name&gt;/&lt;folder name&gt;/&lt;file name&gt;
 """
 list_items(; aws_config::AbstractAWSConfig=global_aws_config()) = mediastore_data("GET", "/"; aws_config=aws_config)
-list_items(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = mediastore_data("GET", "/", params; aws_config=aws_config)
+list_items(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = mediastore_data("GET", "/", params; aws_config=aws_config)
 
 """
     put_object(body, path)

--- a/src/services/mediatailor.jl
+++ b/src/services/mediatailor.jl
@@ -278,7 +278,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   next page of results.
 """
 list_channels(; aws_config::AbstractAWSConfig=global_aws_config()) = mediatailor("GET", "/channels"; aws_config=aws_config)
-list_channels(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = mediatailor("GET", "/channels", params; aws_config=aws_config)
+list_channels(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = mediatailor("GET", "/channels", params; aws_config=aws_config)
 
 """
     list_playback_configurations()
@@ -297,7 +297,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   maximum allowed. Use the token to fetch the next page of results.
 """
 list_playback_configurations(; aws_config::AbstractAWSConfig=global_aws_config()) = mediatailor("GET", "/playbackConfigurations"; aws_config=aws_config)
-list_playback_configurations(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = mediatailor("GET", "/playbackConfigurations", params; aws_config=aws_config)
+list_playback_configurations(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = mediatailor("GET", "/playbackConfigurations", params; aws_config=aws_config)
 
 """
     list_source_locations()
@@ -313,7 +313,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   next page of results.
 """
 list_source_locations(; aws_config::AbstractAWSConfig=global_aws_config()) = mediatailor("GET", "/sourceLocations"; aws_config=aws_config)
-list_source_locations(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = mediatailor("GET", "/sourceLocations", params; aws_config=aws_config)
+list_source_locations(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = mediatailor("GET", "/sourceLocations", params; aws_config=aws_config)
 
 """
     list_tags_for_resource(resource_arn)
@@ -411,7 +411,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"tags"`: The tags to assign to the playback configuration.
 """
 put_playback_configuration(; aws_config::AbstractAWSConfig=global_aws_config()) = mediatailor("PUT", "/playbackConfiguration"; aws_config=aws_config)
-put_playback_configuration(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = mediatailor("PUT", "/playbackConfiguration", params; aws_config=aws_config)
+put_playback_configuration(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = mediatailor("PUT", "/playbackConfiguration", params; aws_config=aws_config)
 
 """
     start_channel(channel_name)

--- a/src/services/mgn.jl
+++ b/src/services/mgn.jl
@@ -250,7 +250,7 @@ Initialize Application Migration Service.
 
 """
 initialize_service(; aws_config::AbstractAWSConfig=global_aws_config()) = mgn("POST", "/InitializeService"; aws_config=aws_config)
-initialize_service(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = mgn("POST", "/InitializeService", params; aws_config=aws_config)
+initialize_service(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = mgn("POST", "/InitializeService", params; aws_config=aws_config)
 
 """
     list_tags_for_resource(resource_arn)

--- a/src/services/mobile.jl
+++ b/src/services/mobile.jl
@@ -21,7 +21,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   This snapshot identifier is included in the share URL when a project is exported.
 """
 create_project(; aws_config::AbstractAWSConfig=global_aws_config()) = mobile("POST", "/projects"; aws_config=aws_config)
-create_project(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = mobile("POST", "/projects", params; aws_config=aws_config)
+create_project(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = mobile("POST", "/projects", params; aws_config=aws_config)
 
 """
     delete_project(project_id)
@@ -114,7 +114,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   request to list more bundles.
 """
 list_bundles(; aws_config::AbstractAWSConfig=global_aws_config()) = mobile("GET", "/bundles"; aws_config=aws_config)
-list_bundles(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = mobile("GET", "/bundles", params; aws_config=aws_config)
+list_bundles(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = mobile("GET", "/bundles", params; aws_config=aws_config)
 
 """
     list_projects()
@@ -130,7 +130,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   request to list more projects.
 """
 list_projects(; aws_config::AbstractAWSConfig=global_aws_config()) = mobile("GET", "/projects"; aws_config=aws_config)
-list_projects(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = mobile("GET", "/projects", params; aws_config=aws_config)
+list_projects(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = mobile("GET", "/projects", params; aws_config=aws_config)
 
 """
     update_project(project_id)

--- a/src/services/mq.jl
+++ b/src/services/mq.jl
@@ -79,7 +79,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"tags"`: Create tags when creating the configuration.
 """
 create_configuration(; aws_config::AbstractAWSConfig=global_aws_config()) = mq("POST", "/v1/configurations"; aws_config=aws_config)
-create_configuration(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = mq("POST", "/v1/configurations", params; aws_config=aws_config)
+create_configuration(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = mq("POST", "/v1/configurations", params; aws_config=aws_config)
 
 """
     create_tags(resource-arn)
@@ -194,7 +194,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   To request the first page, leave nextToken empty.
 """
 describe_broker_engine_types(; aws_config::AbstractAWSConfig=global_aws_config()) = mq("GET", "/v1/broker-engine-types"; aws_config=aws_config)
-describe_broker_engine_types(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = mq("GET", "/v1/broker-engine-types", params; aws_config=aws_config)
+describe_broker_engine_types(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = mq("GET", "/v1/broker-engine-types", params; aws_config=aws_config)
 
 """
     describe_broker_instance_options()
@@ -213,7 +213,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"storageType"`: Filter response by storage type.
 """
 describe_broker_instance_options(; aws_config::AbstractAWSConfig=global_aws_config()) = mq("GET", "/v1/broker-instance-options"; aws_config=aws_config)
-describe_broker_instance_options(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = mq("GET", "/v1/broker-instance-options", params; aws_config=aws_config)
+describe_broker_instance_options(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = mq("GET", "/v1/broker-instance-options", params; aws_config=aws_config)
 
 """
     describe_configuration(configuration-id)
@@ -272,7 +272,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   To request the first page, leave nextToken empty.
 """
 list_brokers(; aws_config::AbstractAWSConfig=global_aws_config()) = mq("GET", "/v1/brokers"; aws_config=aws_config)
-list_brokers(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = mq("GET", "/v1/brokers", params; aws_config=aws_config)
+list_brokers(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = mq("GET", "/v1/brokers", params; aws_config=aws_config)
 
 """
     list_configuration_revisions(configuration-id)
@@ -307,7 +307,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   To request the first page, leave nextToken empty.
 """
 list_configurations(; aws_config::AbstractAWSConfig=global_aws_config()) = mq("GET", "/v1/configurations"; aws_config=aws_config)
-list_configurations(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = mq("GET", "/v1/configurations", params; aws_config=aws_config)
+list_configurations(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = mq("GET", "/v1/configurations", params; aws_config=aws_config)
 
 """
     list_tags(resource-arn)

--- a/src/services/mwaa.jl
+++ b/src/services/mwaa.jl
@@ -135,7 +135,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`: The Next Token when listing MWAA environments.
 """
 list_environments(; aws_config::AbstractAWSConfig=global_aws_config()) = mwaa("GET", "/environments"; aws_config=aws_config)
-list_environments(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = mwaa("GET", "/environments", params; aws_config=aws_config)
+list_environments(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = mwaa("GET", "/environments", params; aws_config=aws_config)
 
 """
     list_tags_for_resource(resource_arn)

--- a/src/services/networkmanager.jl
+++ b/src/services/networkmanager.jl
@@ -134,7 +134,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"Tags"`: The tags to apply to the resource during creation.
 """
 create_global_network(; aws_config::AbstractAWSConfig=global_aws_config()) = networkmanager("POST", "/global-networks"; aws_config=aws_config)
-create_global_network(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = networkmanager("POST", "/global-networks", params; aws_config=aws_config)
+create_global_network(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = networkmanager("POST", "/global-networks", params; aws_config=aws_config)
 
 """
     create_link(bandwidth, site_id, global_network_id)
@@ -286,7 +286,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: The token for the next page of results.
 """
 describe_global_networks(; aws_config::AbstractAWSConfig=global_aws_config()) = networkmanager("GET", "/global-networks"; aws_config=aws_config)
-describe_global_networks(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = networkmanager("GET", "/global-networks", params; aws_config=aws_config)
+describe_global_networks(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = networkmanager("GET", "/global-networks", params; aws_config=aws_config)
 
 """
     disassociate_customer_gateway(customer_gateway_arn, global_network_id)

--- a/src/services/outposts.jl
+++ b/src/services/outposts.jl
@@ -92,7 +92,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`:
 """
 list_outposts(; aws_config::AbstractAWSConfig=global_aws_config()) = outposts("GET", "/outposts"; aws_config=aws_config)
-list_outposts(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = outposts("GET", "/outposts", params; aws_config=aws_config)
+list_outposts(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = outposts("GET", "/outposts", params; aws_config=aws_config)
 
 """
     list_sites()
@@ -106,7 +106,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`:
 """
 list_sites(; aws_config::AbstractAWSConfig=global_aws_config()) = outposts("GET", "/sites"; aws_config=aws_config)
-list_sites(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = outposts("GET", "/sites", params; aws_config=aws_config)
+list_sites(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = outposts("GET", "/sites", params; aws_config=aws_config)
 
 """
     list_tags_for_resource(resource_arn)

--- a/src/services/pinpoint.jl
+++ b/src/services/pinpoint.jl
@@ -700,7 +700,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   paginated response.
 """
 get_apps(; aws_config::AbstractAWSConfig=global_aws_config()) = pinpoint("GET", "/v1/apps"; aws_config=aws_config)
-get_apps(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = pinpoint("GET", "/v1/apps", params; aws_config=aws_config)
+get_apps(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = pinpoint("GET", "/v1/apps", params; aws_config=aws_config)
 
 """
     get_baidu_channel(application-id)
@@ -1174,7 +1174,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   paginated response.
 """
 get_recommender_configurations(; aws_config::AbstractAWSConfig=global_aws_config()) = pinpoint("GET", "/v1/recommenders"; aws_config=aws_config)
-get_recommender_configurations(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = pinpoint("GET", "/v1/recommenders", params; aws_config=aws_config)
+get_recommender_configurations(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = pinpoint("GET", "/v1/recommenders", params; aws_config=aws_config)
 
 """
     get_segment(application-id, segment-id)
@@ -1474,7 +1474,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   include this parameter in your request.
 """
 list_templates(; aws_config::AbstractAWSConfig=global_aws_config()) = pinpoint("GET", "/v1/templates"; aws_config=aws_config)
-list_templates(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = pinpoint("GET", "/v1/templates", params; aws_config=aws_config)
+list_templates(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = pinpoint("GET", "/v1/templates", params; aws_config=aws_config)
 
 """
     phone_number_validate(number_validate_request)

--- a/src/services/pinpoint_email.jl
+++ b/src/services/pinpoint_email.jl
@@ -203,7 +203,7 @@ account in the current AWS Region.
 
 """
 get_account(; aws_config::AbstractAWSConfig=global_aws_config()) = pinpoint_email("GET", "/v1/email/account"; aws_config=aws_config)
-get_account(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = pinpoint_email("GET", "/v1/email/account", params; aws_config=aws_config)
+get_account(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = pinpoint_email("GET", "/v1/email/account", params; aws_config=aws_config)
 
 """
     get_blacklist_reports(blacklist_item_names)
@@ -291,7 +291,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"PoolName"`: The name of the IP pool that the dedicated IP address is associated with.
 """
 get_dedicated_ips(; aws_config::AbstractAWSConfig=global_aws_config()) = pinpoint_email("GET", "/v1/email/dedicated-ips"; aws_config=aws_config)
-get_dedicated_ips(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = pinpoint_email("GET", "/v1/email/dedicated-ips", params; aws_config=aws_config)
+get_dedicated_ips(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = pinpoint_email("GET", "/v1/email/dedicated-ips", params; aws_config=aws_config)
 
 """
     get_deliverability_dashboard_options()
@@ -308,7 +308,7 @@ Pricing.
 
 """
 get_deliverability_dashboard_options(; aws_config::AbstractAWSConfig=global_aws_config()) = pinpoint_email("GET", "/v1/email/deliverability-dashboard"; aws_config=aws_config)
-get_deliverability_dashboard_options(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = pinpoint_email("GET", "/v1/email/deliverability-dashboard", params; aws_config=aws_config)
+get_deliverability_dashboard_options(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = pinpoint_email("GET", "/v1/email/deliverability-dashboard", params; aws_config=aws_config)
 
 """
     get_deliverability_test_report(report_id)
@@ -394,7 +394,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   response includes a NextToken element, which you can use to obtain additional results.
 """
 list_configuration_sets(; aws_config::AbstractAWSConfig=global_aws_config()) = pinpoint_email("GET", "/v1/email/configuration-sets"; aws_config=aws_config)
-list_configuration_sets(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = pinpoint_email("GET", "/v1/email/configuration-sets", params; aws_config=aws_config)
+list_configuration_sets(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = pinpoint_email("GET", "/v1/email/configuration-sets", params; aws_config=aws_config)
 
 """
     list_dedicated_ip_pools()
@@ -412,7 +412,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   response includes a NextToken element, which you can use to obtain additional results.
 """
 list_dedicated_ip_pools(; aws_config::AbstractAWSConfig=global_aws_config()) = pinpoint_email("GET", "/v1/email/dedicated-ip-pools"; aws_config=aws_config)
-list_dedicated_ip_pools(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = pinpoint_email("GET", "/v1/email/dedicated-ip-pools", params; aws_config=aws_config)
+list_dedicated_ip_pools(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = pinpoint_email("GET", "/v1/email/dedicated-ip-pools", params; aws_config=aws_config)
 
 """
     list_deliverability_test_reports()
@@ -433,7 +433,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   more than 1000.
 """
 list_deliverability_test_reports(; aws_config::AbstractAWSConfig=global_aws_config()) = pinpoint_email("GET", "/v1/email/deliverability-dashboard/test-reports"; aws_config=aws_config)
-list_deliverability_test_reports(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = pinpoint_email("GET", "/v1/email/deliverability-dashboard/test-reports", params; aws_config=aws_config)
+list_deliverability_test_reports(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = pinpoint_email("GET", "/v1/email/deliverability-dashboard/test-reports", params; aws_config=aws_config)
 
 """
     list_domain_deliverability_campaigns(end_date, start_date, subscribed_domain)
@@ -483,7 +483,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   value you specify has to be at least 0, and can be no more than 1000.
 """
 list_email_identities(; aws_config::AbstractAWSConfig=global_aws_config()) = pinpoint_email("GET", "/v1/email/identities"; aws_config=aws_config)
-list_email_identities(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = pinpoint_email("GET", "/v1/email/identities", params; aws_config=aws_config)
+list_email_identities(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = pinpoint_email("GET", "/v1/email/identities", params; aws_config=aws_config)
 
 """
     list_tags_for_resource(resource_arn)
@@ -516,7 +516,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Set to true to enable the automatic warm-up feature, or set to false to disable it.
 """
 put_account_dedicated_ip_warmup_attributes(; aws_config::AbstractAWSConfig=global_aws_config()) = pinpoint_email("PUT", "/v1/email/account/dedicated-ips/warmup"; aws_config=aws_config)
-put_account_dedicated_ip_warmup_attributes(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = pinpoint_email("PUT", "/v1/email/account/dedicated-ips/warmup", params; aws_config=aws_config)
+put_account_dedicated_ip_warmup_attributes(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = pinpoint_email("PUT", "/v1/email/account/dedicated-ips/warmup", params; aws_config=aws_config)
 
 """
     put_account_sending_attributes()
@@ -532,7 +532,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   ability to send email.
 """
 put_account_sending_attributes(; aws_config::AbstractAWSConfig=global_aws_config()) = pinpoint_email("PUT", "/v1/email/account/sending"; aws_config=aws_config)
-put_account_sending_attributes(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = pinpoint_email("PUT", "/v1/email/account/sending", params; aws_config=aws_config)
+put_account_sending_attributes(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = pinpoint_email("PUT", "/v1/email/account/sending", params; aws_config=aws_config)
 
 """
     put_configuration_set_delivery_options(configuration_set_name)

--- a/src/services/pinpoint_sms_voice.jl
+++ b/src/services/pinpoint_sms_voice.jl
@@ -16,7 +16,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"ConfigurationSetName"`: The name that you want to give the configuration set.
 """
 create_configuration_set(; aws_config::AbstractAWSConfig=global_aws_config()) = pinpoint_sms_voice("POST", "/v1/sms-voice/configuration-sets"; aws_config=aws_config)
-create_configuration_set(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = pinpoint_sms_voice("POST", "/v1/sms-voice/configuration-sets", params; aws_config=aws_config)
+create_configuration_set(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = pinpoint_sms_voice("POST", "/v1/sms-voice/configuration-sets", params; aws_config=aws_config)
 
 """
     create_configuration_set_event_destination(configuration_set_name)
@@ -90,7 +90,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"PageSize"`: Used to specify the number of items that should be returned in the response.
 """
 list_configuration_sets(; aws_config::AbstractAWSConfig=global_aws_config()) = pinpoint_sms_voice("GET", "/v1/sms-voice/configuration-sets"; aws_config=aws_config)
-list_configuration_sets(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = pinpoint_sms_voice("GET", "/v1/sms-voice/configuration-sets", params; aws_config=aws_config)
+list_configuration_sets(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = pinpoint_sms_voice("GET", "/v1/sms-voice/configuration-sets", params; aws_config=aws_config)
 
 """
     send_voice_message()
@@ -111,7 +111,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   when they receive the message, because you can specify a CallerId parameter in the request.
 """
 send_voice_message(; aws_config::AbstractAWSConfig=global_aws_config()) = pinpoint_sms_voice("POST", "/v1/sms-voice/voice/message"; aws_config=aws_config)
-send_voice_message(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = pinpoint_sms_voice("POST", "/v1/sms-voice/voice/message", params; aws_config=aws_config)
+send_voice_message(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = pinpoint_sms_voice("POST", "/v1/sms-voice/voice/message", params; aws_config=aws_config)
 
 """
     update_configuration_set_event_destination(configuration_set_name, event_destination_name)

--- a/src/services/polly.jl
+++ b/src/services/polly.jl
@@ -51,7 +51,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   operation. If present, this indicates where to continue the listing.
 """
 describe_voices(; aws_config::AbstractAWSConfig=global_aws_config()) = polly("GET", "/v1/voices"; aws_config=aws_config)
-describe_voices(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = polly("GET", "/v1/voices", params; aws_config=aws_config)
+describe_voices(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = polly("GET", "/v1/voices", params; aws_config=aws_config)
 
 """
     get_lexicon(lexicon_name)
@@ -95,7 +95,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   If present, indicates where to continue the list of lexicons.
 """
 list_lexicons(; aws_config::AbstractAWSConfig=global_aws_config()) = polly("GET", "/v1/lexicons"; aws_config=aws_config)
-list_lexicons(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = polly("GET", "/v1/lexicons", params; aws_config=aws_config)
+list_lexicons(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = polly("GET", "/v1/lexicons", params; aws_config=aws_config)
 
 """
     list_speech_synthesis_tasks()
@@ -113,7 +113,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"Status"`: Status of the speech synthesis tasks returned in a List operation
 """
 list_speech_synthesis_tasks(; aws_config::AbstractAWSConfig=global_aws_config()) = polly("GET", "/v1/synthesisTasks"; aws_config=aws_config)
-list_speech_synthesis_tasks(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = polly("GET", "/v1/synthesisTasks", params; aws_config=aws_config)
+list_speech_synthesis_tasks(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = polly("GET", "/v1/synthesisTasks", params; aws_config=aws_config)
 
 """
     put_lexicon(content, lexicon_name)

--- a/src/services/qldb.jl
+++ b/src/services/qldb.jl
@@ -255,7 +255,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   ListJournalS3Exports call, then you should use that value as input here.
 """
 list_journal_s3_exports(; aws_config::AbstractAWSConfig=global_aws_config()) = qldb("GET", "/journal-s3-exports"; aws_config=aws_config)
-list_journal_s3_exports(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = qldb("GET", "/journal-s3-exports", params; aws_config=aws_config)
+list_journal_s3_exports(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = qldb("GET", "/journal-s3-exports", params; aws_config=aws_config)
 
 """
     list_journal_s3_exports_for_ledger(name)
@@ -299,7 +299,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   call, then you should use that value as input here.
 """
 list_ledgers(; aws_config::AbstractAWSConfig=global_aws_config()) = qldb("GET", "/ledgers"; aws_config=aws_config)
-list_ledgers(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = qldb("GET", "/ledgers", params; aws_config=aws_config)
+list_ledgers(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = qldb("GET", "/ledgers", params; aws_config=aws_config)
 
 """
     list_tags_for_resource(resource_arn)

--- a/src/services/ram.jl
+++ b/src/services/ram.jl
@@ -153,7 +153,7 @@ account for the AWS Organization.
 
 """
 enable_sharing_with_aws_organization(; aws_config::AbstractAWSConfig=global_aws_config()) = ram("POST", "/enablesharingwithawsorganization"; aws_config=aws_config)
-enable_sharing_with_aws_organization(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = ram("POST", "/enablesharingwithawsorganization", params; aws_config=aws_config)
+enable_sharing_with_aws_organization(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = ram("POST", "/enablesharingwithawsorganization", params; aws_config=aws_config)
 
 """
     get_permission(permission_arn)
@@ -231,7 +231,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"resourceShareInvitationArns"`: The Amazon Resource Names (ARN) of the invitations.
 """
 get_resource_share_invitations(; aws_config::AbstractAWSConfig=global_aws_config()) = ram("POST", "/getresourceshareinvitations"; aws_config=aws_config)
-get_resource_share_invitations(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = ram("POST", "/getresourceshareinvitations", params; aws_config=aws_config)
+get_resource_share_invitations(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = ram("POST", "/getresourceshareinvitations", params; aws_config=aws_config)
 
 """
     get_resource_shares(resource_owner)
@@ -289,7 +289,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   to list only permissions that apply to EC2 subnets, specify ec2:Subnet.
 """
 list_permissions(; aws_config::AbstractAWSConfig=global_aws_config()) = ram("POST", "/listpermissions"; aws_config=aws_config)
-list_permissions(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = ram("POST", "/listpermissions", params; aws_config=aws_config)
+list_permissions(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = ram("POST", "/listpermissions", params; aws_config=aws_config)
 
 """
     list_principals(resource_owner)
@@ -353,7 +353,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: The token for the next page of results.
 """
 list_resource_types(; aws_config::AbstractAWSConfig=global_aws_config()) = ram("POST", "/listresourcetypes"; aws_config=aws_config)
-list_resource_types(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = ram("POST", "/listresourcetypes", params; aws_config=aws_config)
+list_resource_types(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = ram("POST", "/listresourcetypes", params; aws_config=aws_config)
 
 """
     list_resources(resource_owner)

--- a/src/services/rds.jl
+++ b/src/services/rds.jl
@@ -631,10 +631,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"PreferredBackupWindow"`: The daily time range during which automated backups are
   created if automated backups are enabled using the BackupRetentionPeriod parameter.  The
   default is a 30-minute window selected at random from an 8-hour block of time for each AWS
-  Region. To see the time blocks available, see  Adjusting the Preferred DB Cluster
-  Maintenance Window in the Amazon Aurora User Guide.  Constraints:   Must be in the format
-  hh24:mi-hh24:mi.   Must be in Universal Coordinated Time (UTC).   Must not conflict with
-  the preferred maintenance window.   Must be at least 30 minutes.
+  Region. To view the time blocks available, see  Backup window in the Amazon Aurora User
+  Guide.  Constraints:   Must be in the format hh24:mi-hh24:mi.   Must be in Universal
+  Coordinated Time (UTC).   Must not conflict with the preferred maintenance window.   Must
+  be at least 30 minutes.
 - `"PreferredMaintenanceWindow"`: The weekly time range during which system maintenance can
   occur, in Universal Coordinated Time (UTC). Format: ddd:hh24:mi-ddd:hh24:mi  The default is
   a 30-minute window selected at random from an 8-hour block of time for each AWS Region,
@@ -974,14 +974,13 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Valid values: 1150-65535 except 1234, 1434, 3260, 3343, 3389, 47001, and 49152-49156.
   Amazon Aurora   Default: 3306   Valid values: 1150-65535  Type: Integer
 - `"PreferredBackupWindow"`:  The daily time range during which automated backups are
-  created if automated backups are enabled, using the BackupRetentionPeriod parameter. For
-  more information, see The Backup Window in the Amazon RDS User Guide.   Amazon Aurora  Not
-  applicable. The daily time range for creating automated backups is managed by the DB
-  cluster.  The default is a 30-minute window selected at random from an 8-hour block of time
-  for each AWS Region. To see the time blocks available, see  Adjusting the Preferred DB
-  Instance Maintenance Window in the Amazon RDS User Guide.  Constraints:   Must be in the
-  format hh24:mi-hh24:mi.   Must be in Universal Coordinated Time (UTC).   Must not conflict
-  with the preferred maintenance window.   Must be at least 30 minutes.
+  created if automated backups are enabled, using the BackupRetentionPeriod parameter. The
+  default is a 30-minute window selected at random from an 8-hour block of time for each AWS
+  Region. For more information, see Backup window in the Amazon RDS User Guide.   Amazon
+  Aurora  Not applicable. The daily time range for creating automated backups is managed by
+  the DB cluster. Constraints:   Must be in the format hh24:mi-hh24:mi.   Must be in
+  Universal Coordinated Time (UTC).   Must not conflict with the preferred maintenance
+  window.   Must be at least 30 minutes.
 - `"PreferredMaintenanceWindow"`: The time range each week during which system maintenance
   can occur, in Universal Coordinated Time (UTC). For more information, see Amazon RDS
   Maintenance Window.   Format: ddd:hh24:mi-ddd:hh24:mi  The default is a 30-minute window
@@ -1435,8 +1434,8 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"SourceIds"`: The list of identifiers of the event sources for which events are
   returned. If not specified, then all sources are included in the response. An identifier
   must begin with a letter and must contain only ASCII letters, digits, and hyphens. It can't
-  end with a hyphen or contain two consecutive hyphens. Constraints:   If a SourceIds value
-  is supplied, SourceType must also be provided.   If the source type is a DB instance, a
+  end with a hyphen or contain two consecutive hyphens. Constraints:   If SourceIds are
+  supplied, SourceType must also be provided.   If the source type is a DB instance, a
   DBInstanceIdentifier value must be supplied.   If the source type is a DB cluster, a
   DBClusterIdentifier value must be supplied.   If the source type is a DB parameter group, a
   DBParameterGroupName value must be supplied.   If the source type is a DB security group, a
@@ -3328,10 +3327,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"PreferredBackupWindow"`: The daily time range during which automated backups are
   created if automated backups are enabled, using the BackupRetentionPeriod parameter.  The
   default is a 30-minute window selected at random from an 8-hour block of time for each AWS
-  Region. To see the time blocks available, see  Adjusting the Preferred DB Cluster
-  Maintenance Window in the Amazon Aurora User Guide.  Constraints:   Must be in the format
-  hh24:mi-hh24:mi.   Must be in Universal Coordinated Time (UTC).   Must not conflict with
-  the preferred maintenance window.   Must be at least 30 minutes.
+  Region. To view the time blocks available, see  Backup window in the Amazon Aurora User
+  Guide.  Constraints:   Must be in the format hh24:mi-hh24:mi.   Must be in Universal
+  Coordinated Time (UTC).   Must not conflict with the preferred maintenance window.   Must
+  be at least 30 minutes.
 - `"PreferredMaintenanceWindow"`: The weekly time range during which system maintenance can
   occur, in Universal Coordinated Time (UTC). Format: ddd:hh24:mi-ddd:hh24:mi  The default is
   a 30-minute window selected at random from an 8-hour block of time for each AWS Region,
@@ -3491,16 +3490,17 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   AWS Backup.
 - `"BackupRetentionPeriod"`: The number of days to retain automated backups. Setting this
   parameter to a positive number enables backups. Setting this parameter to 0 disables
-  automated backups. Changing this parameter can result in an outage if you change from 0 to
-  a non-zero value or from a non-zero value to 0. These changes are applied during the next
-  maintenance window unless the ApplyImmediately parameter is enabled for this request. If
-  you change the parameter from one non-zero value to another non-zero value, the change is
-  asynchronously applied as soon as possible.  Amazon Aurora  Not applicable. The retention
-  period for automated backups is managed by the DB cluster. For more information, see
-  ModifyDBCluster. Default: Uses existing setting Constraints:   Must be a value from 0 to 35
-    Can be specified for a MySQL read replica only if the source is running MySQL 5.6 or
-  later   Can be specified for a PostgreSQL read replica only if the source is running
-  PostgreSQL 9.3.5   Can't be set to 0 if the DB instance is a source to read replicas
+  automated backups.  Enabling and disabling backups can result in a brief I/O suspension
+  that lasts from a few seconds to a few minutes, depending on the size and class of your DB
+  instance.  These changes are applied during the next maintenance window unless the
+  ApplyImmediately parameter is enabled for this request. If you change the parameter from
+  one non-zero value to another non-zero value, the change is asynchronously applied as soon
+  as possible.  Amazon Aurora  Not applicable. The retention period for automated backups is
+  managed by the DB cluster. For more information, see ModifyDBCluster. Default: Uses
+  existing setting Constraints:   Must be a value from 0 to 35   Can be specified for a MySQL
+  read replica only if the source is running MySQL 5.6 or later   Can be specified for a
+  PostgreSQL read replica only if the source is running PostgreSQL 9.3.5   Can't be set to 0
+  if the DB instance is a source to read replicas
 - `"CACertificateIdentifier"`: Indicates the certificate that needs to be associated with
   the instance.
 - `"CertificateRotationRestart"`: A value that indicates whether the DB instance is
@@ -3670,9 +3670,11 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"PreferredBackupWindow"`:  The daily time range during which automated backups are
   created if automated backups are enabled, as determined by the BackupRetentionPeriod
   parameter. Changing this parameter doesn't result in an outage and the change is
-  asynchronously applied as soon as possible.   Amazon Aurora  Not applicable. The daily time
-  range for creating automated backups is managed by the DB cluster. For more information,
-  see ModifyDBCluster. Constraints:   Must be in the format hh24:mi-hh24:mi   Must be in
+  asynchronously applied as soon as possible. The default is a 30-minute window selected at
+  random from an 8-hour block of time for each AWS Region. For more information, see Backup
+  window in the Amazon RDS User Guide.   Amazon Aurora  Not applicable. The daily time range
+  for creating automated backups is managed by the DB cluster. For more information, see
+  ModifyDBCluster. Constraints:   Must be in the format hh24:mi-hh24:mi   Must be in
   Universal Time Coordinated (UTC)   Must not conflict with the preferred maintenance window
    Must be at least 30 minutes
 - `"PreferredMaintenanceWindow"`: The weekly time range (in UTC) during which system
@@ -3682,7 +3684,8 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   maintenance window is changed to include the current time, then changing this parameter
   will cause a reboot of the DB instance. If moving this window to the current time, there
   must be at least 30 minutes between the current time and end of the window to ensure
-  pending changes are applied. Default: Uses existing setting Format: ddd:hh24:mi-ddd:hh24:mi
+  pending changes are applied. For more information, see Amazon RDS Maintenance Window in the
+  Amazon RDS User Guide.  Default: Uses existing setting Format: ddd:hh24:mi-ddd:hh24:mi
   Valid Days: Mon | Tue | Wed | Thu | Fri | Sat | Sun Constraints: Must be at least 30 minutes
 - `"ProcessorFeatures"`: The number of CPU cores and the number of threads per core for the
   DB instance class of the DB instance.
@@ -4413,10 +4416,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"PreferredBackupWindow"`: The daily time range during which automated backups are
   created if automated backups are enabled using the BackupRetentionPeriod parameter.  The
   default is a 30-minute window selected at random from an 8-hour block of time for each AWS
-  Region. To see the time blocks available, see  Adjusting the Preferred Maintenance Window
-  in the Amazon Aurora User Guide.  Constraints:   Must be in the format hh24:mi-hh24:mi.
-  Must be in Universal Coordinated Time (UTC).   Must not conflict with the preferred
-  maintenance window.   Must be at least 30 minutes.
+  Region. To view the time blocks available, see  Backup window in the Amazon Aurora User
+  Guide.  Constraints:   Must be in the format hh24:mi-hh24:mi.   Must be in Universal
+  Coordinated Time (UTC).   Must not conflict with the preferred maintenance window.   Must
+  be at least 30 minutes.
 - `"PreferredMaintenanceWindow"`: The weekly time range during which system maintenance can
   occur, in Universal Coordinated Time (UTC). Format: ddd:hh24:mi-ddd:hh24:mi  The default is
   a 30-minute window selected at random from an 8-hour block of time for each AWS Region,
@@ -4877,9 +4880,9 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"Port"`: The port number on which the database accepts connections.  Type: Integer
   Valid Values: 1150-65535  Default: 3306
 - `"PreferredBackupWindow"`: The time range each day during which automated backups are
-  created if automated backups are enabled. For more information, see The Backup Window in
-  the Amazon RDS User Guide.  Constraints:   Must be in the format hh24:mi-hh24:mi.   Must be
-  in Universal Coordinated Time (UTC).   Must not conflict with the preferred maintenance
+  created if automated backups are enabled. For more information, see Backup window in the
+  Amazon RDS User Guide.  Constraints:   Must be in the format hh24:mi-hh24:mi.   Must be in
+  Universal Coordinated Time (UTC).   Must not conflict with the preferred maintenance
   window.   Must be at least 30 minutes.
 - `"PreferredMaintenanceWindow"`: The time range each week during which system maintenance
   can occur, in Universal Coordinated Time (UTC). For more information, see Amazon RDS
@@ -5050,7 +5053,7 @@ restore_dbinstance_to_point_in_time(TargetDBInstanceIdentifier, params::Abstract
     revoke_dbsecurity_group_ingress(dbsecurity_group_name, params::Dict{String,<:Any})
 
 Revokes ingress from a DBSecurityGroup for previously authorized IP ranges or EC2 or VPC
-Security Groups. Required parameters for this API are one of CIDRIP, EC2SecurityGroupId for
+security groups. Required parameters for this API are one of CIDRIP, EC2SecurityGroupId for
 VPC, or (EC2SecurityGroupOwnerId and either EC2SecurityGroupName or EC2SecurityGroupId).
 
 # Arguments

--- a/src/services/redshift.jl
+++ b/src/services/redshift.jl
@@ -228,6 +228,11 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   major version of the Amazon Redshift engine is released, you can request that the service
   automatically apply upgrades during the maintenance window to the Amazon Redshift engine
   that is running on your cluster. Default: true
+- `"AquaConfigurationStatus"`: The value represents how the cluster is configured to use
+  AQUA (Advanced Query Accelerator) when it is created. Possible values include the
+  following.   enabled - Use AQUA if it is available for the current AWS Region and Amazon
+  Redshift node type.   disabled - Don't use AQUA.    auto - Amazon Redshift determines
+  whether to use AQUA.
 - `"AutomatedSnapshotRetentionPeriod"`: The number of days that automated snapshots are
   retained. If the value is 0, automated snapshots are disabled. Even if automated snapshots
   are disabled, you can still create manual snapshots when you want with
@@ -2112,6 +2117,25 @@ get_reserved_node_exchange_offerings(ReservedNodeId; aws_config::AbstractAWSConf
 get_reserved_node_exchange_offerings(ReservedNodeId, params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = redshift("GetReservedNodeExchangeOfferings", Dict{String, Any}(mergewith(_merge, Dict{String, Any}("ReservedNodeId"=>ReservedNodeId), params)); aws_config=aws_config)
 
 """
+    modify_aqua_configuration(cluster_identifier)
+    modify_aqua_configuration(cluster_identifier, params::Dict{String,<:Any})
+
+Modifies whether a cluster can use AQUA (Advanced Query Accelerator).
+
+# Arguments
+- `cluster_identifier`: The identifier of the cluster to be modified.
+
+# Optional Parameters
+Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys are:
+- `"AquaConfigurationStatus"`: The new value of AQUA configuration status. Possible values
+  include the following.   enabled - Use AQUA if it is available for the current AWS Region
+  and Amazon Redshift node type.   disabled - Don't use AQUA.    auto - Amazon Redshift
+  determines whether to use AQUA.
+"""
+modify_aqua_configuration(ClusterIdentifier; aws_config::AbstractAWSConfig=global_aws_config()) = redshift("ModifyAquaConfiguration", Dict{String, Any}("ClusterIdentifier"=>ClusterIdentifier); aws_config=aws_config)
+modify_aqua_configuration(ClusterIdentifier, params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = redshift("ModifyAquaConfiguration", Dict{String, Any}(mergewith(_merge, Dict{String, Any}("ClusterIdentifier"=>ClusterIdentifier), params)); aws_config=aws_config)
+
+"""
     modify_cluster(cluster_identifier)
     modify_cluster(cluster_identifier, params::Dict{String,<:Any})
 
@@ -2679,6 +2703,11 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"AllowVersionUpgrade"`: If true, major version upgrades can be applied during the
   maintenance window to the Amazon Redshift engine that is running on the cluster.  Default:
   true
+- `"AquaConfigurationStatus"`: The value represents how the cluster is configured to use
+  AQUA (Advanced Query Accelerator) after the cluster is restored. Possible values include
+  the following.   enabled - Use AQUA if it is available for the current AWS Region and
+  Amazon Redshift node type.   disabled - Don't use AQUA.    auto - Amazon Redshift
+  determines whether to use AQUA.
 - `"AutomatedSnapshotRetentionPeriod"`: The number of days that automated snapshots are
   retained. If the value is 0, automated snapshots are disabled. Even if automated snapshots
   are disabled, you can still create manual snapshots when you want with

--- a/src/services/resource_groups.jl
+++ b/src/services/resource_groups.jl
@@ -55,7 +55,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"GroupName"`: Deprecated - don't use this parameter. Use Group instead.
 """
 delete_group(; aws_config::AbstractAWSConfig=global_aws_config()) = resource_groups("POST", "/delete-group"; aws_config=aws_config)
-delete_group(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = resource_groups("POST", "/delete-group", params; aws_config=aws_config)
+delete_group(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = resource_groups("POST", "/delete-group", params; aws_config=aws_config)
 
 """
     get_group()
@@ -70,7 +70,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"GroupName"`: Deprecated - don't use this parameter. Use Group instead.
 """
 get_group(; aws_config::AbstractAWSConfig=global_aws_config()) = resource_groups("POST", "/get-group"; aws_config=aws_config)
-get_group(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = resource_groups("POST", "/get-group", params; aws_config=aws_config)
+get_group(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = resource_groups("POST", "/get-group", params; aws_config=aws_config)
 
 """
     get_group_configuration()
@@ -86,7 +86,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"Group"`: The name or the ARN of the resource group.
 """
 get_group_configuration(; aws_config::AbstractAWSConfig=global_aws_config()) = resource_groups("POST", "/get-group-configuration"; aws_config=aws_config)
-get_group_configuration(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = resource_groups("POST", "/get-group-configuration", params; aws_config=aws_config)
+get_group_configuration(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = resource_groups("POST", "/get-group-configuration", params; aws_config=aws_config)
 
 """
     get_group_query()
@@ -103,7 +103,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"GroupName"`: Don't use this parameter. Use Group instead.
 """
 get_group_query(; aws_config::AbstractAWSConfig=global_aws_config()) = resource_groups("POST", "/get-group-query"; aws_config=aws_config)
-get_group_query(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = resource_groups("POST", "/get-group-query", params; aws_config=aws_config)
+get_group_query(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = resource_groups("POST", "/get-group-query", params; aws_config=aws_config)
 
 """
     get_tags(arn)
@@ -178,7 +178,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   to indicate where the output should continue from.
 """
 list_group_resources(; aws_config::AbstractAWSConfig=global_aws_config()) = resource_groups("POST", "/list-group-resources"; aws_config=aws_config)
-list_group_resources(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = resource_groups("POST", "/list-group-resources", params; aws_config=aws_config)
+list_group_resources(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = resource_groups("POST", "/list-group-resources", params; aws_config=aws_config)
 
 """
     list_groups()
@@ -210,7 +210,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   to indicate where the output should continue from.
 """
 list_groups(; aws_config::AbstractAWSConfig=global_aws_config()) = resource_groups("POST", "/groups-list"; aws_config=aws_config)
-list_groups(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = resource_groups("POST", "/groups-list", params; aws_config=aws_config)
+list_groups(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = resource_groups("POST", "/groups-list", params; aws_config=aws_config)
 
 """
     put_group_configuration()
@@ -233,7 +233,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   update.
 """
 put_group_configuration(; aws_config::AbstractAWSConfig=global_aws_config()) = resource_groups("POST", "/put-group-configuration"; aws_config=aws_config)
-put_group_configuration(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = resource_groups("POST", "/put-group-configuration", params; aws_config=aws_config)
+put_group_configuration(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = resource_groups("POST", "/put-group-configuration", params; aws_config=aws_config)
 
 """
     search_resources(resource_query)
@@ -333,7 +333,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"GroupName"`: Don't use this parameter. Use Group instead.
 """
 update_group(; aws_config::AbstractAWSConfig=global_aws_config()) = resource_groups("POST", "/update-group"; aws_config=aws_config)
-update_group(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = resource_groups("POST", "/update-group", params; aws_config=aws_config)
+update_group(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = resource_groups("POST", "/update-group", params; aws_config=aws_config)
 
 """
     update_group_query(resource_query)

--- a/src/services/robomaker.jl
+++ b/src/services/robomaker.jl
@@ -334,7 +334,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"templateLocation"`: The location of the world template.
 """
 create_world_template(; aws_config::AbstractAWSConfig=global_aws_config()) = robomaker("POST", "/createWorldTemplate"; aws_config=aws_config)
-create_world_template(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = robomaker("POST", "/createWorldTemplate", params; aws_config=aws_config)
+create_world_template(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = robomaker("POST", "/createWorldTemplate", params; aws_config=aws_config)
 
 """
     delete_fleet(fleet)
@@ -582,7 +582,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"template"`: The Amazon Resource Name (arn) of the world template.
 """
 get_world_template_body(; aws_config::AbstractAWSConfig=global_aws_config()) = robomaker("POST", "/getWorldTemplateBody"; aws_config=aws_config)
-get_world_template_body(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = robomaker("POST", "/getWorldTemplateBody", params; aws_config=aws_config)
+get_world_template_body(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = robomaker("POST", "/getWorldTemplateBody", params; aws_config=aws_config)
 
 """
     list_deployment_jobs()
@@ -610,7 +610,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   object's NextToken parameter is set to null.
 """
 list_deployment_jobs(; aws_config::AbstractAWSConfig=global_aws_config()) = robomaker("POST", "/listDeploymentJobs"; aws_config=aws_config)
-list_deployment_jobs(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = robomaker("POST", "/listDeploymentJobs", params; aws_config=aws_config)
+list_deployment_jobs(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = robomaker("POST", "/listDeploymentJobs", params; aws_config=aws_config)
 
 """
     list_fleets()
@@ -637,7 +637,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   purposes.
 """
 list_fleets(; aws_config::AbstractAWSConfig=global_aws_config()) = robomaker("POST", "/listFleets"; aws_config=aws_config)
-list_fleets(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = robomaker("POST", "/listFleets", params; aws_config=aws_config)
+list_fleets(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = robomaker("POST", "/listFleets", params; aws_config=aws_config)
 
 """
     list_robot_applications()
@@ -665,7 +665,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"versionQualifier"`: The version qualifier of the robot application.
 """
 list_robot_applications(; aws_config::AbstractAWSConfig=global_aws_config()) = robomaker("POST", "/listRobotApplications"; aws_config=aws_config)
-list_robot_applications(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = robomaker("POST", "/listRobotApplications", params; aws_config=aws_config)
+list_robot_applications(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = robomaker("POST", "/listRobotApplications", params; aws_config=aws_config)
 
 """
     list_robots()
@@ -691,7 +691,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   NextToken parameter is set to null.
 """
 list_robots(; aws_config::AbstractAWSConfig=global_aws_config()) = robomaker("POST", "/listRobots"; aws_config=aws_config)
-list_robots(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = robomaker("POST", "/listRobots", params; aws_config=aws_config)
+list_robots(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = robomaker("POST", "/listRobots", params; aws_config=aws_config)
 
 """
     list_simulation_applications()
@@ -719,7 +719,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"versionQualifier"`: The version qualifier of the simulation application.
 """
 list_simulation_applications(; aws_config::AbstractAWSConfig=global_aws_config()) = robomaker("POST", "/listSimulationApplications"; aws_config=aws_config)
-list_simulation_applications(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = robomaker("POST", "/listSimulationApplications", params; aws_config=aws_config)
+list_simulation_applications(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = robomaker("POST", "/listSimulationApplications", params; aws_config=aws_config)
 
 """
     list_simulation_job_batches()
@@ -742,7 +742,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   response object's NextToken parameter is set to null.
 """
 list_simulation_job_batches(; aws_config::AbstractAWSConfig=global_aws_config()) = robomaker("POST", "/listSimulationJobBatches"; aws_config=aws_config)
-list_simulation_job_batches(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = robomaker("POST", "/listSimulationJobBatches", params; aws_config=aws_config)
+list_simulation_job_batches(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = robomaker("POST", "/listSimulationJobBatches", params; aws_config=aws_config)
 
 """
     list_simulation_jobs()
@@ -771,7 +771,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   object's NextToken parameter is set to null.
 """
 list_simulation_jobs(; aws_config::AbstractAWSConfig=global_aws_config()) = robomaker("POST", "/listSimulationJobs"; aws_config=aws_config)
-list_simulation_jobs(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = robomaker("POST", "/listSimulationJobs", params; aws_config=aws_config)
+list_simulation_jobs(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = robomaker("POST", "/listSimulationJobs", params; aws_config=aws_config)
 
 """
     list_tags_for_resource(resource_arn)
@@ -809,7 +809,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   object's NextToken parameter is set to null.
 """
 list_world_export_jobs(; aws_config::AbstractAWSConfig=global_aws_config()) = robomaker("POST", "/listWorldExportJobs"; aws_config=aws_config)
-list_world_export_jobs(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = robomaker("POST", "/listWorldExportJobs", params; aws_config=aws_config)
+list_world_export_jobs(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = robomaker("POST", "/listWorldExportJobs", params; aws_config=aws_config)
 
 """
     list_world_generation_jobs()
@@ -833,7 +833,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   response object's NextToken parameter is set to null.
 """
 list_world_generation_jobs(; aws_config::AbstractAWSConfig=global_aws_config()) = robomaker("POST", "/listWorldGenerationJobs"; aws_config=aws_config)
-list_world_generation_jobs(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = robomaker("POST", "/listWorldGenerationJobs", params; aws_config=aws_config)
+list_world_generation_jobs(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = robomaker("POST", "/listWorldGenerationJobs", params; aws_config=aws_config)
 
 """
     list_world_templates()
@@ -856,7 +856,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   object's NextToken parameter is set to null.
 """
 list_world_templates(; aws_config::AbstractAWSConfig=global_aws_config()) = robomaker("POST", "/listWorldTemplates"; aws_config=aws_config)
-list_world_templates(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = robomaker("POST", "/listWorldTemplates", params; aws_config=aws_config)
+list_world_templates(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = robomaker("POST", "/listWorldTemplates", params; aws_config=aws_config)
 
 """
     list_worlds()
@@ -879,7 +879,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   NextToken parameter is set to null.
 """
 list_worlds(; aws_config::AbstractAWSConfig=global_aws_config()) = robomaker("POST", "/listWorlds"; aws_config=aws_config)
-list_worlds(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = robomaker("POST", "/listWorlds", params; aws_config=aws_config)
+list_worlds(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = robomaker("POST", "/listWorlds", params; aws_config=aws_config)
 
 """
     register_robot(fleet, robot)

--- a/src/services/route_53.jl
+++ b/src/services/route_53.jl
@@ -193,7 +193,8 @@ Migrating DNS Service for an Existing Domain to Amazon Route 53 in the Amazon Ro
 Developer Guide.    When you submit a CreateHostedZone request, the initial status of the
 hosted zone is PENDING. For public hosted zones, this means that the NS and SOA records are
 not yet available on all Route 53 DNS servers. When the NS and SOA records are available,
-the status of the zone changes to INSYNC.
+the status of the zone changes to INSYNC. The CreateHostedZone request requires the caller
+to have an ec2:DescribeVpcs permission.
 
 # Arguments
 - `caller_reference`: A unique string that identifies the request and that allows failed
@@ -243,8 +244,8 @@ KSKs per hosted zone.
   Status  Enabled  Key spec  ECC_NIST_P256  Key usage  Sign and verify  Key policy  The key
   policy must give permission for the following actions:   DescribeKey   GetPublicKey   Sign
    The key policy must also include the Amazon Route 53 service in the principal for your
-  account. Specify the following:    \"Service\": \"api-service.dnssec.route53.aws.internal\"
-       For more information about working with a customer managed CMK in AWS KMS, see AWS Key
+  account. Specify the following:    \"Service\": \"dnssec.route53.aws.amazonaws.com\"
+  For more information about working with a customer managed CMK in AWS KMS, see AWS Key
   Management Service concepts.
 - `name`: A string used to identify a key-signing key (KSK). Name can include numbers,
   letters, and underscores (_). Name must be unique for each key-signing key in the same
@@ -543,7 +544,7 @@ delete_hosted_zone(Id, params::AbstractDict{String, <:Any}; aws_config::Abstract
     delete_key_signing_key(hosted_zone_id, name, params::Dict{String,<:Any})
 
 Deletes a key-signing key (KSK). Before you can delete a KSK, you must deactivate it. The
-KSK must be deactived before you can delete it regardless of whether the hosted zone is
+KSK must be deactivated before you can delete it regardless of whether the hosted zone is
 enabled for DNSSEC signing.
 
 # Arguments
@@ -757,7 +758,7 @@ Developer Guide.
 
 """
 get_checker_ip_ranges(; aws_config::AbstractAWSConfig=global_aws_config()) = route_53("GET", "/2013-04-01/checkeripranges"; aws_config=aws_config)
-get_checker_ip_ranges(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = route_53("GET", "/2013-04-01/checkeripranges", params; aws_config=aws_config)
+get_checker_ip_ranges(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = route_53("GET", "/2013-04-01/checkeripranges", params; aws_config=aws_config)
 
 """
     get_dnssec(id)
@@ -802,7 +803,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   supported subdivision codes, use the ListGeoLocations API.
 """
 get_geo_location(; aws_config::AbstractAWSConfig=global_aws_config()) = route_53("GET", "/2013-04-01/geolocation"; aws_config=aws_config)
-get_geo_location(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = route_53("GET", "/2013-04-01/geolocation", params; aws_config=aws_config)
+get_geo_location(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = route_53("GET", "/2013-04-01/geolocation", params; aws_config=aws_config)
 
 """
     get_health_check(health_check_id)
@@ -827,7 +828,7 @@ Retrieves the number of health checks that are associated with the current AWS a
 
 """
 get_health_check_count(; aws_config::AbstractAWSConfig=global_aws_config()) = route_53("GET", "/2013-04-01/healthcheckcount"; aws_config=aws_config)
-get_health_check_count(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = route_53("GET", "/2013-04-01/healthcheckcount", params; aws_config=aws_config)
+get_health_check_count(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = route_53("GET", "/2013-04-01/healthcheckcount", params; aws_config=aws_config)
 
 """
     get_health_check_last_failure_reason(health_check_id)
@@ -885,7 +886,7 @@ Retrieves the number of hosted zones that are associated with the current AWS ac
 
 """
 get_hosted_zone_count(; aws_config::AbstractAWSConfig=global_aws_config()) = route_53("GET", "/2013-04-01/hostedzonecount"; aws_config=aws_config)
-get_hosted_zone_count(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = route_53("GET", "/2013-04-01/hostedzonecount", params; aws_config=aws_config)
+get_hosted_zone_count(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = route_53("GET", "/2013-04-01/hostedzonecount", params; aws_config=aws_config)
 
 """
     get_hosted_zone_limit(id, type)
@@ -996,7 +997,7 @@ account.
 
 """
 get_traffic_policy_instance_count(; aws_config::AbstractAWSConfig=global_aws_config()) = route_53("GET", "/2013-04-01/trafficpolicyinstancecount"; aws_config=aws_config)
-get_traffic_policy_instance_count(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = route_53("GET", "/2013-04-01/trafficpolicyinstancecount", params; aws_config=aws_config)
+get_traffic_policy_instance_count(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = route_53("GET", "/2013-04-01/trafficpolicyinstancecount", params; aws_config=aws_config)
 
 """
     list_geo_locations()
@@ -1033,7 +1034,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   states), you must include both startcountrycode and startsubdivisioncode.
 """
 list_geo_locations(; aws_config::AbstractAWSConfig=global_aws_config()) = route_53("GET", "/2013-04-01/geolocations"; aws_config=aws_config)
-list_geo_locations(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = route_53("GET", "/2013-04-01/geolocations", params; aws_config=aws_config)
+list_geo_locations(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = route_53("GET", "/2013-04-01/geolocations", params; aws_config=aws_config)
 
 """
     list_health_checks()
@@ -1055,7 +1056,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   checks.
 """
 list_health_checks(; aws_config::AbstractAWSConfig=global_aws_config()) = route_53("GET", "/2013-04-01/healthcheck"; aws_config=aws_config)
-list_health_checks(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = route_53("GET", "/2013-04-01/healthcheck", params; aws_config=aws_config)
+list_health_checks(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = route_53("GET", "/2013-04-01/healthcheck", params; aws_config=aws_config)
 
 """
     list_hosted_zones()
@@ -1083,7 +1084,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   zone that Route 53 will return if you submit another request.
 """
 list_hosted_zones(; aws_config::AbstractAWSConfig=global_aws_config()) = route_53("GET", "/2013-04-01/hostedzone"; aws_config=aws_config)
-list_hosted_zones(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = route_53("GET", "/2013-04-01/hostedzone", params; aws_config=aws_config)
+list_hosted_zones(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = route_53("GET", "/2013-04-01/hostedzone", params; aws_config=aws_config)
 
 """
     list_hosted_zones_by_name()
@@ -1136,7 +1137,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   NextHostedZoneId specify the first hosted zone in the next group of maxitems hosted zones.
 """
 list_hosted_zones_by_name(; aws_config::AbstractAWSConfig=global_aws_config()) = route_53("GET", "/2013-04-01/hostedzonesbyname"; aws_config=aws_config)
-list_hosted_zones_by_name(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = route_53("GET", "/2013-04-01/hostedzonesbyname", params; aws_config=aws_config)
+list_hosted_zones_by_name(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = route_53("GET", "/2013-04-01/hostedzonesbyname", params; aws_config=aws_config)
 
 """
     list_hosted_zones_by_vpc(vpcid, vpcregion)
@@ -1199,7 +1200,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   value for NextToken in the request.
 """
 list_query_logging_configs(; aws_config::AbstractAWSConfig=global_aws_config()) = route_53("GET", "/2013-04-01/queryloggingconfig"; aws_config=aws_config)
-list_query_logging_configs(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = route_53("GET", "/2013-04-01/queryloggingconfig", params; aws_config=aws_config)
+list_query_logging_configs(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = route_53("GET", "/2013-04-01/queryloggingconfig", params; aws_config=aws_config)
 
 """
     list_resource_record_sets(id)
@@ -1285,7 +1286,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   returns only the first 100 reusable delegation sets.
 """
 list_reusable_delegation_sets(; aws_config::AbstractAWSConfig=global_aws_config()) = route_53("GET", "/2013-04-01/delegationset"; aws_config=aws_config)
-list_reusable_delegation_sets(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = route_53("GET", "/2013-04-01/delegationset", params; aws_config=aws_config)
+list_reusable_delegation_sets(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = route_53("GET", "/2013-04-01/delegationset", params; aws_config=aws_config)
 
 """
     list_tags_for_resource(resource_id, resource_type)
@@ -1350,7 +1351,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   returned in the previous response.
 """
 list_traffic_policies(; aws_config::AbstractAWSConfig=global_aws_config()) = route_53("GET", "/2013-04-01/trafficpolicies"; aws_config=aws_config)
-list_traffic_policies(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = route_53("GET", "/2013-04-01/trafficpolicies", params; aws_config=aws_config)
+list_traffic_policies(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = route_53("GET", "/2013-04-01/trafficpolicies", params; aws_config=aws_config)
 
 """
     list_traffic_policy_instances()
@@ -1394,7 +1395,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   more traffic policy instances to get.
 """
 list_traffic_policy_instances(; aws_config::AbstractAWSConfig=global_aws_config()) = route_53("GET", "/2013-04-01/trafficpolicyinstances"; aws_config=aws_config)
-list_traffic_policy_instances(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = route_53("GET", "/2013-04-01/trafficpolicyinstances", params; aws_config=aws_config)
+list_traffic_policy_instances(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = route_53("GET", "/2013-04-01/trafficpolicyinstances", params; aws_config=aws_config)
 
 """
     list_traffic_policy_instances_by_hosted_zone(id)
@@ -1548,7 +1549,8 @@ list_vpcassociation_authorizations(Id, params::AbstractDict{String, <:Any}; aws_
 
 Gets the value that Amazon Route 53 returns in response to a DNS request for a specified
 record name and type. You can optionally specify the IP address of a DNS resolver, an EDNS0
-client subnet IP address, and a subnet mask.
+client subnet IP address, and a subnet mask.  This call only supports querying public
+hosted zones.
 
 # Arguments
 - `hostedzoneid`: The ID of the hosted zone that you want Amazon Route 53 to simulate a

--- a/src/services/s3.jl
+++ b/src/services/s3.jl
@@ -2206,7 +2206,7 @@ Returns a list of all buckets owned by the authenticated sender of the request.
 
 """
 list_buckets(; aws_config::AbstractAWSConfig=global_aws_config()) = s3("GET", "/"; aws_config=aws_config)
-list_buckets(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = s3("GET", "/", params; aws_config=aws_config)
+list_buckets(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = s3("GET", "/", params; aws_config=aws_config)
 
 """
     list_multipart_uploads(bucket)

--- a/src/services/s3outposts.jl
+++ b/src/services/s3outposts.jl
@@ -56,4 +56,4 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: The next endpoint requested in the list.
 """
 list_endpoints(; aws_config::AbstractAWSConfig=global_aws_config()) = s3outposts("GET", "/S3Outposts/ListEndpoints"; aws_config=aws_config)
-list_endpoints(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = s3outposts("GET", "/S3Outposts/ListEndpoints", params; aws_config=aws_config)
+list_endpoints(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = s3outposts("GET", "/S3Outposts/ListEndpoints", params; aws_config=aws_config)

--- a/src/services/savingsplans.jl
+++ b/src/services/savingsplans.jl
@@ -78,7 +78,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"states"`: The states.
 """
 describe_savings_plans(; aws_config::AbstractAWSConfig=global_aws_config()) = savingsplans("POST", "/DescribeSavingsPlans"; aws_config=aws_config)
-describe_savings_plans(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = savingsplans("POST", "/DescribeSavingsPlans", params; aws_config=aws_config)
+describe_savings_plans(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = savingsplans("POST", "/DescribeSavingsPlans", params; aws_config=aws_config)
 
 """
     describe_savings_plans_offering_rates()
@@ -101,7 +101,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"usageTypes"`: The usage details of the line item in the billing report.
 """
 describe_savings_plans_offering_rates(; aws_config::AbstractAWSConfig=global_aws_config()) = savingsplans("POST", "/DescribeSavingsPlansOfferingRates"; aws_config=aws_config)
-describe_savings_plans_offering_rates(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = savingsplans("POST", "/DescribeSavingsPlansOfferingRates", params; aws_config=aws_config)
+describe_savings_plans_offering_rates(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = savingsplans("POST", "/DescribeSavingsPlansOfferingRates", params; aws_config=aws_config)
 
 """
     describe_savings_plans_offerings()
@@ -127,7 +127,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"usageTypes"`: The usage details of the line item in the billing report.
 """
 describe_savings_plans_offerings(; aws_config::AbstractAWSConfig=global_aws_config()) = savingsplans("POST", "/DescribeSavingsPlansOfferings"; aws_config=aws_config)
-describe_savings_plans_offerings(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = savingsplans("POST", "/DescribeSavingsPlansOfferings", params; aws_config=aws_config)
+describe_savings_plans_offerings(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = savingsplans("POST", "/DescribeSavingsPlansOfferings", params; aws_config=aws_config)
 
 """
     list_tags_for_resource(resource_arn)

--- a/src/services/schemas.jl
+++ b/src/services/schemas.jl
@@ -95,7 +95,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"registryName"`: The name of the registry.
 """
 delete_resource_policy(; aws_config::AbstractAWSConfig=global_aws_config()) = schemas("DELETE", "/v1/policy"; aws_config=aws_config)
-delete_resource_policy(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = schemas("DELETE", "/v1/policy", params; aws_config=aws_config)
+delete_resource_policy(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = schemas("DELETE", "/v1/policy", params; aws_config=aws_config)
 
 """
     delete_schema(registry_name, schema_name)
@@ -250,7 +250,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"registryName"`: The name of the registry.
 """
 get_resource_policy(; aws_config::AbstractAWSConfig=global_aws_config()) = schemas("GET", "/v1/policy"; aws_config=aws_config)
-get_resource_policy(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = schemas("GET", "/v1/policy", params; aws_config=aws_config)
+get_resource_policy(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = schemas("GET", "/v1/policy", params; aws_config=aws_config)
 
 """
     list_discoverers()
@@ -270,7 +270,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   with the specified prefix.
 """
 list_discoverers(; aws_config::AbstractAWSConfig=global_aws_config()) = schemas("GET", "/v1/discoverers"; aws_config=aws_config)
-list_discoverers(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = schemas("GET", "/v1/discoverers", params; aws_config=aws_config)
+list_discoverers(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = schemas("GET", "/v1/discoverers", params; aws_config=aws_config)
 
 """
     list_registries()
@@ -290,7 +290,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   the ones provided by AWS.
 """
 list_registries(; aws_config::AbstractAWSConfig=global_aws_config()) = schemas("GET", "/v1/registries"; aws_config=aws_config)
-list_registries(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = schemas("GET", "/v1/registries", params; aws_config=aws_config)
+list_registries(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = schemas("GET", "/v1/registries", params; aws_config=aws_config)
 
 """
     list_schema_versions(registry_name, schema_name)

--- a/src/services/securityhub.jl
+++ b/src/services/securityhub.jl
@@ -281,7 +281,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   value returned from the previous response.
 """
 describe_action_targets(; aws_config::AbstractAWSConfig=global_aws_config()) = securityhub("POST", "/actionTargets/get"; aws_config=aws_config)
-describe_action_targets(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = securityhub("POST", "/actionTargets/get", params; aws_config=aws_config)
+describe_action_targets(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = securityhub("POST", "/actionTargets/get", params; aws_config=aws_config)
 
 """
     describe_hub()
@@ -295,7 +295,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"HubArn"`: The ARN of the Hub resource to retrieve.
 """
 describe_hub(; aws_config::AbstractAWSConfig=global_aws_config()) = securityhub("GET", "/accounts"; aws_config=aws_config)
-describe_hub(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = securityhub("GET", "/accounts", params; aws_config=aws_config)
+describe_hub(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = securityhub("GET", "/accounts", params; aws_config=aws_config)
 
 """
     describe_organization_configuration()
@@ -306,7 +306,7 @@ called from a Security Hub administrator account.
 
 """
 describe_organization_configuration(; aws_config::AbstractAWSConfig=global_aws_config()) = securityhub("GET", "/organization/configuration"; aws_config=aws_config)
-describe_organization_configuration(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = securityhub("GET", "/organization/configuration", params; aws_config=aws_config)
+describe_organization_configuration(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = securityhub("GET", "/organization/configuration", params; aws_config=aws_config)
 
 """
     describe_products()
@@ -327,7 +327,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"ProductArn"`: The ARN of the integration to return.
 """
 describe_products(; aws_config::AbstractAWSConfig=global_aws_config()) = securityhub("GET", "/products"; aws_config=aws_config)
-describe_products(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = securityhub("GET", "/products", params; aws_config=aws_config)
+describe_products(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = securityhub("GET", "/products", params; aws_config=aws_config)
 
 """
     describe_standards()
@@ -345,7 +345,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   returned from the previous response.
 """
 describe_standards(; aws_config::AbstractAWSConfig=global_aws_config()) = securityhub("GET", "/standards"; aws_config=aws_config)
-describe_standards(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = securityhub("GET", "/standards", params; aws_config=aws_config)
+describe_standards(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = securityhub("GET", "/standards", params; aws_config=aws_config)
 
 """
     describe_standards_controls(standards_subscription_arn)
@@ -415,7 +415,7 @@ export them before you disable Security Hub.
 
 """
 disable_security_hub(; aws_config::AbstractAWSConfig=global_aws_config()) = securityhub("DELETE", "/accounts"; aws_config=aws_config)
-disable_security_hub(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = securityhub("DELETE", "/accounts", params; aws_config=aws_config)
+disable_security_hub(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = securityhub("DELETE", "/accounts", params; aws_config=aws_config)
 
 """
     disassociate_from_master_account()
@@ -428,7 +428,7 @@ can disassociate a member account.
 
 """
 disassociate_from_master_account(; aws_config::AbstractAWSConfig=global_aws_config()) = securityhub("POST", "/master/disassociate"; aws_config=aws_config)
-disassociate_from_master_account(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = securityhub("POST", "/master/disassociate", params; aws_config=aws_config)
+disassociate_from_master_account(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = securityhub("POST", "/master/disassociate", params; aws_config=aws_config)
 
 """
     disassociate_members(account_ids)
@@ -500,7 +500,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"Tags"`: The tags to add to the hub resource when you enable Security Hub.
 """
 enable_security_hub(; aws_config::AbstractAWSConfig=global_aws_config()) = securityhub("POST", "/accounts"; aws_config=aws_config)
-enable_security_hub(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = securityhub("POST", "/accounts", params; aws_config=aws_config)
+enable_security_hub(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = securityhub("POST", "/accounts", params; aws_config=aws_config)
 
 """
     get_enabled_standards()
@@ -519,7 +519,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   standards to retrieve.
 """
 get_enabled_standards(; aws_config::AbstractAWSConfig=global_aws_config()) = securityhub("POST", "/standards/get"; aws_config=aws_config)
-get_enabled_standards(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = securityhub("POST", "/standards/get", params; aws_config=aws_config)
+get_enabled_standards(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = securityhub("POST", "/standards/get", params; aws_config=aws_config)
 
 """
     get_findings()
@@ -541,7 +541,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"SortCriteria"`: The finding attributes used to sort the list of returned findings.
 """
 get_findings(; aws_config::AbstractAWSConfig=global_aws_config()) = securityhub("POST", "/findings"; aws_config=aws_config)
-get_findings(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = securityhub("POST", "/findings", params; aws_config=aws_config)
+get_findings(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = securityhub("POST", "/findings", params; aws_config=aws_config)
 
 """
     get_insight_results(insight_arn)
@@ -574,7 +574,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   from the previous response.
 """
 get_insights(; aws_config::AbstractAWSConfig=global_aws_config()) = securityhub("POST", "/insights/get"; aws_config=aws_config)
-get_insights(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = securityhub("POST", "/insights/get", params; aws_config=aws_config)
+get_insights(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = securityhub("POST", "/insights/get", params; aws_config=aws_config)
 
 """
     get_invitations_count()
@@ -585,7 +585,7 @@ member account, not including the currently accepted invitation.
 
 """
 get_invitations_count(; aws_config::AbstractAWSConfig=global_aws_config()) = securityhub("GET", "/invitations/count"; aws_config=aws_config)
-get_invitations_count(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = securityhub("GET", "/invitations/count", params; aws_config=aws_config)
+get_invitations_count(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = securityhub("GET", "/invitations/count", params; aws_config=aws_config)
 
 """
     get_master_account()
@@ -597,7 +597,7 @@ invited manually.
 
 """
 get_master_account(; aws_config::AbstractAWSConfig=global_aws_config()) = securityhub("GET", "/master"; aws_config=aws_config)
-get_master_account(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = securityhub("GET", "/master", params; aws_config=aws_config)
+get_master_account(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = securityhub("GET", "/master", params; aws_config=aws_config)
 
 """
     get_members(account_ids)
@@ -652,7 +652,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   parameter to the value returned from the previous response.
 """
 list_enabled_products_for_import(; aws_config::AbstractAWSConfig=global_aws_config()) = securityhub("GET", "/productSubscriptions"; aws_config=aws_config)
-list_enabled_products_for_import(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = securityhub("GET", "/productSubscriptions", params; aws_config=aws_config)
+list_enabled_products_for_import(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = securityhub("GET", "/productSubscriptions", params; aws_config=aws_config)
 
 """
     list_invitations()
@@ -671,7 +671,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   returned from the previous response.
 """
 list_invitations(; aws_config::AbstractAWSConfig=global_aws_config()) = securityhub("GET", "/invitations"; aws_config=aws_config)
-list_invitations(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = securityhub("GET", "/invitations", params; aws_config=aws_config)
+list_invitations(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = securityhub("GET", "/invitations", params; aws_config=aws_config)
 
 """
     list_members()
@@ -695,7 +695,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   includes all existing member accounts.
 """
 list_members(; aws_config::AbstractAWSConfig=global_aws_config()) = securityhub("GET", "/members"; aws_config=aws_config)
-list_members(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = securityhub("GET", "/members", params; aws_config=aws_config)
+list_members(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = securityhub("GET", "/members", params; aws_config=aws_config)
 
 """
     list_organization_admin_accounts()
@@ -713,7 +713,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   parameter to the value returned from the previous response.
 """
 list_organization_admin_accounts(; aws_config::AbstractAWSConfig=global_aws_config()) = securityhub("GET", "/organization/admin"; aws_config=aws_config)
-list_organization_admin_accounts(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = securityhub("GET", "/organization/admin", params; aws_config=aws_config)
+list_organization_admin_accounts(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = securityhub("GET", "/organization/admin", params; aws_config=aws_config)
 
 """
     list_tags_for_resource(resource_arn)
@@ -839,7 +839,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   enabled automatically. To not automatically enable new controls, set this to false.
 """
 update_security_hub_configuration(; aws_config::AbstractAWSConfig=global_aws_config()) = securityhub("PATCH", "/accounts"; aws_config=aws_config)
-update_security_hub_configuration(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = securityhub("PATCH", "/accounts", params; aws_config=aws_config)
+update_security_hub_configuration(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = securityhub("PATCH", "/accounts", params; aws_config=aws_config)
 
 """
     update_standards_control(standards_control_arn)

--- a/src/services/serverlessapplicationrepository.jl
+++ b/src/services/serverlessapplicationrepository.jl
@@ -281,7 +281,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: A token to specify where to start paginating.
 """
 list_applications(; aws_config::AbstractAWSConfig=global_aws_config()) = serverlessapplicationrepository("GET", "/applications"; aws_config=aws_config)
-list_applications(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = serverlessapplicationrepository("GET", "/applications", params; aws_config=aws_config)
+list_applications(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = serverlessapplicationrepository("GET", "/applications", params; aws_config=aws_config)
 
 """
     put_application_policy(application_id, statements)

--- a/src/services/service_catalog_appregistry.jl
+++ b/src/services/service_catalog_appregistry.jl
@@ -196,7 +196,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   call.
 """
 list_applications(; aws_config::AbstractAWSConfig=global_aws_config()) = service_catalog_appregistry("GET", "/applications"; aws_config=aws_config)
-list_applications(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = service_catalog_appregistry("GET", "/applications", params; aws_config=aws_config)
+list_applications(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = service_catalog_appregistry("GET", "/applications", params; aws_config=aws_config)
 
 """
     list_associated_attribute_groups(application)
@@ -251,7 +251,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   call.
 """
 list_attribute_groups(; aws_config::AbstractAWSConfig=global_aws_config()) = service_catalog_appregistry("GET", "/attribute-groups"; aws_config=aws_config)
-list_attribute_groups(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = service_catalog_appregistry("GET", "/attribute-groups", params; aws_config=aws_config)
+list_attribute_groups(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = service_catalog_appregistry("GET", "/attribute-groups", params; aws_config=aws_config)
 
 """
     list_tags_for_resource(resource_arn)

--- a/src/services/sesv2.jl
+++ b/src/services/sesv2.jl
@@ -432,7 +432,7 @@ account in the current AWS Region.
 
 """
 get_account(; aws_config::AbstractAWSConfig=global_aws_config()) = sesv2("GET", "/v2/email/account"; aws_config=aws_config)
-get_account(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = sesv2("GET", "/v2/email/account", params; aws_config=aws_config)
+get_account(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = sesv2("GET", "/v2/email/account", params; aws_config=aws_config)
 
 """
     get_blacklist_reports(blacklist_item_names)
@@ -564,7 +564,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"PoolName"`: The name of the IP pool that the dedicated IP address is associated with.
 """
 get_dedicated_ips(; aws_config::AbstractAWSConfig=global_aws_config()) = sesv2("GET", "/v2/email/dedicated-ips"; aws_config=aws_config)
-get_dedicated_ips(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = sesv2("GET", "/v2/email/dedicated-ips", params; aws_config=aws_config)
+get_dedicated_ips(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = sesv2("GET", "/v2/email/dedicated-ips", params; aws_config=aws_config)
 
 """
     get_deliverability_dashboard_options()
@@ -580,7 +580,7 @@ and cost of a Deliverability dashboard subscription, see Amazon SES Pricing.
 
 """
 get_deliverability_dashboard_options(; aws_config::AbstractAWSConfig=global_aws_config()) = sesv2("GET", "/v2/email/deliverability-dashboard"; aws_config=aws_config)
-get_deliverability_dashboard_options(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = sesv2("GET", "/v2/email/deliverability-dashboard", params; aws_config=aws_config)
+get_deliverability_dashboard_options(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = sesv2("GET", "/v2/email/deliverability-dashboard", params; aws_config=aws_config)
 
 """
     get_deliverability_test_report(report_id)
@@ -723,7 +723,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   response includes a NextToken element, which you can use to obtain additional results.
 """
 list_configuration_sets(; aws_config::AbstractAWSConfig=global_aws_config()) = sesv2("GET", "/v2/email/configuration-sets"; aws_config=aws_config)
-list_configuration_sets(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = sesv2("GET", "/v2/email/configuration-sets", params; aws_config=aws_config)
+list_configuration_sets(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = sesv2("GET", "/v2/email/configuration-sets", params; aws_config=aws_config)
 
 """
     list_contact_lists()
@@ -743,7 +743,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   to retrieve additional lists.
 """
 list_contact_lists(; aws_config::AbstractAWSConfig=global_aws_config()) = sesv2("GET", "/v2/email/contact-lists"; aws_config=aws_config)
-list_contact_lists(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = sesv2("GET", "/v2/email/contact-lists", params; aws_config=aws_config)
+list_contact_lists(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = sesv2("GET", "/v2/email/contact-lists", params; aws_config=aws_config)
 
 """
     list_contacts(contact_list_name)
@@ -790,7 +790,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   be no more than 50.
 """
 list_custom_verification_email_templates(; aws_config::AbstractAWSConfig=global_aws_config()) = sesv2("GET", "/v2/email/custom-verification-email-templates"; aws_config=aws_config)
-list_custom_verification_email_templates(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = sesv2("GET", "/v2/email/custom-verification-email-templates", params; aws_config=aws_config)
+list_custom_verification_email_templates(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = sesv2("GET", "/v2/email/custom-verification-email-templates", params; aws_config=aws_config)
 
 """
     list_dedicated_ip_pools()
@@ -807,7 +807,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   response includes a NextToken element, which you can use to obtain additional results.
 """
 list_dedicated_ip_pools(; aws_config::AbstractAWSConfig=global_aws_config()) = sesv2("GET", "/v2/email/dedicated-ip-pools"; aws_config=aws_config)
-list_dedicated_ip_pools(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = sesv2("GET", "/v2/email/dedicated-ip-pools", params; aws_config=aws_config)
+list_dedicated_ip_pools(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = sesv2("GET", "/v2/email/dedicated-ip-pools", params; aws_config=aws_config)
 
 """
     list_deliverability_test_reports()
@@ -828,7 +828,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   more than 1000.
 """
 list_deliverability_test_reports(; aws_config::AbstractAWSConfig=global_aws_config()) = sesv2("GET", "/v2/email/deliverability-dashboard/test-reports"; aws_config=aws_config)
-list_deliverability_test_reports(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = sesv2("GET", "/v2/email/deliverability-dashboard/test-reports", params; aws_config=aws_config)
+list_deliverability_test_reports(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = sesv2("GET", "/v2/email/deliverability-dashboard/test-reports", params; aws_config=aws_config)
 
 """
     list_domain_deliverability_campaigns(end_date, start_date, subscribed_domain)
@@ -878,7 +878,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   value you specify has to be at least 0, and can be no more than 1000.
 """
 list_email_identities(; aws_config::AbstractAWSConfig=global_aws_config()) = sesv2("GET", "/v2/email/identities"; aws_config=aws_config)
-list_email_identities(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = sesv2("GET", "/v2/email/identities", params; aws_config=aws_config)
+list_email_identities(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = sesv2("GET", "/v2/email/identities", params; aws_config=aws_config)
 
 """
     list_email_templates()
@@ -897,7 +897,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   value you specify has to be at least 1, and can be no more than 10.
 """
 list_email_templates(; aws_config::AbstractAWSConfig=global_aws_config()) = sesv2("GET", "/v2/email/templates"; aws_config=aws_config)
-list_email_templates(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = sesv2("GET", "/v2/email/templates", params; aws_config=aws_config)
+list_email_templates(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = sesv2("GET", "/v2/email/templates", params; aws_config=aws_config)
 
 """
     list_import_jobs()
@@ -918,7 +918,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   additional addresses.
 """
 list_import_jobs(; aws_config::AbstractAWSConfig=global_aws_config()) = sesv2("GET", "/v2/email/import-jobs"; aws_config=aws_config)
-list_import_jobs(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = sesv2("GET", "/v2/email/import-jobs", params; aws_config=aws_config)
+list_import_jobs(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = sesv2("GET", "/v2/email/import-jobs", params; aws_config=aws_config)
 
 """
     list_suppressed_destinations()
@@ -943,7 +943,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   specify should be in Unix time format.
 """
 list_suppressed_destinations(; aws_config::AbstractAWSConfig=global_aws_config()) = sesv2("GET", "/v2/email/suppression/addresses"; aws_config=aws_config)
-list_suppressed_destinations(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = sesv2("GET", "/v2/email/suppression/addresses", params; aws_config=aws_config)
+list_suppressed_destinations(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = sesv2("GET", "/v2/email/suppression/addresses", params; aws_config=aws_config)
 
 """
     list_tags_for_resource(resource_arn)
@@ -976,7 +976,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   to true to enable the automatic warm-up feature, or set to false to disable it.
 """
 put_account_dedicated_ip_warmup_attributes(; aws_config::AbstractAWSConfig=global_aws_config()) = sesv2("PUT", "/v2/email/account/dedicated-ips/warmup"; aws_config=aws_config)
-put_account_dedicated_ip_warmup_attributes(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = sesv2("PUT", "/v2/email/account/dedicated-ips/warmup", params; aws_config=aws_config)
+put_account_dedicated_ip_warmup_attributes(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = sesv2("PUT", "/v2/email/account/dedicated-ips/warmup", params; aws_config=aws_config)
 
 """
     put_account_details(mail_type, use_case_description, website_url)
@@ -1021,7 +1021,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   ability to send email.
 """
 put_account_sending_attributes(; aws_config::AbstractAWSConfig=global_aws_config()) = sesv2("PUT", "/v2/email/account/sending"; aws_config=aws_config)
-put_account_sending_attributes(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = sesv2("PUT", "/v2/email/account/sending", params; aws_config=aws_config)
+put_account_sending_attributes(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = sesv2("PUT", "/v2/email/account/sending", params; aws_config=aws_config)
 
 """
     put_account_suppression_attributes()
@@ -1039,7 +1039,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   message sent to that address results in a hard bounce.
 """
 put_account_suppression_attributes(; aws_config::AbstractAWSConfig=global_aws_config()) = sesv2("PUT", "/v2/email/account/suppression"; aws_config=aws_config)
-put_account_suppression_attributes(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = sesv2("PUT", "/v2/email/account/suppression", params; aws_config=aws_config)
+put_account_suppression_attributes(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = sesv2("PUT", "/v2/email/account/suppression", params; aws_config=aws_config)
 
 """
     put_configuration_set_delivery_options(configuration_set_name)

--- a/src/services/signer.jl
+++ b/src/services/signer.jl
@@ -132,7 +132,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"status"`: A status value with which to filter your results.
 """
 list_signing_jobs(; aws_config::AbstractAWSConfig=global_aws_config()) = signer("GET", "/signing-jobs"; aws_config=aws_config)
-list_signing_jobs(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = signer("GET", "/signing-jobs", params; aws_config=aws_config)
+list_signing_jobs(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = signer("GET", "/signing-jobs", params; aws_config=aws_config)
 
 """
     list_signing_platforms()
@@ -156,7 +156,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"target"`: The validation template that is used by the target signing platform.
 """
 list_signing_platforms(; aws_config::AbstractAWSConfig=global_aws_config()) = signer("GET", "/signing-platforms"; aws_config=aws_config)
-list_signing_platforms(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = signer("GET", "/signing-platforms", params; aws_config=aws_config)
+list_signing_platforms(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = signer("GET", "/signing-platforms", params; aws_config=aws_config)
 
 """
     list_signing_profiles()
@@ -182,7 +182,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   list.
 """
 list_signing_profiles(; aws_config::AbstractAWSConfig=global_aws_config()) = signer("GET", "/signing-profiles"; aws_config=aws_config)
-list_signing_profiles(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = signer("GET", "/signing-profiles", params; aws_config=aws_config)
+list_signing_profiles(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = signer("GET", "/signing-profiles", params; aws_config=aws_config)
 
 """
     list_tags_for_resource(resource_arn)

--- a/src/services/sts.jl
+++ b/src/services/sts.jl
@@ -13,67 +13,50 @@ that you might not normally have access to. These temporary credentials consist 
 access key ID, a secret access key, and a security token. Typically, you use AssumeRole
 within your account or for cross-account access. For a comparison of AssumeRole with other
 API operations that produce temporary credentials, see Requesting Temporary Security
-Credentials and Comparing the AWS STS API operations in the IAM User Guide.  You cannot use
-AWS account root user credentials to call AssumeRole. You must use credentials for an IAM
-user or an IAM role to call AssumeRole.  For cross-account access, imagine that you own
-multiple accounts and need to access resources in each account. You could create long-term
-credentials in each account to access those resources. However, managing all those
-credentials and remembering which one can access which account can be time consuming.
-Instead, you can create one set of long-term credentials in one account. Then use temporary
-security credentials to access all the other accounts by assuming roles in those accounts.
-For more information about roles, see IAM Roles in the IAM User Guide.   Session Duration
-By default, the temporary security credentials created by AssumeRole last for one hour.
-However, you can use the optional DurationSeconds parameter to specify the duration of your
-session. You can provide a value from 900 seconds (15 minutes) up to the maximum session
-duration setting for the role. This setting can have a value from 1 hour to 12 hours. To
-learn how to view the maximum value for your role, see View the Maximum Session Duration
-Setting for a Role in the IAM User Guide. The maximum session duration limit applies when
-you use the AssumeRole* API operations or the assume-role* CLI commands. However the limit
-does not apply when you use those operations to create a console URL. For more information,
-see Using IAM Roles in the IAM User Guide.  Permissions  The temporary security credentials
-created by AssumeRole can be used to make API calls to any AWS service with the following
-exception: You cannot call the AWS STS GetFederationToken or GetSessionToken API
-operations. (Optional) You can pass inline or managed session policies to this operation.
-You can pass a single JSON policy document to use as an inline session policy. You can also
-specify up to 10 managed policies to use as managed session policies. The plain text that
-you use for both inline and managed session policies can't exceed 2,048 characters. Passing
-policies to this operation returns new temporary credentials. The resulting session's
-permissions are the intersection of the role's identity-based policy and the session
-policies. You can use the role's temporary credentials in subsequent AWS API calls to
-access resources in the account that owns the role. You cannot use session policies to
-grant more permissions than those allowed by the identity-based policy of the role that is
-being assumed. For more information, see Session Policies in the IAM User Guide. To assume
-a role from a different account, your AWS account must be trusted by the role. The trust
-relationship is defined in the role's trust policy when the role is created. That trust
-policy states which accounts are allowed to delegate that access to users in the account.
-A user who wants to access a role in a different account must also have permissions that
-are delegated from the user account administrator. The administrator must attach a policy
-that allows the user to call AssumeRole for the ARN of the role in the other account. If
-the user is in the same account as the role, then you can do either of the following:
-Attach a policy to the user (identical to the previous user in a different account).   Add
-the user as a principal directly in the role's trust policy.   In this case, the trust
-policy acts as an IAM resource-based policy. Users in the same account as the role do not
-need explicit permission to assume the role. For more information about trust policies and
-resource-based policies, see IAM Policies in the IAM User Guide.  Tags  (Optional) You can
-pass tag key-value pairs to your session. These tags are called session tags. For more
-information about session tags, see Passing Session Tags in STS in the IAM User Guide. An
-administrator must grant you the permissions necessary to pass session tags. The
-administrator can also create granular permissions to allow you to pass only specific
-session tags. For more information, see Tutorial: Using Tags for Attribute-Based Access
-Control in the IAM User Guide. You can set the session tags as transitive. Transitive tags
-persist during role chaining. For more information, see Chaining Roles with Session Tags in
-the IAM User Guide.  Using MFA with AssumeRole  (Optional) You can include multi-factor
-authentication (MFA) information when you call AssumeRole. This is useful for cross-account
-scenarios to ensure that the user that assumes the role has been authenticated with an AWS
-MFA device. In that scenario, the trust policy of the role being assumed includes a
-condition that tests for MFA authentication. If the caller does not include valid MFA
-information, the request to assume the role is denied. The condition in a trust policy that
-tests for MFA authentication might look like the following example.  \"Condition\":
-{\"Bool\": {\"aws:MultiFactorAuthPresent\": true}}  For more information, see Configuring
-MFA-Protected API Access in the IAM User Guide guide. To use MFA with AssumeRole, you pass
-values for the SerialNumber and TokenCode parameters. The SerialNumber value identifies the
-user's hardware or virtual MFA device. The TokenCode is the time-based one-time password
-(TOTP) that the MFA device produces.
+Credentials and Comparing the AWS STS API operations in the IAM User Guide.  Permissions
+The temporary security credentials created by AssumeRole can be used to make API calls to
+any AWS service with the following exception: You cannot call the AWS STS
+GetFederationToken or GetSessionToken API operations. (Optional) You can pass inline or
+managed session policies to this operation. You can pass a single JSON policy document to
+use as an inline session policy. You can also specify up to 10 managed policies to use as
+managed session policies. The plaintext that you use for both inline and managed session
+policies can't exceed 2,048 characters. Passing policies to this operation returns new
+temporary credentials. The resulting session's permissions are the intersection of the
+role's identity-based policy and the session policies. You can use the role's temporary
+credentials in subsequent AWS API calls to access resources in the account that owns the
+role. You cannot use session policies to grant more permissions than those allowed by the
+identity-based policy of the role that is being assumed. For more information, see Session
+Policies in the IAM User Guide. To assume a role from a different account, your AWS account
+must be trusted by the role. The trust relationship is defined in the role's trust policy
+when the role is created. That trust policy states which accounts are allowed to delegate
+that access to users in the account.  A user who wants to access a role in a different
+account must also have permissions that are delegated from the user account administrator.
+The administrator must attach a policy that allows the user to call AssumeRole for the ARN
+of the role in the other account. If the user is in the same account as the role, then you
+can do either of the following:   Attach a policy to the user (identical to the previous
+user in a different account).   Add the user as a principal directly in the role's trust
+policy.   In this case, the trust policy acts as an IAM resource-based policy. Users in the
+same account as the role do not need explicit permission to assume the role. For more
+information about trust policies and resource-based policies, see IAM Policies in the IAM
+User Guide.  Tags  (Optional) You can pass tag key-value pairs to your session. These tags
+are called session tags. For more information about session tags, see Passing Session Tags
+in STS in the IAM User Guide. An administrator must grant you the permissions necessary to
+pass session tags. The administrator can also create granular permissions to allow you to
+pass only specific session tags. For more information, see Tutorial: Using Tags for
+Attribute-Based Access Control in the IAM User Guide. You can set the session tags as
+transitive. Transitive tags persist during role chaining. For more information, see
+Chaining Roles with Session Tags in the IAM User Guide.  Using MFA with AssumeRole
+(Optional) You can include multi-factor authentication (MFA) information when you call
+AssumeRole. This is useful for cross-account scenarios to ensure that the user that assumes
+the role has been authenticated with an AWS MFA device. In that scenario, the trust policy
+of the role being assumed includes a condition that tests for MFA authentication. If the
+caller does not include valid MFA information, the request to assume the role is denied.
+The condition in a trust policy that tests for MFA authentication might look like the
+following example.  \"Condition\": {\"Bool\": {\"aws:MultiFactorAuthPresent\": true}}  For
+more information, see Configuring MFA-Protected API Access in the IAM User Guide guide. To
+use MFA with AssumeRole, you pass values for the SerialNumber and TokenCode parameters. The
+SerialNumber value identifies the user's hardware or virtual MFA device. The TokenCode is
+the time-based one-time password (TOTP) that the MFA device produces.
 
 # Arguments
 - `role_arn`: The Amazon Resource Name (ARN) of the role to assume.
@@ -90,18 +73,20 @@ user's hardware or virtual MFA device. The TokenCode is the time-based one-time 
 
 # Optional Parameters
 Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys are:
-- `"DurationSeconds"`: The duration, in seconds, of the role session. The value can range
-  from 900 seconds (15 minutes) up to the maximum session duration setting for the role. This
-  setting can have a value from 1 hour to 12 hours. If you specify a value higher than this
-  setting, the operation fails. For example, if you specify a session duration of 12 hours,
-  but your administrator set the maximum session duration to 6 hours, your operation fails.
-  To learn how to view the maximum value for your role, see View the Maximum Session Duration
-  Setting for a Role in the IAM User Guide. By default, the value is set to 3600 seconds.
-  The DurationSeconds parameter is separate from the duration of a console session that you
-  might request using the returned credentials. The request to the federation endpoint for a
-  console sign-in token takes a SessionDuration parameter that specifies the maximum length
-  of the console session. For more information, see Creating a URL that Enables Federated
-  Users to Access the AWS Management Console in the IAM User Guide.
+- `"DurationSeconds"`: The duration, in seconds, of the role session. The value specified
+  can can range from 900 seconds (15 minutes) up to the maximum session duration that is set
+  for the role. The maximum session duration setting can have a value from 1 hour to 12
+  hours. If you specify a value higher than this setting or the administrator setting
+  (whichever is lower), the operation fails. For example, if you specify a session duration
+  of 12 hours, but your administrator set the maximum session duration to 6 hours, your
+  operation fails. To learn how to view the maximum value for your role, see View the Maximum
+  Session Duration Setting for a Role in the IAM User Guide. By default, the value is set to
+  3600 seconds.   The DurationSeconds parameter is separate from the duration of a console
+  session that you might request using the returned credentials. The request to the
+  federation endpoint for a console sign-in token takes a SessionDuration parameter that
+  specifies the maximum length of the console session. For more information, see Creating a
+  URL that Enables Federated Users to Access the AWS Management Console in the IAM User
+  Guide.
 - `"ExternalId"`: A unique identifier that might be required when you assume a role in
   another account. If the administrator of the account to which the role belongs provided you
   with an external ID, then provide that value in the ExternalId parameter. This value can be
@@ -120,23 +105,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   credentials in subsequent AWS API calls to access resources in the account that owns the
   role. You cannot use session policies to grant more permissions than those allowed by the
   identity-based policy of the role that is being assumed. For more information, see Session
-  Policies in the IAM User Guide. The plain text that you use for both inline and managed
+  Policies in the IAM User Guide. The plaintext that you use for both inline and managed
   session policies can't exceed 2,048 characters. The JSON policy characters can be any ASCII
   character from the space character to the end of the valid character list (u0020 through
   u00FF). It can also include the tab (u0009), linefeed (u000A), and carriage return (u000D)
   characters.  An AWS conversion compresses the passed session policies and session tags into
   a packed binary format that has a separate limit. Your request can fail for this limit even
-  if your plain text meets the other requirements. The PackedPolicySize response element
+  if your plaintext meets the other requirements. The PackedPolicySize response element
   indicates by percentage how close the policies and tags for your request are to the upper
   size limit.
 - `"PolicyArns"`: The Amazon Resource Names (ARNs) of the IAM managed policies that you
   want to use as managed session policies. The policies must exist in the same account as the
   role. This parameter is optional. You can provide up to 10 managed policy ARNs. However,
-  the plain text that you use for both inline and managed session policies can't exceed 2,048
+  the plaintext that you use for both inline and managed session policies can't exceed 2,048
   characters. For more information about ARNs, see Amazon Resource Names (ARNs) and AWS
   Service Namespaces in the AWS General Reference.  An AWS conversion compresses the passed
   session policies and session tags into a packed binary format that has a separate limit.
-  Your request can fail for this limit even if your plain text meets the other requirements.
+  Your request can fail for this limit even if your plaintext meets the other requirements.
   The PackedPolicySize response element indicates by percentage how close the policies and
   tags for your request are to the upper size limit.   Passing policies to this operation
   returns new temporary credentials. The resulting session's permissions are the intersection
@@ -153,14 +138,25 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   validate this parameter is a string of characters consisting of upper- and lower-case
   alphanumeric characters with no spaces. You can also include underscores or any of the
   following characters: =,.@-
+- `"SourceIdentity"`: The source identity specified by the principal that is calling the
+  AssumeRole operation. You can require users to specify a source identity when they assume a
+  role. You do this by using the sts:SourceIdentity condition key in a role trust policy. You
+  can use source identity information in AWS CloudTrail logs to determine who took actions
+  with a role. You can use the aws:SourceIdentity condition key to further control access to
+  AWS resources based on the value of source identity. For more information about using
+  source identity, see Monitor and control actions taken with assumed roles in the IAM User
+  Guide. The regex used to validate this parameter is a string of characters consisting of
+  upper- and lower-case alphanumeric characters with no spaces. You can also include
+  underscores or any of the following characters: =,.@-. You cannot use a value that begins
+  with the text aws:. This prefix is reserved for AWS internal use.
 - `"Tags"`: A list of session tags that you want to pass. Each session tag consists of a
   key name and an associated value. For more information about session tags, see Tagging AWS
   STS Sessions in the IAM User Guide. This parameter is optional. You can pass up to 50
-  session tags. The plain text session tag keys can’t exceed 128 characters, and the values
+  session tags. The plaintext session tag keys can’t exceed 128 characters, and the values
   can’t exceed 256 characters. For these and additional limits, see IAM and STS Character
   Limits in the IAM User Guide.  An AWS conversion compresses the passed session policies and
   session tags into a packed binary format that has a separate limit. Your request can fail
-  for this limit even if your plain text meets the other requirements. The PackedPolicySize
+  for this limit even if your plaintext meets the other requirements. The PackedPolicySize
   response element indicates by percentage how close the policies and tags for your request
   are to the upper size limit.   You can pass a session tag with the same key as a tag that
   is already attached to the role. When you do, session tags override a role tag with the
@@ -174,8 +170,8 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   operation fails. To view the inherited tags for a session, see the AWS CloudTrail logs. For
   more information, see Viewing Session Tags in CloudTrail in the IAM User Guide.
 - `"TokenCode"`: The value provided by the MFA device, if the trust policy of the role
-  being assumed requires MFA (that is, if the policy includes a condition that tests for
-  MFA). If the role being assumed requires MFA and if the TokenCode value is missing or
+  being assumed requires MFA. (In other words, if the policy includes a condition that tests
+  for MFA). If the role being assumed requires MFA and if the TokenCode value is missing or
   expired, the AssumeRole call returns an \"access denied\" error. The format for this
   parameter, as described by its regex pattern, is a sequence of six numeric digits.
 - `"TransitiveTagKeys"`: A list of keys for session tags that you want to set as
@@ -212,34 +208,40 @@ for your role, see View the Maximum Session Duration Setting for a Role in the I
 Guide. The maximum session duration limit applies when you use the AssumeRole* API
 operations or the assume-role* CLI commands. However the limit does not apply when you use
 those operations to create a console URL. For more information, see Using IAM Roles in the
-IAM User Guide.  Permissions  The temporary security credentials created by
-AssumeRoleWithSAML can be used to make API calls to any AWS service with the following
-exception: you cannot call the STS GetFederationToken or GetSessionToken API operations.
-(Optional) You can pass inline or managed session policies to this operation. You can pass
-a single JSON policy document to use as an inline session policy. You can also specify up
-to 10 managed policies to use as managed session policies. The plain text that you use for
-both inline and managed session policies can't exceed 2,048 characters. Passing policies to
-this operation returns new temporary credentials. The resulting session's permissions are
-the intersection of the role's identity-based policy and the session policies. You can use
-the role's temporary credentials in subsequent AWS API calls to access resources in the
-account that owns the role. You cannot use session policies to grant more permissions than
-those allowed by the identity-based policy of the role that is being assumed. For more
-information, see Session Policies in the IAM User Guide. Calling AssumeRoleWithSAML does
-not require the use of AWS security credentials. The identity of the caller is validated by
-using keys in the metadata document that is uploaded for the SAML provider entity for your
-identity provider.   Calling AssumeRoleWithSAML can result in an entry in your AWS
-CloudTrail logs. The entry includes the value in the NameID element of the SAML assertion.
-We recommend that you use a NameIDType that is not associated with any personally
-identifiable information (PII). For example, you could instead use the persistent
-identifier (urn:oasis:names:tc:SAML:2.0:nameid-format:persistent).   Tags  (Optional) You
-can configure your IdP to pass attributes into your SAML assertion as session tags. Each
+IAM User Guide.   Role chaining limits your AWS CLI or AWS API role session to a maximum of
+one hour. When you use the AssumeRole API operation to assume a role, you can specify the
+duration of your role session with the DurationSeconds parameter. You can specify a
+parameter value of up to 43200 seconds (12 hours), depending on the maximum session
+duration setting for your role. However, if you assume a role using role chaining and
+provide a DurationSeconds parameter value greater than one hour, the operation fails.
+Permissions  The temporary security credentials created by AssumeRoleWithSAML can be used
+to make API calls to any AWS service with the following exception: you cannot call the STS
+GetFederationToken or GetSessionToken API operations. (Optional) You can pass inline or
+managed session policies to this operation. You can pass a single JSON policy document to
+use as an inline session policy. You can also specify up to 10 managed policies to use as
+managed session policies. The plaintext that you use for both inline and managed session
+policies can't exceed 2,048 characters. Passing policies to this operation returns new
+temporary credentials. The resulting session's permissions are the intersection of the
+role's identity-based policy and the session policies. You can use the role's temporary
+credentials in subsequent AWS API calls to access resources in the account that owns the
+role. You cannot use session policies to grant more permissions than those allowed by the
+identity-based policy of the role that is being assumed. For more information, see Session
+Policies in the IAM User Guide. Calling AssumeRoleWithSAML does not require the use of AWS
+security credentials. The identity of the caller is validated by using keys in the metadata
+document that is uploaded for the SAML provider entity for your identity provider.
+Calling AssumeRoleWithSAML can result in an entry in your AWS CloudTrail logs. The entry
+includes the value in the NameID element of the SAML assertion. We recommend that you use a
+NameIDType that is not associated with any personally identifiable information (PII). For
+example, you could instead use the persistent identifier
+(urn:oasis:names:tc:SAML:2.0:nameid-format:persistent).   Tags  (Optional) You can
+configure your IdP to pass attributes into your SAML assertion as session tags. Each
 session tag consists of a key name and an associated value. For more information about
 session tags, see Passing Session Tags in STS in the IAM User Guide. You can pass up to 50
-session tags. The plain text session tag keys can’t exceed 128 characters and the values
+session tags. The plaintext session tag keys can’t exceed 128 characters and the values
 can’t exceed 256 characters. For these and additional limits, see IAM and STS Character
 Limits in the IAM User Guide.  An AWS conversion compresses the passed session policies and
 session tags into a packed binary format that has a separate limit. Your request can fail
-for this limit even if your plain text meets the other requirements. The PackedPolicySize
+for this limit even if your plaintext meets the other requirements. The PackedPolicySize
 response element indicates by percentage how close the policies and tags for your request
 are to the upper size limit.   You can pass a session tag with the same key as a tag that
 is attached to the role. When you do, session tags override the role's tags with the same
@@ -262,9 +264,8 @@ Role for SAML 2.0 Federation in the IAM User Guide.
 - `principal_arn`: The Amazon Resource Name (ARN) of the SAML provider in IAM that
   describes the IdP.
 - `role_arn`: The Amazon Resource Name (ARN) of the role that the caller is assuming.
-- `samlassertion`: The base-64 encoded SAML authentication response provided by the IdP.
-  For more information, see Configuring a Relying Party and Adding Claims in the IAM User
-  Guide.
+- `samlassertion`: The base64 encoded SAML authentication response provided by the IdP. For
+  more information, see Configuring a Relying Party and Adding Claims in the IAM User Guide.
 
 # Optional Parameters
 Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys are:
@@ -290,23 +291,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   credentials in subsequent AWS API calls to access resources in the account that owns the
   role. You cannot use session policies to grant more permissions than those allowed by the
   identity-based policy of the role that is being assumed. For more information, see Session
-  Policies in the IAM User Guide.  The plain text that you use for both inline and managed
+  Policies in the IAM User Guide.  The plaintext that you use for both inline and managed
   session policies can't exceed 2,048 characters. The JSON policy characters can be any ASCII
   character from the space character to the end of the valid character list (u0020 through
   u00FF). It can also include the tab (u0009), linefeed (u000A), and carriage return (u000D)
   characters.  An AWS conversion compresses the passed session policies and session tags into
   a packed binary format that has a separate limit. Your request can fail for this limit even
-  if your plain text meets the other requirements. The PackedPolicySize response element
+  if your plaintext meets the other requirements. The PackedPolicySize response element
   indicates by percentage how close the policies and tags for your request are to the upper
   size limit.
 - `"PolicyArns"`: The Amazon Resource Names (ARNs) of the IAM managed policies that you
   want to use as managed session policies. The policies must exist in the same account as the
   role. This parameter is optional. You can provide up to 10 managed policy ARNs. However,
-  the plain text that you use for both inline and managed session policies can't exceed 2,048
+  the plaintext that you use for both inline and managed session policies can't exceed 2,048
   characters. For more information about ARNs, see Amazon Resource Names (ARNs) and AWS
   Service Namespaces in the AWS General Reference.  An AWS conversion compresses the passed
   session policies and session tags into a packed binary format that has a separate limit.
-  Your request can fail for this limit even if your plain text meets the other requirements.
+  Your request can fail for this limit even if your plaintext meets the other requirements.
   The PackedPolicySize response element indicates by percentage how close the policies and
   tags for your request are to the upper size limit.   Passing policies to this operation
   returns new temporary credentials. The resulting session's permissions are the intersection
@@ -356,7 +357,7 @@ AssumeRoleWithWebIdentity can be used to make API calls to any AWS service with 
 following exception: you cannot call the STS GetFederationToken or GetSessionToken API
 operations. (Optional) You can pass inline or managed session policies to this operation.
 You can pass a single JSON policy document to use as an inline session policy. You can also
-specify up to 10 managed policies to use as managed session policies. The plain text that
+specify up to 10 managed policies to use as managed session policies. The plaintext that
 you use for both inline and managed session policies can't exceed 2,048 characters. Passing
 policies to this operation returns new temporary credentials. The resulting session's
 permissions are the intersection of the role's identity-based policy and the session
@@ -367,11 +368,11 @@ being assumed. For more information, see Session Policies in the IAM User Guide.
 (Optional) You can configure your IdP to pass attributes into your web identity token as
 session tags. Each session tag consists of a key name and an associated value. For more
 information about session tags, see Passing Session Tags in STS in the IAM User Guide. You
-can pass up to 50 session tags. The plain text session tag keys can’t exceed 128
+can pass up to 50 session tags. The plaintext session tag keys can’t exceed 128
 characters and the values can’t exceed 256 characters. For these and additional limits,
 see IAM and STS Character Limits in the IAM User Guide.  An AWS conversion compresses the
 passed session policies and session tags into a packed binary format that has a separate
-limit. Your request can fail for this limit even if your plain text meets the other
+limit. Your request can fail for this limit even if your plaintext meets the other
 requirements. The PackedPolicySize response element indicates by percentage how close the
 policies and tags for your request are to the upper size limit.   You can pass a session
 tag with the same key as a tag that is attached to the role. When you do, the session tag
@@ -386,7 +387,7 @@ supported identity provider and create a role that the application can assume. T
 that your application assumes must trust the identity provider that is associated with the
 identity token. In other words, the identity provider must be specified in the role's trust
 policy.   Calling AssumeRoleWithWebIdentity can result in an entry in your AWS CloudTrail
-logs. The entry includes the Subject of the provided Web Identity Token. We recommend that
+logs. The entry includes the Subject of the provided web identity token. We recommend that
 you avoid using any personally identifiable information (PII) in this field. For example,
 you could instead use a GUID or a pairwise identifier, as suggested in the OIDC
 specification.  For more information about how to use web identity federation and the
@@ -437,23 +438,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   credentials in subsequent AWS API calls to access resources in the account that owns the
   role. You cannot use session policies to grant more permissions than those allowed by the
   identity-based policy of the role that is being assumed. For more information, see Session
-  Policies in the IAM User Guide. The plain text that you use for both inline and managed
+  Policies in the IAM User Guide. The plaintext that you use for both inline and managed
   session policies can't exceed 2,048 characters. The JSON policy characters can be any ASCII
   character from the space character to the end of the valid character list (u0020 through
   u00FF). It can also include the tab (u0009), linefeed (u000A), and carriage return (u000D)
   characters.  An AWS conversion compresses the passed session policies and session tags into
   a packed binary format that has a separate limit. Your request can fail for this limit even
-  if your plain text meets the other requirements. The PackedPolicySize response element
+  if your plaintext meets the other requirements. The PackedPolicySize response element
   indicates by percentage how close the policies and tags for your request are to the upper
   size limit.
 - `"PolicyArns"`: The Amazon Resource Names (ARNs) of the IAM managed policies that you
   want to use as managed session policies. The policies must exist in the same account as the
   role. This parameter is optional. You can provide up to 10 managed policy ARNs. However,
-  the plain text that you use for both inline and managed session policies can't exceed 2,048
+  the plaintext that you use for both inline and managed session policies can't exceed 2,048
   characters. For more information about ARNs, see Amazon Resource Names (ARNs) and AWS
   Service Namespaces in the AWS General Reference.  An AWS conversion compresses the passed
   session policies and session tags into a packed binary format that has a separate limit.
-  Your request can fail for this limit even if your plain text meets the other requirements.
+  Your request can fail for this limit even if your plaintext meets the other requirements.
   The PackedPolicySize response element indicates by percentage how close the policies and
   tags for your request are to the upper size limit.   Passing policies to this operation
   returns new temporary credentials. The resulting session's permissions are the intersection
@@ -575,7 +576,7 @@ following:   You cannot call any IAM operations using the AWS CLI or the AWS API
 cannot call any STS operations except GetCallerIdentity.   You must pass an inline or
 managed session policy to this operation. You can pass a single JSON policy document to use
 as an inline session policy. You can also specify up to 10 managed policies to use as
-managed session policies. The plain text that you use for both inline and managed session
+managed session policies. The plaintext that you use for both inline and managed session
 policies can't exceed 2,048 characters. Though the session policy parameters are optional,
 if you do not pass a policy, then the resulting federated user session has no permissions.
 When you pass session policies, the session permissions are the intersection of the IAM
@@ -584,6 +585,40 @@ restrict the permissions for a federated user. You cannot use session policies t
 more permissions than those that are defined in the permissions policy of the IAM user. For
 more information, see Session Policies in the IAM User Guide. For information about using
 GetFederationToken to create temporary security credentials, see
+GetFederationToken—Federation Through a Custom Identity Broker.  You can use the
+credentials to access a resource that has a resource-based policy. If that policy
+specifically references the federated user session in the Principal element of the policy,
+the session has the permissions allowed by the policy. These permissions are granted in
+addition to the permissions granted by the session policies.  Tags  (Optional) You can pass
+tag key-value pairs to your session. These are called session tags. For more information
+about session tags, see Passing Session Tags in STS in the IAM User Guide.  You can create
+a mobile-based or browser-based app that can authenticate users using a web identity
+provider like Login with Amazon, Facebook, Google, or an OpenID Connect-compatible identity
+provider. In this case, we recommend that you use Amazon Cognito or
+AssumeRoleWithWebIdentity. For more information, see Federation Through a Web-based
+Identity Provider in the IAM User Guide.  You can also call GetFederationToken using the
+security credentials of an AWS account root user, but we do not recommend it. Instead, we
+recommend that you create an IAM user for the purpose of the proxy application. Then attach
+a policy to the IAM user that limits federated users to only the actions and resources that
+they need to access. For more information, see IAM Best Practices in the IAM User Guide.
+Session duration  The temporary credentials are valid for the specified duration, from 900
+seconds (15 minutes) up to a maximum of 129,600 seconds (36 hours). The default session
+duration is 43,200 seconds (12 hours). Temporary credentials that are obtained by using AWS
+account root user credentials have a maximum duration of 3,600 seconds (1 hour).
+Permissions  You can use the temporary credentials created by GetFederationToken in any AWS
+service except the following:   You cannot call any IAM operations using the AWS CLI or the
+AWS API.    You cannot call any STS operations except GetCallerIdentity.   You must pass an
+inline or managed session policy to this operation. You can pass a single JSON policy
+document to use as an inline session policy. You can also specify up to 10 managed policies
+to use as managed session policies. The plain text that you use for both inline and managed
+session policies can't exceed 2,048 characters. Though the session policy parameters are
+optional, if you do not pass a policy, then the resulting federated user session has no
+permissions. When you pass session policies, the session permissions are the intersection
+of the IAM user policies and the session policies that you pass. This gives you a way to
+further restrict the permissions for a federated user. You cannot use session policies to
+grant more permissions than those that are defined in the permissions policy of the IAM
+user. For more information, see Session Policies in the IAM User Guide. For information
+about using GetFederationToken to create temporary security credentials, see
 GetFederationToken—Federation Through a Custom Identity Broker.  You can use the
 credentials to access a resource that has a resource-based policy. If that policy
 specifically references the federated user session in the Principal element of the policy,
@@ -629,21 +664,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   resulting credentials can be used to access a resource that has a resource-based policy. If
   that policy specifically references the federated user session in the Principal element of
   the policy, the session has the permissions allowed by the policy. These permissions are
-  granted in addition to the permissions that are granted by the session policies. The plain
-  text that you use for both inline and managed session policies can't exceed 2,048
+  granted in addition to the permissions that are granted by the session policies. The
+  plaintext that you use for both inline and managed session policies can't exceed 2,048
   characters. The JSON policy characters can be any ASCII character from the space character
   to the end of the valid character list (u0020 through u00FF). It can also include the tab
   (u0009), linefeed (u000A), and carriage return (u000D) characters.  An AWS conversion
   compresses the passed session policies and session tags into a packed binary format that
-  has a separate limit. Your request can fail for this limit even if your plain text meets
-  the other requirements. The PackedPolicySize response element indicates by percentage how
-  close the policies and tags for your request are to the upper size limit.
+  has a separate limit. Your request can fail for this limit even if your plaintext meets the
+  other requirements. The PackedPolicySize response element indicates by percentage how close
+  the policies and tags for your request are to the upper size limit.
 - `"PolicyArns"`: The Amazon Resource Names (ARNs) of the IAM managed policies that you
   want to use as a managed session policy. The policies must exist in the same account as the
   IAM user that is requesting federated access. You must pass an inline or managed session
   policy to this operation. You can pass a single JSON policy document to use as an inline
   session policy. You can also specify up to 10 managed policies to use as managed session
-  policies. The plain text that you use for both inline and managed session policies can't
+  policies. The plaintext that you use for both inline and managed session policies can't
   exceed 2,048 characters. You can provide up to 10 managed policy ARNs. For more information
   about ARNs, see Amazon Resource Names (ARNs) and AWS Service Namespaces in the AWS General
   Reference. This parameter is optional. However, if you do not pass any session policies,
@@ -658,17 +693,17 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   permissions allowed by the policy. These permissions are granted in addition to the
   permissions that are granted by the session policies.  An AWS conversion compresses the
   passed session policies and session tags into a packed binary format that has a separate
-  limit. Your request can fail for this limit even if your plain text meets the other
+  limit. Your request can fail for this limit even if your plaintext meets the other
   requirements. The PackedPolicySize response element indicates by percentage how close the
   policies and tags for your request are to the upper size limit.
 - `"Tags"`: A list of session tags. Each session tag consists of a key name and an
   associated value. For more information about session tags, see Passing Session Tags in STS
   in the IAM User Guide. This parameter is optional. You can pass up to 50 session tags. The
-  plain text session tag keys can’t exceed 128 characters and the values can’t exceed 256
+  plaintext session tag keys can’t exceed 128 characters and the values can’t exceed 256
   characters. For these and additional limits, see IAM and STS Character Limits in the IAM
   User Guide.  An AWS conversion compresses the passed session policies and session tags into
   a packed binary format that has a separate limit. Your request can fail for this limit even
-  if your plain text meets the other requirements. The PackedPolicySize response element
+  if your plaintext meets the other requirements. The PackedPolicySize response element
   indicates by percentage how close the policies and tags for your request are to the upper
   size limit.   You can pass a session tag with the same key as a tag that is already
   attached to the user you are federating. When you do, session tags override a user tag with

--- a/src/services/synthetics.jl
+++ b/src/services/synthetics.jl
@@ -109,7 +109,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   token in a subsequent operation to retrieve the next set of results.
 """
 describe_canaries(; aws_config::AbstractAWSConfig=global_aws_config()) = synthetics("POST", "/canaries"; aws_config=aws_config)
-describe_canaries(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = synthetics("POST", "/canaries", params; aws_config=aws_config)
+describe_canaries(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = synthetics("POST", "/canaries", params; aws_config=aws_config)
 
 """
     describe_canaries_last_run()
@@ -126,7 +126,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   token in a subsequent DescribeCanaries operation to retrieve the next set of results.
 """
 describe_canaries_last_run(; aws_config::AbstractAWSConfig=global_aws_config()) = synthetics("POST", "/canaries/last-run"; aws_config=aws_config)
-describe_canaries_last_run(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = synthetics("POST", "/canaries/last-run", params; aws_config=aws_config)
+describe_canaries_last_run(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = synthetics("POST", "/canaries/last-run", params; aws_config=aws_config)
 
 """
     describe_runtime_versions()
@@ -144,7 +144,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   token in a subsequent DescribeRuntimeVersions operation to retrieve the next set of results.
 """
 describe_runtime_versions(; aws_config::AbstractAWSConfig=global_aws_config()) = synthetics("POST", "/runtime-versions"; aws_config=aws_config)
-describe_runtime_versions(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = synthetics("POST", "/runtime-versions", params; aws_config=aws_config)
+describe_runtime_versions(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = synthetics("POST", "/runtime-versions", params; aws_config=aws_config)
 
 """
     get_canary(name)

--- a/src/services/wellarchitected.jl
+++ b/src/services/wellarchitected.jl
@@ -290,7 +290,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`:
 """
 list_lenses(; aws_config::AbstractAWSConfig=global_aws_config()) = wellarchitected("GET", "/lenses"; aws_config=aws_config)
-list_lenses(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = wellarchitected("GET", "/lenses", params; aws_config=aws_config)
+list_lenses(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = wellarchitected("GET", "/lenses", params; aws_config=aws_config)
 
 """
     list_milestones(workload_id)
@@ -322,7 +322,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"WorkloadId"`:
 """
 list_notifications(; aws_config::AbstractAWSConfig=global_aws_config()) = wellarchitected("POST", "/notifications"; aws_config=aws_config)
-list_notifications(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = wellarchitected("POST", "/notifications", params; aws_config=aws_config)
+list_notifications(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = wellarchitected("POST", "/notifications", params; aws_config=aws_config)
 
 """
     list_share_invitations()
@@ -337,7 +337,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"WorkloadNamePrefix"`:
 """
 list_share_invitations(; aws_config::AbstractAWSConfig=global_aws_config()) = wellarchitected("GET", "/shareInvitations"; aws_config=aws_config)
-list_share_invitations(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = wellarchitected("GET", "/shareInvitations", params; aws_config=aws_config)
+list_share_invitations(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = wellarchitected("GET", "/shareInvitations", params; aws_config=aws_config)
 
 """
     list_tags_for_resource(workload_arn)
@@ -383,7 +383,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"WorkloadNamePrefix"`:
 """
 list_workloads(; aws_config::AbstractAWSConfig=global_aws_config()) = wellarchitected("POST", "/workloadsSummaries"; aws_config=aws_config)
-list_workloads(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = wellarchitected("POST", "/workloadsSummaries", params; aws_config=aws_config)
+list_workloads(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = wellarchitected("POST", "/workloadsSummaries", params; aws_config=aws_config)
 
 """
     tag_resource(tags, workload_arn)

--- a/src/services/workdocs.jl
+++ b/src/services/workdocs.jl
@@ -378,7 +378,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   administrative API (SigV4) requests.
 """
 describe_activities(; aws_config::AbstractAWSConfig=global_aws_config()) = workdocs("GET", "/api/v1/activities"; aws_config=aws_config)
-describe_activities(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = workdocs("GET", "/api/v1/activities", params; aws_config=aws_config)
+describe_activities(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = workdocs("GET", "/api/v1/activities", params; aws_config=aws_config)
 
 """
     describe_comments(document_id, version_id)
@@ -564,7 +564,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"userIds"`: The IDs of the users.
 """
 describe_users(; aws_config::AbstractAWSConfig=global_aws_config()) = workdocs("GET", "/api/v1/users"; aws_config=aws_config)
-describe_users(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = workdocs("GET", "/api/v1/users", params; aws_config=aws_config)
+describe_users(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = workdocs("GET", "/api/v1/users", params; aws_config=aws_config)
 
 """
     get_current_user(authentication)
@@ -707,7 +707,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   accessing the API operation using IAM credentials.
 """
 get_resources(; aws_config::AbstractAWSConfig=global_aws_config()) = workdocs("GET", "/api/v1/resources"; aws_config=aws_config)
-get_resources(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = workdocs("GET", "/api/v1/resources", params; aws_config=aws_config)
+get_resources(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = workdocs("GET", "/api/v1/resources", params; aws_config=aws_config)
 
 """
     initiate_document_version_upload(parent_folder_id)

--- a/src/services/worklink.jl
+++ b/src/services/worklink.jl
@@ -296,7 +296,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   operation. If this value is null, it retrieves the first page.
 """
 list_fleets(; aws_config::AbstractAWSConfig=global_aws_config()) = worklink("POST", "/listFleets"; aws_config=aws_config)
-list_fleets(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = worklink("POST", "/listFleets", params; aws_config=aws_config)
+list_fleets(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = worklink("POST", "/listFleets", params; aws_config=aws_config)
 
 """
     list_tags_for_resource(resource_arn)

--- a/src/services/xray.jl
+++ b/src/services/xray.jl
@@ -89,7 +89,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"GroupName"`: The case-sensitive name of the group.
 """
 delete_group(; aws_config::AbstractAWSConfig=global_aws_config()) = xray("POST", "/DeleteGroup"; aws_config=aws_config)
-delete_group(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = xray("POST", "/DeleteGroup", params; aws_config=aws_config)
+delete_group(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = xray("POST", "/DeleteGroup", params; aws_config=aws_config)
 
 """
     delete_sampling_rule()
@@ -105,7 +105,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   not both.
 """
 delete_sampling_rule(; aws_config::AbstractAWSConfig=global_aws_config()) = xray("POST", "/DeleteSamplingRule"; aws_config=aws_config)
-delete_sampling_rule(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = xray("POST", "/DeleteSamplingRule", params; aws_config=aws_config)
+delete_sampling_rule(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = xray("POST", "/DeleteSamplingRule", params; aws_config=aws_config)
 
 """
     get_encryption_config()
@@ -115,7 +115,7 @@ Retrieves the current encryption configuration for X-Ray data.
 
 """
 get_encryption_config(; aws_config::AbstractAWSConfig=global_aws_config()) = xray("POST", "/EncryptionConfig"; aws_config=aws_config)
-get_encryption_config(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = xray("POST", "/EncryptionConfig", params; aws_config=aws_config)
+get_encryption_config(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = xray("POST", "/EncryptionConfig", params; aws_config=aws_config)
 
 """
     get_group()
@@ -129,7 +129,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"GroupName"`: The case-sensitive name of the group.
 """
 get_group(; aws_config::AbstractAWSConfig=global_aws_config()) = xray("POST", "/GetGroup"; aws_config=aws_config)
-get_group(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = xray("POST", "/GetGroup", params; aws_config=aws_config)
+get_group(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = xray("POST", "/GetGroup", params; aws_config=aws_config)
 
 """
     get_groups()
@@ -142,7 +142,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`: Pagination token.
 """
 get_groups(; aws_config::AbstractAWSConfig=global_aws_config()) = xray("POST", "/Groups"; aws_config=aws_config)
-get_groups(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = xray("POST", "/Groups", params; aws_config=aws_config)
+get_groups(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = xray("POST", "/Groups", params; aws_config=aws_config)
 
 """
     get_insight(insight_id)
@@ -242,7 +242,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`: Pagination token.
 """
 get_sampling_rules(; aws_config::AbstractAWSConfig=global_aws_config()) = xray("POST", "/GetSamplingRules"; aws_config=aws_config)
-get_sampling_rules(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = xray("POST", "/GetSamplingRules", params; aws_config=aws_config)
+get_sampling_rules(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = xray("POST", "/GetSamplingRules", params; aws_config=aws_config)
 
 """
     get_sampling_statistic_summaries()
@@ -255,7 +255,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`: Pagination token.
 """
 get_sampling_statistic_summaries(; aws_config::AbstractAWSConfig=global_aws_config()) = xray("POST", "/SamplingStatisticSummaries"; aws_config=aws_config)
-get_sampling_statistic_summaries(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = xray("POST", "/SamplingStatisticSummaries", params; aws_config=aws_config)
+get_sampling_statistic_summaries(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = xray("POST", "/SamplingStatisticSummaries", params; aws_config=aws_config)
 
 """
     get_sampling_targets(sampling_statistics_documents)
@@ -518,7 +518,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   with InsightsEnabled set to true.
 """
 update_group(; aws_config::AbstractAWSConfig=global_aws_config()) = xray("POST", "/UpdateGroup"; aws_config=aws_config)
-update_group(params::AbstractDict{String, Any}; aws_config::AbstractAWSConfig=global_aws_config()) = xray("POST", "/UpdateGroup", params; aws_config=aws_config)
+update_group(params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = xray("POST", "/UpdateGroup", params; aws_config=aws_config)
 
 """
     update_sampling_rule(sampling_rule_update)

--- a/test/AWSMetadataUtilities.jl
+++ b/test/AWSMetadataUtilities.jl
@@ -311,7 +311,7 @@ end
     - `"OptionalParam"`: Optional param
     \"\"\"
     sample_operation(RequiredParam1, RequiredParam2; aws_config::AbstractAWSConfig=global_aws_config()) = sample_service("POST", "/", Dict{String, Any}("RequiredParam1"=>RequiredParam1, "RequiredParam2"=>RequiredParam2); aws_config=aws_config)
-    sample_operation(RequiredParam1, RequiredParam2, params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = sample_service("POST", "/", Dict{String, Any}(mergewith(_merge, Dict{String, Any}("RequiredParam1"=>RequiredParam1, "RequiredParam2"=>RequiredParam2), params)); aws_config=aws_config)
+    sample_operation(RequiredParam1, RequiredParam2, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()) = sample_service("POST", "/", Dict{String, Any}(mergewith(_merge, Dict{String, Any}("RequiredParam1"=>RequiredParam1, "RequiredParam2"=>RequiredParam2), params)); aws_config=aws_config)
     """
 
     result = _generate_high_level_definitions(
@@ -357,7 +357,7 @@ end
             - `"OptionalParam"`: This parameter is optional.
             \"\"\"
             function_name(RequiredParam; aws_config::AbstractAWSConfig=global_aws_config()) = service_name("GET", "request_uri", Dict{String, Any}("RequiredParam"=>RequiredParam); aws_config=aws_config)
-            function_name(RequiredParam, params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = service_name("GET", "request_uri", Dict{String, Any}(mergewith(_merge, Dict{String, Any}("RequiredParam"=>RequiredParam), params)); aws_config=aws_config)
+            function_name(RequiredParam, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()) = service_name("GET", "request_uri", Dict{String, Any}(mergewith(_merge, Dict{String, Any}("RequiredParam"=>RequiredParam), params)); aws_config=aws_config)
             """
 
             result = _generate_high_level_definition(
@@ -394,7 +394,7 @@ end
             - `"OptionalParam"`: This parameter is optional.
             \"\"\"
             function_name(RequiredParam; aws_config::AbstractAWSConfig=global_aws_config()) = service_name("FunctionName", Dict{String, Any}("RequiredParam"=>RequiredParam); aws_config=aws_config)
-            function_name(RequiredParam, params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = service_name("FunctionName", Dict{String, Any}(mergewith(_merge, Dict{String, Any}("RequiredParam"=>RequiredParam), params)); aws_config=aws_config)
+            function_name(RequiredParam, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()) = service_name("FunctionName", Dict{String, Any}(mergewith(_merge, Dict{String, Any}("RequiredParam"=>RequiredParam), params)); aws_config=aws_config)
             """
 
             result = _generate_high_level_definition(
@@ -436,7 +436,7 @@ end
             - `"OptionalParam"`: This parameter i  s optional.
             \"\"\"
             function_name(RequiredParam; aws_config::AbstractAWSConfig=global_aws_config()) = service_name("GET", "request_uri", Dict{String, Any}("OptionalParam"=>string(uuid4()), "headers"=>Dict{String, Any}("RequiredParam"=>RequiredParam)); aws_config=aws_config)
-            function_name(RequiredParam, params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = service_name("GET", "request_uri", Dict{String, Any}(mergewith(_merge, Dict{String, Any}("OptionalParam"=>string(uuid4()), "headers"=>Dict{String, Any}("RequiredParam"=>RequiredParam)), params)); aws_config=aws_config)
+            function_name(RequiredParam, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()) = service_name("GET", "request_uri", Dict{String, Any}(mergewith(_merge, Dict{String, Any}("OptionalParam"=>string(uuid4()), "headers"=>Dict{String, Any}("RequiredParam"=>RequiredParam)), params)); aws_config=aws_config)
             """
             result = _generate_high_level_definition(
                 service_name,
@@ -472,7 +472,7 @@ end
             - `"OptionalParam"`: This parameter i  s optional.
             \"\"\"
             function_name(RequiredParam; aws_config::AbstractAWSConfig=global_aws_config()) = service_name("FunctionName", Dict{String, Any}("RequiredParam"=>RequiredParam, "OptionalParam"=>string(uuid4())); aws_config=aws_config)
-            function_name(RequiredParam, params::AbstractDict{String, <:Any}; aws_config::AbstractAWSConfig=global_aws_config()) = service_name("FunctionName", Dict{String, Any}(mergewith(_merge, Dict{String, Any}("RequiredParam"=>RequiredParam, "OptionalParam"=>string(uuid4())), params)); aws_config=aws_config)
+            function_name(RequiredParam, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()) = service_name("FunctionName", Dict{String, Any}(mergewith(_merge, Dict{String, Any}("RequiredParam"=>RequiredParam, "OptionalParam"=>string(uuid4())), params)); aws_config=aws_config)
             """
 
             result = _generate_high_level_definition(


### PR DESCRIPTION
This has apparently always been incorrect, we want to be using `Dict{String, <:Any}` not `Dict{String, Any}`

- https://github.com/JuliaCloud/AWS.jl/blob/v1.0.0/src/AWSMetadataUtilities.jl#L493