### PR TITLE
Basic interactive MFA support

### DIFF
--- a/src/utilities/credentials.jl
+++ b/src/utilities/credentials.jl
@@ -60,7 +60,10 @@ end
 Retrieve the `AWSCredentials` for a given role from Security Token Services (STS).
 """
 function _aws_get_role(role::AbstractString, ini::Inifile)
-    source_profile, role_arn = aws_get_role_details(role, ini)
+    settings = aws_get_profile_settings(role, ini)
+    source_profile = get(settings, "source_profile", nothing)
+    role_arn = get(settings, "role_arn", nothing)
+
     source_profile === nothing && return nothing
     credentials = nothing
 

--- a/src/utilities/credentials.jl
+++ b/src/utilities/credentials.jl
@@ -63,10 +63,11 @@ function _aws_get_role(role::AbstractString, ini::Inifile)
     settings = aws_get_profile_settings(role, ini)
     source_profile = get(settings, "source_profile", nothing)
     role_arn = get(settings, "role_arn", nothing)
+    mfa_serial = get(settings, "mfa_serial", nothing)
 
     source_profile === nothing && return nothing
-    credentials = nothing
 
+    credentials = nothing
     for f in (dot_aws_credentials, dot_aws_config)
         credentials = f(source_profile)
         credentials === nothing || break
@@ -77,16 +78,20 @@ function _aws_get_role(role::AbstractString, ini::Inifile)
         creds=credentials, region=aws_get_region(; config=ini, profile=source_profile)
     )
 
+    params = LittleDict(
+        "RoleArn" => role_arn, "RoleSessionName" => replace(role, r"[^\w+=,.@-]" => s"-")
+    )
+
+    if mfa_serial !== nothing
+        params["SerialNumber"] = mfa_serial
+        token = Base.getpass("Enter MFA code for $mfa_serial")
+        params["TokenCode"] = read(token, String)
+        Base.shred!(token)
+    end
+
     # RoleSessionName Documentation
     # https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html
-    role = AWSServices.sts(
-        "AssumeRole",
-        LittleDict(
-            "RoleArn" => role_arn,
-            "RoleSessionName" => replace(role, r"[^\w+=,.@-]" => s"-"),
-        );
-        aws_config=config,
-    )
+    role = AWSServices.sts("AssumeRole", params; aws_config=config)
 
     role_creds = role["AssumeRoleResult"]["Credentials"]
 


### PR DESCRIPTION
Experimenting with supporting MFA. Currently Julia will prompt you for an MFA token if you have defined `mfa_serial` in your config file. I'll note the AWS CLI seem to cache credentials under `~/.aws/cli/cache` so we can possibly use that information to avoid having to ask users for one-time passwords when switching between using the AWS CLI and AWS.jl. In an ideal world we would also be able to have AWS.jl write back to the cache.