### PR TITLE
Use region as specifed by the profile

### DIFF
--- a/src/AWS.jl
+++ b/src/AWS.jl
@@ -24,6 +24,8 @@ export JSONService, RestJSONService, RestXMLService, QueryService
 
 const DEFAULT_REGION = "us-east-1"
 
+include(joinpath("utilities", "utilities.jl"))
+
 include("AWSExceptions.jl")
 include("AWSCredentials.jl")
 include("AWSConfig.jl")
@@ -31,7 +33,7 @@ include("AWSMetadata.jl")
 
 include(joinpath("utilities", "request.jl"))
 include(joinpath("utilities", "sign.jl"))
-include(joinpath("utilities", "utilities.jl"))
+
 
 using ..AWSExceptions
 using ..AWSExceptions: AWSException

--- a/src/AWSConfig.jl
+++ b/src/AWSConfig.jl
@@ -12,9 +12,16 @@ region(aws::AWSConfig) = aws.region
 function AWSConfig(;
     profile=nothing,
     creds=AWSCredentials(profile=profile),
-    region=get(ENV, "AWS_DEFAULT_REGION", DEFAULT_REGION),
+    region=nothing,
     output="json",
 )
+    region = @something(
+        region,
+        get(ENV, "AWS_DEFAULT_REGION", nothing),
+        dot_aws_region(profile),
+        DEFAULT_REGION,
+    )
+
     return AWSConfig(creds, region, output)
 end
 

--- a/src/AWSConfig.jl
+++ b/src/AWSConfig.jl
@@ -15,13 +15,7 @@ function AWSConfig(;
     region=nothing,
     output="json",
 )
-    region = @something(
-        region,
-        get(ENV, "AWS_DEFAULT_REGION", nothing),
-        dot_aws_region(profile),
-        DEFAULT_REGION,
-    )
-
+    region = @something region aws_get_region(profile=profile)
     return AWSConfig(creds, region, output)
 end
 

--- a/src/AWSCredentials.jl
+++ b/src/AWSCredentials.jl
@@ -14,6 +14,7 @@ export AWSCredentials,
        check_credentials,
        dot_aws_config,
        dot_aws_credentials,
+       dot_aws_region,
        dot_aws_credentials_file,
        dot_aws_config_file,
        ec2_instance_credentials,
@@ -389,6 +390,29 @@ function dot_aws_config_file()
     get(ENV, "AWS_CONFIG_FILE") do
         joinpath(homedir(), ".aws", "config")
     end
+end
+
+
+"""
+    dot_aws_region(profile=nothing) -> Union{String, Nothing}
+
+Retrieve the region for the default or specified profile from the `~/.aws/config` file.
+If no region is specified then `nothing` is returned.
+
+# Arguments
+- `profile`: Specific profile used to get the region, default is `nothing`
+"""
+function dot_aws_region(profile=nothing)
+    region = nothing
+    config_file = dot_aws_config_file()
+
+    if isfile(config_file)
+        ini = read(Inifile(), config_file)
+        p = _aws_get_profile(profile)
+        region = _get_ini_value(ini, p, "region")
+    end
+
+    return region
 end
 
 

--- a/src/AWSCredentials.jl
+++ b/src/AWSCredentials.jl
@@ -104,10 +104,7 @@ Checks credential locations in the order:
 function AWSCredentials(; profile=nothing, throw_cred_error=true)
     creds = nothing
     credential_function = () -> nothing
-
-    if profile === nothing
-        profile = get(ENV, "AWS_PROFILE", get(ENV, "AWS_DEFAULT_PROFILE", nothing))
-    end
+    profile = _aws_get_profile(profile, fallback=nothing)
 
     # Define our search options, expected to be callable with no arguments.
     # Throw NoCredentials if none are found
@@ -343,7 +340,7 @@ function dot_aws_credentials(profile=nothing)
 
     if isfile(credential_file)
         ini = read(Inifile(), credential_file)
-        p = profile === nothing ? _aws_get_profile() : profile
+        p = _aws_get_profile(profile)
         access_key, secret_key, token = _aws_get_credential_details(p, ini)
 
         if access_key !== nothing
@@ -375,7 +372,7 @@ function dot_aws_config(profile=nothing)
 
     if isfile(config_file)
         ini = read(Inifile(), config_file)
-        p = profile === nothing ? _aws_get_profile() : profile
+        p = _aws_get_profile(profile)
         access_key, secret_key, token = _aws_get_credential_details(p, ini)
 
         if access_key !== nothing

--- a/src/utilities/credentials.jl
+++ b/src/utilities/credentials.jl
@@ -31,6 +31,25 @@ function _get_ini_value(
 end
 
 
+function _aws_profile_config(ini::Inifile, profile::AbstractString)
+    if profile != "default"
+        profile = "profile $profile"
+    end
+
+    return get(sections(ini), profile, Dict())
+end
+
+function _aws_profile_config(ini::Inifile, profile::Nothing=nothing)
+    _aws_profile_config(ini, _aws_get_profile())
+end
+
+function _aws_profile_config(config_file::AbstractString=dot_aws_config_file(), args...)
+    return _aws_profile_config(read(Inifile(), config_file), args...)
+end
+
+_aws_profile_config(config_file::Nothing, args...) = _aws_profile_config(args...)
+
+
 """
 Retrieve the `AWSCredentials` for a given role from Security Token Services (STS).
 """
@@ -45,7 +64,7 @@ function _aws_get_role(role::AbstractString, ini::Inifile)
     end
 
     credentials === nothing && return nothing
-    config = AWSConfig(creds=credentials, region=aws_get_region(source_profile, ini))
+    config = AWSConfig(creds=credentials, region=aws_get_region(config=ini, profile=source_profile))
 
     # RoleSessionName Documentation
     # https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html
@@ -83,12 +102,11 @@ end
 """
 Get the default AWS profile
 """
-function _aws_get_profile(profile=nothing; fallback="default")
+function _aws_get_profile(; default="default")
     @something(
-        profile,
         get(ENV, "AWS_PROFILE", nothing),
         get(ENV, "AWS_DEFAULT_PROFILE", nothing),
-        Some(fallback),
+        Some(default),
     )
 end
 

--- a/src/utilities/credentials.jl
+++ b/src/utilities/credentials.jl
@@ -84,13 +84,12 @@ end
 Get the default AWS profile
 """
 function _aws_get_profile(profile=nothing; fallback="default")
-    if profile !== nothing
-        profile
-    else
-        get(ENV, "AWS_PROFILE") do
-            get(ENV, "AWS_DEFAULT_PROFILE", fallback)
-        end
-    end
+    @something(
+        profile,
+        get(ENV, "AWS_PROFILE", nothing),
+        get(ENV, "AWS_DEFAULT_PROFILE", nothing),
+        Some(fallback),
+    )
 end
 
 

--- a/src/utilities/credentials.jl
+++ b/src/utilities/credentials.jl
@@ -44,6 +44,7 @@ function _aws_profile_config(ini::Inifile, profile::Nothing=nothing)
 end
 
 function _aws_profile_config(config_file::AbstractString=dot_aws_config_file(), args...)
+    isfile(config_file) || return Dict()
     return _aws_profile_config(read(Inifile(), config_file), args...)
 end
 

--- a/src/utilities/credentials.jl
+++ b/src/utilities/credentials.jl
@@ -39,16 +39,18 @@ function _aws_profile_config(ini::Inifile, profile::AbstractString)
     return get(sections(ini), profile, Dict())
 end
 
-function _aws_profile_config(ini::Inifile, profile::Nothing=nothing)
+function _aws_profile_config(ini::Inifile, profile::Nothing)
     _aws_profile_config(ini, _aws_get_profile())
 end
 
-function _aws_profile_config(config_file::AbstractString=dot_aws_config_file(), args...)
+function _aws_profile_config(config_file::AbstractString, profile)
     isfile(config_file) || return Dict()
-    return _aws_profile_config(read(Inifile(), config_file), args...)
+    return _aws_profile_config(read(Inifile(), config_file), profile)
 end
 
-_aws_profile_config(config_file::Nothing, args...) = _aws_profile_config(args...)
+function _aws_profile_config(config_file::Nothing, profile)
+    return _aws_profile_config(dot_aws_config_file(), profile)
+end
 
 
 """

--- a/src/utilities/credentials.jl
+++ b/src/utilities/credentials.jl
@@ -83,9 +83,13 @@ end
 """
 Get the default AWS profile
 """
-function _aws_get_profile()
-    get(ENV, "AWS_DEFAULT_PROFILE") do
-        get(ENV, "AWS_PROFILE", "default")
+function _aws_get_profile(profile=nothing; fallback="default")
+    if profile !== nothing
+        profile
+    else
+        get(ENV, "AWS_PROFILE") do
+            get(ENV, "AWS_DEFAULT_PROFILE", fallback)
+        end
     end
 end
 

--- a/src/utilities/utilities.jl
+++ b/src/utilities/utilities.jl
@@ -98,3 +98,40 @@ function _generate_rest_resource(request_uri::String, args::AbstractDict{String,
 
     return request_uri
 end
+
+
+"""
+    @something(x, y...)
+
+Short-circuiting version of [`something`](@ref something).
+
+# Examples
+```
+julia> f(x) = (println("f(\$x)"); nothing);
+
+julia> a = 1;
+
+julia> a = @something a f(2) f(3) error("Unable to find default for `a`")
+1
+
+julia> b = nothing;
+
+julia> b = @something b f(2) f(3) error("Unable to find default for `b`")
+f(2)
+f(3)
+ERROR: Unable to find default for `b`
+...
+
+julia> b = @something b f(2) f(3) Some(nothing)
+f(2)
+f(3)
+
+```
+"""
+macro something(args...)
+    expr = :(nothing)
+    for arg in reverse(args)
+        expr = :((val = $arg) !== nothing ? val : $expr)
+    end
+    return esc(:(something(let val; $expr; end)))
+end

--- a/test/AWSCredentials.jl
+++ b/test/AWSCredentials.jl
@@ -598,3 +598,49 @@ end
         end
     end
 end
+
+@testset "dot_aws_region" begin
+     test_values = Dict{String, Any}(
+        "Default-Profile" => "default",
+        "Test-Profile" => "test",
+        "Region" => "us-west-2",
+    )
+
+    @testset "~/.aws/config - Default Profile" begin
+        mktemp() do config_file, config_io
+            write(
+                config_io,
+                """
+                [$(test_values["Default-Profile"])]
+                region = $(test_values["Region"])
+                """
+            )
+            close(config_io)
+
+            withenv(
+                "AWS_CONFIG_FILE" => config_file,
+                "AWS_PROFILE" => nothing,
+                "AWS_DEFAULT_PROFILE" => nothing,
+            ) do
+                @test dot_aws_region() == test_values["Region"]
+            end
+        end
+    end
+
+    @testset "~/.aws/config - Specified Profile" begin
+        mktemp() do config_file, config_io
+            write(
+                config_io,
+                """
+                [profile $(test_values["Test-Profile"])]
+                region = $(test_values["Region"])
+                """
+            )
+            close(config_io)
+
+            withenv("AWS_CONFIG_FILE" => config_file) do
+                @test dot_aws_region(test_values["Test-Profile"]) == test_values["Region"]
+            end
+        end
+    end
+end

--- a/test/AWSCredentials.jl
+++ b/test/AWSCredentials.jl
@@ -620,8 +620,10 @@ end
         end
 
         @testset "default profile" begin
-            @test aws_get_region(config=ini, profile="default") == "us-west-2"
-            @test aws_get_region(config=config_file, profile="default") == "us-west-2"
+            withenv("AWS_DEFAULT_REGION" => nothing) do
+                @test aws_get_region(config=ini, profile="default") == "us-west-2"
+                @test aws_get_region(config=config_file, profile="default") == "us-west-2"
+            end
 
             withenv(
                 "AWS_DEFAULT_REGION" => nothing,
@@ -634,8 +636,10 @@ end
         end
 
         @testset "specified profile" begin
-            @test aws_get_region(config=ini, profile="test") == "ap-northeast-1"
-            @test aws_get_region(config=config_file, profile="test") == "ap-northeast-1"
+            withenv("AWS_DEFAULT_REGION" => nothing) do
+                @test aws_get_region(config=ini, profile="test") == "ap-northeast-1"
+                @test aws_get_region(config=config_file, profile="test") == "ap-northeast-1"
+            end
 
             withenv(
                 "AWS_DEFAULT_REGION" => nothing,
@@ -647,8 +651,10 @@ end
         end
 
         @testset "unknown profile" begin
-            @test aws_get_region(config=ini, profile="unknown") == AWS.DEFAULT_REGION
-            @test aws_get_region(config=config_file, profile="unknown") == AWS.DEFAULT_REGION
+            withenv("AWS_DEFAULT_REGION" => nothing) do
+                @test aws_get_region(config=ini, profile="unknown") == AWS.DEFAULT_REGION
+                @test aws_get_region(config=config_file, profile="unknown") == AWS.DEFAULT_REGION
+            end
 
             withenv(
                 "AWS_DEFAULT_REGION" => nothing,
@@ -661,8 +667,10 @@ end
 
         @testset "default keyword" begin
             default = nothing
-            @test aws_get_region(config=ini, profile="unknown", default=default) === default
-            @test aws_get_region(config=config_file, profile="unknown", default=default) === default
+            withenv("AWS_DEFAULT_REGION" => nothing) do
+                @test aws_get_region(config=ini, profile="unknown", default=default) === default
+                @test aws_get_region(config=config_file, profile="unknown", default=default) === default
+            end
 
             withenv(
                 "AWS_DEFAULT_REGION" => nothing,
@@ -670,6 +678,15 @@ end
                 "AWS_PROFILE" => "unknown",
             ) do
                 @test aws_get_region(default=default) === default
+            end
+        end
+
+        @testset "no such config file" begin
+            withenv(
+                "AWS_DEFAULT_REGION" => nothing,
+                "AWS_CONFIG_FILE" => tempname(),
+            ) do
+                @test aws_get_region() == AWS.DEFAULT_REGION
             end
         end
     end

--- a/test/AWSCredentials.jl
+++ b/test/AWSCredentials.jl
@@ -599,47 +599,77 @@ end
     end
 end
 
-@testset "dot_aws_region" begin
-     test_values = Dict{String, Any}(
-        "Default-Profile" => "default",
-        "Test-Profile" => "test",
-        "Region" => "us-west-2",
-    )
+@testset "aws_get_region" begin
+    mktempdir() do dir
+        config_str = """
+            [default]
+            region = us-west-2
 
-    @testset "~/.aws/config - Default Profile" begin
-        mktemp() do config_file, config_io
-            write(
-                config_io,
-                """
-                [$(test_values["Default-Profile"])]
-                region = $(test_values["Region"])
-                """
-            )
-            close(config_io)
+            [profile test]
+            region = ap-northeast-1
+            """
+        config_file = joinpath(dir, "config")
+        write(config_file, config_str)
+        ini = read(Inifile(), IOBuffer(config_str))
+
+        @testset "environmental variable" begin
+            withenv("AWS_DEFAULT_REGION" => "us-gov-east-1") do
+                @test aws_get_region(config=ini, profile="default") == "us-gov-east-1"
+                @test aws_get_region() == "us-gov-east-1"
+            end
+        end
+
+        @testset "default profile" begin
+            @test aws_get_region(config=ini, profile="default") == "us-west-2"
+            @test aws_get_region(config=config_file, profile="default") == "us-west-2"
 
             withenv(
+                "AWS_DEFAULT_REGION" => nothing,
                 "AWS_CONFIG_FILE" => config_file,
                 "AWS_PROFILE" => nothing,
                 "AWS_DEFAULT_PROFILE" => nothing,
             ) do
-                @test dot_aws_region() == test_values["Region"]
+                @test aws_get_region() == "us-west-2"
             end
         end
-    end
 
-    @testset "~/.aws/config - Specified Profile" begin
-        mktemp() do config_file, config_io
-            write(
-                config_io,
-                """
-                [profile $(test_values["Test-Profile"])]
-                region = $(test_values["Region"])
-                """
-            )
-            close(config_io)
+        @testset "specified profile" begin
+            @test aws_get_region(config=ini, profile="test") == "ap-northeast-1"
+            @test aws_get_region(config=config_file, profile="test") == "ap-northeast-1"
 
-            withenv("AWS_CONFIG_FILE" => config_file) do
-                @test dot_aws_region(test_values["Test-Profile"]) == test_values["Region"]
+            withenv(
+                "AWS_DEFAULT_REGION" => nothing,
+                "AWS_CONFIG_FILE" => config_file,
+                "AWS_PROFILE" => "test",
+            ) do
+                @test aws_get_region() == "ap-northeast-1"
+            end
+        end
+
+        @testset "unknown profile" begin
+            @test aws_get_region(config=ini, profile="unknown") == AWS.DEFAULT_REGION
+            @test aws_get_region(config=config_file, profile="unknown") == AWS.DEFAULT_REGION
+
+            withenv(
+                "AWS_DEFAULT_REGION" => nothing,
+                "AWS_CONFIG_FILE" => config_file,
+                "AWS_PROFILE" => "unknown",
+            ) do
+                @test aws_get_region() == AWS.DEFAULT_REGION
+            end
+        end
+
+        @testset "default keyword" begin
+            default = nothing
+            @test aws_get_region(config=ini, profile="unknown", default=default) === default
+            @test aws_get_region(config=config_file, profile="unknown", default=default) === default
+
+            withenv(
+                "AWS_DEFAULT_REGION" => nothing,
+                "AWS_CONFIG_FILE" => config_file,
+                "AWS_PROFILE" => "unknown",
+            ) do
+                @test aws_get_region(default=default) === default
             end
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,6 +11,7 @@ using Compat: mergewith
 using Dates
 using GitHub
 using HTTP
+using IniFile: Inifile
 using JSON
 using OrderedCollections: LittleDict, OrderedDict
 using MbedTLS: digest, MD_SHA256, MD_MD5

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -62,3 +62,13 @@ end
 
     @test AWS._merge("a", "b") == expected
 end
+
+@testset "@something" begin
+    @test_throws ArgumentError AWS.@something()
+    @test_throws ArgumentError AWS.@something(nothing)
+    @test AWS.@something(1) === 1
+    @test AWS.@something(Some(nothing)) === nothing
+
+    @test AWS.@something(1, error("failed")) === 1
+    @test_throws ErrorException AWS.@something(nothing, error("failed"))
+end


### PR DESCRIPTION
Adds support for using the [region specified by a config profile](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html#cli-configure-files-settings).

While developing this I realized that a short-circuiting `something` function would be useful so I added it here. Ideally, this would be added into Base in the future.