### PR TITLE
throw if we can't handle a redirect

### DIFF
--- a/src/utilities/request.jl
+++ b/src/utilities/request.jl
@@ -60,7 +60,7 @@ function submit_request(aws::AbstractAWSConfig, request::Request; return_headers
             if HTTP.header(response, "Location") != ""
                 request.url = HTTP.header(response, "Location")
             else
-                e = HTTP.StatusError(response.status, response.request.method, response.request.target, response)
+                e = HTTP.StatusError(response.status, response)
                 throw(AWSException(e))
             end
         end

--- a/src/utilities/request.jl
+++ b/src/utilities/request.jl
@@ -56,8 +56,13 @@ function submit_request(aws::AbstractAWSConfig, request::Request; return_headers
 
         response = @mock _http_request(request)
 
-        if response.status in REDIRECT_ERROR_CODES && HTTP.header(response, "Location") != ""
-            request.url = HTTP.header(response, "Location")
+        if response.status in REDIRECT_ERROR_CODES
+            if HTTP.header(response, "Location") != ""
+                request.url = HTTP.header(response, "Location")
+            else
+                e = HTTP.StatusError(response.status, response.request.method, response.request.target, response)
+                throw(AWSException(e))
+            end
         end
     catch e
         if e isa HTTP.StatusError

--- a/test/AWS.jl
+++ b/test/AWS.jl
@@ -129,6 +129,18 @@ end
         end
     end
 
+    @testset "301 redirect" begin
+        request = Request(
+            service="s3",
+            api_version="api_version",
+            request_method="HEAD",
+            url="https://s3.us-east-1.amazonaws.com/sample-bucket"
+        )
+        apply(Patches._aws_http_request_patch(Patches._response(;status=301))) do
+            @test_throws AWSException AWS.submit_request(aws, request)
+        end
+    end
+
     @testset "return stream" begin
         request = Request(
             service="s3",


### PR DESCRIPTION
This PR causes `read`ing an `S3Path` with the wrong bucket to give a good error: (note: buckets/keys/ids redacted with XXX)
```julia
julia> read(S3Path("s3://XXX"; config=aws))
ERROR: AWSException: PermanentRedirect -- The bucket you are attempting to access must be addressed using the specified endpoint. Please send all future requests to this endpoint.
HTTP.ExceptionRequest.StatusError(301, "GET", "/XXX", HTTP.Messages.Response:
"""
HTTP/1.1 301 Moved Permanently
x-amz-bucket-region: us-east-2
x-amz-request-id: XXX
x-amz-id-2: XXX
Content-Type: application/xml
Transfer-Encoding: chunked
Date: Mon, 21 Jun 2021 11:05:34 GMT
Server: AmazonS3

<?xml version="1.0" encoding="UTF-8"?>
<Error><Code>PermanentRedirect</Code><Message>The bucket you are attempting to access must be addressed using the specified endpoint. Please send all future requests to this endpoint.</Message><Endpoint>XXX.s3.us-east-2.amazonaws.com</Endpoint><Bucket>XXX</Bucket><RequestId>XXX</RequestId><HostId>XXX</HostId></Error>""")

Stacktrace:
  [1] macro expansion
    @ ~/AWS.jl/src/utilities/request.jl:64 [inlined]
  [2] macro expansion
    @ ~/.julia/packages/Retry/vS1bg/src/repeat_try.jl:192 [inlined]
  [3] submit_request(aws::AWSConfig, request::Request; return_headers::Bool)
    @ AWS ~/AWS.jl/src/utilities/request.jl:54
  [4] (::RestXMLService)(request_method::String, request_uri::String, args::Dict{String, Any}; aws_config::AWSConfig)
    @ AWS ~/.julia/packages/AWS/cUhwq/src/AWS.jl:229
  [5] #get_object#90
    @ ~/.julia/packages/AWS/cUhwq/src/services/s3.jl:1731 [inlined]
  [6] macro expansion
    @ ~/AWSS3.jl/src/AWSS3.jl:85 [inlined]
  [7] macro expansion
    @ ~/.julia/packages/Retry/vS1bg/src/repeat_try.jl:192 [inlined]
  [8] s3_get(aws::AWSConfig, bucket::SubString{String}, path::String; version::String, retry::Bool, raw::Bool, headers::Dict{String, Any}, kwargs::Base.Iterators.Pairs{Union{}, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
    @ AWSS3 ~/AWSS3.jl/src/AWSS3.jl:72
  [9] read(fp::S3Path{AWSConfig})
    @ AWSS3 ~/AWSS3.jl/src/s3path.jl:358
 [10] top-level scope
    @ REPL[103]:1
```
We get the same correct error with this PR with https://github.com/JuliaCloud/AWSS3.jl/pull/162 as well.

Whereas with the release version we get
```julia
julia> read(S3Path("s3://XXX"; config=aws))
ERROR: MethodError: no method matching Vector{UInt8}(::OrderedCollections.LittleDict{Union{String, Symbol}, Any, Vector{Union{String, Symbol}}, Vector{Any}})
Closest candidates are:
  Vector{T}(::Core.Compiler.AbstractRange{T}) where T at range.jl:1042
  Array{T, N}(::Core.Compiler.BitArray{N}) where {T, N} at bitarray.jl:494
  Array{T, N}(::BitArray{N}) where {T, N} at bitarray.jl:494
  ...
Stacktrace:
 [1] read(fp::S3Path{AWSConfig})
   @ AWSS3 ~/.julia/packages/AWSS3/H9WJU/src/s3path.jl:358
 [2] top-level scope
   @ REPL[6]:1
```

This also fixes https://github.com/JuliaCloud/AWSS3.jl/issues/127 and fixes https://github.com/JuliaCloud/AWSS3.jl/issues/151