### PR TITLE
RFC: Return Raw more explicitly

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,6 +16,7 @@ Mocking = "78c3b35d-d492-501b-9361-3d52fe80e533"
 OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 Retry = "20febd7b-183b-5ae2-ac4a-720e7ce64774"
 Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
+Suppressor = "fd094767-a336-5f1f-9728-57cf17d0bbfb"
 URIs = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 XMLDict = "228000da-037f-5747-90a9-8195ccbf91a5"
@@ -30,6 +31,7 @@ MbedTLS = "0.6, 0.7, 1"
 Mocking = "0.7"
 OrderedCollections = "1"
 Retry = "0.3, 0.4"
+Suppressor = "0.2"
 URIs = "1"
 XMLDict = "0.3, 0.4"
 julia = "1"
@@ -42,4 +44,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [targets]
-test = ["Pkg", "Random", "Suppressor", "Test", "UUIDs"]
+test = ["Pkg", "Random", "Test", "UUIDs"]

--- a/src/request.jl
+++ b/src/request.jl
@@ -1,0 +1,37 @@
+const RR_DEPWARN = "Request.return_raw will be removed in AWS@2, use set_return_raw() instead."
+const RR = :return_raw
+
+
+Base.@kwdef mutable struct Request
+    service::String
+    api_version::String
+    request_method::String
+
+    headers::AbstractDict{String, String}=LittleDict{String, String}()
+    content::Union{String, Vector{UInt8}}=""
+    resource::String=""
+    url::String=""
+
+    return_stream::Bool=false
+    response_stream::Union{<:IO, Nothing}=nothing
+    http_options::Array{String}=[]
+    return_raw::Bool=false
+    response_dict_type::Type{<:AbstractDict}=LittleDict
+end
+
+
+function Base.getproperty(r::Request, sym::Symbol)
+    if sym == RR
+        @warn RR_DEPWARN
+    end
+
+    return getfield(r, sym)
+end
+
+function Base.setproperty!(r::Request, sym::Symbol, v)
+    if sym == RR
+        @warn RR_DEPWARN
+    end
+
+    return setfield!(r, sym, v)
+end

--- a/test/AWS.jl
+++ b/test/AWS.jl
@@ -10,7 +10,7 @@ end
 
         @test AWS.global_aws_config().region == region
     finally
-        AWS.aws_config[] = AWSConfig()
+        AWS.AWS_CONFIG[] = AWSConfig()
     end
 end
 
@@ -31,9 +31,9 @@ end
 @testset "set user agent" begin
     new_user_agent = "new user agent"
 
-    @test AWS.user_agent[] == "AWS.jl/1.0.0"
+    @test AWS.USER_AGENT[] == "AWS.jl/1.0.0"
     set_user_agent(new_user_agent)
-    @test AWS.user_agent[] == new_user_agent
+    @test AWS.USER_AGENT[] == new_user_agent
 end
 
 @testset "sign" begin
@@ -149,12 +149,13 @@ end
     end
 
     @testset "return raw" begin
+        set_return_raw(true)
+
         request = Request(
             service="s3",
             api_version="api_version",
             request_method="GET",
-            url="https://s3.us-east-1.amazonaws.com/sample-bucket",
-            return_raw=true
+            url="https://s3.us-east-1.amazonaws.com/sample-bucket"
         )
 
         @testset "body" begin
@@ -175,6 +176,8 @@ end
                 @test headers == Patches.headers
             end
         end
+
+        set_return_raw(false)
     end
 
     @testset "MIME" begin

--- a/test/request.jl
+++ b/test/request.jl
@@ -1,0 +1,6 @@
+@testset "depwarn" begin
+    req = Request(; service="", api_version="", request_method="")
+
+    @test_logs (:warn, AWS.RR_DEPWARN) req.return_raw
+    @test_logs (:warn, AWS.RR_DEPWARN) req.return_raw = true
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -39,6 +39,7 @@ end
     include("AWSExceptions.jl")
     include("AWSMetadataUtilities.jl")
     include("issues.jl")
+    include("request.jl")
     include("test_pkg.jl")
     include("utilities.jl")
 


### PR DESCRIPTION
## Resolves: #224 

## Overview
In #224 it was brought up that the default behavior for making a request should be to return a `Vector{UInt8}` instead of applying heuristics to parse responses back. Applying heuristics makes viewing responses a lot more simple and stops users from needing to parse themselves, however you do end up losing the format of the file.

One of the tenets when creating this iteration of the package was to allow for the easiest interfacing with AWS. Currently you can get raw responses back (as `Vector{UInt8}`), but you need to pass in `return_raw=true` with every request you make. This does not make sense in a large scale application to constantly pass it along.

## Proposed Changes
I think that these changes are a good compromise between the two. It allows for users to set a globally set a variable `set_return_raw(true)` to always return back raw responses. I've also added in functionality upon loading the package to check for an environment variable `AWS_JL_RAW` and set this global variable based off of it. The environment variables main purpose is to quickly use raw responses with EC2/ECS instances.

These changes are backwards compatible, as I do not want to tag `AWS@2` yet, so users can continue to use `Request.return_raw`. However by accessing this property or attempting to manually set it a warning will be output warning that this functionality will be removed in the next major version.

## Other Changes
As I was working on this I came across a couple minor things:

- Moved the `struct Request` into its own file, as `src/AWS.jl` is getting large
- Low-level service functions kwarg `aws` did not match that of high-level functions `aws_config`
- `const` globally to UPPERCASE