### PR TITLE
Added formatting for auto-generation

### DIFF
--- a/.github/workflows/update_apis.yml
+++ b/.github/workflows/update_apis.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        julia-version: [1] 
+        julia-version: [1]
         julia-arch: [x86]
         os: [ubuntu-latest]
     steps:
@@ -22,6 +22,10 @@ jobs:
         run: julia --project -e 'using AWS; AWS.AWSMetadata.parse_aws_metadata();'
         env:
           GITHUB_AUTH: ${{ secrets.GITHUB_TOKEN }}
+      - name: FormatCode
+        run: |
+          julia -e 'using Pkg; Pkg.add("JuliaFormatter")'
+          julia -e 'using JuliaFormatter; format(".", BlueStyle(); verbose=true)'
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3
         with:


### PR DESCRIPTION
I added in auto-formatting for code in https://github.com/JuliaCloud/AWS.jl/pull/423, this will become problematic going forward when code is auto-generated each evening as you'll need to step through accepting all changes as it is breaking BlueStyle.

This PR address' that by adding in an additional step to the `update_apis.yml` action to automatically format the code before creating the merge request.