### PR TITLE
Assume role from profile via instance metadata

### DIFF
--- a/src/AWSCredentials.jl
+++ b/src/AWSCredentials.jl
@@ -274,11 +274,13 @@ function ec2_instance_credentials(profile::AbstractString)
     role_arn === nothing && return instance_profile_creds
 
     # Assume the role.
-    role_session = _role_session_name(
-        "AWS.jl-role-",
-        basename(role_arn),
-        "-" * Dates.format(@mock(now(UTC)), dateformat"yyyymmdd\THHMMSS\Z"),
-    )
+    role_session = get(ENV, "AWS_ROLE_SESSION_NAME") do
+        _role_session_name(
+            "AWS.jl-role-",
+            basename(role_arn),
+            "-" * Dates.format(@mock(now(UTC)), dateformat"yyyymmdd\THHMMSS\Z"),
+        )
+    end
     params = Dict{String, Any}("RoleArn" => role_arn, "RoleSessionName" => role_session)
     duration = _get_ini_value(ini, profile, "duration_seconds")
     if duration !== nothing

--- a/src/AWSCredentials.jl
+++ b/src/AWSCredentials.jl
@@ -239,7 +239,7 @@ ec2_instance_region() = ec2_instance_metadata("/latest/meta-data/placement/regio
 
 Parse the EC2 metadata to retrieve AWSCredentials.
 """
-function ec2_instance_credentials(profile)
+function ec2_instance_credentials(profile::AbstractString)
     ini = read(Inifile(), dot_aws_config_file())
 
     # Any profile except default must specify the credential_source as Ec2InstanceMetadata.

--- a/src/AWSCredentials.jl
+++ b/src/AWSCredentials.jl
@@ -286,7 +286,7 @@ function ec2_instance_credentials(profile::AbstractString)
     if duration !== nothing
         params["DurationSeconds"] = parse(Int, duration)
     end
-    resp = AWSServices.sts(
+    resp = @mock AWSServices.sts(
         "AssumeRole",
         params;
         aws_config=AWSConfig(creds=instance_profile_creds),
@@ -519,14 +519,14 @@ function credentials_from_webtoken()
         )
     end
 
-    resp = AWSServices.sts(
+    resp = @mock AWSServices.sts(
         "AssumeRoleWithWebIdentity",
         Dict(
             "RoleArn" => role_arn,
             "RoleSessionName" => role_session,  # Required by AssumeRoleWithWebIdentity
             "WebIdentityToken" => web_identity,
         );
-        aws_config=AWSConfig(creds=nothing)
+        aws_config=AWSConfig(creds=nothing),
     )
 
     role_creds = resp["AssumeRoleWithWebIdentityResult"]["Credentials"]

--- a/src/AWSCredentials.jl
+++ b/src/AWSCredentials.jl
@@ -114,7 +114,7 @@ function AWSCredentials(; profile=nothing, throw_cred_error=true)
         () -> dot_aws_config(profile),
         credentials_from_webtoken,
         ecs_instance_credentials,
-        ec2_instance_credentials
+        () -> ec2_instance_credentials(profile),
     ]
 
     # Loop through our search locations until we get credentials back
@@ -235,32 +235,63 @@ ec2_instance_region() = ec2_instance_metadata("/latest/meta-data/placement/regio
 
 
 """
-    ec2_instance_credentials() -> AWSCredentials
+    ec2_instance_credentials(profile::AbstractString) -> AWSCredentials
 
 Parse the EC2 metadata to retrieve AWSCredentials.
 """
-function ec2_instance_credentials()
-    info = ec2_instance_metadata("/latest/meta-data/iam/info")
+function ec2_instance_credentials(profile)
+    ini = read(Inifile(), dot_aws_config_file())
 
-    if info === nothing
-        return nothing
+    # Any profile except default must specify the credential_source as Ec2InstanceMetadata.
+    if profile != "default"
+        source = _get_ini_value(ini, profile, "credential_source")
+        source == "Ec2InstanceMetadata" || return nothing
     end
 
+    info = ec2_instance_metadata("/latest/meta-data/iam/info")
+    info === nothing && return nothing
     info = JSON.parse(info)
 
+    # Get credentials for the role associated to the instance via instance profile.
     name = ec2_instance_metadata("/latest/meta-data/iam/security-credentials/")
     creds = ec2_instance_metadata("/latest/meta-data/iam/security-credentials/$name")
-    new_creds = JSON.parse(creds)
-
-    expiry = DateTime(rstrip(new_creds["Expiration"], 'Z'))
-
-    return AWSCredentials(
-        new_creds["AccessKeyId"],
-        new_creds["SecretAccessKey"],
-        new_creds["Token"],
+    parsed = JSON.parse(creds)
+    instance_profile_creds = AWSCredentials(
+        parsed["AccessKeyId"],
+        parsed["SecretAccessKey"],
+        parsed["Token"],
         info["InstanceProfileArn"];
-        expiry=expiry,
-        renew=ec2_instance_credentials
+        expiry=DateTime(rstrip(parsed["Expiration"], 'Z')),
+        renew=ec2_instance_credentials,
+    )
+
+    # Look for a role to assume and return instance profile credentials if there is none.
+    role_arn = _get_ini_value(ini, profile, "role_arn")
+    role_arn === nothing && return instance_profile_creds
+
+    # Assume the role.
+    role_session = _role_session_name(
+        "AWS.jl-role-",
+        basename(role_arn),
+        "-" * Dates.format(@mock(now(UTC)), dateformat"yyyymmdd\THHMMSS\Z"),
+    )
+    params = Dict{String, Any}("RoleArn" => role_arn, "RoleSessionName" => role_session)
+    duration = _get_ini_value(ini, profile, "duration_seconds")
+    if duration !== nothing
+        params["DurationSeconds"] = parse(Int, duration)
+    end
+    resp = AWSServices.sts(
+        "AssumeRole",
+        params;
+        aws_config=AWSConfig(creds=instance_profile_creds),
+    )
+    return AWSCredentials(
+        resp["AssumeRoleResult"]["Credentials"]["AccessKeyId"],
+        resp["AssumeRoleResult"]["Credentials"]["SecretAccessKey"],
+        resp["AssumeRoleResult"]["Credentials"]["SessionToken"],
+        resp["AssumeRoleResult"]["AssumedRoleUser"]["Arn"],
+        expiry=DateTime(rstrip(resp["AssumeRoleResult"]["Credentials"]["Expiration"], 'Z')),
+        renew=() -> ec2_instance_credentials(profile),
     )
 end
 

--- a/src/AWSCredentials.jl
+++ b/src/AWSCredentials.jl
@@ -289,12 +289,14 @@ function ec2_instance_credentials(profile::AbstractString)
         params;
         aws_config=AWSConfig(creds=instance_profile_creds),
     )
+    role_creds = resp["AssumeRoleResult"]["Credentials"]
+    role_user = resp["AssumeRoleResult"]["AssumedRoleUser"]
     return AWSCredentials(
-        resp["AssumeRoleResult"]["Credentials"]["AccessKeyId"],
-        resp["AssumeRoleResult"]["Credentials"]["SecretAccessKey"],
-        resp["AssumeRoleResult"]["Credentials"]["SessionToken"],
-        resp["AssumeRoleResult"]["AssumedRoleUser"]["Arn"],
-        expiry=DateTime(rstrip(resp["AssumeRoleResult"]["Credentials"]["Expiration"], 'Z')),
+        role_creds["AccessKeyId"],
+        role_creds["SecretAccessKey"],
+        role_creds["SessionToken"],
+        role_user["Arn"],
+        expiry=DateTime(rstrip(role_creds["Expiration"], 'Z')),
         renew=() -> ec2_instance_credentials(profile),
     )
 end

--- a/src/AWSCredentials.jl
+++ b/src/AWSCredentials.jl
@@ -266,7 +266,7 @@ function ec2_instance_credentials(profile::AbstractString)
         parsed["Token"],
         info["InstanceProfileArn"];
         expiry=DateTime(rstrip(parsed["Expiration"], 'Z')),
-        renew=ec2_instance_credentials,
+        renew=() -> ec2_instance_credentials(profile),
     )
 
     # Look for a role to assume and return instance profile credentials if there is none.

--- a/src/AWSCredentials.jl
+++ b/src/AWSCredentials.jl
@@ -240,7 +240,11 @@ ec2_instance_region() = ec2_instance_metadata("/latest/meta-data/placement/regio
 Parse the EC2 metadata to retrieve AWSCredentials.
 """
 function ec2_instance_credentials(profile::AbstractString)
-    ini = read(Inifile(), dot_aws_config_file())
+    path = dot_aws_config_file()
+    ini = Inifile()
+    if isfile(path)
+        ini = read(ini, path)
+    end
 
     # Any profile except default must specify the credential_source as Ec2InstanceMetadata.
     if profile != "default"

--- a/test/AWSCredentials.jl
+++ b/test/AWSCredentials.jl
@@ -492,7 +492,10 @@ end
             )
 
             apply(patch) do
-                result = ec2_instance_credentials("foobar")
+                session_name = "foobar-session"
+                result = withenv("AWS_ROLE_SESSION_NAME" => session_name) do
+                    ec2_instance_credentials("foobar")
+                end
 
                 @test result.access_key_id == access_key
                 @test result.secret_key == secret_key
@@ -507,7 +510,7 @@ end
                 @test result.secret_key == secret_key
                 @test result.token == session_token
                 @test result.user_arn == role_arn * "/" * session_name
-                @test result.renew == credentials_from_webtoken
+                @test result.renew !== nothing
                 @test expiry != result.expiry
             end
         end

--- a/test/AWSCredentials.jl
+++ b/test/AWSCredentials.jl
@@ -511,7 +511,7 @@ end
             @test result.access_key_id == access_key
             @test result.secret_key == secret_key
             @test result.token == session_token
-            @test result.user_arn == role_arn * "/" * session_name
+            @test result.user_arn == "$(role_arn)/$(session_name)"
             @test result.renew !== nothing
         end
     end

--- a/test/AWSCredentials.jl
+++ b/test/AWSCredentials.jl
@@ -471,6 +471,10 @@ end
     @testset "Instance - EC2" begin
         role_name = "foobar"
         role_arn = "arn:aws:sts::1234:assumed-role/$role_name"
+        access_key = "access-key-$(randstring(6))"
+        secret_key = "secret-key-$(randstring(6))"
+        session_token = "session-token-$(randstring(6))"
+        session_name = "$role_name-session"
         patch = Patches._assume_role_patch(
             "AssumeRole";
             access_key=access_key,
@@ -487,11 +491,6 @@ end
             @test result.user_arn == test_values["InstanceProfileArn"]
             @test result.expiry == test_values["Expiration"]
             @test result.renew !== nothing
-
-            access_key = "access-key-$(randstring(6))"
-            secret_key = "secret-key-$(randstring(6))"
-            session_token = "session-token-$(randstring(6))"
-            session_name = "$role_name-session"
 
             result = mktemp() do config_file, config_io
                 write(

--- a/test/AWSCredentials.jl
+++ b/test/AWSCredentials.jl
@@ -470,7 +470,7 @@ end
 
     @testset "Instance - EC2" begin
         apply(_http_request_patch) do
-            result = ec2_instance_credentials()
+            result = ec2_instance_credentials("default")
             @test result.access_key_id == test_values["AccessKeyId"]
             @test result.secret_key == test_values["SecretAccessKey"]
             @test result.token == test_values["Token"]

--- a/test/AWSCredentials.jl
+++ b/test/AWSCredentials.jl
@@ -476,7 +476,7 @@ end
             @test result.token == test_values["Token"]
             @test result.user_arn == test_values["InstanceProfileArn"]
             @test result.expiry == test_values["Expiration"]
-            @test result.renew == ec2_instance_credentials
+            @test result.renew !== nothing
         end
     end
 

--- a/test/AWSCredentials.jl
+++ b/test/AWSCredentials.jl
@@ -513,16 +513,6 @@ end
             @test result.token == session_token
             @test result.user_arn == role_arn * "/" * session_name
             @test result.renew !== nothing
-            expiry = result.expiry
-
-            result = check_credentials(result)
-
-            @test result.access_key_id == access_key
-            @test result.secret_key == secret_key
-            @test result.token == session_token
-            @test result.user_arn == role_arn * "/" * session_name
-            @test result.renew !== nothing
-            @test expiry != result.expiry
         end
     end
 

--- a/test/AWSCredentials.jl
+++ b/test/AWSCredentials.jl
@@ -562,7 +562,7 @@ end
                     @test result.access_key_id == access_key
                     @test result.secret_key == secret_key
                     @test result.token == session_token
-                    @test result.user_arn == role_arn * "/" * session_name
+                    @test result.user_arn == "$(role_arn)/$(session_name)"
                     @test result.renew == credentials_from_webtoken
                     expiry = result.expiry
 
@@ -571,7 +571,7 @@ end
                     @test result.access_key_id == access_key
                     @test result.secret_key == secret_key
                     @test result.token == session_token
-                    @test result.user_arn == role_arn * "/" * session_name
+                    @test result.user_arn == "$(role_arn)/$(session_name)"
                     @test result.renew == credentials_from_webtoken
                     @test expiry != result.expiry
                 end
@@ -590,7 +590,7 @@ end
             ) do
                 apply(patches) do
                     result = credentials_from_webtoken()
-                    @test result.user_arn == role_arn * "/" * session_name
+                    @test result.user_arn == "$(role_arn)/$(session_name)"
                 end
             end
         end

--- a/test/AWSCredentials.jl
+++ b/test/AWSCredentials.jl
@@ -483,7 +483,7 @@ end
             role_arn=role_arn,
         )
 
-        apply([_http_request_patch, patch]) do
+        apply([patch, _http_request_patch]) do
             result = ec2_instance_credentials("default")
             @test result.access_key_id == test_values["AccessKeyId"]
             @test result.secret_key == test_values["SecretAccessKey"]

--- a/test/patch.jl
+++ b/test/patch.jl
@@ -67,10 +67,11 @@ _config_file_patch = @patch function dot_aws_config_file()
     return ""
 end
 
-_web_identity_patch = function (;
-    access_key="web_identity_access_key",
-    secret_key="web_identity_secret_key",
-    session_token="web_session_token",
+_assume_role_patch = function (
+    op;
+    access_key="access_key",
+    secret_key="secret_key",
+    session_token="token",
     role_arn="arn:aws:sts:::assumed-role/role-name",
 )
     @patch function AWS._http_request(request)
@@ -83,7 +84,7 @@ _web_identity_patch = function (;
         )
 
         result = Dict(
-            "AssumeRoleWithWebIdentityResult" => Dict(
+            "$(op)Result" => Dict(
                 "Credentials" => creds,
                 "AssumedRoleUser" => Dict(
                     "Arn" => role_arn * "/" * params["RoleSessionName"],

--- a/test/patch.jl
+++ b/test/patch.jl
@@ -84,7 +84,7 @@ _assume_role_patch = function (
                     "Expiration" => string(now(UTC)),
                 ),
                 "AssumedRoleUser" => Dict(
-                    "Arn" => "$(role_arn)/$(params["RoleSessionName"]),
+                    "Arn" => "$(role_arn)/$(params["RoleSessionName"])",
                 ),
             ),
         )

--- a/test/patch.jl
+++ b/test/patch.jl
@@ -74,25 +74,20 @@ _assume_role_patch = function (
     session_token="token",
     role_arn="arn:aws:sts:::assumed-role/role-name",
 )
-    @patch function AWS._http_request(request)
-        params = Dict(split.(split(request.content, '&'), '='))
-        creds = Dict(
-            "AccessKeyId" => access_key,
-            "SecretAccessKey" => secret_key,
-            "SessionToken" => session_token,
-            "Expiration" => string(now(UTC)),
-        )
-
-        result = Dict(
+    @patch function AWSServices.sts(op, params; aws_config)
+        return Dict(
             "$(op)Result" => Dict(
-                "Credentials" => creds,
+                "Credentials" => Dict(
+                    "AccessKeyId" => access_key,
+                    "SecretAccessKey" => secret_key,
+                    "SessionToken" => session_token,
+                    "Expiration" => string(now(UTC)),
+                ),
                 "AssumedRoleUser" => Dict(
                     "Arn" => role_arn * "/" * params["RoleSessionName"],
                 ),
             ),
         )
-
-        return HTTP.Response(200, ["Content-Type" => "text/json", "charset" => "utf-8"], body=json(result))
     end
 end
 

--- a/test/patch.jl
+++ b/test/patch.jl
@@ -84,7 +84,7 @@ _assume_role_patch = function (
                     "Expiration" => string(now(UTC)),
                 ),
                 "AssumedRoleUser" => Dict(
-                    "Arn" => role_arn * "/" * params["RoleSessionName"],
+                    "Arn" => "$(role_arn)/$(params["RoleSessionName"]),
                 ),
             ),
         )


### PR DESCRIPTION
Closes #287 

```ini
[default]
region = us-east-2

[profile role-to-assume]
region = us-east-2
role_arn = arn:aws:iam::account:role/role-to-assume
credential_source = Ec2InstanceMetadata
```

```julia
julia> using AWS

julia> global_aws_config(; profile="default")
AWSConfig(arn:aws:iam::account:instance-profile/role-from-instance-profile (ASIASWQI5NDNRIZLJ3WJ, pAk..., IQo..., 2021-06-18T21:11:05), "us-east-2", "json")

julia> global_aws_config(; profile="role-to-assume")
AWSConfig(arn:aws:sts::account:assumed-role/role-to-assume/AWS.jl-role-role-to-assume-20210618T152950Z (ASIASWQI5NDNRFEK2HJS, AYR..., IQo..., 2021-06-18T15:44:53), "us-east-2", "json")
```

Needs some tests of course.