### PR TITLE
Use a constant for the default region

### DIFF
--- a/src/AWS.jl
+++ b/src/AWS.jl
@@ -19,6 +19,8 @@ export ec2_instance_metadata, ec2_instance_region
 export global_aws_config, generate_service_url, set_user_agent, sign!, sign_aws2!, sign_aws4!
 export JSONService, RestJSONService, RestXMLService, QueryService
 
+const DEFAULT_REGION = "us-east-1"
+
 include("utilities.jl")
 include("AWSExceptions.jl")
 include("AWSCredentials.jl")
@@ -319,7 +321,7 @@ function generate_service_url(aws::AbstractAWSConfig, service::String, resource:
 
     regionless_services = ("iam", "route53")
 
-    if service in regionless_services || (service == "sdb" && reg == "us-east-1")
+    if service in regionless_services || (service == "sdb" && reg == DEFAULT_REGION)
         reg = ""
     end
 

--- a/src/AWSConfig.jl
+++ b/src/AWSConfig.jl
@@ -12,7 +12,7 @@ region(aws::AWSConfig) = aws.region
 function AWSConfig(;
     profile=nothing,
     creds=AWSCredentials(profile=profile),
-    region=get(ENV, "AWS_DEFAULT_REGION", "us-east-1"),
+    region=get(ENV, "AWS_DEFAULT_REGION", DEFAULT_REGION),
     output="json",
 )
     return AWSConfig(creds, region, output)

--- a/src/AWSCredentials.jl
+++ b/src/AWSCredentials.jl
@@ -539,7 +539,7 @@ end
 """
     aws_get_region(profile::AbstractString, ini::Inifile) -> String
 
-Retrieve the AWS Region for a given profile, returns `us-east-1` as a default.
+Retrieve the AWS Region for a given profile, returns "$DEFAULT_REGION" as a default.
 
 # Arguments
 - `profile::AbstractString`: Specific profile used to get the region
@@ -547,7 +547,7 @@ Retrieve the AWS Region for a given profile, returns `us-east-1` as a default.
 """
 function aws_get_region(profile::AbstractString, ini::Inifile)
     region = get(ENV, "AWS_DEFAULT_REGION") do
-        _get_ini_value(ini, profile, "region"; default_value="us-east-1")
+        _get_ini_value(ini, profile, "region"; default_value=DEFAULT_REGION)
     end
 
     return region


### PR DESCRIPTION
Mainly just some code refactoring. Could be useful in conjunction with #349 such that you can do:

```julia
global_aws_config(; region=something(AWS.ec2_instance_region(), AWS.DEFAULT_REGION))
```