### PR TITLE
Follow redirects

### DIFF
--- a/test/AWS.jl
+++ b/test/AWS.jl
@@ -139,18 +139,6 @@ end
         end
     end
 
-    @testset "301 redirect" begin
-        request = Request(;
-            service="s3",
-            api_version="api_version",
-            request_method="HEAD",
-            url="https://s3.us-east-1.amazonaws.com/sample-bucket",
-        )
-        apply(Patches._aws_http_request_patch(Patches._response(; status=301))) do
-            @test_throws AWSException AWS.submit_request(aws, request)
-        end
-    end
-
     @testset "return stream" begin
         request = Request(;
             service="s3",


### PR DESCRIPTION
Closes #397 and closes #413

I'm opening this more to start a conversation than to actually get it merged right away: Why don't we currently follow redirects? I would imagine there is some underlying reason to not just use the default HTTP behaviour. As mentioned in the issues above, it's caused some annoyances.