### PR TITLE
provide hooks for custom backends

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AWS"
 uuid = "fbe9abb3-538b-5e4e-ba9e-bc94f4f92ebc"
 license = "MIT"
-version = "1.47.0"
+version = "1.48.0"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/AWS.jl
+++ b/src/AWS.jl
@@ -353,4 +353,9 @@ function (service::RestJSONService)(
     return submit_request(aws_config, request; return_headers=return_headers)
 end
 
+function __init__()
+    DEFAULT_BACKEND[] = HTTPBackend()
+    return nothing
+end
+
 end  # module AWS

--- a/src/utilities/request.jl
+++ b/src/utilities/request.jl
@@ -8,9 +8,11 @@ An `HTTPBackend` can hold default `http_options::AbstractDict{Symbol,<:Any}`
 to pass to HTTP.jl, which can be overwritten per-request by any `http_options`
 supplied there.
 """
-Base.@kwdef struct HTTPBackend <: AbstractBackend
-    http_options::AbstractDict{Symbol,<:Any}=LittleDict{Symbol,String}()
+struct HTTPBackend{T<:AbstractDict{Symbol,<:Any}} <: AbstractBackend
+    http_options::T
 end
+
+HTTPBackend() = HTTPBackend(LittleDict{Symbol,String}())
 
 const DEFAULT_BACKEND = Ref{Union{Nothing, AbstractBackend}}(HTTPBackend())
 

--- a/src/utilities/request.jl
+++ b/src/utilities/request.jl
@@ -14,7 +14,7 @@ end
 
 HTTPBackend() = HTTPBackend(LittleDict{Symbol,String}())
 
-const DEFAULT_BACKEND = Ref{Union{Nothing, AbstractBackend}}(HTTPBackend())
+const DEFAULT_BACKEND = Ref{AbstractBackend}(HTTPBackend())
 
 Base.@kwdef mutable struct Request
     service::String

--- a/src/utilities/request.jl
+++ b/src/utilities/request.jl
@@ -16,7 +16,8 @@ function HTTPBackend(; kwargs...)
     isempty(kwargs) ? HTTPBackend(LittleDict{Symbol, Any}()) : HTTPBackend(LittleDict(kwargs))
 end
 
-const DEFAULT_BACKEND = Ref{AbstractBackend}(HTTPBackend())
+# populated in `__init__`
+const DEFAULT_BACKEND = Ref{AbstractBackend}()
 
 Base.@kwdef mutable struct Request
     service::String

--- a/src/utilities/request.jl
+++ b/src/utilities/request.jl
@@ -12,7 +12,9 @@ struct HTTPBackend <: AbstractBackend
     http_options::AbstractDict{Symbol,<:Any}
 end
 
-HTTPBackend(; kwargs...) = HTTPBackend(LittleDict(kwargs))
+function HTTPBackend(; kwargs...)
+    isempty(kwargs) ? HTTPBackend(LittleDict{Symbol, Any}()) : HTTPBackend(LittleDict(kwargs))
+end
 
 const DEFAULT_BACKEND = Ref{AbstractBackend}(HTTPBackend())
 

--- a/src/utilities/request.jl
+++ b/src/utilities/request.jl
@@ -12,7 +12,7 @@ struct HTTPBackend <: AbstractBackend
     http_options::AbstractDict{Symbol,<:Any}
 end
 
-HTTPBackend() = HTTPBackend(LittleDict{Symbol,String}())
+HTTPBackend(; kwargs...) = HTTPBackend(LittleDict(kwargs))
 
 const DEFAULT_BACKEND = Ref{AbstractBackend}(HTTPBackend())
 
@@ -170,7 +170,7 @@ function _http_request(http_backend::HTTPBackend, request::Request)
             request.response_stream = Base.BufferStream()
         end
 
-        return HTTP.request(
+        return @mock HTTP.request(
             http_stack,
             request.request_method,
             HTTP.URI(request.url),

--- a/src/utilities/request.jl
+++ b/src/utilities/request.jl
@@ -1,4 +1,4 @@
-# this is used to allow custom dispatches to `_http_request`
+# Used to allow custom dispatches to `_http_request`
 abstract type AbstractBackend end
 
 """

--- a/src/utilities/request.jl
+++ b/src/utilities/request.jl
@@ -8,8 +8,8 @@ An `HTTPBackend` can hold default `http_options::AbstractDict{Symbol,<:Any}`
 to pass to HTTP.jl, which can be overwritten per-request by any `http_options`
 supplied there.
 """
-struct HTTPBackend{T<:AbstractDict{Symbol,<:Any}} <: AbstractBackend
-    http_options::T
+struct HTTPBackend <: AbstractBackend
+    http_options::AbstractDict{Symbol,<:Any}
 end
 
 HTTPBackend() = HTTPBackend(LittleDict{Symbol,String}())

--- a/src/utilities/utilities.jl
+++ b/src/utilities/utilities.jl
@@ -68,6 +68,7 @@ function _extract_common_kw_args(service, args)
         headers=LittleDict{String, String}(_pop!(args, "headers", [])),
         http_options=_pop!(args, "http_options", LittleDict{Symbol, String}()),
         response_dict_type=_pop!(args, "response_dict_type", LittleDict),
+        backend=_pop!(args, "backend", DEFAULT_BACKEND[]),
     )
 end
 

--- a/test/AWS.jl
+++ b/test/AWS.jl
@@ -388,6 +388,15 @@ end
     request.backend = TestBackend(2)
     @test AWS._http_request(request.backend, request) == 2
 
+    request = Request(
+        service="s3",
+        api_version="api_version",
+        request_method="GET",
+        url="https://s3.us-east-1.amazonaws.com/sample-bucket",
+        backend = TestBackend(4)
+    )
+    @test AWS._http_request(request.backend, request) == 4
+
     # Let's test setting the default backend
     prev_backend = AWS.DEFAULT_BACKEND[]
     try

--- a/test/patch.jl
+++ b/test/patch.jl
@@ -56,7 +56,7 @@ end
 
 
 function _aws_http_request_patch(response::HTTP.Messages.Response=_response())
-    return @patch AWS._http_request(request::Request) = response
+    return @patch AWS._http_request(::Any, request::Request) = response
 end
 
 _cred_file_patch = @patch function dot_aws_credentials_file()
@@ -73,7 +73,7 @@ _web_identity_patch = function (;
     session_token="web_session_token",
     role_arn="arn:aws:sts:::assumed-role/role-name",
 )
-    @patch function AWS._http_request(request)
+    @patch function AWS._http_request(::AWS.HTTPBackend, request)
         params = Dict(split.(split(request.content, '&'), '='))
         creds = Dict(
             "AccessKeyId" => access_key,

--- a/test/patch.jl
+++ b/test/patch.jl
@@ -107,4 +107,15 @@ _instance_metadata_timeout_patch = @patch function HTTP.request(method::String, 
     throw(HTTP.ConnectionPool.ConnectTimeout("169.254.169.254", "80"))
 end
 
+# This patch causes `HTTP.request` to return all of its keyword arguments
+# except `require_ssl_verification` and `response_stream`. This is used to
+# test which other options are being passed to `HTTP.Request` inside of
+# `_http_request`.
+_http_options_patch = @patch function HTTP.request(args...; kwargs...)
+    options = Dict(kwargs)
+    delete!(options, :require_ssl_verification)
+    delete!(options, :response_stream)
+    return options
+end
+
 end

--- a/test/patch.jl
+++ b/test/patch.jl
@@ -56,7 +56,7 @@ end
 
 
 function _aws_http_request_patch(response::HTTP.Messages.Response=_response())
-    return @patch AWS._http_request(::AWS.HTTPBackend, request::Request) = response
+    return @patch AWS._http_request(::AWS.AbstractBackend, request::Request) = response
 end
 
 _cred_file_patch = @patch function dot_aws_credentials_file()
@@ -73,7 +73,7 @@ _web_identity_patch = function (;
     session_token="web_session_token",
     role_arn="arn:aws:sts:::assumed-role/role-name",
 )
-    @patch function AWS._http_request(::AWS.HTTPBackend, request)
+    @patch function AWS._http_request(::AWS.AbstractBackend, request)
         params = Dict(split.(split(request.content, '&'), '='))
         creds = Dict(
             "AccessKeyId" => access_key,


### PR DESCRIPTION
Instead of adding a whole new backend as in #396, I thought it would be better to just start with an `AbstractBackend` to provide hooks to use alternate backends. This way we don't need to bump the Julia requirements to start trying out alternate backends downstream. It also provides a smaller incremental step than having AbstractBackends + a specific alternate backend in the same PR.

This also provides what is hopefully a useful feature: you could do
```julia
using AWS
AWS.DEFAULT_BACKEND[] = HTTPBackend(custom_http_options)
```
to specify custom HTTP options globally in your application (which can still be overwritten per-request); I would have found this useful when trying experiments like tweaking the pipelining and connection pooling settings.

In the same way, a Downloads.jl-based backend could pass a `Downloads.Downloader` along inside the backend object instead of requiring adding more fields to Request for the `downloader` like in #396.