### PR TITLE
Fix `aws_get_profile_settings` when profile is missing

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AWS"
 uuid = "fbe9abb3-538b-5e4e-ba9e-bc94f4f92ebc"
 license = "MIT"
-version = "1.60.0"
+version = "1.60.1"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/AWSCredentials.jl
+++ b/src/AWSCredentials.jl
@@ -579,7 +579,7 @@ function aws_get_profile_settings(profile::AbstractString, ini::Inifile)
 
     # Internals of IniFile.jl always return strings for keys/values even though the returned
     # Dict uses more generic type parameters
-    return Dict{String,String}(section)
+    return section !== nothing ? Dict{String,String}(section) : nothing
 end
 
 @deprecate(

--- a/test/AWSCredentials.jl
+++ b/test/AWSCredentials.jl
@@ -64,6 +64,12 @@ end
     end
 end
 
+@testset "aws_get_profile_settings" begin
+    @testset "no profile" begin
+        @test aws_get_profile_settings("foo", Inifile()) === nothing
+    end
+end
+
 @testset "AWSCredentials" begin
     @testset "Defaults" begin
         creds = AWSCredentials("access_key_id", "secret_key")


### PR DESCRIPTION
Bug introduced in #357 