### PR TITLE
Add `@` to special-cased S3 escapes

### DIFF
--- a/src/utilities/utilities.jl
+++ b/src/utilities/utilities.jl
@@ -49,6 +49,7 @@ function _clean_s3_uri(uri::AbstractString)
         '*' => "%2A",
         '+' => "%2B",
         '=' => "%3D",
+        '@' => "%40",
     )
     parsed_uri = URIs.URI(uri)
     cleaned_path = reduce(replace, chars_to_clean, init=parsed_uri.path)

--- a/test/AWS.jl
+++ b/test/AWS.jl
@@ -440,8 +440,8 @@ end
 end
 
 @testset "_clean_s3_uri" begin
-    uri = "/test-bucket/*)=('! +.txt?list-objects=v2"
-    expected_uri = "/test-bucket/%2A%29%3D%28%27%21%20%2B.txt?list-objects=v2"
+    uri = "/test-bucket/*)=('! +@.txt?list-objects=v2"
+    expected_uri = "/test-bucket/%2A%29%3D%28%27%21%20%2B%40.txt?list-objects=v2"
     @test AWS._clean_s3_uri(uri) == expected_uri
 
     # make sure that other parts of the uri aren't changed by `_clean_s3_uri`

--- a/test/AWS.jl
+++ b/test/AWS.jl
@@ -749,7 +749,7 @@ end
 
     @testset "low-level s3" begin
         bucket_name = "aws-jl-test---" * _now_formatted()
-        file_name = "*)=('! +.txt"  # Special characters which S3 allows
+        file_name = "*)=('! +@.txt"  # Special characters which S3 allows
 
         function _bucket_exists(bucket_name)
             try


### PR DESCRIPTION
The `@` character is listed in the docs as a character that "may require special
handling".  This PR adds it to the list of special-cased escapes for S3 keys.