### PR TITLE
Improve `ec2_instance_metadata` and create `ec2_instance_region`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -23,7 +23,7 @@ XMLDict = "228000da-037f-5747-90a9-8195ccbf91a5"
 [compat]
 Compat = "3"
 GitHub = "5"
-HTTP = "0.8, 0.9"
+HTTP = "0.9.6"
 IniFile = "0.5"
 JSON = "0.18, 0.19, 0.20, 0.21"
 MbedTLS = "0.6, 0.7, 1"

--- a/src/AWS.jl
+++ b/src/AWS.jl
@@ -15,6 +15,7 @@ import URIs
 
 export @service
 export _merge, AbstractAWSConfig, AWSConfig, AWSExceptions, AWSServices, Request
+export ec2_instance_metadata, ec2_instance_region
 export global_aws_config, generate_service_url, set_user_agent, sign!, sign_aws2!, sign_aws4!
 export JSONService, RestJSONService, RestXMLService, QueryService
 

--- a/src/AWSCredentials.jl
+++ b/src/AWSCredentials.jl
@@ -323,10 +323,7 @@ end
 Determine the AWS region of the machine executing this code if running inside of an EC2
 instance, otherwise `nothing` is returned.
 """
-function ec2_instance_region()
-    az = ec2_instance_metadata("/latest/meta-data/placement/availability-zone")
-    return az !== nothing ? chop(az) : nothing
-end
+ec2_instance_region() = ec2_instance_metadata("/latest/meta-data/placement/region")
 
 
 """

--- a/src/AWSCredentials.jl
+++ b/src/AWSCredentials.jl
@@ -318,6 +318,18 @@ end
 
 
 """
+    ec2_instance_region() -> Union{String, Nothing}
+
+Determine the AWS region of the machine executing this code if running inside of an EC2
+instance, otherwise `nothing` is returned.
+"""
+function ec2_instance_region()
+    az = ec2_instance_metadata("/latest/meta-data/placement/availability-zone")
+    return az !== nothing ? chop(az) : nothing
+end
+
+
+"""
     ec2_instance_credentials() -> AWSCredentials
 
 Parse the EC2 metadata to retrieve AWSCredentials.

--- a/test/patch.jl
+++ b/test/patch.jl
@@ -101,4 +101,8 @@ _github_tree_patch = @patch function tree(repo, tree_obj; kwargs...)
     end
 end
 
+_instance_metadata_timeout_patch = @patch function HTTP.request(method::String, url; kwargs...)
+    throw(HTTP.ConnectionPool.ConnectTimeout("169.254.169.254", "80"))
+end
+
 end


### PR DESCRIPTION
Replaces the `_ec2_metadata` with the more generalized `ec2_instance_metadata`. The main change here is using HTTP.jl's `connect_timeout` which lets this function fail fast if running in and environment where the EC2 metadata is not available.

Additionally I added a `ec2_instance_region` function which determines the region of an instance when executed on the instance. I originally was planning on using this function as the default for `aws_get_region` but decided against it. It should still be useful in use cases such as:

```julia
global_aws_config(; region=something(AWS.ec2_instance_region(), "us-east-2"))
```

The one caveat with this change is that it requires a much newer version of HTTP.jl. Note the `connect_timeout` keyword was available in earlier revisions but had issues. Additionally, the special exception we're using was only available starting in HTTP.jl 0.9.6.