### PR TITLE
Support specifying features with `@service`

### DIFF
--- a/src/AWSServices.jl
+++ b/src/AWSServices.jl
@@ -601,6 +601,7 @@ const transfer = AWS.JSONService(
 const translate = AWS.JSONService(
     "translate", "translate", "2017-07-01", "1.1", "AWSShineFrontendService_20170701"
 )
+const voice_id = AWS.JSONService("voiceid", "voiceid", "2021-09-27", "1.0", "VoiceID")
 const waf = AWS.JSONService("waf", "waf", "2015-08-24", "1.1", "AWSWAF_20150824")
 const waf_regional = AWS.JSONService(
     "waf-regional", "waf-regional", "2016-11-28", "1.1", "AWSWAF_Regional_20161128"
@@ -609,6 +610,7 @@ const wafv2 = AWS.JSONService("wafv2", "wafv2", "2019-07-29", "1.1", "AWSWAF_201
 const wellarchitected = AWS.RestJSONService(
     "wellarchitected", "wellarchitected", "2020-03-31"
 )
+const wisdom = AWS.RestJSONService("wisdom", "wisdom", "2020-10-19")
 const workdocs = AWS.RestJSONService("workdocs", "workdocs", "2016-05-01")
 const worklink = AWS.RestJSONService("worklink", "worklink", "2018-09-25")
 const workmail = AWS.JSONService(

--- a/src/api_generation/high_level.jl
+++ b/src/api_generation/high_level.jl
@@ -144,28 +144,28 @@ function _generate_high_level_definition(
 
         if required_keys && (idempotent || headers)
             return """
-                $formatted_function_name($(join(req_keys, ", ")); aws_config::AbstractAWSConfig=global_aws_config()) = $service_name(\"$method\", \"$request_uri\", $params_headers_str; aws_config=aws_config)
-                $formatted_function_name($(join(req_keys, ", ")), params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()) = $service_name(\"$method\", \"$request_uri\", Dict{String, Any}(mergewith(_merge, $params_headers_str, params)); aws_config=aws_config)
+                $formatted_function_name($(join(req_keys, ", ")); aws_config::AbstractAWSConfig=global_aws_config()) = $service_name(\"$method\", \"$request_uri\", $params_headers_str; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
+                $formatted_function_name($(join(req_keys, ", ")), params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()) = $service_name(\"$method\", \"$request_uri\", Dict{String, Any}(mergewith(_merge, $params_headers_str, params)); aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
                 """
         elseif !required_keys && (idempotent || headers)
             return """
-                $formatted_function_name(; aws_config::AbstractAWSConfig=global_aws_config()) = $service_name(\"$method\", \"$request_uri\", $params_headers_str; aws_config=aws_config)
-                $formatted_function_name(params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()) = $service_name(\"$method\", \"$request_uri\", Dict{String, Any}(mergewith(_merge, $params_headers_str, params)); aws_config=aws_config)
+                $formatted_function_name(; aws_config::AbstractAWSConfig=global_aws_config()) = $service_name(\"$method\", \"$request_uri\", $params_headers_str; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
+                $formatted_function_name(params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()) = $service_name(\"$method\", \"$request_uri\", Dict{String, Any}(mergewith(_merge, $params_headers_str, params)); aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
                 """
         elseif required_keys && !isempty(req_kv)
             return """
-                $formatted_function_name($(join(req_keys, ", ")); aws_config::AbstractAWSConfig=global_aws_config()) = $service_name(\"$method\", \"$request_uri\", $req_str); aws_config=aws_config)
-                $formatted_function_name($(join(req_keys, ", ")), params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()) = $service_name(\"$method\", \"$request_uri\", Dict{String, Any}(mergewith(_merge, $req_str), params)); aws_config=aws_config)
+                $formatted_function_name($(join(req_keys, ", ")); aws_config::AbstractAWSConfig=global_aws_config()) = $service_name(\"$method\", \"$request_uri\", $req_str); aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
+                $formatted_function_name($(join(req_keys, ", ")), params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()) = $service_name(\"$method\", \"$request_uri\", Dict{String, Any}(mergewith(_merge, $req_str), params)); aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
                 """
         elseif required_keys
             return """
-                $formatted_function_name($(join(req_keys, ", ")); aws_config::AbstractAWSConfig=global_aws_config()) = $service_name(\"$method\", \"$request_uri\"; aws_config=aws_config)
-                $formatted_function_name($(join(req_keys, ", ")), params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()) = $service_name(\"$method\", \"$request_uri\", params; aws_config=aws_config)
+                $formatted_function_name($(join(req_keys, ", ")); aws_config::AbstractAWSConfig=global_aws_config()) = $service_name(\"$method\", \"$request_uri\"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
+                $formatted_function_name($(join(req_keys, ", ")), params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()) = $service_name(\"$method\", \"$request_uri\", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
                 """
         else
             return """
-                $formatted_function_name(; aws_config::AbstractAWSConfig=global_aws_config()) = $service_name(\"$method\", \"$request_uri\"; aws_config=aws_config)
-                $formatted_function_name(params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()) = $service_name(\"$method\", \"$request_uri\", params; aws_config=aws_config)
+                $formatted_function_name(; aws_config::AbstractAWSConfig=global_aws_config()) = $service_name(\"$method\", \"$request_uri\"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
+                $formatted_function_name(params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()) = $service_name(\"$method\", \"$request_uri\", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
                 """
         end
     end
@@ -193,23 +193,23 @@ function _generate_high_level_definition(
 
         if required && idempotent
             return """
-                $formatted_function_name($(join(req_keys, ", ")); aws_config::AbstractAWSConfig=global_aws_config()) = $service_name(\"$function_name\", Dict{String, Any}($(join(req_kv, ", ")), $(join(idempotent_kv, ", "))); aws_config=aws_config)
-                $formatted_function_name($(join(req_keys, ", ")), params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()) = $service_name(\"$function_name\", Dict{String, Any}(mergewith(_merge, Dict{String, Any}($(join(req_kv, ", ")), $(join(idempotent_kv, ", "))), params)); aws_config=aws_config)
+                $formatted_function_name($(join(req_keys, ", ")); aws_config::AbstractAWSConfig=global_aws_config()) = $service_name(\"$function_name\", Dict{String, Any}($(join(req_kv, ", ")), $(join(idempotent_kv, ", "))); aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
+                $formatted_function_name($(join(req_keys, ", ")), params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()) = $service_name(\"$function_name\", Dict{String, Any}(mergewith(_merge, Dict{String, Any}($(join(req_kv, ", ")), $(join(idempotent_kv, ", "))), params)); aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
                 """
         elseif required
             return """
-                $formatted_function_name($(join(req_keys, ", ")); aws_config::AbstractAWSConfig=global_aws_config()) = $service_name(\"$function_name\", Dict{String, Any}($(join(req_kv, ", "))); aws_config=aws_config)
-                $formatted_function_name($(join(req_keys, ", ")), params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()) = $service_name(\"$function_name\", Dict{String, Any}(mergewith(_merge, Dict{String, Any}($(join(req_kv, ", "))), params)); aws_config=aws_config)
+                $formatted_function_name($(join(req_keys, ", ")); aws_config::AbstractAWSConfig=global_aws_config()) = $service_name(\"$function_name\", Dict{String, Any}($(join(req_kv, ", "))); aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
+                $formatted_function_name($(join(req_keys, ", ")), params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()) = $service_name(\"$function_name\", Dict{String, Any}(mergewith(_merge, Dict{String, Any}($(join(req_kv, ", "))), params)); aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
                 """
         elseif idempotent
             return """
-                $formatted_function_name(; aws_config::AbstractAWSConfig=global_aws_config()) = $service_name(\"$function_name\", Dict{String, Any}($(join(idempotent_kv, ", "))); aws_config=aws_config)
-                $formatted_function_name(params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()) = $service_name(\"$function_name\", Dict{String, Any}(mergewith(_merge, Dict{String, Any}($(join(idempotent_kv, ", "))), params)); aws_config=aws_config)
+                $formatted_function_name(; aws_config::AbstractAWSConfig=global_aws_config()) = $service_name(\"$function_name\", Dict{String, Any}($(join(idempotent_kv, ", "))); aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
+                $formatted_function_name(params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()) = $service_name(\"$function_name\", Dict{String, Any}(mergewith(_merge, Dict{String, Any}($(join(idempotent_kv, ", "))), params)); aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
                 """
         else
             return """
-                $formatted_function_name(; aws_config::AbstractAWSConfig=global_aws_config()) = $service_name(\"$function_name\"; aws_config=aws_config)
-                $formatted_function_name(params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()) = $service_name(\"$function_name\", params; aws_config=aws_config)
+                $formatted_function_name(; aws_config::AbstractAWSConfig=global_aws_config()) = $service_name(\"$function_name\"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
+                $formatted_function_name(params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()) = $service_name(\"$function_name\", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
                 """
         end
     end

--- a/src/services/accessanalyzer.jl
+++ b/src/services/accessanalyzer.jl
@@ -31,6 +31,7 @@ function apply_archive_rule(
             "clientToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function apply_archive_rule(
@@ -54,6 +55,7 @@ function apply_archive_rule(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -70,13 +72,22 @@ Cancels the requested policy generation.
 
 """
 function cancel_policy_generation(jobId; aws_config::AbstractAWSConfig=global_aws_config())
-    return accessanalyzer("PUT", "/policy/generation/$(jobId)"; aws_config=aws_config)
+    return accessanalyzer(
+        "PUT",
+        "/policy/generation/$(jobId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function cancel_policy_generation(
     jobId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return accessanalyzer(
-        "PUT", "/policy/generation/$(jobId)", params; aws_config=aws_config
+        "PUT",
+        "/policy/generation/$(jobId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -111,6 +122,7 @@ function create_access_preview(
             "clientToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_access_preview(
@@ -134,6 +146,7 @@ function create_access_preview(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -166,6 +179,7 @@ function create_analyzer(
             "analyzerName" => analyzerName, "type" => type, "clientToken" => string(uuid4())
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_analyzer(
@@ -189,6 +203,7 @@ function create_analyzer(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -220,6 +235,7 @@ function create_archive_rule(
             "filter" => filter, "ruleName" => ruleName, "clientToken" => string(uuid4())
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_archive_rule(
@@ -244,6 +260,7 @@ function create_archive_rule(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -268,6 +285,7 @@ function delete_analyzer(analyzerName; aws_config::AbstractAWSConfig=global_aws_
         "/analyzer/$(analyzerName)",
         Dict{String,Any}("clientToken" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_analyzer(
@@ -282,6 +300,7 @@ function delete_analyzer(
             mergewith(_merge, Dict{String,Any}("clientToken" => string(uuid4())), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -307,6 +326,7 @@ function delete_archive_rule(
         "/analyzer/$(analyzerName)/archive-rule/$(ruleName)",
         Dict{String,Any}("clientToken" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_archive_rule(
@@ -322,6 +342,7 @@ function delete_archive_rule(
             mergewith(_merge, Dict{String,Any}("clientToken" => string(uuid4())), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -344,6 +365,7 @@ function get_access_preview(
         "/access-preview/$(accessPreviewId)",
         Dict{String,Any}("analyzerArn" => analyzerArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_access_preview(
@@ -359,6 +381,7 @@ function get_access_preview(
             mergewith(_merge, Dict{String,Any}("analyzerArn" => analyzerArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -381,6 +404,7 @@ function get_analyzed_resource(
         "/analyzed-resource",
         Dict{String,Any}("analyzerArn" => analyzerArn, "resourceArn" => resourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_analyzed_resource(
@@ -402,6 +426,7 @@ function get_analyzed_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -416,14 +441,25 @@ Retrieves information about the specified analyzer.
 
 """
 function get_analyzer(analyzerName; aws_config::AbstractAWSConfig=global_aws_config())
-    return accessanalyzer("GET", "/analyzer/$(analyzerName)"; aws_config=aws_config)
+    return accessanalyzer(
+        "GET",
+        "/analyzer/$(analyzerName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_analyzer(
     analyzerName,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return accessanalyzer("GET", "/analyzer/$(analyzerName)", params; aws_config=aws_config)
+    return accessanalyzer(
+        "GET",
+        "/analyzer/$(analyzerName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -442,7 +478,10 @@ function get_archive_rule(
     analyzerName, ruleName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return accessanalyzer(
-        "GET", "/analyzer/$(analyzerName)/archive-rule/$(ruleName)"; aws_config=aws_config
+        "GET",
+        "/analyzer/$(analyzerName)/archive-rule/$(ruleName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_archive_rule(
@@ -456,6 +495,7 @@ function get_archive_rule(
         "/analyzer/$(analyzerName)/archive-rule/$(ruleName)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -476,6 +516,7 @@ function get_finding(analyzerArn, id; aws_config::AbstractAWSConfig=global_aws_c
         "/finding/$(id)",
         Dict{String,Any}("analyzerArn" => analyzerArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_finding(
@@ -491,6 +532,7 @@ function get_finding(
             mergewith(_merge, Dict{String,Any}("analyzerArn" => analyzerArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -518,13 +560,22 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   service-level template.
 """
 function get_generated_policy(jobId; aws_config::AbstractAWSConfig=global_aws_config())
-    return accessanalyzer("GET", "/policy/generation/$(jobId)"; aws_config=aws_config)
+    return accessanalyzer(
+        "GET",
+        "/policy/generation/$(jobId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_generated_policy(
     jobId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return accessanalyzer(
-        "GET", "/policy/generation/$(jobId)", params; aws_config=aws_config
+        "GET",
+        "/policy/generation/$(jobId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -552,6 +603,7 @@ function list_access_preview_findings(
         "/access-preview/$(accessPreviewId)",
         Dict{String,Any}("analyzerArn" => analyzerArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_access_preview_findings(
@@ -567,6 +619,7 @@ function list_access_preview_findings(
             mergewith(_merge, Dict{String,Any}("analyzerArn" => analyzerArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -592,6 +645,7 @@ function list_access_previews(
         "/access-preview",
         Dict{String,Any}("analyzerArn" => analyzerArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_access_previews(
@@ -606,6 +660,7 @@ function list_access_previews(
             mergewith(_merge, Dict{String,Any}("analyzerArn" => analyzerArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -633,6 +688,7 @@ function list_analyzed_resources(
         "/analyzed-resource",
         Dict{String,Any}("analyzerArn" => analyzerArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_analyzed_resources(
@@ -647,6 +703,7 @@ function list_analyzed_resources(
             mergewith(_merge, Dict{String,Any}("analyzerArn" => analyzerArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -663,12 +720,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"type"`: The type of analyzer.
 """
 function list_analyzers(; aws_config::AbstractAWSConfig=global_aws_config())
-    return accessanalyzer("GET", "/analyzer"; aws_config=aws_config)
+    return accessanalyzer(
+        "GET", "/analyzer"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_analyzers(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return accessanalyzer("GET", "/analyzer", params; aws_config=aws_config)
+    return accessanalyzer(
+        "GET", "/analyzer", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -687,7 +748,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function list_archive_rules(analyzerName; aws_config::AbstractAWSConfig=global_aws_config())
     return accessanalyzer(
-        "GET", "/analyzer/$(analyzerName)/archive-rule"; aws_config=aws_config
+        "GET",
+        "/analyzer/$(analyzerName)/archive-rule";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_archive_rules(
@@ -696,7 +760,11 @@ function list_archive_rules(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return accessanalyzer(
-        "GET", "/analyzer/$(analyzerName)/archive-rule", params; aws_config=aws_config
+        "GET",
+        "/analyzer/$(analyzerName)/archive-rule",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -724,6 +792,7 @@ function list_findings(analyzerArn; aws_config::AbstractAWSConfig=global_aws_con
         "/finding",
         Dict{String,Any}("analyzerArn" => analyzerArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_findings(
@@ -738,6 +807,7 @@ function list_findings(
             mergewith(_merge, Dict{String,Any}("analyzerArn" => analyzerArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -756,12 +826,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   for a specific principal.
 """
 function list_policy_generations(; aws_config::AbstractAWSConfig=global_aws_config())
-    return accessanalyzer("GET", "/policy/generation"; aws_config=aws_config)
+    return accessanalyzer(
+        "GET", "/policy/generation"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_policy_generations(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return accessanalyzer("GET", "/policy/generation", params; aws_config=aws_config)
+    return accessanalyzer(
+        "GET",
+        "/policy/generation",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -777,14 +855,25 @@ Retrieves a list of tags applied to the specified resource.
 function list_tags_for_resource(
     resourceArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return accessanalyzer("GET", "/tags/$(resourceArn)"; aws_config=aws_config)
+    return accessanalyzer(
+        "GET",
+        "/tags/$(resourceArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_tags_for_resource(
     resourceArn,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return accessanalyzer("GET", "/tags/$(resourceArn)", params; aws_config=aws_config)
+    return accessanalyzer(
+        "GET",
+        "/tags/$(resourceArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -819,6 +908,7 @@ function start_policy_generation(
             "clientToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_policy_generation(
@@ -840,6 +930,7 @@ function start_policy_generation(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -863,6 +954,7 @@ function start_resource_scan(
         "/resource/scan",
         Dict{String,Any}("analyzerArn" => analyzerArn, "resourceArn" => resourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_resource_scan(
@@ -884,6 +976,7 @@ function start_resource_scan(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -904,6 +997,7 @@ function tag_resource(resourceArn, tags; aws_config::AbstractAWSConfig=global_aw
         "/tags/$(resourceArn)",
         Dict{String,Any}("tags" => tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -917,6 +1011,7 @@ function tag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tags" => tags), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -939,6 +1034,7 @@ function untag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}("tagKeys" => tagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -952,6 +1048,7 @@ function untag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tagKeys" => tagKeys), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -979,6 +1076,7 @@ function update_archive_rule(
         "/analyzer/$(analyzerName)/archive-rule/$(ruleName)",
         Dict{String,Any}("filter" => filter, "clientToken" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_archive_rule(
@@ -999,6 +1097,7 @@ function update_archive_rule(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1032,6 +1131,7 @@ function update_findings(
             "clientToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_findings(
@@ -1055,6 +1155,7 @@ function update_findings(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1091,6 +1192,7 @@ function validate_policy(
         "/policy/validation",
         Dict{String,Any}("policyDocument" => policyDocument, "policyType" => policyType);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function validate_policy(
@@ -1112,5 +1214,6 @@ function validate_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/acm.jl
+++ b/src/services/acm.jl
@@ -36,6 +36,7 @@ function add_tags_to_certificate(
         "AddTagsToCertificate",
         Dict{String,Any}("CertificateArn" => CertificateArn, "Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function add_tags_to_certificate(
@@ -54,6 +55,7 @@ function add_tags_to_certificate(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -83,6 +85,7 @@ function delete_certificate(
         "DeleteCertificate",
         Dict{String,Any}("CertificateArn" => CertificateArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_certificate(
@@ -96,6 +99,7 @@ function delete_certificate(
             mergewith(_merge, Dict{String,Any}("CertificateArn" => CertificateArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -119,6 +123,7 @@ function describe_certificate(
         "DescribeCertificate",
         Dict{String,Any}("CertificateArn" => CertificateArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_certificate(
@@ -132,6 +137,7 @@ function describe_certificate(
             mergewith(_merge, Dict{String,Any}("CertificateArn" => CertificateArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -162,6 +168,7 @@ function export_certificate(
         "ExportCertificate",
         Dict{String,Any}("CertificateArn" => CertificateArn, "Passphrase" => Passphrase);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function export_certificate(
@@ -182,6 +189,7 @@ function export_certificate(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -193,12 +201,19 @@ Returns the account configuration options associated with an Amazon Web Services
 
 """
 function get_account_configuration(; aws_config::AbstractAWSConfig=global_aws_config())
-    return acm("GetAccountConfiguration"; aws_config=aws_config)
+    return acm(
+        "GetAccountConfiguration"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_account_configuration(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return acm("GetAccountConfiguration", params; aws_config=aws_config)
+    return acm(
+        "GetAccountConfiguration",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -221,6 +236,7 @@ function get_certificate(CertificateArn; aws_config::AbstractAWSConfig=global_aw
         "GetCertificate",
         Dict{String,Any}("CertificateArn" => CertificateArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_certificate(
@@ -234,6 +250,7 @@ function get_certificate(
             mergewith(_merge, Dict{String,Any}("CertificateArn" => CertificateArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -289,6 +306,7 @@ function import_certificate(
         "ImportCertificate",
         Dict{String,Any}("Certificate" => Certificate, "PrivateKey" => PrivateKey);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function import_certificate(
@@ -307,6 +325,7 @@ function import_certificate(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -333,12 +352,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   NextToken from the response you just received.
 """
 function list_certificates(; aws_config::AbstractAWSConfig=global_aws_config())
-    return acm("ListCertificates"; aws_config=aws_config)
+    return acm("ListCertificates"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_certificates(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return acm("ListCertificates", params; aws_config=aws_config)
+    return acm(
+        "ListCertificates", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -363,6 +384,7 @@ function list_tags_for_certificate(
         "ListTagsForCertificate",
         Dict{String,Any}("CertificateArn" => CertificateArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags_for_certificate(
@@ -376,6 +398,7 @@ function list_tags_for_certificate(
             mergewith(_merge, Dict{String,Any}("CertificateArn" => CertificateArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -407,6 +430,7 @@ function put_account_configuration(
         "PutAccountConfiguration",
         Dict{String,Any}("IdempotencyToken" => IdempotencyToken);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_account_configuration(
@@ -422,6 +446,7 @@ function put_account_configuration(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -451,6 +476,7 @@ function remove_tags_from_certificate(
         "RemoveTagsFromCertificate",
         Dict{String,Any}("CertificateArn" => CertificateArn, "Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function remove_tags_from_certificate(
@@ -469,6 +495,7 @@ function remove_tags_from_certificate(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -495,6 +522,7 @@ function renew_certificate(
         "RenewCertificate",
         Dict{String,Any}("CertificateArn" => CertificateArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function renew_certificate(
@@ -508,6 +536,7 @@ function renew_certificate(
             mergewith(_merge, Dict{String,Any}("CertificateArn" => CertificateArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -581,6 +610,7 @@ function request_certificate(DomainName; aws_config::AbstractAWSConfig=global_aw
         "RequestCertificate",
         Dict{String,Any}("DomainName" => DomainName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function request_certificate(
@@ -594,6 +624,7 @@ function request_certificate(
             mergewith(_merge, Dict{String,Any}("DomainName" => DomainName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -643,6 +674,7 @@ function resend_validation_email(
             "ValidationDomain" => ValidationDomain,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function resend_validation_email(
@@ -666,6 +698,7 @@ function resend_validation_email(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -693,6 +726,7 @@ function update_certificate_options(
         "UpdateCertificateOptions",
         Dict{String,Any}("CertificateArn" => CertificateArn, "Options" => Options);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_certificate_options(
@@ -711,5 +745,6 @@ function update_certificate_options(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/acm_pca.jl
+++ b/src/services/acm_pca.jl
@@ -65,6 +65,7 @@ function create_certificate_authority(
             "CertificateAuthorityType" => CertificateAuthorityType,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_certificate_authority(
@@ -87,6 +88,7 @@ function create_certificate_authority(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -126,6 +128,7 @@ function create_certificate_authority_audit_report(
             "S3BucketName" => S3BucketName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_certificate_authority_audit_report(
@@ -149,6 +152,7 @@ function create_certificate_authority_audit_report(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -197,6 +201,7 @@ function create_permission(
             "Principal" => Principal,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_permission(
@@ -220,6 +225,7 @@ function create_permission(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -261,6 +267,7 @@ function delete_certificate_authority(
         "DeleteCertificateAuthority",
         Dict{String,Any}("CertificateAuthorityArn" => CertificateAuthorityArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_certificate_authority(
@@ -278,6 +285,7 @@ function delete_certificate_authority(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -320,6 +328,7 @@ function delete_permission(
             "CertificateAuthorityArn" => CertificateAuthorityArn, "Principal" => Principal
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_permission(
@@ -341,6 +350,7 @@ function delete_permission(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -377,6 +387,7 @@ function delete_policy(ResourceArn; aws_config::AbstractAWSConfig=global_aws_con
         "DeletePolicy",
         Dict{String,Any}("ResourceArn" => ResourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_policy(
@@ -390,6 +401,7 @@ function delete_policy(
             mergewith(_merge, Dict{String,Any}("ResourceArn" => ResourceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -424,6 +436,7 @@ function describe_certificate_authority(
         "DescribeCertificateAuthority",
         Dict{String,Any}("CertificateAuthorityArn" => CertificateAuthorityArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_certificate_authority(
@@ -441,6 +454,7 @@ function describe_certificate_authority(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -473,6 +487,7 @@ function describe_certificate_authority_audit_report(
             "CertificateAuthorityArn" => CertificateAuthorityArn,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_certificate_authority_audit_report(
@@ -494,6 +509,7 @@ function describe_certificate_authority_audit_report(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -530,6 +546,7 @@ function get_certificate(
             "CertificateAuthorityArn" => CertificateAuthorityArn,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_certificate(
@@ -551,6 +568,7 @@ function get_certificate(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -576,6 +594,7 @@ function get_certificate_authority_certificate(
         "GetCertificateAuthorityCertificate",
         Dict{String,Any}("CertificateAuthorityArn" => CertificateAuthorityArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_certificate_authority_certificate(
@@ -593,6 +612,7 @@ function get_certificate_authority_certificate(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -620,6 +640,7 @@ function get_certificate_authority_csr(
         "GetCertificateAuthorityCsr",
         Dict{String,Any}("CertificateAuthorityArn" => CertificateAuthorityArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_certificate_authority_csr(
@@ -637,6 +658,7 @@ function get_certificate_authority_csr(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -666,7 +688,10 @@ for Cross-Account Access.
 """
 function get_policy(ResourceArn; aws_config::AbstractAWSConfig=global_aws_config())
     return acm_pca(
-        "GetPolicy", Dict{String,Any}("ResourceArn" => ResourceArn); aws_config=aws_config
+        "GetPolicy",
+        Dict{String,Any}("ResourceArn" => ResourceArn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_policy(
@@ -680,6 +705,7 @@ function get_policy(
             mergewith(_merge, Dict{String,Any}("ResourceArn" => ResourceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -741,6 +767,7 @@ function import_certificate_authority_certificate(
             "CertificateAuthorityArn" => CertificateAuthorityArn,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function import_certificate_authority_certificate(
@@ -762,6 +789,7 @@ function import_certificate_authority_certificate(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -848,6 +876,7 @@ function issue_certificate(
             "Validity" => Validity,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function issue_certificate(
@@ -873,6 +902,7 @@ function issue_certificate(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -896,12 +926,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   authorities based on their owner. The default is SELF.
 """
 function list_certificate_authorities(; aws_config::AbstractAWSConfig=global_aws_config())
-    return acm_pca("ListCertificateAuthorities"; aws_config=aws_config)
+    return acm_pca(
+        "ListCertificateAuthorities"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_certificate_authorities(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return acm_pca("ListCertificateAuthorities", params; aws_config=aws_config)
+    return acm_pca(
+        "ListCertificateAuthorities",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -945,6 +982,7 @@ function list_permissions(
         "ListPermissions",
         Dict{String,Any}("CertificateAuthorityArn" => CertificateAuthorityArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_permissions(
@@ -962,6 +1000,7 @@ function list_permissions(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -996,6 +1035,7 @@ function list_tags(
         "ListTags",
         Dict{String,Any}("CertificateAuthorityArn" => CertificateAuthorityArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags(
@@ -1013,6 +1053,7 @@ function list_tags(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1049,6 +1090,7 @@ function put_policy(Policy, ResourceArn; aws_config::AbstractAWSConfig=global_aw
         "PutPolicy",
         Dict{String,Any}("Policy" => Policy, "ResourceArn" => ResourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_policy(
@@ -1067,6 +1109,7 @@ function put_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1101,6 +1144,7 @@ function restore_certificate_authority(
         "RestoreCertificateAuthority",
         Dict{String,Any}("CertificateAuthorityArn" => CertificateAuthorityArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function restore_certificate_authority(
@@ -1118,6 +1162,7 @@ function restore_certificate_authority(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1168,6 +1213,7 @@ function revoke_certificate(
             "RevocationReason" => RevocationReason,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function revoke_certificate(
@@ -1191,6 +1237,7 @@ function revoke_certificate(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1223,6 +1270,7 @@ function tag_certificate_authority(
             "CertificateAuthorityArn" => CertificateAuthorityArn, "Tags" => Tags
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_certificate_authority(
@@ -1243,6 +1291,7 @@ function tag_certificate_authority(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1272,6 +1321,7 @@ function untag_certificate_authority(
             "CertificateAuthorityArn" => CertificateAuthorityArn, "Tags" => Tags
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_certificate_authority(
@@ -1292,6 +1342,7 @@ function untag_certificate_authority(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1327,6 +1378,7 @@ function update_certificate_authority(
         "UpdateCertificateAuthority",
         Dict{String,Any}("CertificateAuthorityArn" => CertificateAuthorityArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_certificate_authority(
@@ -1344,5 +1396,6 @@ function update_certificate_authority(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/alexa_for_business.jl
+++ b/src/services/alexa_for_business.jl
@@ -17,7 +17,10 @@ private, the user implicitly accepts access to this skill during enablement.
 """
 function approve_skill(SkillId; aws_config::AbstractAWSConfig=global_aws_config())
     return alexa_for_business(
-        "ApproveSkill", Dict{String,Any}("SkillId" => SkillId); aws_config=aws_config
+        "ApproveSkill",
+        Dict{String,Any}("SkillId" => SkillId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function approve_skill(
@@ -27,6 +30,7 @@ function approve_skill(
         "ApproveSkill",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("SkillId" => SkillId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -48,6 +52,7 @@ function associate_contact_with_address_book(
         "AssociateContactWithAddressBook",
         Dict{String,Any}("AddressBookArn" => AddressBookArn, "ContactArn" => ContactArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_contact_with_address_book(
@@ -68,6 +73,7 @@ function associate_contact_with_address_book(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -91,6 +97,7 @@ function associate_device_with_network_profile(
             "DeviceArn" => DeviceArn, "NetworkProfileArn" => NetworkProfileArn
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_device_with_network_profile(
@@ -111,6 +118,7 @@ function associate_device_with_network_profile(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -128,12 +136,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"RoomArn"`: The ARN of the room with which to associate the device. Required.
 """
 function associate_device_with_room(; aws_config::AbstractAWSConfig=global_aws_config())
-    return alexa_for_business("AssociateDeviceWithRoom"; aws_config=aws_config)
+    return alexa_for_business(
+        "AssociateDeviceWithRoom"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function associate_device_with_room(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return alexa_for_business("AssociateDeviceWithRoom", params; aws_config=aws_config)
+    return alexa_for_business(
+        "AssociateDeviceWithRoom",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -151,12 +166,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function associate_skill_group_with_room(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return alexa_for_business("AssociateSkillGroupWithRoom"; aws_config=aws_config)
+    return alexa_for_business(
+        "AssociateSkillGroupWithRoom";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function associate_skill_group_with_room(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return alexa_for_business("AssociateSkillGroupWithRoom", params; aws_config=aws_config)
+    return alexa_for_business(
+        "AssociateSkillGroupWithRoom",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -179,6 +203,7 @@ function associate_skill_with_skill_group(
         "AssociateSkillWithSkillGroup",
         Dict{String,Any}("SkillId" => SkillId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_skill_with_skill_group(
@@ -188,6 +213,7 @@ function associate_skill_with_skill_group(
         "AssociateSkillWithSkillGroup",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("SkillId" => SkillId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -208,6 +234,7 @@ function associate_skill_with_users(
         "AssociateSkillWithUsers",
         Dict{String,Any}("SkillId" => SkillId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_skill_with_users(
@@ -217,6 +244,7 @@ function associate_skill_with_users(
         "AssociateSkillWithUsers",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("SkillId" => SkillId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -241,6 +269,7 @@ function create_address_book(Name; aws_config::AbstractAWSConfig=global_aws_conf
         "CreateAddressBook",
         Dict{String,Any}("Name" => Name, "ClientRequestToken" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_address_book(
@@ -256,6 +285,7 @@ function create_address_book(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -293,6 +323,7 @@ function create_business_report_schedule(
             "ClientRequestToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_business_report_schedule(
@@ -315,6 +346,7 @@ function create_business_report_schedule(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -351,6 +383,7 @@ function create_conference_provider(
             "ClientRequestToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_conference_provider(
@@ -375,6 +408,7 @@ function create_conference_provider(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -406,6 +440,7 @@ function create_contact(FirstName; aws_config::AbstractAWSConfig=global_aws_conf
         "CreateContact",
         Dict{String,Any}("FirstName" => FirstName, "ClientRequestToken" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_contact(
@@ -425,6 +460,7 @@ function create_contact(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -451,6 +487,7 @@ function create_gateway_group(
         "CreateGatewayGroup",
         Dict{String,Any}("ClientRequestToken" => ClientRequestToken, "Name" => Name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_gateway_group(
@@ -471,6 +508,7 @@ function create_gateway_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -518,6 +556,7 @@ function create_network_profile(
             "Ssid" => Ssid,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_network_profile(
@@ -543,6 +582,7 @@ function create_network_profile(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -594,6 +634,7 @@ function create_profile(
             "ClientRequestToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_profile(
@@ -624,6 +665,7 @@ function create_profile(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -650,6 +692,7 @@ function create_room(RoomName; aws_config::AbstractAWSConfig=global_aws_config()
         "CreateRoom",
         Dict{String,Any}("RoomName" => RoomName, "ClientRequestToken" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_room(
@@ -669,6 +712,7 @@ function create_room(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -697,6 +741,7 @@ function create_skill_group(
             "SkillGroupName" => SkillGroupName, "ClientRequestToken" => string(uuid4())
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_skill_group(
@@ -717,6 +762,7 @@ function create_skill_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -743,6 +789,7 @@ function create_user(UserId; aws_config::AbstractAWSConfig=global_aws_config())
         "CreateUser",
         Dict{String,Any}("UserId" => UserId, "ClientRequestToken" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_user(
@@ -760,6 +807,7 @@ function create_user(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -780,6 +828,7 @@ function delete_address_book(
         "DeleteAddressBook",
         Dict{String,Any}("AddressBookArn" => AddressBookArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_address_book(
@@ -793,6 +842,7 @@ function delete_address_book(
             mergewith(_merge, Dict{String,Any}("AddressBookArn" => AddressBookArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -813,6 +863,7 @@ function delete_business_report_schedule(
         "DeleteBusinessReportSchedule",
         Dict{String,Any}("ScheduleArn" => ScheduleArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_business_report_schedule(
@@ -826,6 +877,7 @@ function delete_business_report_schedule(
             mergewith(_merge, Dict{String,Any}("ScheduleArn" => ScheduleArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -846,6 +898,7 @@ function delete_conference_provider(
         "DeleteConferenceProvider",
         Dict{String,Any}("ConferenceProviderArn" => ConferenceProviderArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_conference_provider(
@@ -863,6 +916,7 @@ function delete_conference_provider(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -878,7 +932,10 @@ Deletes a contact by the contact ARN.
 """
 function delete_contact(ContactArn; aws_config::AbstractAWSConfig=global_aws_config())
     return alexa_for_business(
-        "DeleteContact", Dict{String,Any}("ContactArn" => ContactArn); aws_config=aws_config
+        "DeleteContact",
+        Dict{String,Any}("ContactArn" => ContactArn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_contact(
@@ -892,6 +949,7 @@ function delete_contact(
             mergewith(_merge, Dict{String,Any}("ContactArn" => ContactArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -907,7 +965,10 @@ Removes a device from Alexa For Business.
 """
 function delete_device(DeviceArn; aws_config::AbstractAWSConfig=global_aws_config())
     return alexa_for_business(
-        "DeleteDevice", Dict{String,Any}("DeviceArn" => DeviceArn); aws_config=aws_config
+        "DeleteDevice",
+        Dict{String,Any}("DeviceArn" => DeviceArn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_device(
@@ -921,6 +982,7 @@ function delete_device(
             mergewith(_merge, Dict{String,Any}("DeviceArn" => DeviceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -944,6 +1006,7 @@ function delete_device_usage_data(
         "DeleteDeviceUsageData",
         Dict{String,Any}("DeviceArn" => DeviceArn, "DeviceUsageType" => DeviceUsageType);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_device_usage_data(
@@ -964,6 +1027,7 @@ function delete_device_usage_data(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -984,6 +1048,7 @@ function delete_gateway_group(
         "DeleteGatewayGroup",
         Dict{String,Any}("GatewayGroupArn" => GatewayGroupArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_gateway_group(
@@ -999,6 +1064,7 @@ function delete_gateway_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1019,6 +1085,7 @@ function delete_network_profile(
         "DeleteNetworkProfile",
         Dict{String,Any}("NetworkProfileArn" => NetworkProfileArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_network_profile(
@@ -1034,6 +1101,7 @@ function delete_network_profile(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1048,12 +1116,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"ProfileArn"`: The ARN of the room profile to delete. Required.
 """
 function delete_profile(; aws_config::AbstractAWSConfig=global_aws_config())
-    return alexa_for_business("DeleteProfile"; aws_config=aws_config)
+    return alexa_for_business(
+        "DeleteProfile"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function delete_profile(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return alexa_for_business("DeleteProfile", params; aws_config=aws_config)
+    return alexa_for_business(
+        "DeleteProfile", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1067,12 +1139,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"RoomArn"`: The ARN of the room to delete. Required.
 """
 function delete_room(; aws_config::AbstractAWSConfig=global_aws_config())
-    return alexa_for_business("DeleteRoom"; aws_config=aws_config)
+    return alexa_for_business(
+        "DeleteRoom"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function delete_room(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return alexa_for_business("DeleteRoom", params; aws_config=aws_config)
+    return alexa_for_business(
+        "DeleteRoom", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1096,6 +1172,7 @@ function delete_room_skill_parameter(
         "DeleteRoomSkillParameter",
         Dict{String,Any}("ParameterKey" => ParameterKey, "SkillId" => SkillId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_room_skill_parameter(
@@ -1114,6 +1191,7 @@ function delete_room_skill_parameter(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1137,6 +1215,7 @@ function delete_skill_authorization(
         "DeleteSkillAuthorization",
         Dict{String,Any}("SkillId" => SkillId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_skill_authorization(
@@ -1146,6 +1225,7 @@ function delete_skill_authorization(
         "DeleteSkillAuthorization",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("SkillId" => SkillId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1160,12 +1240,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"SkillGroupArn"`: The ARN of the skill group to delete. Required.
 """
 function delete_skill_group(; aws_config::AbstractAWSConfig=global_aws_config())
-    return alexa_for_business("DeleteSkillGroup"; aws_config=aws_config)
+    return alexa_for_business(
+        "DeleteSkillGroup"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function delete_skill_group(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return alexa_for_business("DeleteSkillGroup", params; aws_config=aws_config)
+    return alexa_for_business(
+        "DeleteSkillGroup", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1186,6 +1270,7 @@ function delete_user(EnrollmentId; aws_config::AbstractAWSConfig=global_aws_conf
         "DeleteUser",
         Dict{String,Any}("EnrollmentId" => EnrollmentId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_user(
@@ -1199,6 +1284,7 @@ function delete_user(
             mergewith(_merge, Dict{String,Any}("EnrollmentId" => EnrollmentId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1220,6 +1306,7 @@ function disassociate_contact_from_address_book(
         "DisassociateContactFromAddressBook",
         Dict{String,Any}("AddressBookArn" => AddressBookArn, "ContactArn" => ContactArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disassociate_contact_from_address_book(
@@ -1240,6 +1327,7 @@ function disassociate_contact_from_address_book(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1256,12 +1344,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"DeviceArn"`: The ARN of the device to disassociate from a room. Required.
 """
 function disassociate_device_from_room(; aws_config::AbstractAWSConfig=global_aws_config())
-    return alexa_for_business("DisassociateDeviceFromRoom"; aws_config=aws_config)
+    return alexa_for_business(
+        "DisassociateDeviceFromRoom"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function disassociate_device_from_room(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return alexa_for_business("DisassociateDeviceFromRoom", params; aws_config=aws_config)
+    return alexa_for_business(
+        "DisassociateDeviceFromRoom",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1284,6 +1379,7 @@ function disassociate_skill_from_skill_group(
         "DisassociateSkillFromSkillGroup",
         Dict{String,Any}("SkillId" => SkillId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disassociate_skill_from_skill_group(
@@ -1293,6 +1389,7 @@ function disassociate_skill_from_skill_group(
         "DisassociateSkillFromSkillGroup",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("SkillId" => SkillId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1314,6 +1411,7 @@ function disassociate_skill_from_users(
         "DisassociateSkillFromUsers",
         Dict{String,Any}("SkillId" => SkillId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disassociate_skill_from_users(
@@ -1323,6 +1421,7 @@ function disassociate_skill_from_users(
         "DisassociateSkillFromUsers",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("SkillId" => SkillId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1342,13 +1441,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function disassociate_skill_group_from_room(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return alexa_for_business("DisassociateSkillGroupFromRoom"; aws_config=aws_config)
+    return alexa_for_business(
+        "DisassociateSkillGroupFromRoom";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function disassociate_skill_group_from_room(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return alexa_for_business(
-        "DisassociateSkillGroupFromRoom", params; aws_config=aws_config
+        "DisassociateSkillGroupFromRoom",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1369,6 +1475,7 @@ function forget_smart_home_appliances(
         "ForgetSmartHomeAppliances",
         Dict{String,Any}("RoomArn" => RoomArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function forget_smart_home_appliances(
@@ -1378,6 +1485,7 @@ function forget_smart_home_appliances(
         "ForgetSmartHomeAppliances",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("RoomArn" => RoomArn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1396,6 +1504,7 @@ function get_address_book(AddressBookArn; aws_config::AbstractAWSConfig=global_a
         "GetAddressBook",
         Dict{String,Any}("AddressBookArn" => AddressBookArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_address_book(
@@ -1409,6 +1518,7 @@ function get_address_book(
             mergewith(_merge, Dict{String,Any}("AddressBookArn" => AddressBookArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1420,12 +1530,19 @@ Retrieves the existing conference preferences.
 
 """
 function get_conference_preference(; aws_config::AbstractAWSConfig=global_aws_config())
-    return alexa_for_business("GetConferencePreference"; aws_config=aws_config)
+    return alexa_for_business(
+        "GetConferencePreference"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_conference_preference(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return alexa_for_business("GetConferencePreference", params; aws_config=aws_config)
+    return alexa_for_business(
+        "GetConferencePreference",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1445,6 +1562,7 @@ function get_conference_provider(
         "GetConferenceProvider",
         Dict{String,Any}("ConferenceProviderArn" => ConferenceProviderArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_conference_provider(
@@ -1462,6 +1580,7 @@ function get_conference_provider(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1477,7 +1596,10 @@ Gets the contact details by the contact ARN.
 """
 function get_contact(ContactArn; aws_config::AbstractAWSConfig=global_aws_config())
     return alexa_for_business(
-        "GetContact", Dict{String,Any}("ContactArn" => ContactArn); aws_config=aws_config
+        "GetContact",
+        Dict{String,Any}("ContactArn" => ContactArn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_contact(
@@ -1491,6 +1613,7 @@ function get_contact(
             mergewith(_merge, Dict{String,Any}("ContactArn" => ContactArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1505,12 +1628,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"DeviceArn"`: The ARN of the device for which to request details. Required.
 """
 function get_device(; aws_config::AbstractAWSConfig=global_aws_config())
-    return alexa_for_business("GetDevice"; aws_config=aws_config)
+    return alexa_for_business(
+        "GetDevice"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_device(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return alexa_for_business("GetDevice", params; aws_config=aws_config)
+    return alexa_for_business(
+        "GetDevice", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1525,7 +1652,10 @@ Retrieves the details of a gateway.
 """
 function get_gateway(GatewayArn; aws_config::AbstractAWSConfig=global_aws_config())
     return alexa_for_business(
-        "GetGateway", Dict{String,Any}("GatewayArn" => GatewayArn); aws_config=aws_config
+        "GetGateway",
+        Dict{String,Any}("GatewayArn" => GatewayArn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_gateway(
@@ -1539,6 +1669,7 @@ function get_gateway(
             mergewith(_merge, Dict{String,Any}("GatewayArn" => GatewayArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1559,6 +1690,7 @@ function get_gateway_group(
         "GetGatewayGroup",
         Dict{String,Any}("GatewayGroupArn" => GatewayGroupArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_gateway_group(
@@ -1574,6 +1706,7 @@ function get_gateway_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1585,12 +1718,19 @@ Retrieves the configured values for the user enrollment invitation email templat
 
 """
 function get_invitation_configuration(; aws_config::AbstractAWSConfig=global_aws_config())
-    return alexa_for_business("GetInvitationConfiguration"; aws_config=aws_config)
+    return alexa_for_business(
+        "GetInvitationConfiguration"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_invitation_configuration(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return alexa_for_business("GetInvitationConfiguration", params; aws_config=aws_config)
+    return alexa_for_business(
+        "GetInvitationConfiguration",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1610,6 +1750,7 @@ function get_network_profile(
         "GetNetworkProfile",
         Dict{String,Any}("NetworkProfileArn" => NetworkProfileArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_network_profile(
@@ -1625,6 +1766,7 @@ function get_network_profile(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1639,12 +1781,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"ProfileArn"`: The ARN of the room profile for which to request details. Required.
 """
 function get_profile(; aws_config::AbstractAWSConfig=global_aws_config())
-    return alexa_for_business("GetProfile"; aws_config=aws_config)
+    return alexa_for_business(
+        "GetProfile"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_profile(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return alexa_for_business("GetProfile", params; aws_config=aws_config)
+    return alexa_for_business(
+        "GetProfile", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1658,12 +1804,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"RoomArn"`: The ARN of the room for which to request details. Required.
 """
 function get_room(; aws_config::AbstractAWSConfig=global_aws_config())
-    return alexa_for_business("GetRoom"; aws_config=aws_config)
+    return alexa_for_business(
+        "GetRoom"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_room(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return alexa_for_business("GetRoom", params; aws_config=aws_config)
+    return alexa_for_business(
+        "GetRoom", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1688,6 +1838,7 @@ function get_room_skill_parameter(
         "GetRoomSkillParameter",
         Dict{String,Any}("ParameterKey" => ParameterKey, "SkillId" => SkillId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_room_skill_parameter(
@@ -1706,6 +1857,7 @@ function get_room_skill_parameter(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1720,12 +1872,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"SkillGroupArn"`: The ARN of the skill group for which to get details. Required.
 """
 function get_skill_group(; aws_config::AbstractAWSConfig=global_aws_config())
-    return alexa_for_business("GetSkillGroup"; aws_config=aws_config)
+    return alexa_for_business(
+        "GetSkillGroup"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_skill_group(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return alexa_for_business("GetSkillGroup", params; aws_config=aws_config)
+    return alexa_for_business(
+        "GetSkillGroup", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1742,12 +1898,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`: The token used to list the remaining schedules from the previous API call.
 """
 function list_business_report_schedules(; aws_config::AbstractAWSConfig=global_aws_config())
-    return alexa_for_business("ListBusinessReportSchedules"; aws_config=aws_config)
+    return alexa_for_business(
+        "ListBusinessReportSchedules";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_business_report_schedules(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return alexa_for_business("ListBusinessReportSchedules", params; aws_config=aws_config)
+    return alexa_for_business(
+        "ListBusinessReportSchedules",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1763,12 +1928,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`: The tokens used for pagination.
 """
 function list_conference_providers(; aws_config::AbstractAWSConfig=global_aws_config())
-    return alexa_for_business("ListConferenceProviders"; aws_config=aws_config)
+    return alexa_for_business(
+        "ListConferenceProviders"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_conference_providers(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return alexa_for_business("ListConferenceProviders", params; aws_config=aws_config)
+    return alexa_for_business(
+        "ListConferenceProviders",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1799,6 +1971,7 @@ function list_device_events(DeviceArn; aws_config::AbstractAWSConfig=global_aws_
         "ListDeviceEvents",
         Dict{String,Any}("DeviceArn" => DeviceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_device_events(
@@ -1812,6 +1985,7 @@ function list_device_events(
             mergewith(_merge, Dict{String,Any}("DeviceArn" => DeviceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1830,12 +2004,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   summaries.
 """
 function list_gateway_groups(; aws_config::AbstractAWSConfig=global_aws_config())
-    return alexa_for_business("ListGatewayGroups"; aws_config=aws_config)
+    return alexa_for_business(
+        "ListGatewayGroups"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_gateway_groups(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return alexa_for_business("ListGatewayGroups", params; aws_config=aws_config)
+    return alexa_for_business(
+        "ListGatewayGroups", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1853,12 +2031,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`: The token used to paginate though multiple pages of gateway summaries.
 """
 function list_gateways(; aws_config::AbstractAWSConfig=global_aws_config())
-    return alexa_for_business("ListGateways"; aws_config=aws_config)
+    return alexa_for_business(
+        "ListGateways"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_gateways(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return alexa_for_business("ListGateways", params; aws_config=aws_config)
+    return alexa_for_business(
+        "ListGateways", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1880,12 +2062,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"SkillType"`: Whether the skill is publicly available or is a private skill.
 """
 function list_skills(; aws_config::AbstractAWSConfig=global_aws_config())
-    return alexa_for_business("ListSkills"; aws_config=aws_config)
+    return alexa_for_business(
+        "ListSkills"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_skills(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return alexa_for_business("ListSkills", params; aws_config=aws_config)
+    return alexa_for_business(
+        "ListSkills", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1900,12 +2086,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`: The tokens used for pagination.
 """
 function list_skills_store_categories(; aws_config::AbstractAWSConfig=global_aws_config())
-    return alexa_for_business("ListSkillsStoreCategories"; aws_config=aws_config)
+    return alexa_for_business(
+        "ListSkillsStoreCategories"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_skills_store_categories(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return alexa_for_business("ListSkillsStoreCategories", params; aws_config=aws_config)
+    return alexa_for_business(
+        "ListSkillsStoreCategories",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1930,6 +2123,7 @@ function list_skills_store_skills_by_category(
         "ListSkillsStoreSkillsByCategory",
         Dict{String,Any}("CategoryId" => CategoryId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_skills_store_skills_by_category(
@@ -1943,6 +2137,7 @@ function list_skills_store_skills_by_category(
             mergewith(_merge, Dict{String,Any}("CategoryId" => CategoryId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1967,6 +2162,7 @@ function list_smart_home_appliances(
         "ListSmartHomeAppliances",
         Dict{String,Any}("RoomArn" => RoomArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_smart_home_appliances(
@@ -1976,6 +2172,7 @@ function list_smart_home_appliances(
         "ListSmartHomeAppliances",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("RoomArn" => RoomArn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1999,7 +2196,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function list_tags(Arn; aws_config::AbstractAWSConfig=global_aws_config())
     return alexa_for_business(
-        "ListTags", Dict{String,Any}("Arn" => Arn); aws_config=aws_config
+        "ListTags",
+        Dict{String,Any}("Arn" => Arn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags(
@@ -2009,6 +2209,7 @@ function list_tags(
         "ListTags",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Arn" => Arn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2029,6 +2230,7 @@ function put_conference_preference(
         "PutConferencePreference",
         Dict{String,Any}("ConferencePreference" => ConferencePreference);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_conference_preference(
@@ -2046,6 +2248,7 @@ function put_conference_preference(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2073,6 +2276,7 @@ function put_invitation_configuration(
         "PutInvitationConfiguration",
         Dict{String,Any}("OrganizationName" => OrganizationName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_invitation_configuration(
@@ -2088,6 +2292,7 @@ function put_invitation_configuration(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2113,6 +2318,7 @@ function put_room_skill_parameter(
         "PutRoomSkillParameter",
         Dict{String,Any}("RoomSkillParameter" => RoomSkillParameter, "SkillId" => SkillId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_room_skill_parameter(
@@ -2133,6 +2339,7 @@ function put_room_skill_parameter(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2162,6 +2369,7 @@ function put_skill_authorization(
             "AuthorizationResult" => AuthorizationResult, "SkillId" => SkillId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_skill_authorization(
@@ -2182,6 +2390,7 @@ function put_skill_authorization(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2226,6 +2435,7 @@ function register_avsdevice(
             "UserCode" => UserCode,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function register_avsdevice(
@@ -2251,6 +2461,7 @@ function register_avsdevice(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2268,7 +2479,10 @@ rejected can be added later by calling the ApproveSkill API.
 """
 function reject_skill(SkillId; aws_config::AbstractAWSConfig=global_aws_config())
     return alexa_for_business(
-        "RejectSkill", Dict{String,Any}("SkillId" => SkillId); aws_config=aws_config
+        "RejectSkill",
+        Dict{String,Any}("SkillId" => SkillId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function reject_skill(
@@ -2278,6 +2492,7 @@ function reject_skill(
         "RejectSkill",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("SkillId" => SkillId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2303,6 +2518,7 @@ function resolve_room(SkillId, UserId; aws_config::AbstractAWSConfig=global_aws_
         "ResolveRoom",
         Dict{String,Any}("SkillId" => SkillId, "UserId" => UserId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function resolve_room(
@@ -2319,6 +2535,7 @@ function resolve_room(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2334,12 +2551,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"UserArn"`: The ARN of the user for whom to revoke an enrollment invitation. Required.
 """
 function revoke_invitation(; aws_config::AbstractAWSConfig=global_aws_config())
-    return alexa_for_business("RevokeInvitation"; aws_config=aws_config)
+    return alexa_for_business(
+        "RevokeInvitation"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function revoke_invitation(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return alexa_for_business("RevokeInvitation", params; aws_config=aws_config)
+    return alexa_for_business(
+        "RevokeInvitation", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -2362,12 +2583,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   The supported sort key is AddressBookName.
 """
 function search_address_books(; aws_config::AbstractAWSConfig=global_aws_config())
-    return alexa_for_business("SearchAddressBooks"; aws_config=aws_config)
+    return alexa_for_business(
+        "SearchAddressBooks"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function search_address_books(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return alexa_for_business("SearchAddressBooks", params; aws_config=aws_config)
+    return alexa_for_business(
+        "SearchAddressBooks", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -2390,12 +2615,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   supported sort keys are DisplayName, FirstName, and LastName.
 """
 function search_contacts(; aws_config::AbstractAWSConfig=global_aws_config())
-    return alexa_for_business("SearchContacts"; aws_config=aws_config)
+    return alexa_for_business(
+        "SearchContacts"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function search_contacts(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return alexa_for_business("SearchContacts", params; aws_config=aws_config)
+    return alexa_for_business(
+        "SearchContacts", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -2421,12 +2650,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   ConnectionStatus, NetworkProfileName, NetworkProfileArn, Feature, and FailureCode.
 """
 function search_devices(; aws_config::AbstractAWSConfig=global_aws_config())
-    return alexa_for_business("SearchDevices"; aws_config=aws_config)
+    return alexa_for_business(
+        "SearchDevices"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function search_devices(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return alexa_for_business("SearchDevices", params; aws_config=aws_config)
+    return alexa_for_business(
+        "SearchDevices", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -2449,12 +2682,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Valid sort criteria includes NetworkProfileName, Ssid, and SecurityType.
 """
 function search_network_profiles(; aws_config::AbstractAWSConfig=global_aws_config())
-    return alexa_for_business("SearchNetworkProfiles"; aws_config=aws_config)
+    return alexa_for_business(
+        "SearchNetworkProfiles"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function search_network_profiles(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return alexa_for_business("SearchNetworkProfiles", params; aws_config=aws_config)
+    return alexa_for_business(
+        "SearchNetworkProfiles",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2477,12 +2717,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Supported sort keys are ProfileName and Address.
 """
 function search_profiles(; aws_config::AbstractAWSConfig=global_aws_config())
-    return alexa_for_business("SearchProfiles"; aws_config=aws_config)
+    return alexa_for_business(
+        "SearchProfiles"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function search_profiles(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return alexa_for_business("SearchProfiles", params; aws_config=aws_config)
+    return alexa_for_business(
+        "SearchProfiles", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -2505,12 +2749,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   supported sort keys are RoomName and ProfileName.
 """
 function search_rooms(; aws_config::AbstractAWSConfig=global_aws_config())
-    return alexa_for_business("SearchRooms"; aws_config=aws_config)
+    return alexa_for_business(
+        "SearchRooms"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function search_rooms(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return alexa_for_business("SearchRooms", params; aws_config=aws_config)
+    return alexa_for_business(
+        "SearchRooms", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -2533,12 +2781,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   supported sort key is SkillGroupName.
 """
 function search_skill_groups(; aws_config::AbstractAWSConfig=global_aws_config())
-    return alexa_for_business("SearchSkillGroups"; aws_config=aws_config)
+    return alexa_for_business(
+        "SearchSkillGroups"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function search_skill_groups(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return alexa_for_business("SearchSkillGroups", params; aws_config=aws_config)
+    return alexa_for_business(
+        "SearchSkillGroups", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -2561,12 +2813,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Supported sort keys are UserId, FirstName, LastName, Email, and EnrollmentStatus.
 """
 function search_users(; aws_config::AbstractAWSConfig=global_aws_config())
-    return alexa_for_business("SearchUsers"; aws_config=aws_config)
+    return alexa_for_business(
+        "SearchUsers"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function search_users(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return alexa_for_business("SearchUsers", params; aws_config=aws_config)
+    return alexa_for_business(
+        "SearchUsers", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -2604,6 +2860,7 @@ function send_announcement(
             "RoomFilters" => RoomFilters,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function send_announcement(
@@ -2627,6 +2884,7 @@ function send_announcement(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2642,12 +2900,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"UserArn"`: The ARN of the user to whom to send an invitation. Required.
 """
 function send_invitation(; aws_config::AbstractAWSConfig=global_aws_config())
-    return alexa_for_business("SendInvitation"; aws_config=aws_config)
+    return alexa_for_business(
+        "SendInvitation"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function send_invitation(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return alexa_for_business("SendInvitation", params; aws_config=aws_config)
+    return alexa_for_business(
+        "SendInvitation", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -2673,7 +2935,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function start_device_sync(Features; aws_config::AbstractAWSConfig=global_aws_config())
     return alexa_for_business(
-        "StartDeviceSync", Dict{String,Any}("Features" => Features); aws_config=aws_config
+        "StartDeviceSync",
+        Dict{String,Any}("Features" => Features);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_device_sync(
@@ -2687,6 +2952,7 @@ function start_device_sync(
             mergewith(_merge, Dict{String,Any}("Features" => Features), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2707,6 +2973,7 @@ function start_smart_home_appliance_discovery(
         "StartSmartHomeApplianceDiscovery",
         Dict{String,Any}("RoomArn" => RoomArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_smart_home_appliance_discovery(
@@ -2716,6 +2983,7 @@ function start_smart_home_appliance_discovery(
         "StartSmartHomeApplianceDiscovery",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("RoomArn" => RoomArn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2733,7 +3001,10 @@ Adds metadata tags to a specified resource.
 """
 function tag_resource(Arn, Tags; aws_config::AbstractAWSConfig=global_aws_config())
     return alexa_for_business(
-        "TagResource", Dict{String,Any}("Arn" => Arn, "Tags" => Tags); aws_config=aws_config
+        "TagResource",
+        Dict{String,Any}("Arn" => Arn, "Tags" => Tags);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -2748,6 +3019,7 @@ function tag_resource(
             mergewith(_merge, Dict{String,Any}("Arn" => Arn, "Tags" => Tags), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2768,6 +3040,7 @@ function untag_resource(Arn, TagKeys; aws_config::AbstractAWSConfig=global_aws_c
         "UntagResource",
         Dict{String,Any}("Arn" => Arn, "TagKeys" => TagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -2782,6 +3055,7 @@ function untag_resource(
             mergewith(_merge, Dict{String,Any}("Arn" => Arn, "TagKeys" => TagKeys), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2806,6 +3080,7 @@ function update_address_book(
         "UpdateAddressBook",
         Dict{String,Any}("AddressBookArn" => AddressBookArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_address_book(
@@ -2819,6 +3094,7 @@ function update_address_book(
             mergewith(_merge, Dict{String,Any}("AddressBookArn" => AddressBookArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2847,6 +3123,7 @@ function update_business_report_schedule(
         "UpdateBusinessReportSchedule",
         Dict{String,Any}("ScheduleArn" => ScheduleArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_business_report_schedule(
@@ -2860,6 +3137,7 @@ function update_business_report_schedule(
             mergewith(_merge, Dict{String,Any}("ScheduleArn" => ScheduleArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2893,6 +3171,7 @@ function update_conference_provider(
             "MeetingSetting" => MeetingSetting,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_conference_provider(
@@ -2916,6 +3195,7 @@ function update_conference_provider(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2941,7 +3221,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function update_contact(ContactArn; aws_config::AbstractAWSConfig=global_aws_config())
     return alexa_for_business(
-        "UpdateContact", Dict{String,Any}("ContactArn" => ContactArn); aws_config=aws_config
+        "UpdateContact",
+        Dict{String,Any}("ContactArn" => ContactArn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_contact(
@@ -2955,6 +3238,7 @@ function update_contact(
             mergewith(_merge, Dict{String,Any}("ContactArn" => ContactArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2970,12 +3254,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"DeviceName"`: The updated device name. Required.
 """
 function update_device(; aws_config::AbstractAWSConfig=global_aws_config())
-    return alexa_for_business("UpdateDevice"; aws_config=aws_config)
+    return alexa_for_business(
+        "UpdateDevice"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function update_device(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return alexa_for_business("UpdateDevice", params; aws_config=aws_config)
+    return alexa_for_business(
+        "UpdateDevice", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -2997,7 +3285,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function update_gateway(GatewayArn; aws_config::AbstractAWSConfig=global_aws_config())
     return alexa_for_business(
-        "UpdateGateway", Dict{String,Any}("GatewayArn" => GatewayArn); aws_config=aws_config
+        "UpdateGateway",
+        Dict{String,Any}("GatewayArn" => GatewayArn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_gateway(
@@ -3011,6 +3302,7 @@ function update_gateway(
             mergewith(_merge, Dict{String,Any}("GatewayArn" => GatewayArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3036,6 +3328,7 @@ function update_gateway_group(
         "UpdateGatewayGroup",
         Dict{String,Any}("GatewayGroupArn" => GatewayGroupArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_gateway_group(
@@ -3051,6 +3344,7 @@ function update_gateway_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3084,6 +3378,7 @@ function update_network_profile(
         "UpdateNetworkProfile",
         Dict{String,Any}("NetworkProfileArn" => NetworkProfileArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_network_profile(
@@ -3099,6 +3394,7 @@ function update_network_profile(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3128,12 +3424,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"WakeWord"`: The updated wake word for the room profile.
 """
 function update_profile(; aws_config::AbstractAWSConfig=global_aws_config())
-    return alexa_for_business("UpdateProfile"; aws_config=aws_config)
+    return alexa_for_business(
+        "UpdateProfile"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function update_profile(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return alexa_for_business("UpdateProfile", params; aws_config=aws_config)
+    return alexa_for_business(
+        "UpdateProfile", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -3151,12 +3451,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"RoomName"`: The updated name for the room.
 """
 function update_room(; aws_config::AbstractAWSConfig=global_aws_config())
-    return alexa_for_business("UpdateRoom"; aws_config=aws_config)
+    return alexa_for_business(
+        "UpdateRoom"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function update_room(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return alexa_for_business("UpdateRoom", params; aws_config=aws_config)
+    return alexa_for_business(
+        "UpdateRoom", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -3172,10 +3476,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"SkillGroupName"`: The updated name for the skill group.
 """
 function update_skill_group(; aws_config::AbstractAWSConfig=global_aws_config())
-    return alexa_for_business("UpdateSkillGroup"; aws_config=aws_config)
+    return alexa_for_business(
+        "UpdateSkillGroup"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function update_skill_group(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return alexa_for_business("UpdateSkillGroup", params; aws_config=aws_config)
+    return alexa_for_business(
+        "UpdateSkillGroup", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end

--- a/src/services/amp.jl
+++ b/src/services/amp.jl
@@ -24,6 +24,7 @@ function create_workspace(; aws_config::AbstractAWSConfig=global_aws_config())
         "/workspaces",
         Dict{String,Any}("clientToken" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_workspace(
@@ -36,6 +37,7 @@ function create_workspace(
             mergewith(_merge, Dict{String,Any}("clientToken" => string(uuid4())), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -59,6 +61,7 @@ function delete_workspace(workspaceId; aws_config::AbstractAWSConfig=global_aws_
         "/workspaces/$(workspaceId)",
         Dict{String,Any}("clientToken" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_workspace(
@@ -73,6 +76,7 @@ function delete_workspace(
             mergewith(_merge, Dict{String,Any}("clientToken" => string(uuid4())), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -87,14 +91,25 @@ Describes an existing AMP workspace.
 
 """
 function describe_workspace(workspaceId; aws_config::AbstractAWSConfig=global_aws_config())
-    return amp("GET", "/workspaces/$(workspaceId)"; aws_config=aws_config)
+    return amp(
+        "GET",
+        "/workspaces/$(workspaceId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_workspace(
     workspaceId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return amp("GET", "/workspaces/$(workspaceId)", params; aws_config=aws_config)
+    return amp(
+        "GET",
+        "/workspaces/$(workspaceId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -110,14 +125,25 @@ Lists the tags you have assigned to the resource.
 function list_tags_for_resource(
     resourceArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return amp("GET", "/tags/$(resourceArn)"; aws_config=aws_config)
+    return amp(
+        "GET",
+        "/tags/$(resourceArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_tags_for_resource(
     resourceArn,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return amp("GET", "/tags/$(resourceArn)", params; aws_config=aws_config)
+    return amp(
+        "GET",
+        "/tags/$(resourceArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -135,12 +161,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   is obtained from the output of the previous ListWorkspaces request.
 """
 function list_workspaces(; aws_config::AbstractAWSConfig=global_aws_config())
-    return amp("GET", "/workspaces"; aws_config=aws_config)
+    return amp("GET", "/workspaces"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_workspaces(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return amp("GET", "/workspaces", params; aws_config=aws_config)
+    return amp(
+        "GET", "/workspaces", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -160,6 +188,7 @@ function tag_resource(resourceArn, tags; aws_config::AbstractAWSConfig=global_aw
         "/tags/$(resourceArn)",
         Dict{String,Any}("tags" => tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -173,6 +202,7 @@ function tag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tags" => tags), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -195,6 +225,7 @@ function untag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}("tagKeys" => tagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -208,6 +239,7 @@ function untag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tagKeys" => tagKeys), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -234,6 +266,7 @@ function update_workspace_alias(
         "/workspaces/$(workspaceId)/alias",
         Dict{String,Any}("clientToken" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_workspace_alias(
@@ -248,5 +281,6 @@ function update_workspace_alias(
             mergewith(_merge, Dict{String,Any}("clientToken" => string(uuid4())), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/amplify.jl
+++ b/src/services/amplify.jl
@@ -44,7 +44,13 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"tags"`:  The tag for an Amplify app.
 """
 function create_app(name; aws_config::AbstractAWSConfig=global_aws_config())
-    return amplify("POST", "/apps", Dict{String,Any}("name" => name); aws_config=aws_config)
+    return amplify(
+        "POST",
+        "/apps",
+        Dict{String,Any}("name" => name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function create_app(
     name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -54,6 +60,7 @@ function create_app(
         "/apps",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("name" => name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -80,6 +87,7 @@ function create_backend_environment(
         "/apps/$(appId)/backendenvironments",
         Dict{String,Any}("environmentName" => environmentName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_backend_environment(
@@ -97,6 +105,7 @@ function create_backend_environment(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -140,6 +149,7 @@ function create_branch(appId, branchName; aws_config::AbstractAWSConfig=global_a
         "/apps/$(appId)/branches",
         Dict{String,Any}("branchName" => branchName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_branch(
@@ -155,6 +165,7 @@ function create_branch(
             mergewith(_merge, Dict{String,Any}("branchName" => branchName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -180,7 +191,10 @@ function create_deployment(
     appId, branchName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return amplify(
-        "POST", "/apps/$(appId)/branches/$(branchName)/deployments"; aws_config=aws_config
+        "POST",
+        "/apps/$(appId)/branches/$(branchName)/deployments";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_deployment(
@@ -194,6 +208,7 @@ function create_deployment(
         "/apps/$(appId)/branches/$(branchName)/deployments",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -227,6 +242,7 @@ function create_domain_association(
             "domainName" => domainName, "subDomainSettings" => subDomainSettings
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_domain_association(
@@ -249,6 +265,7 @@ function create_domain_association(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -274,6 +291,7 @@ function create_webhook(
         "/apps/$(appId)/webhooks",
         Dict{String,Any}("branchName" => branchName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_webhook(
@@ -289,6 +307,7 @@ function create_webhook(
             mergewith(_merge, Dict{String,Any}("branchName" => branchName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -303,12 +322,20 @@ end
 
 """
 function delete_app(appId; aws_config::AbstractAWSConfig=global_aws_config())
-    return amplify("DELETE", "/apps/$(appId)"; aws_config=aws_config)
+    return amplify(
+        "DELETE", "/apps/$(appId)"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function delete_app(
     appId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return amplify("DELETE", "/apps/$(appId)", params; aws_config=aws_config)
+    return amplify(
+        "DELETE",
+        "/apps/$(appId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -329,6 +356,7 @@ function delete_backend_environment(
         "DELETE",
         "/apps/$(appId)/backendenvironments/$(environmentName)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_backend_environment(
@@ -342,6 +370,7 @@ function delete_backend_environment(
         "/apps/$(appId)/backendenvironments/$(environmentName)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -357,7 +386,12 @@ end
 
 """
 function delete_branch(appId, branchName; aws_config::AbstractAWSConfig=global_aws_config())
-    return amplify("DELETE", "/apps/$(appId)/branches/$(branchName)"; aws_config=aws_config)
+    return amplify(
+        "DELETE",
+        "/apps/$(appId)/branches/$(branchName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_branch(
     appId,
@@ -366,7 +400,11 @@ function delete_branch(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return amplify(
-        "DELETE", "/apps/$(appId)/branches/$(branchName)", params; aws_config=aws_config
+        "DELETE",
+        "/apps/$(appId)/branches/$(branchName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -384,7 +422,12 @@ end
 function delete_domain_association(
     appId, domainName; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return amplify("DELETE", "/apps/$(appId)/domains/$(domainName)"; aws_config=aws_config)
+    return amplify(
+        "DELETE",
+        "/apps/$(appId)/domains/$(domainName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_domain_association(
     appId,
@@ -393,7 +436,11 @@ function delete_domain_association(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return amplify(
-        "DELETE", "/apps/$(appId)/domains/$(domainName)", params; aws_config=aws_config
+        "DELETE",
+        "/apps/$(appId)/domains/$(domainName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -416,6 +463,7 @@ function delete_job(
         "DELETE",
         "/apps/$(appId)/branches/$(branchName)/jobs/$(jobId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_job(
@@ -430,6 +478,7 @@ function delete_job(
         "/apps/$(appId)/branches/$(branchName)/jobs/$(jobId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -444,14 +493,25 @@ end
 
 """
 function delete_webhook(webhookId; aws_config::AbstractAWSConfig=global_aws_config())
-    return amplify("DELETE", "/webhooks/$(webhookId)"; aws_config=aws_config)
+    return amplify(
+        "DELETE",
+        "/webhooks/$(webhookId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_webhook(
     webhookId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return amplify("DELETE", "/webhooks/$(webhookId)", params; aws_config=aws_config)
+    return amplify(
+        "DELETE",
+        "/webhooks/$(webhookId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -479,6 +539,7 @@ function generate_access_logs(
         "/apps/$(appId)/accesslogs",
         Dict{String,Any}("domainName" => domainName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function generate_access_logs(
@@ -494,6 +555,7 @@ function generate_access_logs(
             mergewith(_merge, Dict{String,Any}("domainName" => domainName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -508,12 +570,20 @@ end
 
 """
 function get_app(appId; aws_config::AbstractAWSConfig=global_aws_config())
-    return amplify("GET", "/apps/$(appId)"; aws_config=aws_config)
+    return amplify(
+        "GET", "/apps/$(appId)"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_app(
     appId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return amplify("GET", "/apps/$(appId)", params; aws_config=aws_config)
+    return amplify(
+        "GET",
+        "/apps/$(appId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -527,14 +597,25 @@ end
 
 """
 function get_artifact_url(artifactId; aws_config::AbstractAWSConfig=global_aws_config())
-    return amplify("GET", "/artifacts/$(artifactId)"; aws_config=aws_config)
+    return amplify(
+        "GET",
+        "/artifacts/$(artifactId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_artifact_url(
     artifactId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return amplify("GET", "/artifacts/$(artifactId)", params; aws_config=aws_config)
+    return amplify(
+        "GET",
+        "/artifacts/$(artifactId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -555,6 +636,7 @@ function get_backend_environment(
         "GET",
         "/apps/$(appId)/backendenvironments/$(environmentName)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_backend_environment(
@@ -568,6 +650,7 @@ function get_backend_environment(
         "/apps/$(appId)/backendenvironments/$(environmentName)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -583,7 +666,12 @@ end
 
 """
 function get_branch(appId, branchName; aws_config::AbstractAWSConfig=global_aws_config())
-    return amplify("GET", "/apps/$(appId)/branches/$(branchName)"; aws_config=aws_config)
+    return amplify(
+        "GET",
+        "/apps/$(appId)/branches/$(branchName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_branch(
     appId,
@@ -592,7 +680,11 @@ function get_branch(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return amplify(
-        "GET", "/apps/$(appId)/branches/$(branchName)", params; aws_config=aws_config
+        "GET",
+        "/apps/$(appId)/branches/$(branchName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -610,7 +702,12 @@ end
 function get_domain_association(
     appId, domainName; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return amplify("GET", "/apps/$(appId)/domains/$(domainName)"; aws_config=aws_config)
+    return amplify(
+        "GET",
+        "/apps/$(appId)/domains/$(domainName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_domain_association(
     appId,
@@ -619,7 +716,11 @@ function get_domain_association(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return amplify(
-        "GET", "/apps/$(appId)/domains/$(domainName)", params; aws_config=aws_config
+        "GET",
+        "/apps/$(appId)/domains/$(domainName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -639,7 +740,10 @@ function get_job(
     appId, branchName, jobId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return amplify(
-        "GET", "/apps/$(appId)/branches/$(branchName)/jobs/$(jobId)"; aws_config=aws_config
+        "GET",
+        "/apps/$(appId)/branches/$(branchName)/jobs/$(jobId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_job(
@@ -654,6 +758,7 @@ function get_job(
         "/apps/$(appId)/branches/$(branchName)/jobs/$(jobId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -668,14 +773,25 @@ end
 
 """
 function get_webhook(webhookId; aws_config::AbstractAWSConfig=global_aws_config())
-    return amplify("GET", "/webhooks/$(webhookId)"; aws_config=aws_config)
+    return amplify(
+        "GET",
+        "/webhooks/$(webhookId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_webhook(
     webhookId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return amplify("GET", "/webhooks/$(webhookId)", params; aws_config=aws_config)
+    return amplify(
+        "GET",
+        "/webhooks/$(webhookId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -691,12 +807,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   result. Pass its value in another request to retrieve more entries.
 """
 function list_apps(; aws_config::AbstractAWSConfig=global_aws_config())
-    return amplify("GET", "/apps"; aws_config=aws_config)
+    return amplify("GET", "/apps"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_apps(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return amplify("GET", "/apps", params; aws_config=aws_config)
+    return amplify(
+        "GET", "/apps", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -724,6 +842,7 @@ function list_artifacts(
         "GET",
         "/apps/$(appId)/branches/$(branchName)/jobs/$(jobId)/artifacts";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_artifacts(
@@ -738,6 +857,7 @@ function list_artifacts(
         "/apps/$(appId)/branches/$(branchName)/jobs/$(jobId)/artifacts",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -759,13 +879,22 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   here to list more backend environments.
 """
 function list_backend_environments(appId; aws_config::AbstractAWSConfig=global_aws_config())
-    return amplify("GET", "/apps/$(appId)/backendenvironments"; aws_config=aws_config)
+    return amplify(
+        "GET",
+        "/apps/$(appId)/backendenvironments";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_backend_environments(
     appId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return amplify(
-        "GET", "/apps/$(appId)/backendenvironments", params; aws_config=aws_config
+        "GET",
+        "/apps/$(appId)/backendenvironments",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -786,12 +915,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   branches.
 """
 function list_branches(appId; aws_config::AbstractAWSConfig=global_aws_config())
-    return amplify("GET", "/apps/$(appId)/branches"; aws_config=aws_config)
+    return amplify(
+        "GET",
+        "/apps/$(appId)/branches";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_branches(
     appId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return amplify("GET", "/apps/$(appId)/branches", params; aws_config=aws_config)
+    return amplify(
+        "GET",
+        "/apps/$(appId)/branches",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -811,12 +951,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   projects.
 """
 function list_domain_associations(appId; aws_config::AbstractAWSConfig=global_aws_config())
-    return amplify("GET", "/apps/$(appId)/domains"; aws_config=aws_config)
+    return amplify(
+        "GET",
+        "/apps/$(appId)/domains";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_domain_associations(
     appId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return amplify("GET", "/apps/$(appId)/domains", params; aws_config=aws_config)
+    return amplify(
+        "GET",
+        "/apps/$(appId)/domains",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -838,7 +989,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function list_jobs(appId, branchName; aws_config::AbstractAWSConfig=global_aws_config())
     return amplify(
-        "GET", "/apps/$(appId)/branches/$(branchName)/jobs"; aws_config=aws_config
+        "GET",
+        "/apps/$(appId)/branches/$(branchName)/jobs";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_jobs(
@@ -848,7 +1002,11 @@ function list_jobs(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return amplify(
-        "GET", "/apps/$(appId)/branches/$(branchName)/jobs", params; aws_config=aws_config
+        "GET",
+        "/apps/$(appId)/branches/$(branchName)/jobs",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -865,14 +1023,25 @@ end
 function list_tags_for_resource(
     resourceArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return amplify("GET", "/tags/$(resourceArn)"; aws_config=aws_config)
+    return amplify(
+        "GET",
+        "/tags/$(resourceArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_tags_for_resource(
     resourceArn,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return amplify("GET", "/tags/$(resourceArn)", params; aws_config=aws_config)
+    return amplify(
+        "GET",
+        "/tags/$(resourceArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -892,12 +1061,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   more webhooks.
 """
 function list_webhooks(appId; aws_config::AbstractAWSConfig=global_aws_config())
-    return amplify("GET", "/apps/$(appId)/webhooks"; aws_config=aws_config)
+    return amplify(
+        "GET",
+        "/apps/$(appId)/webhooks";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_webhooks(
     appId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return amplify("GET", "/apps/$(appId)/webhooks", params; aws_config=aws_config)
+    return amplify(
+        "GET",
+        "/apps/$(appId)/webhooks",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -925,6 +1105,7 @@ function start_deployment(
         "POST",
         "/apps/$(appId)/branches/$(branchName)/deployments/start";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_deployment(
@@ -938,6 +1119,7 @@ function start_deployment(
         "/apps/$(appId)/branches/$(branchName)/deployments/start",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -973,6 +1155,7 @@ function start_job(
         "/apps/$(appId)/branches/$(branchName)/jobs",
         Dict{String,Any}("jobType" => jobType);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_job(
@@ -987,6 +1170,7 @@ function start_job(
         "/apps/$(appId)/branches/$(branchName)/jobs",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("jobType" => jobType), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1009,6 +1193,7 @@ function stop_job(
         "DELETE",
         "/apps/$(appId)/branches/$(branchName)/jobs/$(jobId)/stop";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function stop_job(
@@ -1023,6 +1208,7 @@ function stop_job(
         "/apps/$(appId)/branches/$(branchName)/jobs/$(jobId)/stop",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1043,6 +1229,7 @@ function tag_resource(resourceArn, tags; aws_config::AbstractAWSConfig=global_aw
         "/tags/$(resourceArn)",
         Dict{String,Any}("tags" => tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -1056,6 +1243,7 @@ function tag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tags" => tags), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1078,6 +1266,7 @@ function untag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}("tagKeys" => tagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -1091,6 +1280,7 @@ function untag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tagKeys" => tagKeys), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1133,12 +1323,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"repository"`:  The name of the repository for an Amplify app
 """
 function update_app(appId; aws_config::AbstractAWSConfig=global_aws_config())
-    return amplify("POST", "/apps/$(appId)"; aws_config=aws_config)
+    return amplify(
+        "POST", "/apps/$(appId)"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function update_app(
     appId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return amplify("POST", "/apps/$(appId)", params; aws_config=aws_config)
+    return amplify(
+        "POST",
+        "/apps/$(appId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1175,7 +1373,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"ttl"`:  The content Time to Live (TTL) for the website in seconds.
 """
 function update_branch(appId, branchName; aws_config::AbstractAWSConfig=global_aws_config())
-    return amplify("POST", "/apps/$(appId)/branches/$(branchName)"; aws_config=aws_config)
+    return amplify(
+        "POST",
+        "/apps/$(appId)/branches/$(branchName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function update_branch(
     appId,
@@ -1184,7 +1387,11 @@ function update_branch(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return amplify(
-        "POST", "/apps/$(appId)/branches/$(branchName)", params; aws_config=aws_config
+        "POST",
+        "/apps/$(appId)/branches/$(branchName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1215,6 +1422,7 @@ function update_domain_association(
         "/apps/$(appId)/domains/$(domainName)",
         Dict{String,Any}("subDomainSettings" => subDomainSettings);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_domain_association(
@@ -1233,6 +1441,7 @@ function update_domain_association(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1251,12 +1460,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"description"`:  The description for a webhook.
 """
 function update_webhook(webhookId; aws_config::AbstractAWSConfig=global_aws_config())
-    return amplify("POST", "/webhooks/$(webhookId)"; aws_config=aws_config)
+    return amplify(
+        "POST",
+        "/webhooks/$(webhookId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function update_webhook(
     webhookId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return amplify("POST", "/webhooks/$(webhookId)", params; aws_config=aws_config)
+    return amplify(
+        "POST",
+        "/webhooks/$(webhookId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end

--- a/src/services/amplifybackend.jl
+++ b/src/services/amplifybackend.jl
@@ -27,6 +27,7 @@ function clone_backend(
         "/backend/$(appId)/environments/$(backendEnvironmentName)/clone",
         Dict{String,Any}("targetEnvironmentName" => targetEnvironmentName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function clone_backend(
@@ -47,6 +48,7 @@ function clone_backend(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -82,6 +84,7 @@ function create_backend(
             "backendEnvironmentName" => backendEnvironmentName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_backend(
@@ -106,6 +109,7 @@ function create_backend(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -138,6 +142,7 @@ function create_backend_api(
             "resourceName" => resourceName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_backend_api(
@@ -163,6 +168,7 @@ function create_backend_api(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -195,6 +201,7 @@ function create_backend_auth(
             "resourceName" => resourceName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_backend_auth(
@@ -220,6 +227,7 @@ function create_backend_auth(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -237,12 +245,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"backendManagerAppId"`: The app ID for the backend manager.
 """
 function create_backend_config(appId; aws_config::AbstractAWSConfig=global_aws_config())
-    return amplifybackend("POST", "/backend/$(appId)/config"; aws_config=aws_config)
+    return amplifybackend(
+        "POST",
+        "/backend/$(appId)/config";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function create_backend_config(
     appId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return amplifybackend("POST", "/backend/$(appId)/config", params; aws_config=aws_config)
+    return amplifybackend(
+        "POST",
+        "/backend/$(appId)/config",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -256,13 +275,22 @@ Generates a one-time challenge code to authenticate a user into your Amplify Adm
 
 """
 function create_token(appId; aws_config::AbstractAWSConfig=global_aws_config())
-    return amplifybackend("POST", "/backend/$(appId)/challenge"; aws_config=aws_config)
+    return amplifybackend(
+        "POST",
+        "/backend/$(appId)/challenge";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function create_token(
     appId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return amplifybackend(
-        "POST", "/backend/$(appId)/challenge", params; aws_config=aws_config
+        "POST",
+        "/backend/$(appId)/challenge",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -284,6 +312,7 @@ function delete_backend(
         "POST",
         "/backend/$(appId)/environments/$(backendEnvironmentName)/remove";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_backend(
@@ -297,6 +326,7 @@ function delete_backend(
         "/backend/$(appId)/environments/$(backendEnvironmentName)/remove",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -327,6 +357,7 @@ function delete_backend_api(
         "/backend/$(appId)/api/$(backendEnvironmentName)/remove",
         Dict{String,Any}("resourceName" => resourceName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_backend_api(
@@ -343,6 +374,7 @@ function delete_backend_api(
             mergewith(_merge, Dict{String,Any}("resourceName" => resourceName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -369,6 +401,7 @@ function delete_backend_auth(
         "/backend/$(appId)/auth/$(backendEnvironmentName)/remove",
         Dict{String,Any}("resourceName" => resourceName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_backend_auth(
@@ -385,6 +418,7 @@ function delete_backend_auth(
             mergewith(_merge, Dict{String,Any}("resourceName" => resourceName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -401,7 +435,10 @@ Deletes the challenge token based on the given appId and sessionId.
 """
 function delete_token(appId, sessionId; aws_config::AbstractAWSConfig=global_aws_config())
     return amplifybackend(
-        "POST", "/backend/$(appId)/challenge/$(sessionId)/remove"; aws_config=aws_config
+        "POST",
+        "/backend/$(appId)/challenge/$(sessionId)/remove";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_token(
@@ -415,6 +452,7 @@ function delete_token(
         "/backend/$(appId)/challenge/$(sessionId)/remove",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -441,6 +479,7 @@ function generate_backend_apimodels(
         "/backend/$(appId)/api/$(backendEnvironmentName)/generateModels",
         Dict{String,Any}("resourceName" => resourceName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function generate_backend_apimodels(
@@ -457,6 +496,7 @@ function generate_backend_apimodels(
             mergewith(_merge, Dict{String,Any}("resourceName" => resourceName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -474,13 +514,22 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"backendEnvironmentName"`: The name of the backend environment.
 """
 function get_backend(appId; aws_config::AbstractAWSConfig=global_aws_config())
-    return amplifybackend("POST", "/backend/$(appId)/details"; aws_config=aws_config)
+    return amplifybackend(
+        "POST",
+        "/backend/$(appId)/details";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_backend(
     appId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return amplifybackend(
-        "POST", "/backend/$(appId)/details", params; aws_config=aws_config
+        "POST",
+        "/backend/$(appId)/details",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -511,6 +560,7 @@ function get_backend_api(
         "/backend/$(appId)/api/$(backendEnvironmentName)/details",
         Dict{String,Any}("resourceName" => resourceName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_backend_api(
@@ -527,6 +577,7 @@ function get_backend_api(
             mergewith(_merge, Dict{String,Any}("resourceName" => resourceName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -553,6 +604,7 @@ function get_backend_apimodels(
         "/backend/$(appId)/api/$(backendEnvironmentName)/getModels",
         Dict{String,Any}("resourceName" => resourceName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_backend_apimodels(
@@ -569,6 +621,7 @@ function get_backend_apimodels(
             mergewith(_merge, Dict{String,Any}("resourceName" => resourceName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -595,6 +648,7 @@ function get_backend_auth(
         "/backend/$(appId)/auth/$(backendEnvironmentName)/details",
         Dict{String,Any}("resourceName" => resourceName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_backend_auth(
@@ -611,6 +665,7 @@ function get_backend_auth(
             mergewith(_merge, Dict{String,Any}("resourceName" => resourceName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -633,6 +688,7 @@ function get_backend_job(
         "GET",
         "/backend/$(appId)/job/$(backendEnvironmentName)/$(jobId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_backend_job(
@@ -647,6 +703,7 @@ function get_backend_job(
         "/backend/$(appId)/job/$(backendEnvironmentName)/$(jobId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -663,7 +720,10 @@ Gets the challenge token based on the given appId and sessionId.
 """
 function get_token(appId, sessionId; aws_config::AbstractAWSConfig=global_aws_config())
     return amplifybackend(
-        "GET", "/backend/$(appId)/challenge/$(sessionId)"; aws_config=aws_config
+        "GET",
+        "/backend/$(appId)/challenge/$(sessionId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_token(
@@ -673,7 +733,11 @@ function get_token(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return amplifybackend(
-        "GET", "/backend/$(appId)/challenge/$(sessionId)", params; aws_config=aws_config
+        "GET",
+        "/backend/$(appId)/challenge/$(sessionId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -711,6 +775,7 @@ function import_backend_auth(
             "webClientId" => webClientId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function import_backend_auth(
@@ -737,6 +802,7 @@ function import_backend_auth(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -764,7 +830,10 @@ function list_backend_jobs(
     appId, backendEnvironmentName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return amplifybackend(
-        "POST", "/backend/$(appId)/job/$(backendEnvironmentName)"; aws_config=aws_config
+        "POST",
+        "/backend/$(appId)/job/$(backendEnvironmentName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_backend_jobs(
@@ -778,6 +847,7 @@ function list_backend_jobs(
         "/backend/$(appId)/job/$(backendEnvironmentName)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -795,12 +865,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"cleanAmplifyApp"`: Cleans up the Amplify Console app if this value is set to true.
 """
 function remove_all_backends(appId; aws_config::AbstractAWSConfig=global_aws_config())
-    return amplifybackend("POST", "/backend/$(appId)/remove"; aws_config=aws_config)
+    return amplifybackend(
+        "POST",
+        "/backend/$(appId)/remove";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function remove_all_backends(
     appId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return amplifybackend("POST", "/backend/$(appId)/remove", params; aws_config=aws_config)
+    return amplifybackend(
+        "POST",
+        "/backend/$(appId)/remove",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -814,13 +895,22 @@ Removes the AWS resources required to access the Amplify Admin UI.
 
 """
 function remove_backend_config(appId; aws_config::AbstractAWSConfig=global_aws_config())
-    return amplifybackend("POST", "/backend/$(appId)/config/remove"; aws_config=aws_config)
+    return amplifybackend(
+        "POST",
+        "/backend/$(appId)/config/remove";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function remove_backend_config(
     appId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return amplifybackend(
-        "POST", "/backend/$(appId)/config/remove", params; aws_config=aws_config
+        "POST",
+        "/backend/$(appId)/config/remove",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -851,6 +941,7 @@ function update_backend_api(
         "/backend/$(appId)/api/$(backendEnvironmentName)",
         Dict{String,Any}("resourceName" => resourceName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_backend_api(
@@ -867,6 +958,7 @@ function update_backend_api(
             mergewith(_merge, Dict{String,Any}("resourceName" => resourceName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -897,6 +989,7 @@ function update_backend_auth(
             "resourceConfig" => resourceConfig, "resourceName" => resourceName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_backend_auth(
@@ -920,6 +1013,7 @@ function update_backend_auth(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -937,13 +1031,22 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"loginAuthConfig"`: Describes the Amazon Cognito configuration for Admin UI access.
 """
 function update_backend_config(appId; aws_config::AbstractAWSConfig=global_aws_config())
-    return amplifybackend("POST", "/backend/$(appId)/config/update"; aws_config=aws_config)
+    return amplifybackend(
+        "POST",
+        "/backend/$(appId)/config/update";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function update_backend_config(
     appId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return amplifybackend(
-        "POST", "/backend/$(appId)/config/update", params; aws_config=aws_config
+        "POST",
+        "/backend/$(appId)/config/update",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -972,6 +1075,7 @@ function update_backend_job(
         "POST",
         "/backend/$(appId)/job/$(backendEnvironmentName)/$(jobId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_backend_job(
@@ -986,5 +1090,6 @@ function update_backend_job(
         "/backend/$(appId)/job/$(backendEnvironmentName)/$(jobId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/api_gateway.jl
+++ b/src/services/api_gateway.jl
@@ -27,12 +27,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"value"`: Specifies a value of the API key.
 """
 function create_api_key(; aws_config::AbstractAWSConfig=global_aws_config())
-    return api_gateway("POST", "/apikeys"; aws_config=aws_config)
+    return api_gateway(
+        "POST", "/apikeys"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function create_api_key(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return api_gateway("POST", "/apikeys", params; aws_config=aws_config)
+    return api_gateway(
+        "POST", "/apikeys", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -105,6 +109,7 @@ function create_authorizer(
         "/restapis/$(restapi_id)/authorizers",
         Dict{String,Any}("name" => name, "type" => type);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_authorizer(
@@ -121,6 +126,7 @@ function create_authorizer(
             mergewith(_merge, Dict{String,Any}("name" => name, "type" => type), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -151,6 +157,7 @@ function create_base_path_mapping(
         "/domainnames/$(domain_name)/basepathmappings",
         Dict{String,Any}("restApiId" => restApiId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_base_path_mapping(
@@ -166,6 +173,7 @@ function create_base_path_mapping(
             mergewith(_merge, Dict{String,Any}("restApiId" => restApiId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -196,7 +204,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   characters, and the values must match [A-Za-z0-9-._~:/?#&amp;=,]+.
 """
 function create_deployment(restapi_id; aws_config::AbstractAWSConfig=global_aws_config())
-    return api_gateway("POST", "/restapis/$(restapi_id)/deployments"; aws_config=aws_config)
+    return api_gateway(
+        "POST",
+        "/restapis/$(restapi_id)/deployments";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function create_deployment(
     restapi_id,
@@ -204,7 +217,11 @@ function create_deployment(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return api_gateway(
-        "POST", "/restapis/$(restapi_id)/deployments", params; aws_config=aws_config
+        "POST",
+        "/restapis/$(restapi_id)/deployments",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -231,6 +248,7 @@ function create_documentation_part(
         "/restapis/$(restapi_id)/documentation/parts",
         Dict{String,Any}("location" => location, "properties" => properties);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_documentation_part(
@@ -251,6 +269,7 @@ function create_documentation_part(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -277,6 +296,7 @@ function create_documentation_version(
         "/restapis/$(restapi_id)/documentation/versions",
         Dict{String,Any}("documentationVersion" => documentationVersion);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_documentation_version(
@@ -296,6 +316,7 @@ function create_documentation_version(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -348,6 +369,7 @@ function create_domain_name(domainName; aws_config::AbstractAWSConfig=global_aws
         "/domainnames",
         Dict{String,Any}("domainName" => domainName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_domain_name(
@@ -362,6 +384,7 @@ function create_domain_name(
             mergewith(_merge, Dict{String,Any}("domainName" => domainName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -390,6 +413,7 @@ function create_model(
         "/restapis/$(restapi_id)/models",
         Dict{String,Any}("contentType" => contentType, "name" => name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_model(
@@ -410,6 +434,7 @@ function create_model(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -434,7 +459,10 @@ function create_request_validator(
     restapi_id; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return api_gateway(
-        "POST", "/restapis/$(restapi_id)/requestvalidators"; aws_config=aws_config
+        "POST",
+        "/restapis/$(restapi_id)/requestvalidators";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_request_validator(
@@ -443,7 +471,11 @@ function create_request_validator(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return api_gateway(
-        "POST", "/restapis/$(restapi_id)/requestvalidators", params; aws_config=aws_config
+        "POST",
+        "/restapis/$(restapi_id)/requestvalidators",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -467,6 +499,7 @@ function create_resource(
         "/restapis/$(restapi_id)/resources/$(parent_id)",
         Dict{String,Any}("pathPart" => pathPart);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_resource(
@@ -483,6 +516,7 @@ function create_resource(
             mergewith(_merge, Dict{String,Any}("pathPart" => pathPart), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -524,7 +558,11 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function create_rest_api(name; aws_config::AbstractAWSConfig=global_aws_config())
     return api_gateway(
-        "POST", "/restapis", Dict{String,Any}("name" => name); aws_config=aws_config
+        "POST",
+        "/restapis",
+        Dict{String,Any}("name" => name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_rest_api(
@@ -535,6 +573,7 @@ function create_rest_api(
         "/restapis",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("name" => name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -574,6 +613,7 @@ function create_stage(
         "/restapis/$(restapi_id)/stages",
         Dict{String,Any}("deploymentId" => deploymentId, "stageName" => stageName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_stage(
@@ -594,6 +634,7 @@ function create_stage(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -619,7 +660,11 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function create_usage_plan(name; aws_config::AbstractAWSConfig=global_aws_config())
     return api_gateway(
-        "POST", "/usageplans", Dict{String,Any}("name" => name); aws_config=aws_config
+        "POST",
+        "/usageplans",
+        Dict{String,Any}("name" => name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_usage_plan(
@@ -630,6 +675,7 @@ function create_usage_plan(
         "/usageplans",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("name" => name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -654,6 +700,7 @@ function create_usage_plan_key(
         "/usageplans/$(usageplanId)/keys",
         Dict{String,Any}("keyId" => keyId, "keyType" => keyType);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_usage_plan_key(
@@ -672,6 +719,7 @@ function create_usage_plan_key(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -703,6 +751,7 @@ function create_vpc_link(
         "/vpclinks",
         Dict{String,Any}("name" => name, "targetArns" => targetArns);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_vpc_link(
@@ -720,6 +769,7 @@ function create_vpc_link(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -734,12 +784,23 @@ Deletes the ApiKey resource.
 
 """
 function delete_api_key(api_Key; aws_config::AbstractAWSConfig=global_aws_config())
-    return api_gateway("DELETE", "/apikeys/$(api_Key)"; aws_config=aws_config)
+    return api_gateway(
+        "DELETE",
+        "/apikeys/$(api_Key)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_api_key(
     api_Key, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return api_gateway("DELETE", "/apikeys/$(api_Key)", params; aws_config=aws_config)
+    return api_gateway(
+        "DELETE",
+        "/apikeys/$(api_Key)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -760,6 +821,7 @@ function delete_authorizer(
         "DELETE",
         "/restapis/$(restapi_id)/authorizers/$(authorizer_id)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_authorizer(
@@ -773,6 +835,7 @@ function delete_authorizer(
         "/restapis/$(restapi_id)/authorizers/$(authorizer_id)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -795,6 +858,7 @@ function delete_base_path_mapping(
         "DELETE",
         "/domainnames/$(domain_name)/basepathmappings/$(base_path)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_base_path_mapping(
@@ -808,6 +872,7 @@ function delete_base_path_mapping(
         "/domainnames/$(domain_name)/basepathmappings/$(base_path)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -826,7 +891,10 @@ function delete_client_certificate(
     clientcertificate_id; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return api_gateway(
-        "DELETE", "/clientcertificates/$(clientcertificate_id)"; aws_config=aws_config
+        "DELETE",
+        "/clientcertificates/$(clientcertificate_id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_client_certificate(
@@ -839,6 +907,7 @@ function delete_client_certificate(
         "/clientcertificates/$(clientcertificate_id)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -861,6 +930,7 @@ function delete_deployment(
         "DELETE",
         "/restapis/$(restapi_id)/deployments/$(deployment_id)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_deployment(
@@ -874,6 +944,7 @@ function delete_deployment(
         "/restapis/$(restapi_id)/deployments/$(deployment_id)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -895,6 +966,7 @@ function delete_documentation_part(
         "DELETE",
         "/restapis/$(restapi_id)/documentation/parts/$(part_id)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_documentation_part(
@@ -908,6 +980,7 @@ function delete_documentation_part(
         "/restapis/$(restapi_id)/documentation/parts/$(part_id)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -930,6 +1003,7 @@ function delete_documentation_version(
         "DELETE",
         "/restapis/$(restapi_id)/documentation/versions/$(doc_version)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_documentation_version(
@@ -943,6 +1017,7 @@ function delete_documentation_version(
         "/restapis/$(restapi_id)/documentation/versions/$(doc_version)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -957,7 +1032,12 @@ Deletes the DomainName resource.
 
 """
 function delete_domain_name(domain_name; aws_config::AbstractAWSConfig=global_aws_config())
-    return api_gateway("DELETE", "/domainnames/$(domain_name)"; aws_config=aws_config)
+    return api_gateway(
+        "DELETE",
+        "/domainnames/$(domain_name)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_domain_name(
     domain_name,
@@ -965,7 +1045,11 @@ function delete_domain_name(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return api_gateway(
-        "DELETE", "/domainnames/$(domain_name)", params; aws_config=aws_config
+        "DELETE",
+        "/domainnames/$(domain_name)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -988,6 +1072,7 @@ function delete_gateway_response(
         "DELETE",
         "/restapis/$(restapi_id)/gatewayresponses/$(response_type)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_gateway_response(
@@ -1001,6 +1086,7 @@ function delete_gateway_response(
         "/restapis/$(restapi_id)/gatewayresponses/$(response_type)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1023,6 +1109,7 @@ function delete_integration(
         "DELETE",
         "/restapis/$(restapi_id)/resources/$(resource_id)/methods/$(http_method)/integration";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_integration(
@@ -1037,6 +1124,7 @@ function delete_integration(
         "/restapis/$(restapi_id)/resources/$(resource_id)/methods/$(http_method)/integration",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1065,6 +1153,7 @@ function delete_integration_response(
         "DELETE",
         "/restapis/$(restapi_id)/resources/$(resource_id)/methods/$(http_method)/integration/responses/$(status_code)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_integration_response(
@@ -1080,6 +1169,7 @@ function delete_integration_response(
         "/restapis/$(restapi_id)/resources/$(resource_id)/methods/$(http_method)/integration/responses/$(status_code)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1102,6 +1192,7 @@ function delete_method(
         "DELETE",
         "/restapis/$(restapi_id)/resources/$(resource_id)/methods/$(http_method)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_method(
@@ -1116,6 +1207,7 @@ function delete_method(
         "/restapis/$(restapi_id)/resources/$(resource_id)/methods/$(http_method)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1143,6 +1235,7 @@ function delete_method_response(
         "DELETE",
         "/restapis/$(restapi_id)/resources/$(resource_id)/methods/$(http_method)/responses/$(status_code)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_method_response(
@@ -1158,6 +1251,7 @@ function delete_method_response(
         "/restapis/$(restapi_id)/resources/$(resource_id)/methods/$(http_method)/responses/$(status_code)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1176,7 +1270,10 @@ function delete_model(
     model_name, restapi_id; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return api_gateway(
-        "DELETE", "/restapis/$(restapi_id)/models/$(model_name)"; aws_config=aws_config
+        "DELETE",
+        "/restapis/$(restapi_id)/models/$(model_name)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_model(
@@ -1190,6 +1287,7 @@ function delete_model(
         "/restapis/$(restapi_id)/models/$(model_name)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1211,6 +1309,7 @@ function delete_request_validator(
         "DELETE",
         "/restapis/$(restapi_id)/requestvalidators/$(requestvalidator_id)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_request_validator(
@@ -1224,6 +1323,7 @@ function delete_request_validator(
         "/restapis/$(restapi_id)/requestvalidators/$(requestvalidator_id)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1242,7 +1342,10 @@ function delete_resource(
     resource_id, restapi_id; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return api_gateway(
-        "DELETE", "/restapis/$(restapi_id)/resources/$(resource_id)"; aws_config=aws_config
+        "DELETE",
+        "/restapis/$(restapi_id)/resources/$(resource_id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_resource(
@@ -1256,6 +1359,7 @@ function delete_resource(
         "/restapis/$(restapi_id)/resources/$(resource_id)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1270,14 +1374,25 @@ Deletes the specified API.
 
 """
 function delete_rest_api(restapi_id; aws_config::AbstractAWSConfig=global_aws_config())
-    return api_gateway("DELETE", "/restapis/$(restapi_id)"; aws_config=aws_config)
+    return api_gateway(
+        "DELETE",
+        "/restapis/$(restapi_id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_rest_api(
     restapi_id,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return api_gateway("DELETE", "/restapis/$(restapi_id)", params; aws_config=aws_config)
+    return api_gateway(
+        "DELETE",
+        "/restapis/$(restapi_id)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1295,7 +1410,10 @@ function delete_stage(
     restapi_id, stage_name; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return api_gateway(
-        "DELETE", "/restapis/$(restapi_id)/stages/$(stage_name)"; aws_config=aws_config
+        "DELETE",
+        "/restapis/$(restapi_id)/stages/$(stage_name)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_stage(
@@ -1309,6 +1427,7 @@ function delete_stage(
         "/restapis/$(restapi_id)/stages/$(stage_name)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1323,7 +1442,12 @@ Deletes a usage plan of a given plan Id.
 
 """
 function delete_usage_plan(usageplanId; aws_config::AbstractAWSConfig=global_aws_config())
-    return api_gateway("DELETE", "/usageplans/$(usageplanId)"; aws_config=aws_config)
+    return api_gateway(
+        "DELETE",
+        "/usageplans/$(usageplanId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_usage_plan(
     usageplanId,
@@ -1331,7 +1455,11 @@ function delete_usage_plan(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return api_gateway(
-        "DELETE", "/usageplans/$(usageplanId)", params; aws_config=aws_config
+        "DELETE",
+        "/usageplans/$(usageplanId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1351,7 +1479,10 @@ function delete_usage_plan_key(
     keyId, usageplanId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return api_gateway(
-        "DELETE", "/usageplans/$(usageplanId)/keys/$(keyId)"; aws_config=aws_config
+        "DELETE",
+        "/usageplans/$(usageplanId)/keys/$(keyId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_usage_plan_key(
@@ -1361,7 +1492,11 @@ function delete_usage_plan_key(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return api_gateway(
-        "DELETE", "/usageplans/$(usageplanId)/keys/$(keyId)", params; aws_config=aws_config
+        "DELETE",
+        "/usageplans/$(usageplanId)/keys/$(keyId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1377,14 +1512,25 @@ Deletes an existing VpcLink of a specified identifier.
 
 """
 function delete_vpc_link(vpclink_id; aws_config::AbstractAWSConfig=global_aws_config())
-    return api_gateway("DELETE", "/vpclinks/$(vpclink_id)"; aws_config=aws_config)
+    return api_gateway(
+        "DELETE",
+        "/vpclinks/$(vpclink_id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_vpc_link(
     vpclink_id,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return api_gateway("DELETE", "/vpclinks/$(vpclink_id)", params; aws_config=aws_config)
+    return api_gateway(
+        "DELETE",
+        "/vpclinks/$(vpclink_id)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1405,6 +1551,7 @@ function flush_stage_authorizers_cache(
         "DELETE",
         "/restapis/$(restapi_id)/stages/$(stage_name)/cache/authorizers";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function flush_stage_authorizers_cache(
@@ -1418,6 +1565,7 @@ function flush_stage_authorizers_cache(
         "/restapis/$(restapi_id)/stages/$(stage_name)/cache/authorizers",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1439,6 +1587,7 @@ function flush_stage_cache(
         "DELETE",
         "/restapis/$(restapi_id)/stages/$(stage_name)/cache/data";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function flush_stage_cache(
@@ -1452,6 +1601,7 @@ function flush_stage_cache(
         "/restapis/$(restapi_id)/stages/$(stage_name)/cache/data",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1469,12 +1619,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   to 256 characters.
 """
 function generate_client_certificate(; aws_config::AbstractAWSConfig=global_aws_config())
-    return api_gateway("POST", "/clientcertificates"; aws_config=aws_config)
+    return api_gateway(
+        "POST",
+        "/clientcertificates";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function generate_client_certificate(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return api_gateway("POST", "/clientcertificates", params; aws_config=aws_config)
+    return api_gateway(
+        "POST",
+        "/clientcertificates",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1485,12 +1646,16 @@ Gets information about the current Account resource.
 
 """
 function get_account(; aws_config::AbstractAWSConfig=global_aws_config())
-    return api_gateway("GET", "/account"; aws_config=aws_config)
+    return api_gateway(
+        "GET", "/account"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_account(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return api_gateway("GET", "/account", params; aws_config=aws_config)
+    return api_gateway(
+        "GET", "/account", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1508,12 +1673,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   contains the key value.
 """
 function get_api_key(api_Key; aws_config::AbstractAWSConfig=global_aws_config())
-    return api_gateway("GET", "/apikeys/$(api_Key)"; aws_config=aws_config)
+    return api_gateway(
+        "GET", "/apikeys/$(api_Key)"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_api_key(
     api_Key, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return api_gateway("GET", "/apikeys/$(api_Key)", params; aws_config=aws_config)
+    return api_gateway(
+        "GET",
+        "/apikeys/$(api_Key)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1534,12 +1707,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"position"`: The current pagination position in the paged result set.
 """
 function get_api_keys(; aws_config::AbstractAWSConfig=global_aws_config())
-    return api_gateway("GET", "/apikeys"; aws_config=aws_config)
+    return api_gateway(
+        "GET", "/apikeys"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_api_keys(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return api_gateway("GET", "/apikeys", params; aws_config=aws_config)
+    return api_gateway(
+        "GET", "/apikeys", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1557,7 +1734,10 @@ function get_authorizer(
     authorizer_id, restapi_id; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return api_gateway(
-        "GET", "/restapis/$(restapi_id)/authorizers/$(authorizer_id)"; aws_config=aws_config
+        "GET",
+        "/restapis/$(restapi_id)/authorizers/$(authorizer_id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_authorizer(
@@ -1571,6 +1751,7 @@ function get_authorizer(
         "/restapis/$(restapi_id)/authorizers/$(authorizer_id)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1590,7 +1771,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"position"`: The current pagination position in the paged result set.
 """
 function get_authorizers(restapi_id; aws_config::AbstractAWSConfig=global_aws_config())
-    return api_gateway("GET", "/restapis/$(restapi_id)/authorizers"; aws_config=aws_config)
+    return api_gateway(
+        "GET",
+        "/restapis/$(restapi_id)/authorizers";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_authorizers(
     restapi_id,
@@ -1598,7 +1784,11 @@ function get_authorizers(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return api_gateway(
-        "GET", "/restapis/$(restapi_id)/authorizers", params; aws_config=aws_config
+        "GET",
+        "/restapis/$(restapi_id)/authorizers",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1623,6 +1813,7 @@ function get_base_path_mapping(
         "GET",
         "/domainnames/$(domain_name)/basepathmappings/$(base_path)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_base_path_mapping(
@@ -1636,6 +1827,7 @@ function get_base_path_mapping(
         "/domainnames/$(domain_name)/basepathmappings/$(base_path)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1658,7 +1850,10 @@ function get_base_path_mappings(
     domain_name; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return api_gateway(
-        "GET", "/domainnames/$(domain_name)/basepathmappings"; aws_config=aws_config
+        "GET",
+        "/domainnames/$(domain_name)/basepathmappings";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_base_path_mappings(
@@ -1667,7 +1862,11 @@ function get_base_path_mappings(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return api_gateway(
-        "GET", "/domainnames/$(domain_name)/basepathmappings", params; aws_config=aws_config
+        "GET",
+        "/domainnames/$(domain_name)/basepathmappings",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1686,7 +1885,10 @@ function get_client_certificate(
     clientcertificate_id; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return api_gateway(
-        "GET", "/clientcertificates/$(clientcertificate_id)"; aws_config=aws_config
+        "GET",
+        "/clientcertificates/$(clientcertificate_id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_client_certificate(
@@ -1695,7 +1897,11 @@ function get_client_certificate(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return api_gateway(
-        "GET", "/clientcertificates/$(clientcertificate_id)", params; aws_config=aws_config
+        "GET",
+        "/clientcertificates/$(clientcertificate_id)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1712,12 +1918,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"position"`: The current pagination position in the paged result set.
 """
 function get_client_certificates(; aws_config::AbstractAWSConfig=global_aws_config())
-    return api_gateway("GET", "/clientcertificates"; aws_config=aws_config)
+    return api_gateway(
+        "GET", "/clientcertificates"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_client_certificates(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return api_gateway("GET", "/clientcertificates", params; aws_config=aws_config)
+    return api_gateway(
+        "GET",
+        "/clientcertificates",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1746,7 +1960,10 @@ function get_deployment(
     deployment_id, restapi_id; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return api_gateway(
-        "GET", "/restapis/$(restapi_id)/deployments/$(deployment_id)"; aws_config=aws_config
+        "GET",
+        "/restapis/$(restapi_id)/deployments/$(deployment_id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_deployment(
@@ -1760,6 +1977,7 @@ function get_deployment(
         "/restapis/$(restapi_id)/deployments/$(deployment_id)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1779,7 +1997,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"position"`: The current pagination position in the paged result set.
 """
 function get_deployments(restapi_id; aws_config::AbstractAWSConfig=global_aws_config())
-    return api_gateway("GET", "/restapis/$(restapi_id)/deployments"; aws_config=aws_config)
+    return api_gateway(
+        "GET",
+        "/restapis/$(restapi_id)/deployments";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_deployments(
     restapi_id,
@@ -1787,7 +2010,11 @@ function get_deployments(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return api_gateway(
-        "GET", "/restapis/$(restapi_id)/deployments", params; aws_config=aws_config
+        "GET",
+        "/restapis/$(restapi_id)/deployments",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1809,6 +2036,7 @@ function get_documentation_part(
         "GET",
         "/restapis/$(restapi_id)/documentation/parts/$(part_id)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_documentation_part(
@@ -1822,6 +2050,7 @@ function get_documentation_part(
         "/restapis/$(restapi_id)/documentation/parts/$(part_id)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1850,7 +2079,10 @@ function get_documentation_parts(
     restapi_id; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return api_gateway(
-        "GET", "/restapis/$(restapi_id)/documentation/parts"; aws_config=aws_config
+        "GET",
+        "/restapis/$(restapi_id)/documentation/parts";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_documentation_parts(
@@ -1859,7 +2091,11 @@ function get_documentation_parts(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return api_gateway(
-        "GET", "/restapis/$(restapi_id)/documentation/parts", params; aws_config=aws_config
+        "GET",
+        "/restapis/$(restapi_id)/documentation/parts",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1882,6 +2118,7 @@ function get_documentation_version(
         "GET",
         "/restapis/$(restapi_id)/documentation/versions/$(doc_version)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_documentation_version(
@@ -1895,6 +2132,7 @@ function get_documentation_version(
         "/restapis/$(restapi_id)/documentation/versions/$(doc_version)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1917,7 +2155,10 @@ function get_documentation_versions(
     restapi_id; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return api_gateway(
-        "GET", "/restapis/$(restapi_id)/documentation/versions"; aws_config=aws_config
+        "GET",
+        "/restapis/$(restapi_id)/documentation/versions";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_documentation_versions(
@@ -1930,6 +2171,7 @@ function get_documentation_versions(
         "/restapis/$(restapi_id)/documentation/versions",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1945,14 +2187,25 @@ called.
 
 """
 function get_domain_name(domain_name; aws_config::AbstractAWSConfig=global_aws_config())
-    return api_gateway("GET", "/domainnames/$(domain_name)"; aws_config=aws_config)
+    return api_gateway(
+        "GET",
+        "/domainnames/$(domain_name)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_domain_name(
     domain_name,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return api_gateway("GET", "/domainnames/$(domain_name)", params; aws_config=aws_config)
+    return api_gateway(
+        "GET",
+        "/domainnames/$(domain_name)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1968,12 +2221,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"position"`: The current pagination position in the paged result set.
 """
 function get_domain_names(; aws_config::AbstractAWSConfig=global_aws_config())
-    return api_gateway("GET", "/domainnames"; aws_config=aws_config)
+    return api_gateway(
+        "GET", "/domainnames"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_domain_names(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return api_gateway("GET", "/domainnames", params; aws_config=aws_config)
+    return api_gateway(
+        "GET",
+        "/domainnames",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2008,6 +2269,7 @@ function get_export(
         "GET",
         "/restapis/$(restapi_id)/stages/$(stage_name)/exports/$(export_type)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_export(
@@ -2022,6 +2284,7 @@ function get_export(
         "/restapis/$(restapi_id)/stages/$(stage_name)/exports/$(export_type)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2043,6 +2306,7 @@ function get_gateway_response(
         "GET",
         "/restapis/$(restapi_id)/gatewayresponses/$(response_type)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_gateway_response(
@@ -2056,6 +2320,7 @@ function get_gateway_response(
         "/restapis/$(restapi_id)/gatewayresponses/$(response_type)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2082,7 +2347,10 @@ function get_gateway_responses(
     restapi_id; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return api_gateway(
-        "GET", "/restapis/$(restapi_id)/gatewayresponses"; aws_config=aws_config
+        "GET",
+        "/restapis/$(restapi_id)/gatewayresponses";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_gateway_responses(
@@ -2091,7 +2359,11 @@ function get_gateway_responses(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return api_gateway(
-        "GET", "/restapis/$(restapi_id)/gatewayresponses", params; aws_config=aws_config
+        "GET",
+        "/restapis/$(restapi_id)/gatewayresponses",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2114,6 +2386,7 @@ function get_integration(
         "GET",
         "/restapis/$(restapi_id)/resources/$(resource_id)/methods/$(http_method)/integration";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_integration(
@@ -2128,6 +2401,7 @@ function get_integration(
         "/restapis/$(restapi_id)/resources/$(resource_id)/methods/$(http_method)/integration",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2156,6 +2430,7 @@ function get_integration_response(
         "GET",
         "/restapis/$(restapi_id)/resources/$(resource_id)/methods/$(http_method)/integration/responses/$(status_code)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_integration_response(
@@ -2171,6 +2446,7 @@ function get_integration_response(
         "/restapis/$(restapi_id)/resources/$(resource_id)/methods/$(http_method)/integration/responses/$(status_code)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2193,6 +2469,7 @@ function get_method(
         "GET",
         "/restapis/$(restapi_id)/resources/$(resource_id)/methods/$(http_method)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_method(
@@ -2207,6 +2484,7 @@ function get_method(
         "/restapis/$(restapi_id)/resources/$(resource_id)/methods/$(http_method)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2234,6 +2512,7 @@ function get_method_response(
         "GET",
         "/restapis/$(restapi_id)/resources/$(resource_id)/methods/$(http_method)/responses/$(status_code)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_method_response(
@@ -2249,6 +2528,7 @@ function get_method_response(
         "/restapis/$(restapi_id)/resources/$(resource_id)/methods/$(http_method)/responses/$(status_code)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2271,7 +2551,10 @@ function get_model(
     model_name, restapi_id; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return api_gateway(
-        "GET", "/restapis/$(restapi_id)/models/$(model_name)"; aws_config=aws_config
+        "GET",
+        "/restapis/$(restapi_id)/models/$(model_name)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_model(
@@ -2281,7 +2564,11 @@ function get_model(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return api_gateway(
-        "GET", "/restapis/$(restapi_id)/models/$(model_name)", params; aws_config=aws_config
+        "GET",
+        "/restapis/$(restapi_id)/models/$(model_name)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2304,6 +2591,7 @@ function get_model_template(
         "GET",
         "/restapis/$(restapi_id)/models/$(model_name)/default_template";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_model_template(
@@ -2317,6 +2605,7 @@ function get_model_template(
         "/restapis/$(restapi_id)/models/$(model_name)/default_template",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2336,7 +2625,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"position"`: The current pagination position in the paged result set.
 """
 function get_models(restapi_id; aws_config::AbstractAWSConfig=global_aws_config())
-    return api_gateway("GET", "/restapis/$(restapi_id)/models"; aws_config=aws_config)
+    return api_gateway(
+        "GET",
+        "/restapis/$(restapi_id)/models";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_models(
     restapi_id,
@@ -2344,7 +2638,11 @@ function get_models(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return api_gateway(
-        "GET", "/restapis/$(restapi_id)/models", params; aws_config=aws_config
+        "GET",
+        "/restapis/$(restapi_id)/models",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2366,6 +2664,7 @@ function get_request_validator(
         "GET",
         "/restapis/$(restapi_id)/requestvalidators/$(requestvalidator_id)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_request_validator(
@@ -2379,6 +2678,7 @@ function get_request_validator(
         "/restapis/$(restapi_id)/requestvalidators/$(requestvalidator_id)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2401,7 +2701,10 @@ function get_request_validators(
     restapi_id; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return api_gateway(
-        "GET", "/restapis/$(restapi_id)/requestvalidators"; aws_config=aws_config
+        "GET",
+        "/restapis/$(restapi_id)/requestvalidators";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_request_validators(
@@ -2410,7 +2713,11 @@ function get_request_validators(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return api_gateway(
-        "GET", "/restapis/$(restapi_id)/requestvalidators", params; aws_config=aws_config
+        "GET",
+        "/restapis/$(restapi_id)/requestvalidators",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2437,7 +2744,10 @@ function get_resource(
     resource_id, restapi_id; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return api_gateway(
-        "GET", "/restapis/$(restapi_id)/resources/$(resource_id)"; aws_config=aws_config
+        "GET",
+        "/restapis/$(restapi_id)/resources/$(resource_id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_resource(
@@ -2451,6 +2761,7 @@ function get_resource(
         "/restapis/$(restapi_id)/resources/$(resource_id)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2476,7 +2787,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"position"`: The current pagination position in the paged result set.
 """
 function get_resources(restapi_id; aws_config::AbstractAWSConfig=global_aws_config())
-    return api_gateway("GET", "/restapis/$(restapi_id)/resources"; aws_config=aws_config)
+    return api_gateway(
+        "GET",
+        "/restapis/$(restapi_id)/resources";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_resources(
     restapi_id,
@@ -2484,7 +2800,11 @@ function get_resources(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return api_gateway(
-        "GET", "/restapis/$(restapi_id)/resources", params; aws_config=aws_config
+        "GET",
+        "/restapis/$(restapi_id)/resources",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2499,14 +2819,25 @@ Lists the RestApi resource in the collection.
 
 """
 function get_rest_api(restapi_id; aws_config::AbstractAWSConfig=global_aws_config())
-    return api_gateway("GET", "/restapis/$(restapi_id)"; aws_config=aws_config)
+    return api_gateway(
+        "GET",
+        "/restapis/$(restapi_id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_rest_api(
     restapi_id,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return api_gateway("GET", "/restapis/$(restapi_id)", params; aws_config=aws_config)
+    return api_gateway(
+        "GET",
+        "/restapis/$(restapi_id)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2522,12 +2853,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"position"`: The current pagination position in the paged result set.
 """
 function get_rest_apis(; aws_config::AbstractAWSConfig=global_aws_config())
-    return api_gateway("GET", "/restapis"; aws_config=aws_config)
+    return api_gateway(
+        "GET", "/restapis"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_rest_apis(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return api_gateway("GET", "/restapis", params; aws_config=aws_config)
+    return api_gateway(
+        "GET", "/restapis", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -2557,6 +2892,7 @@ function get_sdk(
         "GET",
         "/restapis/$(restapi_id)/stages/$(stage_name)/sdks/$(sdk_type)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_sdk(
@@ -2571,6 +2907,7 @@ function get_sdk(
         "/restapis/$(restapi_id)/stages/$(stage_name)/sdks/$(sdk_type)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2585,14 +2922,25 @@ end
 
 """
 function get_sdk_type(sdktype_id; aws_config::AbstractAWSConfig=global_aws_config())
-    return api_gateway("GET", "/sdktypes/$(sdktype_id)"; aws_config=aws_config)
+    return api_gateway(
+        "GET",
+        "/sdktypes/$(sdktype_id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_sdk_type(
     sdktype_id,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return api_gateway("GET", "/sdktypes/$(sdktype_id)", params; aws_config=aws_config)
+    return api_gateway(
+        "GET",
+        "/sdktypes/$(sdktype_id)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2608,12 +2956,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"position"`: The current pagination position in the paged result set.
 """
 function get_sdk_types(; aws_config::AbstractAWSConfig=global_aws_config())
-    return api_gateway("GET", "/sdktypes"; aws_config=aws_config)
+    return api_gateway(
+        "GET", "/sdktypes"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_sdk_types(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return api_gateway("GET", "/sdktypes", params; aws_config=aws_config)
+    return api_gateway(
+        "GET", "/sdktypes", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -2631,7 +2983,10 @@ function get_stage(
     restapi_id, stage_name; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return api_gateway(
-        "GET", "/restapis/$(restapi_id)/stages/$(stage_name)"; aws_config=aws_config
+        "GET",
+        "/restapis/$(restapi_id)/stages/$(stage_name)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_stage(
@@ -2641,7 +2996,11 @@ function get_stage(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return api_gateway(
-        "GET", "/restapis/$(restapi_id)/stages/$(stage_name)", params; aws_config=aws_config
+        "GET",
+        "/restapis/$(restapi_id)/stages/$(stage_name)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2659,7 +3018,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"deploymentId"`: The stages' deployment identifiers.
 """
 function get_stages(restapi_id; aws_config::AbstractAWSConfig=global_aws_config())
-    return api_gateway("GET", "/restapis/$(restapi_id)/stages"; aws_config=aws_config)
+    return api_gateway(
+        "GET",
+        "/restapis/$(restapi_id)/stages";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_stages(
     restapi_id,
@@ -2667,7 +3031,11 @@ function get_stages(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return api_gateway(
-        "GET", "/restapis/$(restapi_id)/stages", params; aws_config=aws_config
+        "GET",
+        "/restapis/$(restapi_id)/stages",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2688,14 +3056,25 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   result set.
 """
 function get_tags(resource_arn; aws_config::AbstractAWSConfig=global_aws_config())
-    return api_gateway("GET", "/tags/$(resource_arn)"; aws_config=aws_config)
+    return api_gateway(
+        "GET",
+        "/tags/$(resource_arn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_tags(
     resource_arn,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return api_gateway("GET", "/tags/$(resource_arn)", params; aws_config=aws_config)
+    return api_gateway(
+        "GET",
+        "/tags/$(resource_arn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2724,6 +3103,7 @@ function get_usage(
         "/usageplans/$(usageplanId)/usage",
         Dict{String,Any}("endDate" => endDate, "startDate" => startDate);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_usage(
@@ -2744,6 +3124,7 @@ function get_usage(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2758,14 +3139,25 @@ Gets a usage plan of a given plan identifier.
 
 """
 function get_usage_plan(usageplanId; aws_config::AbstractAWSConfig=global_aws_config())
-    return api_gateway("GET", "/usageplans/$(usageplanId)"; aws_config=aws_config)
+    return api_gateway(
+        "GET",
+        "/usageplans/$(usageplanId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_usage_plan(
     usageplanId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return api_gateway("GET", "/usageplans/$(usageplanId)", params; aws_config=aws_config)
+    return api_gateway(
+        "GET",
+        "/usageplans/$(usageplanId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2785,7 +3177,10 @@ function get_usage_plan_key(
     keyId, usageplanId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return api_gateway(
-        "GET", "/usageplans/$(usageplanId)/keys/$(keyId)"; aws_config=aws_config
+        "GET",
+        "/usageplans/$(usageplanId)/keys/$(keyId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_usage_plan_key(
@@ -2795,7 +3190,11 @@ function get_usage_plan_key(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return api_gateway(
-        "GET", "/usageplans/$(usageplanId)/keys/$(keyId)", params; aws_config=aws_config
+        "GET",
+        "/usageplans/$(usageplanId)/keys/$(keyId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2817,7 +3216,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"position"`: The current pagination position in the paged result set.
 """
 function get_usage_plan_keys(usageplanId; aws_config::AbstractAWSConfig=global_aws_config())
-    return api_gateway("GET", "/usageplans/$(usageplanId)/keys"; aws_config=aws_config)
+    return api_gateway(
+        "GET",
+        "/usageplans/$(usageplanId)/keys";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_usage_plan_keys(
     usageplanId,
@@ -2825,7 +3229,11 @@ function get_usage_plan_keys(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return api_gateway(
-        "GET", "/usageplans/$(usageplanId)/keys", params; aws_config=aws_config
+        "GET",
+        "/usageplans/$(usageplanId)/keys",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2843,12 +3251,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"position"`: The current pagination position in the paged result set.
 """
 function get_usage_plans(; aws_config::AbstractAWSConfig=global_aws_config())
-    return api_gateway("GET", "/usageplans"; aws_config=aws_config)
+    return api_gateway(
+        "GET", "/usageplans"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_usage_plans(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return api_gateway("GET", "/usageplans", params; aws_config=aws_config)
+    return api_gateway(
+        "GET", "/usageplans", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -2863,14 +3275,25 @@ Gets a specified VPC link under the caller's account in a region.
 
 """
 function get_vpc_link(vpclink_id; aws_config::AbstractAWSConfig=global_aws_config())
-    return api_gateway("GET", "/vpclinks/$(vpclink_id)"; aws_config=aws_config)
+    return api_gateway(
+        "GET",
+        "/vpclinks/$(vpclink_id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_vpc_link(
     vpclink_id,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return api_gateway("GET", "/vpclinks/$(vpclink_id)", params; aws_config=aws_config)
+    return api_gateway(
+        "GET",
+        "/vpclinks/$(vpclink_id)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2886,12 +3309,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"position"`: The current pagination position in the paged result set.
 """
 function get_vpc_links(; aws_config::AbstractAWSConfig=global_aws_config())
-    return api_gateway("GET", "/vpclinks"; aws_config=aws_config)
+    return api_gateway(
+        "GET", "/vpclinks"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_vpc_links(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return api_gateway("GET", "/vpclinks", params; aws_config=aws_config)
+    return api_gateway(
+        "GET", "/vpclinks", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -2917,6 +3344,7 @@ function import_api_keys(body, format; aws_config::AbstractAWSConfig=global_aws_
         "/apikeys?mode=import",
         Dict{String,Any}("body" => body, "format" => format);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function import_api_keys(
@@ -2932,6 +3360,7 @@ function import_api_keys(
             mergewith(_merge, Dict{String,Any}("body" => body, "format" => format), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2962,6 +3391,7 @@ function import_documentation_parts(
         "/restapis/$(restapi_id)/documentation/parts",
         Dict{String,Any}("body" => body);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function import_documentation_parts(
@@ -2975,6 +3405,7 @@ function import_documentation_parts(
         "/restapis/$(restapi_id)/documentation/parts",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("body" => body), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3013,6 +3444,7 @@ function import_rest_api(body; aws_config::AbstractAWSConfig=global_aws_config()
         "/restapis?mode=import",
         Dict{String,Any}("body" => body);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function import_rest_api(
@@ -3023,6 +3455,7 @@ function import_rest_api(
         "/restapis?mode=import",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("body" => body), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3052,6 +3485,7 @@ function put_gateway_response(
         "PUT",
         "/restapis/$(restapi_id)/gatewayresponses/$(response_type)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_gateway_response(
@@ -3065,6 +3499,7 @@ function put_gateway_response(
         "/restapis/$(restapi_id)/gatewayresponses/$(response_type)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3157,6 +3592,7 @@ function put_integration(
         "/restapis/$(restapi_id)/resources/$(resource_id)/methods/$(http_method)/integration",
         Dict{String,Any}("type" => type);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_integration(
@@ -3172,6 +3608,7 @@ function put_integration(
         "/restapis/$(restapi_id)/resources/$(resource_id)/methods/$(http_method)/integration",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("type" => type), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3220,6 +3657,7 @@ function put_integration_response(
         "PUT",
         "/restapis/$(restapi_id)/resources/$(resource_id)/methods/$(http_method)/integration/responses/$(status_code)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_integration_response(
@@ -3235,6 +3673,7 @@ function put_integration_response(
         "/restapis/$(restapi_id)/resources/$(resource_id)/methods/$(http_method)/integration/responses/$(status_code)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3292,6 +3731,7 @@ function put_method(
         "/restapis/$(restapi_id)/resources/$(resource_id)/methods/$(http_method)",
         Dict{String,Any}("authorizationType" => authorizationType);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_method(
@@ -3311,6 +3751,7 @@ function put_method(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3354,6 +3795,7 @@ function put_method_response(
         "PUT",
         "/restapis/$(restapi_id)/resources/$(resource_id)/methods/$(http_method)/responses/$(status_code)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_method_response(
@@ -3369,6 +3811,7 @@ function put_method_response(
         "/restapis/$(restapi_id)/resources/$(resource_id)/methods/$(http_method)/responses/$(status_code)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3403,6 +3846,7 @@ function put_rest_api(body, restapi_id; aws_config::AbstractAWSConfig=global_aws
         "/restapis/$(restapi_id)",
         Dict{String,Any}("body" => body);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_rest_api(
@@ -3416,6 +3860,7 @@ function put_rest_api(
         "/restapis/$(restapi_id)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("body" => body), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3438,6 +3883,7 @@ function tag_resource(resource_arn, tags; aws_config::AbstractAWSConfig=global_a
         "/tags/$(resource_arn)",
         Dict{String,Any}("tags" => tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -3451,6 +3897,7 @@ function tag_resource(
         "/tags/$(resource_arn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tags" => tags), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3489,6 +3936,7 @@ function test_invoke_authorizer(
         "POST",
         "/restapis/$(restapi_id)/authorizers/$(authorizer_id)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function test_invoke_authorizer(
@@ -3502,6 +3950,7 @@ function test_invoke_authorizer(
         "/restapis/$(restapi_id)/authorizers/$(authorizer_id)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3538,6 +3987,7 @@ function test_invoke_method(
         "POST",
         "/restapis/$(restapi_id)/resources/$(resource_id)/methods/$(http_method)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function test_invoke_method(
@@ -3552,6 +4002,7 @@ function test_invoke_method(
         "/restapis/$(restapi_id)/resources/$(resource_id)/methods/$(http_method)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3574,6 +4025,7 @@ function untag_resource(
         "/tags/$(resource_arn)",
         Dict{String,Any}("tagKeys" => tagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -3587,6 +4039,7 @@ function untag_resource(
         "/tags/$(resource_arn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tagKeys" => tagKeys), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3602,12 +4055,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   and in the order specified in this list.
 """
 function update_account(; aws_config::AbstractAWSConfig=global_aws_config())
-    return api_gateway("PATCH", "/account"; aws_config=aws_config)
+    return api_gateway(
+        "PATCH", "/account"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function update_account(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return api_gateway("PATCH", "/account", params; aws_config=aws_config)
+    return api_gateway(
+        "PATCH", "/account", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -3625,12 +4082,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   and in the order specified in this list.
 """
 function update_api_key(api_Key; aws_config::AbstractAWSConfig=global_aws_config())
-    return api_gateway("PATCH", "/apikeys/$(api_Key)"; aws_config=aws_config)
+    return api_gateway(
+        "PATCH",
+        "/apikeys/$(api_Key)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function update_api_key(
     api_Key, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return api_gateway("PATCH", "/apikeys/$(api_Key)", params; aws_config=aws_config)
+    return api_gateway(
+        "PATCH",
+        "/apikeys/$(api_Key)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -3655,6 +4123,7 @@ function update_authorizer(
         "PATCH",
         "/restapis/$(restapi_id)/authorizers/$(authorizer_id)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_authorizer(
@@ -3668,6 +4137,7 @@ function update_authorizer(
         "/restapis/$(restapi_id)/authorizers/$(authorizer_id)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3694,6 +4164,7 @@ function update_base_path_mapping(
         "PATCH",
         "/domainnames/$(domain_name)/basepathmappings/$(base_path)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_base_path_mapping(
@@ -3707,6 +4178,7 @@ function update_base_path_mapping(
         "/domainnames/$(domain_name)/basepathmappings/$(base_path)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3729,7 +4201,10 @@ function update_client_certificate(
     clientcertificate_id; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return api_gateway(
-        "PATCH", "/clientcertificates/$(clientcertificate_id)"; aws_config=aws_config
+        "PATCH",
+        "/clientcertificates/$(clientcertificate_id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_client_certificate(
@@ -3742,6 +4217,7 @@ function update_client_certificate(
         "/clientcertificates/$(clientcertificate_id)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3768,6 +4244,7 @@ function update_deployment(
         "PATCH",
         "/restapis/$(restapi_id)/deployments/$(deployment_id)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_deployment(
@@ -3781,6 +4258,7 @@ function update_deployment(
         "/restapis/$(restapi_id)/deployments/$(deployment_id)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3806,6 +4284,7 @@ function update_documentation_part(
         "PATCH",
         "/restapis/$(restapi_id)/documentation/parts/$(part_id)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_documentation_part(
@@ -3819,6 +4298,7 @@ function update_documentation_part(
         "/restapis/$(restapi_id)/documentation/parts/$(part_id)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3845,6 +4325,7 @@ function update_documentation_version(
         "PATCH",
         "/restapis/$(restapi_id)/documentation/versions/$(doc_version)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_documentation_version(
@@ -3858,6 +4339,7 @@ function update_documentation_version(
         "/restapis/$(restapi_id)/documentation/versions/$(doc_version)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3876,7 +4358,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   and in the order specified in this list.
 """
 function update_domain_name(domain_name; aws_config::AbstractAWSConfig=global_aws_config())
-    return api_gateway("PATCH", "/domainnames/$(domain_name)"; aws_config=aws_config)
+    return api_gateway(
+        "PATCH",
+        "/domainnames/$(domain_name)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function update_domain_name(
     domain_name,
@@ -3884,7 +4371,11 @@ function update_domain_name(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return api_gateway(
-        "PATCH", "/domainnames/$(domain_name)", params; aws_config=aws_config
+        "PATCH",
+        "/domainnames/$(domain_name)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3910,6 +4401,7 @@ function update_gateway_response(
         "PATCH",
         "/restapis/$(restapi_id)/gatewayresponses/$(response_type)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_gateway_response(
@@ -3923,6 +4415,7 @@ function update_gateway_response(
         "/restapis/$(restapi_id)/gatewayresponses/$(response_type)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3949,6 +4442,7 @@ function update_integration(
         "PATCH",
         "/restapis/$(restapi_id)/resources/$(resource_id)/methods/$(http_method)/integration";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_integration(
@@ -3963,6 +4457,7 @@ function update_integration(
         "/restapis/$(restapi_id)/resources/$(resource_id)/methods/$(http_method)/integration",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3995,6 +4490,7 @@ function update_integration_response(
         "PATCH",
         "/restapis/$(restapi_id)/resources/$(resource_id)/methods/$(http_method)/integration/responses/$(status_code)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_integration_response(
@@ -4010,6 +4506,7 @@ function update_integration_response(
         "/restapis/$(restapi_id)/resources/$(resource_id)/methods/$(http_method)/integration/responses/$(status_code)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4036,6 +4533,7 @@ function update_method(
         "PATCH",
         "/restapis/$(restapi_id)/resources/$(resource_id)/methods/$(http_method)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_method(
@@ -4050,6 +4548,7 @@ function update_method(
         "/restapis/$(restapi_id)/resources/$(resource_id)/methods/$(http_method)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4081,6 +4580,7 @@ function update_method_response(
         "PATCH",
         "/restapis/$(restapi_id)/resources/$(resource_id)/methods/$(http_method)/responses/$(status_code)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_method_response(
@@ -4096,6 +4596,7 @@ function update_method_response(
         "/restapis/$(restapi_id)/resources/$(resource_id)/methods/$(http_method)/responses/$(status_code)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4118,7 +4619,10 @@ function update_model(
     model_name, restapi_id; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return api_gateway(
-        "PATCH", "/restapis/$(restapi_id)/models/$(model_name)"; aws_config=aws_config
+        "PATCH",
+        "/restapis/$(restapi_id)/models/$(model_name)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_model(
@@ -4132,6 +4636,7 @@ function update_model(
         "/restapis/$(restapi_id)/models/$(model_name)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4157,6 +4662,7 @@ function update_request_validator(
         "PATCH",
         "/restapis/$(restapi_id)/requestvalidators/$(requestvalidator_id)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_request_validator(
@@ -4170,6 +4676,7 @@ function update_request_validator(
         "/restapis/$(restapi_id)/requestvalidators/$(requestvalidator_id)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4192,7 +4699,10 @@ function update_resource(
     resource_id, restapi_id; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return api_gateway(
-        "PATCH", "/restapis/$(restapi_id)/resources/$(resource_id)"; aws_config=aws_config
+        "PATCH",
+        "/restapis/$(restapi_id)/resources/$(resource_id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_resource(
@@ -4206,6 +4716,7 @@ function update_resource(
         "/restapis/$(restapi_id)/resources/$(resource_id)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4224,14 +4735,25 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   and in the order specified in this list.
 """
 function update_rest_api(restapi_id; aws_config::AbstractAWSConfig=global_aws_config())
-    return api_gateway("PATCH", "/restapis/$(restapi_id)"; aws_config=aws_config)
+    return api_gateway(
+        "PATCH",
+        "/restapis/$(restapi_id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function update_rest_api(
     restapi_id,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return api_gateway("PATCH", "/restapis/$(restapi_id)", params; aws_config=aws_config)
+    return api_gateway(
+        "PATCH",
+        "/restapis/$(restapi_id)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -4253,7 +4775,10 @@ function update_stage(
     restapi_id, stage_name; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return api_gateway(
-        "PATCH", "/restapis/$(restapi_id)/stages/$(stage_name)"; aws_config=aws_config
+        "PATCH",
+        "/restapis/$(restapi_id)/stages/$(stage_name)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_stage(
@@ -4267,6 +4792,7 @@ function update_stage(
         "/restapis/$(restapi_id)/stages/$(stage_name)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4289,7 +4815,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function update_usage(keyId, usageplanId; aws_config::AbstractAWSConfig=global_aws_config())
     return api_gateway(
-        "PATCH", "/usageplans/$(usageplanId)/keys/$(keyId)/usage"; aws_config=aws_config
+        "PATCH",
+        "/usageplans/$(usageplanId)/keys/$(keyId)/usage";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_usage(
@@ -4303,6 +4832,7 @@ function update_usage(
         "/usageplans/$(usageplanId)/keys/$(keyId)/usage",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4321,14 +4851,25 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   and in the order specified in this list.
 """
 function update_usage_plan(usageplanId; aws_config::AbstractAWSConfig=global_aws_config())
-    return api_gateway("PATCH", "/usageplans/$(usageplanId)"; aws_config=aws_config)
+    return api_gateway(
+        "PATCH",
+        "/usageplans/$(usageplanId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function update_usage_plan(
     usageplanId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return api_gateway("PATCH", "/usageplans/$(usageplanId)", params; aws_config=aws_config)
+    return api_gateway(
+        "PATCH",
+        "/usageplans/$(usageplanId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -4347,12 +4888,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   and in the order specified in this list.
 """
 function update_vpc_link(vpclink_id; aws_config::AbstractAWSConfig=global_aws_config())
-    return api_gateway("PATCH", "/vpclinks/$(vpclink_id)"; aws_config=aws_config)
+    return api_gateway(
+        "PATCH",
+        "/vpclinks/$(vpclink_id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function update_vpc_link(
     vpclink_id,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return api_gateway("PATCH", "/vpclinks/$(vpclink_id)", params; aws_config=aws_config)
+    return api_gateway(
+        "PATCH",
+        "/vpclinks/$(vpclink_id)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end

--- a/src/services/apigatewaymanagementapi.jl
+++ b/src/services/apigatewaymanagementapi.jl
@@ -16,7 +16,10 @@ Delete the connection with the provided id.
 """
 function delete_connection(connectionId; aws_config::AbstractAWSConfig=global_aws_config())
     return apigatewaymanagementapi(
-        "DELETE", "/@connections/$(connectionId)"; aws_config=aws_config
+        "DELETE",
+        "/@connections/$(connectionId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_connection(
@@ -25,7 +28,11 @@ function delete_connection(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return apigatewaymanagementapi(
-        "DELETE", "/@connections/$(connectionId)", params; aws_config=aws_config
+        "DELETE",
+        "/@connections/$(connectionId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -41,7 +48,10 @@ Get information about the connection with the provided id.
 """
 function get_connection(connectionId; aws_config::AbstractAWSConfig=global_aws_config())
     return apigatewaymanagementapi(
-        "GET", "/@connections/$(connectionId)"; aws_config=aws_config
+        "GET",
+        "/@connections/$(connectionId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_connection(
@@ -50,7 +60,11 @@ function get_connection(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return apigatewaymanagementapi(
-        "GET", "/@connections/$(connectionId)", params; aws_config=aws_config
+        "GET",
+        "/@connections/$(connectionId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -73,6 +87,7 @@ function post_to_connection(
         "/@connections/$(connectionId)",
         Dict{String,Any}("Data" => Data);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function post_to_connection(
@@ -86,5 +101,6 @@ function post_to_connection(
         "/@connections/$(connectionId)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Data" => Data), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/apigatewayv2.jl
+++ b/src/services/apigatewayv2.jl
@@ -56,6 +56,7 @@ function create_api(name, protocolType; aws_config::AbstractAWSConfig=global_aws
         "/v2/apis",
         Dict{String,Any}("name" => name, "protocolType" => protocolType);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_api(
@@ -75,6 +76,7 @@ function create_api(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -101,6 +103,7 @@ function create_api_mapping(
         "/v2/domainnames/$(domainName)/apimappings",
         Dict{String,Any}("apiId" => apiId, "stage" => stage);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_api_mapping(
@@ -117,6 +120,7 @@ function create_api_mapping(
             mergewith(_merge, Dict{String,Any}("apiId" => apiId, "stage" => stage), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -196,6 +200,7 @@ function create_authorizer(
             "name" => name,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_authorizer(
@@ -221,6 +226,7 @@ function create_authorizer(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -239,13 +245,22 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"stageName"`: The name of the Stage resource for the Deployment resource to create.
 """
 function create_deployment(apiId; aws_config::AbstractAWSConfig=global_aws_config())
-    return apigatewayv2("POST", "/v2/apis/$(apiId)/deployments"; aws_config=aws_config)
+    return apigatewayv2(
+        "POST",
+        "/v2/apis/$(apiId)/deployments";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function create_deployment(
     apiId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return apigatewayv2(
-        "POST", "/v2/apis/$(apiId)/deployments", params; aws_config=aws_config
+        "POST",
+        "/v2/apis/$(apiId)/deployments",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -271,6 +286,7 @@ function create_domain_name(domainName; aws_config::AbstractAWSConfig=global_aws
         "/v2/domainnames",
         Dict{String,Any}("domainName" => domainName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_domain_name(
@@ -285,6 +301,7 @@ function create_domain_name(
             mergewith(_merge, Dict{String,Any}("domainName" => domainName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -403,6 +420,7 @@ function create_integration(
         "/v2/apis/$(apiId)/integrations",
         Dict{String,Any}("integrationType" => integrationType);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_integration(
@@ -420,6 +438,7 @@ function create_integration(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -469,6 +488,7 @@ function create_integration_response(
         "/v2/apis/$(apiId)/integrations/$(integrationId)/integrationresponses",
         Dict{String,Any}("integrationResponseKey" => integrationResponseKey);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_integration_response(
@@ -489,6 +509,7 @@ function create_integration_response(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -517,6 +538,7 @@ function create_model(
         "/v2/apis/$(apiId)/models",
         Dict{String,Any}("name" => name, "schema" => schema);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_model(
@@ -533,6 +555,7 @@ function create_model(
             mergewith(_merge, Dict{String,Any}("name" => name, "schema" => schema), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -575,6 +598,7 @@ function create_route(apiId, routeKey; aws_config::AbstractAWSConfig=global_aws_
         "/v2/apis/$(apiId)/routes",
         Dict{String,Any}("routeKey" => routeKey);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_route(
@@ -590,6 +614,7 @@ function create_route(
             mergewith(_merge, Dict{String,Any}("routeKey" => routeKey), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -619,6 +644,7 @@ function create_route_response(
         "/v2/apis/$(apiId)/routes/$(routeId)/routeresponses",
         Dict{String,Any}("routeResponseKey" => routeResponseKey);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_route_response(
@@ -637,6 +663,7 @@ function create_route_response(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -672,6 +699,7 @@ function create_stage(apiId, stageName; aws_config::AbstractAWSConfig=global_aws
         "/v2/apis/$(apiId)/stages",
         Dict{String,Any}("stageName" => stageName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_stage(
@@ -687,6 +715,7 @@ function create_stage(
             mergewith(_merge, Dict{String,Any}("stageName" => stageName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -711,6 +740,7 @@ function create_vpc_link(name, subnetIds; aws_config::AbstractAWSConfig=global_a
         "/v2/vpclinks",
         Dict{String,Any}("name" => name, "subnetIds" => subnetIds);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_vpc_link(
@@ -728,6 +758,7 @@ function create_vpc_link(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -751,6 +782,7 @@ function delete_access_log_settings(
         "DELETE",
         "/v2/apis/$(apiId)/stages/$(stageName)/accesslogsettings";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_access_log_settings(
@@ -764,6 +796,7 @@ function delete_access_log_settings(
         "/v2/apis/$(apiId)/stages/$(stageName)/accesslogsettings",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -778,12 +811,23 @@ Deletes an Api resource.
 
 """
 function delete_api(apiId; aws_config::AbstractAWSConfig=global_aws_config())
-    return apigatewayv2("DELETE", "/v2/apis/$(apiId)"; aws_config=aws_config)
+    return apigatewayv2(
+        "DELETE",
+        "/v2/apis/$(apiId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_api(
     apiId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return apigatewayv2("DELETE", "/v2/apis/$(apiId)", params; aws_config=aws_config)
+    return apigatewayv2(
+        "DELETE",
+        "/v2/apis/$(apiId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -804,6 +848,7 @@ function delete_api_mapping(
         "DELETE",
         "/v2/domainnames/$(domainName)/apimappings/$(apiMappingId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_api_mapping(
@@ -817,6 +862,7 @@ function delete_api_mapping(
         "/v2/domainnames/$(domainName)/apimappings/$(apiMappingId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -835,7 +881,10 @@ function delete_authorizer(
     apiId, authorizerId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return apigatewayv2(
-        "DELETE", "/v2/apis/$(apiId)/authorizers/$(authorizerId)"; aws_config=aws_config
+        "DELETE",
+        "/v2/apis/$(apiId)/authorizers/$(authorizerId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_authorizer(
@@ -849,6 +898,7 @@ function delete_authorizer(
         "/v2/apis/$(apiId)/authorizers/$(authorizerId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -863,12 +913,23 @@ Deletes a CORS configuration.
 
 """
 function delete_cors_configuration(apiId; aws_config::AbstractAWSConfig=global_aws_config())
-    return apigatewayv2("DELETE", "/v2/apis/$(apiId)/cors"; aws_config=aws_config)
+    return apigatewayv2(
+        "DELETE",
+        "/v2/apis/$(apiId)/cors";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_cors_configuration(
     apiId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return apigatewayv2("DELETE", "/v2/apis/$(apiId)/cors", params; aws_config=aws_config)
+    return apigatewayv2(
+        "DELETE",
+        "/v2/apis/$(apiId)/cors",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -886,7 +947,10 @@ function delete_deployment(
     apiId, deploymentId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return apigatewayv2(
-        "DELETE", "/v2/apis/$(apiId)/deployments/$(deploymentId)"; aws_config=aws_config
+        "DELETE",
+        "/v2/apis/$(apiId)/deployments/$(deploymentId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_deployment(
@@ -900,6 +964,7 @@ function delete_deployment(
         "/v2/apis/$(apiId)/deployments/$(deploymentId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -914,7 +979,12 @@ Deletes a domain name.
 
 """
 function delete_domain_name(domainName; aws_config::AbstractAWSConfig=global_aws_config())
-    return apigatewayv2("DELETE", "/v2/domainnames/$(domainName)"; aws_config=aws_config)
+    return apigatewayv2(
+        "DELETE",
+        "/v2/domainnames/$(domainName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_domain_name(
     domainName,
@@ -922,7 +992,11 @@ function delete_domain_name(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return apigatewayv2(
-        "DELETE", "/v2/domainnames/$(domainName)", params; aws_config=aws_config
+        "DELETE",
+        "/v2/domainnames/$(domainName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -941,7 +1015,10 @@ function delete_integration(
     apiId, integrationId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return apigatewayv2(
-        "DELETE", "/v2/apis/$(apiId)/integrations/$(integrationId)"; aws_config=aws_config
+        "DELETE",
+        "/v2/apis/$(apiId)/integrations/$(integrationId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_integration(
@@ -955,6 +1032,7 @@ function delete_integration(
         "/v2/apis/$(apiId)/integrations/$(integrationId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -980,6 +1058,7 @@ function delete_integration_response(
         "DELETE",
         "/v2/apis/$(apiId)/integrations/$(integrationId)/integrationresponses/$(integrationResponseId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_integration_response(
@@ -994,6 +1073,7 @@ function delete_integration_response(
         "/v2/apis/$(apiId)/integrations/$(integrationId)/integrationresponses/$(integrationResponseId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1010,7 +1090,10 @@ Deletes a Model.
 """
 function delete_model(apiId, modelId; aws_config::AbstractAWSConfig=global_aws_config())
     return apigatewayv2(
-        "DELETE", "/v2/apis/$(apiId)/models/$(modelId)"; aws_config=aws_config
+        "DELETE",
+        "/v2/apis/$(apiId)/models/$(modelId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_model(
@@ -1020,7 +1103,11 @@ function delete_model(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return apigatewayv2(
-        "DELETE", "/v2/apis/$(apiId)/models/$(modelId)", params; aws_config=aws_config
+        "DELETE",
+        "/v2/apis/$(apiId)/models/$(modelId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1037,7 +1124,10 @@ Deletes a Route.
 """
 function delete_route(apiId, routeId; aws_config::AbstractAWSConfig=global_aws_config())
     return apigatewayv2(
-        "DELETE", "/v2/apis/$(apiId)/routes/$(routeId)"; aws_config=aws_config
+        "DELETE",
+        "/v2/apis/$(apiId)/routes/$(routeId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_route(
@@ -1047,7 +1137,11 @@ function delete_route(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return apigatewayv2(
-        "DELETE", "/v2/apis/$(apiId)/routes/$(routeId)", params; aws_config=aws_config
+        "DELETE",
+        "/v2/apis/$(apiId)/routes/$(routeId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1070,6 +1164,7 @@ function delete_route_request_parameter(
         "DELETE",
         "/v2/apis/$(apiId)/routes/$(routeId)/requestparameters/$(requestParameterKey)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_route_request_parameter(
@@ -1084,6 +1179,7 @@ function delete_route_request_parameter(
         "/v2/apis/$(apiId)/routes/$(routeId)/requestparameters/$(requestParameterKey)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1106,6 +1202,7 @@ function delete_route_response(
         "DELETE",
         "/v2/apis/$(apiId)/routes/$(routeId)/routeresponses/$(routeResponseId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_route_response(
@@ -1120,6 +1217,7 @@ function delete_route_response(
         "/v2/apis/$(apiId)/routes/$(routeId)/routeresponses/$(routeResponseId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1143,6 +1241,7 @@ function delete_route_settings(
         "DELETE",
         "/v2/apis/$(apiId)/stages/$(stageName)/routesettings/$(routeKey)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_route_settings(
@@ -1157,6 +1256,7 @@ function delete_route_settings(
         "/v2/apis/$(apiId)/stages/$(stageName)/routesettings/$(routeKey)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1174,7 +1274,10 @@ Deletes a Stage.
 """
 function delete_stage(apiId, stageName; aws_config::AbstractAWSConfig=global_aws_config())
     return apigatewayv2(
-        "DELETE", "/v2/apis/$(apiId)/stages/$(stageName)"; aws_config=aws_config
+        "DELETE",
+        "/v2/apis/$(apiId)/stages/$(stageName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_stage(
@@ -1184,7 +1287,11 @@ function delete_stage(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return apigatewayv2(
-        "DELETE", "/v2/apis/$(apiId)/stages/$(stageName)", params; aws_config=aws_config
+        "DELETE",
+        "/v2/apis/$(apiId)/stages/$(stageName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1199,7 +1306,12 @@ Deletes a VPC link.
 
 """
 function delete_vpc_link(vpcLinkId; aws_config::AbstractAWSConfig=global_aws_config())
-    return apigatewayv2("DELETE", "/v2/vpclinks/$(vpcLinkId)"; aws_config=aws_config)
+    return apigatewayv2(
+        "DELETE",
+        "/v2/vpclinks/$(vpcLinkId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_vpc_link(
     vpcLinkId,
@@ -1207,7 +1319,11 @@ function delete_vpc_link(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return apigatewayv2(
-        "DELETE", "/v2/vpclinks/$(vpcLinkId)", params; aws_config=aws_config
+        "DELETE",
+        "/v2/vpclinks/$(vpcLinkId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1241,6 +1357,7 @@ function export_api(
         "/v2/apis/$(apiId)/exports/$(specification)",
         Dict{String,Any}("outputType" => outputType);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function export_api(
@@ -1257,6 +1374,7 @@ function export_api(
             mergewith(_merge, Dict{String,Any}("outputType" => outputType), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1271,12 +1389,20 @@ Gets an Api resource.
 
 """
 function get_api(apiId; aws_config::AbstractAWSConfig=global_aws_config())
-    return apigatewayv2("GET", "/v2/apis/$(apiId)"; aws_config=aws_config)
+    return apigatewayv2(
+        "GET", "/v2/apis/$(apiId)"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_api(
     apiId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return apigatewayv2("GET", "/v2/apis/$(apiId)", params; aws_config=aws_config)
+    return apigatewayv2(
+        "GET",
+        "/v2/apis/$(apiId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1297,6 +1423,7 @@ function get_api_mapping(
         "GET",
         "/v2/domainnames/$(domainName)/apimappings/$(apiMappingId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_api_mapping(
@@ -1310,6 +1437,7 @@ function get_api_mapping(
         "/v2/domainnames/$(domainName)/apimappings/$(apiMappingId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1330,7 +1458,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function get_api_mappings(domainName; aws_config::AbstractAWSConfig=global_aws_config())
     return apigatewayv2(
-        "GET", "/v2/domainnames/$(domainName)/apimappings"; aws_config=aws_config
+        "GET",
+        "/v2/domainnames/$(domainName)/apimappings";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_api_mappings(
@@ -1339,7 +1470,11 @@ function get_api_mappings(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return apigatewayv2(
-        "GET", "/v2/domainnames/$(domainName)/apimappings", params; aws_config=aws_config
+        "GET",
+        "/v2/domainnames/$(domainName)/apimappings",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1356,12 +1491,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   element of the collection.
 """
 function get_apis(; aws_config::AbstractAWSConfig=global_aws_config())
-    return apigatewayv2("GET", "/v2/apis"; aws_config=aws_config)
+    return apigatewayv2(
+        "GET", "/v2/apis"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_apis(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return apigatewayv2("GET", "/v2/apis", params; aws_config=aws_config)
+    return apigatewayv2(
+        "GET", "/v2/apis", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1379,7 +1518,10 @@ function get_authorizer(
     apiId, authorizerId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return apigatewayv2(
-        "GET", "/v2/apis/$(apiId)/authorizers/$(authorizerId)"; aws_config=aws_config
+        "GET",
+        "/v2/apis/$(apiId)/authorizers/$(authorizerId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_authorizer(
@@ -1393,6 +1535,7 @@ function get_authorizer(
         "/v2/apis/$(apiId)/authorizers/$(authorizerId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1412,13 +1555,22 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   element of the collection.
 """
 function get_authorizers(apiId; aws_config::AbstractAWSConfig=global_aws_config())
-    return apigatewayv2("GET", "/v2/apis/$(apiId)/authorizers"; aws_config=aws_config)
+    return apigatewayv2(
+        "GET",
+        "/v2/apis/$(apiId)/authorizers";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_authorizers(
     apiId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return apigatewayv2(
-        "GET", "/v2/apis/$(apiId)/authorizers", params; aws_config=aws_config
+        "GET",
+        "/v2/apis/$(apiId)/authorizers",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1437,7 +1589,10 @@ function get_deployment(
     apiId, deploymentId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return apigatewayv2(
-        "GET", "/v2/apis/$(apiId)/deployments/$(deploymentId)"; aws_config=aws_config
+        "GET",
+        "/v2/apis/$(apiId)/deployments/$(deploymentId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_deployment(
@@ -1451,6 +1606,7 @@ function get_deployment(
         "/v2/apis/$(apiId)/deployments/$(deploymentId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1470,13 +1626,22 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   element of the collection.
 """
 function get_deployments(apiId; aws_config::AbstractAWSConfig=global_aws_config())
-    return apigatewayv2("GET", "/v2/apis/$(apiId)/deployments"; aws_config=aws_config)
+    return apigatewayv2(
+        "GET",
+        "/v2/apis/$(apiId)/deployments";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_deployments(
     apiId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return apigatewayv2(
-        "GET", "/v2/apis/$(apiId)/deployments", params; aws_config=aws_config
+        "GET",
+        "/v2/apis/$(apiId)/deployments",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1491,7 +1656,12 @@ Gets a domain name.
 
 """
 function get_domain_name(domainName; aws_config::AbstractAWSConfig=global_aws_config())
-    return apigatewayv2("GET", "/v2/domainnames/$(domainName)"; aws_config=aws_config)
+    return apigatewayv2(
+        "GET",
+        "/v2/domainnames/$(domainName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_domain_name(
     domainName,
@@ -1499,7 +1669,11 @@ function get_domain_name(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return apigatewayv2(
-        "GET", "/v2/domainnames/$(domainName)", params; aws_config=aws_config
+        "GET",
+        "/v2/domainnames/$(domainName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1516,12 +1690,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   element of the collection.
 """
 function get_domain_names(; aws_config::AbstractAWSConfig=global_aws_config())
-    return apigatewayv2("GET", "/v2/domainnames"; aws_config=aws_config)
+    return apigatewayv2(
+        "GET", "/v2/domainnames"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_domain_names(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return apigatewayv2("GET", "/v2/domainnames", params; aws_config=aws_config)
+    return apigatewayv2(
+        "GET",
+        "/v2/domainnames",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1539,7 +1721,10 @@ function get_integration(
     apiId, integrationId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return apigatewayv2(
-        "GET", "/v2/apis/$(apiId)/integrations/$(integrationId)"; aws_config=aws_config
+        "GET",
+        "/v2/apis/$(apiId)/integrations/$(integrationId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_integration(
@@ -1553,6 +1738,7 @@ function get_integration(
         "/v2/apis/$(apiId)/integrations/$(integrationId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1578,6 +1764,7 @@ function get_integration_response(
         "GET",
         "/v2/apis/$(apiId)/integrations/$(integrationId)/integrationresponses/$(integrationResponseId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_integration_response(
@@ -1592,6 +1779,7 @@ function get_integration_response(
         "/v2/apis/$(apiId)/integrations/$(integrationId)/integrationresponses/$(integrationResponseId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1618,6 +1806,7 @@ function get_integration_responses(
         "GET",
         "/v2/apis/$(apiId)/integrations/$(integrationId)/integrationresponses";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_integration_responses(
@@ -1631,6 +1820,7 @@ function get_integration_responses(
         "/v2/apis/$(apiId)/integrations/$(integrationId)/integrationresponses",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1650,13 +1840,22 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   element of the collection.
 """
 function get_integrations(apiId; aws_config::AbstractAWSConfig=global_aws_config())
-    return apigatewayv2("GET", "/v2/apis/$(apiId)/integrations"; aws_config=aws_config)
+    return apigatewayv2(
+        "GET",
+        "/v2/apis/$(apiId)/integrations";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_integrations(
     apiId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return apigatewayv2(
-        "GET", "/v2/apis/$(apiId)/integrations", params; aws_config=aws_config
+        "GET",
+        "/v2/apis/$(apiId)/integrations",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1672,7 +1871,12 @@ Gets a Model.
 
 """
 function get_model(apiId, modelId; aws_config::AbstractAWSConfig=global_aws_config())
-    return apigatewayv2("GET", "/v2/apis/$(apiId)/models/$(modelId)"; aws_config=aws_config)
+    return apigatewayv2(
+        "GET",
+        "/v2/apis/$(apiId)/models/$(modelId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_model(
     apiId,
@@ -1681,7 +1885,11 @@ function get_model(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return apigatewayv2(
-        "GET", "/v2/apis/$(apiId)/models/$(modelId)", params; aws_config=aws_config
+        "GET",
+        "/v2/apis/$(apiId)/models/$(modelId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1700,7 +1908,10 @@ function get_model_template(
     apiId, modelId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return apigatewayv2(
-        "GET", "/v2/apis/$(apiId)/models/$(modelId)/template"; aws_config=aws_config
+        "GET",
+        "/v2/apis/$(apiId)/models/$(modelId)/template";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_model_template(
@@ -1710,7 +1921,11 @@ function get_model_template(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return apigatewayv2(
-        "GET", "/v2/apis/$(apiId)/models/$(modelId)/template", params; aws_config=aws_config
+        "GET",
+        "/v2/apis/$(apiId)/models/$(modelId)/template",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1730,12 +1945,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   element of the collection.
 """
 function get_models(apiId; aws_config::AbstractAWSConfig=global_aws_config())
-    return apigatewayv2("GET", "/v2/apis/$(apiId)/models"; aws_config=aws_config)
+    return apigatewayv2(
+        "GET",
+        "/v2/apis/$(apiId)/models";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_models(
     apiId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return apigatewayv2("GET", "/v2/apis/$(apiId)/models", params; aws_config=aws_config)
+    return apigatewayv2(
+        "GET",
+        "/v2/apis/$(apiId)/models",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1750,7 +1976,12 @@ Gets a Route.
 
 """
 function get_route(apiId, routeId; aws_config::AbstractAWSConfig=global_aws_config())
-    return apigatewayv2("GET", "/v2/apis/$(apiId)/routes/$(routeId)"; aws_config=aws_config)
+    return apigatewayv2(
+        "GET",
+        "/v2/apis/$(apiId)/routes/$(routeId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_route(
     apiId,
@@ -1759,7 +1990,11 @@ function get_route(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return apigatewayv2(
-        "GET", "/v2/apis/$(apiId)/routes/$(routeId)", params; aws_config=aws_config
+        "GET",
+        "/v2/apis/$(apiId)/routes/$(routeId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1782,6 +2017,7 @@ function get_route_response(
         "GET",
         "/v2/apis/$(apiId)/routes/$(routeId)/routeresponses/$(routeResponseId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_route_response(
@@ -1796,6 +2032,7 @@ function get_route_response(
         "/v2/apis/$(apiId)/routes/$(routeId)/routeresponses/$(routeResponseId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1819,7 +2056,10 @@ function get_route_responses(
     apiId, routeId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return apigatewayv2(
-        "GET", "/v2/apis/$(apiId)/routes/$(routeId)/routeresponses"; aws_config=aws_config
+        "GET",
+        "/v2/apis/$(apiId)/routes/$(routeId)/routeresponses";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_route_responses(
@@ -1833,6 +2073,7 @@ function get_route_responses(
         "/v2/apis/$(apiId)/routes/$(routeId)/routeresponses",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1852,12 +2093,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   element of the collection.
 """
 function get_routes(apiId; aws_config::AbstractAWSConfig=global_aws_config())
-    return apigatewayv2("GET", "/v2/apis/$(apiId)/routes"; aws_config=aws_config)
+    return apigatewayv2(
+        "GET",
+        "/v2/apis/$(apiId)/routes";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_routes(
     apiId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return apigatewayv2("GET", "/v2/apis/$(apiId)/routes", params; aws_config=aws_config)
+    return apigatewayv2(
+        "GET",
+        "/v2/apis/$(apiId)/routes",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1874,7 +2126,10 @@ Gets a Stage.
 """
 function get_stage(apiId, stageName; aws_config::AbstractAWSConfig=global_aws_config())
     return apigatewayv2(
-        "GET", "/v2/apis/$(apiId)/stages/$(stageName)"; aws_config=aws_config
+        "GET",
+        "/v2/apis/$(apiId)/stages/$(stageName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_stage(
@@ -1884,7 +2139,11 @@ function get_stage(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return apigatewayv2(
-        "GET", "/v2/apis/$(apiId)/stages/$(stageName)", params; aws_config=aws_config
+        "GET",
+        "/v2/apis/$(apiId)/stages/$(stageName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1904,12 +2163,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   element of the collection.
 """
 function get_stages(apiId; aws_config::AbstractAWSConfig=global_aws_config())
-    return apigatewayv2("GET", "/v2/apis/$(apiId)/stages"; aws_config=aws_config)
+    return apigatewayv2(
+        "GET",
+        "/v2/apis/$(apiId)/stages";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_stages(
     apiId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return apigatewayv2("GET", "/v2/apis/$(apiId)/stages", params; aws_config=aws_config)
+    return apigatewayv2(
+        "GET",
+        "/v2/apis/$(apiId)/stages",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1923,14 +2193,25 @@ Gets a collection of Tag resources.
 
 """
 function get_tags(resource_arn; aws_config::AbstractAWSConfig=global_aws_config())
-    return apigatewayv2("GET", "/v2/tags/$(resource-arn)"; aws_config=aws_config)
+    return apigatewayv2(
+        "GET",
+        "/v2/tags/$(resource-arn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_tags(
     resource_arn,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return apigatewayv2("GET", "/v2/tags/$(resource-arn)", params; aws_config=aws_config)
+    return apigatewayv2(
+        "GET",
+        "/v2/tags/$(resource-arn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1944,14 +2225,25 @@ Gets a VPC link.
 
 """
 function get_vpc_link(vpcLinkId; aws_config::AbstractAWSConfig=global_aws_config())
-    return apigatewayv2("GET", "/v2/vpclinks/$(vpcLinkId)"; aws_config=aws_config)
+    return apigatewayv2(
+        "GET",
+        "/v2/vpclinks/$(vpcLinkId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_vpc_link(
     vpcLinkId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return apigatewayv2("GET", "/v2/vpclinks/$(vpcLinkId)", params; aws_config=aws_config)
+    return apigatewayv2(
+        "GET",
+        "/v2/vpclinks/$(vpcLinkId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1967,12 +2259,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   element of the collection.
 """
 function get_vpc_links(; aws_config::AbstractAWSConfig=global_aws_config())
-    return apigatewayv2("GET", "/v2/vpclinks"; aws_config=aws_config)
+    return apigatewayv2(
+        "GET", "/v2/vpclinks"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_vpc_links(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return apigatewayv2("GET", "/v2/vpclinks", params; aws_config=aws_config)
+    return apigatewayv2(
+        "GET",
+        "/v2/vpclinks",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1994,7 +2294,11 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function import_api(body; aws_config::AbstractAWSConfig=global_aws_config())
     return apigatewayv2(
-        "PUT", "/v2/apis", Dict{String,Any}("body" => body); aws_config=aws_config
+        "PUT",
+        "/v2/apis",
+        Dict{String,Any}("body" => body);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function import_api(
@@ -2005,6 +2309,7 @@ function import_api(
         "/v2/apis",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("body" => body), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2028,7 +2333,11 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function reimport_api(apiId, body; aws_config::AbstractAWSConfig=global_aws_config())
     return apigatewayv2(
-        "PUT", "/v2/apis/$(apiId)", Dict{String,Any}("body" => body); aws_config=aws_config
+        "PUT",
+        "/v2/apis/$(apiId)",
+        Dict{String,Any}("body" => body);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function reimport_api(
@@ -2042,6 +2351,7 @@ function reimport_api(
         "/v2/apis/$(apiId)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("body" => body), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2064,6 +2374,7 @@ function reset_authorizers_cache(
         "DELETE",
         "/v2/apis/$(apiId)/stages/$(stageName)/cache/authorizers";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function reset_authorizers_cache(
@@ -2077,6 +2388,7 @@ function reset_authorizers_cache(
         "/v2/apis/$(apiId)/stages/$(stageName)/cache/authorizers",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2094,14 +2406,25 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"tags"`: The collection of tags. Each tag element is associated with a given resource.
 """
 function tag_resource(resource_arn; aws_config::AbstractAWSConfig=global_aws_config())
-    return apigatewayv2("POST", "/v2/tags/$(resource-arn)"; aws_config=aws_config)
+    return apigatewayv2(
+        "POST",
+        "/v2/tags/$(resource-arn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function tag_resource(
     resource_arn,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return apigatewayv2("POST", "/v2/tags/$(resource-arn)", params; aws_config=aws_config)
+    return apigatewayv2(
+        "POST",
+        "/v2/tags/$(resource-arn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2123,6 +2446,7 @@ function untag_resource(
         "/v2/tags/$(resource-arn)",
         Dict{String,Any}("tagKeys" => tagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -2136,6 +2460,7 @@ function untag_resource(
         "/v2/tags/$(resource-arn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tagKeys" => tagKeys), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2184,12 +2509,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"version"`: A version identifier for the API.
 """
 function update_api(apiId; aws_config::AbstractAWSConfig=global_aws_config())
-    return apigatewayv2("PATCH", "/v2/apis/$(apiId)"; aws_config=aws_config)
+    return apigatewayv2(
+        "PATCH", "/v2/apis/$(apiId)"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function update_api(
     apiId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return apigatewayv2("PATCH", "/v2/apis/$(apiId)", params; aws_config=aws_config)
+    return apigatewayv2(
+        "PATCH",
+        "/v2/apis/$(apiId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2216,6 +2549,7 @@ function update_api_mapping(
         "/v2/domainnames/$(domainName)/apimappings/$(apiMappingId)",
         Dict{String,Any}("apiId" => apiId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_api_mapping(
@@ -2230,6 +2564,7 @@ function update_api_mapping(
         "/v2/domainnames/$(domainName)/apimappings/$(apiMappingId)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("apiId" => apiId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2298,7 +2633,10 @@ function update_authorizer(
     apiId, authorizerId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return apigatewayv2(
-        "PATCH", "/v2/apis/$(apiId)/authorizers/$(authorizerId)"; aws_config=aws_config
+        "PATCH",
+        "/v2/apis/$(apiId)/authorizers/$(authorizerId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_authorizer(
@@ -2312,6 +2650,7 @@ function update_authorizer(
         "/v2/apis/$(apiId)/authorizers/$(authorizerId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2333,7 +2672,10 @@ function update_deployment(
     apiId, deploymentId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return apigatewayv2(
-        "PATCH", "/v2/apis/$(apiId)/deployments/$(deploymentId)"; aws_config=aws_config
+        "PATCH",
+        "/v2/apis/$(apiId)/deployments/$(deploymentId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_deployment(
@@ -2347,6 +2689,7 @@ function update_deployment(
         "/v2/apis/$(apiId)/deployments/$(deploymentId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2366,7 +2709,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   domain name.
 """
 function update_domain_name(domainName; aws_config::AbstractAWSConfig=global_aws_config())
-    return apigatewayv2("PATCH", "/v2/domainnames/$(domainName)"; aws_config=aws_config)
+    return apigatewayv2(
+        "PATCH",
+        "/v2/domainnames/$(domainName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function update_domain_name(
     domainName,
@@ -2374,7 +2722,11 @@ function update_domain_name(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return apigatewayv2(
-        "PATCH", "/v2/domainnames/$(domainName)", params; aws_config=aws_config
+        "PATCH",
+        "/v2/domainnames/$(domainName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2489,7 +2841,10 @@ function update_integration(
     apiId, integrationId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return apigatewayv2(
-        "PATCH", "/v2/apis/$(apiId)/integrations/$(integrationId)"; aws_config=aws_config
+        "PATCH",
+        "/v2/apis/$(apiId)/integrations/$(integrationId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_integration(
@@ -2503,6 +2858,7 @@ function update_integration(
         "/v2/apis/$(apiId)/integrations/$(integrationId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2558,6 +2914,7 @@ function update_integration_response(
         "PATCH",
         "/v2/apis/$(apiId)/integrations/$(integrationId)/integrationresponses/$(integrationResponseId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_integration_response(
@@ -2572,6 +2929,7 @@ function update_integration_response(
         "/v2/apis/$(apiId)/integrations/$(integrationId)/integrationresponses/$(integrationResponseId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2595,7 +2953,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function update_model(apiId, modelId; aws_config::AbstractAWSConfig=global_aws_config())
     return apigatewayv2(
-        "PATCH", "/v2/apis/$(apiId)/models/$(modelId)"; aws_config=aws_config
+        "PATCH",
+        "/v2/apis/$(apiId)/models/$(modelId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_model(
@@ -2605,7 +2966,11 @@ function update_model(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return apigatewayv2(
-        "PATCH", "/v2/apis/$(apiId)/models/$(modelId)", params; aws_config=aws_config
+        "PATCH",
+        "/v2/apis/$(apiId)/models/$(modelId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2645,7 +3010,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function update_route(apiId, routeId; aws_config::AbstractAWSConfig=global_aws_config())
     return apigatewayv2(
-        "PATCH", "/v2/apis/$(apiId)/routes/$(routeId)"; aws_config=aws_config
+        "PATCH",
+        "/v2/apis/$(apiId)/routes/$(routeId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_route(
@@ -2655,7 +3023,11 @@ function update_route(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return apigatewayv2(
-        "PATCH", "/v2/apis/$(apiId)/routes/$(routeId)", params; aws_config=aws_config
+        "PATCH",
+        "/v2/apis/$(apiId)/routes/$(routeId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2685,6 +3057,7 @@ function update_route_response(
         "PATCH",
         "/v2/apis/$(apiId)/routes/$(routeId)/routeresponses/$(routeResponseId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_route_response(
@@ -2699,6 +3072,7 @@ function update_route_response(
         "/v2/apis/$(apiId)/routes/$(routeId)/routeresponses/$(routeResponseId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2730,7 +3104,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function update_stage(apiId, stageName; aws_config::AbstractAWSConfig=global_aws_config())
     return apigatewayv2(
-        "PATCH", "/v2/apis/$(apiId)/stages/$(stageName)"; aws_config=aws_config
+        "PATCH",
+        "/v2/apis/$(apiId)/stages/$(stageName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_stage(
@@ -2740,7 +3117,11 @@ function update_stage(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return apigatewayv2(
-        "PATCH", "/v2/apis/$(apiId)/stages/$(stageName)", params; aws_config=aws_config
+        "PATCH",
+        "/v2/apis/$(apiId)/stages/$(stageName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2758,12 +3139,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"name"`: The name of the VPC link.
 """
 function update_vpc_link(vpcLinkId; aws_config::AbstractAWSConfig=global_aws_config())
-    return apigatewayv2("PATCH", "/v2/vpclinks/$(vpcLinkId)"; aws_config=aws_config)
+    return apigatewayv2(
+        "PATCH",
+        "/v2/vpclinks/$(vpcLinkId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function update_vpc_link(
     vpcLinkId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return apigatewayv2("PATCH", "/v2/vpclinks/$(vpcLinkId)", params; aws_config=aws_config)
+    return apigatewayv2(
+        "PATCH",
+        "/v2/vpclinks/$(vpcLinkId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end

--- a/src/services/app_mesh.jl
+++ b/src/services/app_mesh.jl
@@ -50,6 +50,7 @@ function create_gateway_route(
             "clientToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_gateway_route(
@@ -75,6 +76,7 @@ function create_gateway_route(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -107,6 +109,7 @@ function create_mesh(meshName; aws_config::AbstractAWSConfig=global_aws_config()
         "/v20190125/meshes",
         Dict{String,Any}("meshName" => meshName, "clientToken" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_mesh(
@@ -125,6 +128,7 @@ function create_mesh(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -171,6 +175,7 @@ function create_route(
             "routeName" => routeName, "spec" => spec, "clientToken" => string(uuid4())
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_route(
@@ -196,6 +201,7 @@ function create_route(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -240,6 +246,7 @@ function create_virtual_gateway(
             "clientToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_virtual_gateway(
@@ -264,6 +271,7 @@ function create_virtual_gateway(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -319,6 +327,7 @@ function create_virtual_node(
             "clientToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_virtual_node(
@@ -343,6 +352,7 @@ function create_virtual_node(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -387,6 +397,7 @@ function create_virtual_router(
             "clientToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_virtual_router(
@@ -411,6 +422,7 @@ function create_virtual_router(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -455,6 +467,7 @@ function create_virtual_service(
             "clientToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_virtual_service(
@@ -479,6 +492,7 @@ function create_virtual_service(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -509,6 +523,7 @@ function delete_gateway_route(
         "DELETE",
         "/v20190125/meshes/$(meshName)/virtualGateway/$(virtualGatewayName)/gatewayRoutes/$(gatewayRouteName)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_gateway_route(
@@ -523,6 +538,7 @@ function delete_gateway_route(
         "/v20190125/meshes/$(meshName)/virtualGateway/$(virtualGatewayName)/gatewayRoutes/$(gatewayRouteName)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -539,7 +555,12 @@ itself.
 
 """
 function delete_mesh(meshName; aws_config::AbstractAWSConfig=global_aws_config())
-    return app_mesh("DELETE", "/v20190125/meshes/$(meshName)"; aws_config=aws_config)
+    return app_mesh(
+        "DELETE",
+        "/v20190125/meshes/$(meshName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_mesh(
     meshName,
@@ -547,7 +568,11 @@ function delete_mesh(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return app_mesh(
-        "DELETE", "/v20190125/meshes/$(meshName)", params; aws_config=aws_config
+        "DELETE",
+        "/v20190125/meshes/$(meshName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -578,6 +603,7 @@ function delete_route(
         "DELETE",
         "/v20190125/meshes/$(meshName)/virtualRouter/$(virtualRouterName)/routes/$(routeName)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_route(
@@ -592,6 +618,7 @@ function delete_route(
         "/v20190125/meshes/$(meshName)/virtualRouter/$(virtualRouterName)/routes/$(routeName)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -619,6 +646,7 @@ function delete_virtual_gateway(
         "DELETE",
         "/v20190125/meshes/$(meshName)/virtualGateways/$(virtualGatewayName)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_virtual_gateway(
@@ -632,6 +660,7 @@ function delete_virtual_gateway(
         "/v20190125/meshes/$(meshName)/virtualGateways/$(virtualGatewayName)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -659,6 +688,7 @@ function delete_virtual_node(
         "DELETE",
         "/v20190125/meshes/$(meshName)/virtualNodes/$(virtualNodeName)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_virtual_node(
@@ -672,6 +702,7 @@ function delete_virtual_node(
         "/v20190125/meshes/$(meshName)/virtualNodes/$(virtualNodeName)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -699,6 +730,7 @@ function delete_virtual_router(
         "DELETE",
         "/v20190125/meshes/$(meshName)/virtualRouters/$(virtualRouterName)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_virtual_router(
@@ -712,6 +744,7 @@ function delete_virtual_router(
         "/v20190125/meshes/$(meshName)/virtualRouters/$(virtualRouterName)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -738,6 +771,7 @@ function delete_virtual_service(
         "DELETE",
         "/v20190125/meshes/$(meshName)/virtualServices/$(virtualServiceName)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_virtual_service(
@@ -751,6 +785,7 @@ function delete_virtual_service(
         "/v20190125/meshes/$(meshName)/virtualServices/$(virtualServiceName)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -782,6 +817,7 @@ function describe_gateway_route(
         "GET",
         "/v20190125/meshes/$(meshName)/virtualGateway/$(virtualGatewayName)/gatewayRoutes/$(gatewayRouteName)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_gateway_route(
@@ -796,6 +832,7 @@ function describe_gateway_route(
         "/v20190125/meshes/$(meshName)/virtualGateway/$(virtualGatewayName)/gatewayRoutes/$(gatewayRouteName)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -815,14 +852,25 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   information about mesh sharing, see Working with shared meshes.
 """
 function describe_mesh(meshName; aws_config::AbstractAWSConfig=global_aws_config())
-    return app_mesh("GET", "/v20190125/meshes/$(meshName)"; aws_config=aws_config)
+    return app_mesh(
+        "GET",
+        "/v20190125/meshes/$(meshName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_mesh(
     meshName,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return app_mesh("GET", "/v20190125/meshes/$(meshName)", params; aws_config=aws_config)
+    return app_mesh(
+        "GET",
+        "/v20190125/meshes/$(meshName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -852,6 +900,7 @@ function describe_route(
         "GET",
         "/v20190125/meshes/$(meshName)/virtualRouter/$(virtualRouterName)/routes/$(routeName)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_route(
@@ -866,6 +915,7 @@ function describe_route(
         "/v20190125/meshes/$(meshName)/virtualRouter/$(virtualRouterName)/routes/$(routeName)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -892,6 +942,7 @@ function describe_virtual_gateway(
         "GET",
         "/v20190125/meshes/$(meshName)/virtualGateways/$(virtualGatewayName)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_virtual_gateway(
@@ -905,6 +956,7 @@ function describe_virtual_gateway(
         "/v20190125/meshes/$(meshName)/virtualGateways/$(virtualGatewayName)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -931,6 +983,7 @@ function describe_virtual_node(
         "GET",
         "/v20190125/meshes/$(meshName)/virtualNodes/$(virtualNodeName)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_virtual_node(
@@ -944,6 +997,7 @@ function describe_virtual_node(
         "/v20190125/meshes/$(meshName)/virtualNodes/$(virtualNodeName)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -970,6 +1024,7 @@ function describe_virtual_router(
         "GET",
         "/v20190125/meshes/$(meshName)/virtualRouters/$(virtualRouterName)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_virtual_router(
@@ -983,6 +1038,7 @@ function describe_virtual_router(
         "/v20190125/meshes/$(meshName)/virtualRouters/$(virtualRouterName)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1009,6 +1065,7 @@ function describe_virtual_service(
         "GET",
         "/v20190125/meshes/$(meshName)/virtualServices/$(virtualServiceName)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_virtual_service(
@@ -1022,6 +1079,7 @@ function describe_virtual_service(
         "/v20190125/meshes/$(meshName)/virtualServices/$(virtualServiceName)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1057,6 +1115,7 @@ function list_gateway_routes(
         "GET",
         "/v20190125/meshes/$(meshName)/virtualGateway/$(virtualGatewayName)/gatewayRoutes";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_gateway_routes(
@@ -1070,6 +1129,7 @@ function list_gateway_routes(
         "/v20190125/meshes/$(meshName)/virtualGateway/$(virtualGatewayName)/gatewayRoutes",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1094,12 +1154,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   items in a list and not for other programmatic purposes.
 """
 function list_meshes(; aws_config::AbstractAWSConfig=global_aws_config())
-    return app_mesh("GET", "/v20190125/meshes"; aws_config=aws_config)
+    return app_mesh(
+        "GET", "/v20190125/meshes"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_meshes(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return app_mesh("GET", "/v20190125/meshes", params; aws_config=aws_config)
+    return app_mesh(
+        "GET",
+        "/v20190125/meshes",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1134,6 +1202,7 @@ function list_routes(
         "GET",
         "/v20190125/meshes/$(meshName)/virtualRouter/$(virtualRouterName)/routes";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_routes(
@@ -1147,6 +1216,7 @@ function list_routes(
         "/v20190125/meshes/$(meshName)/virtualRouter/$(virtualRouterName)/routes",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1180,6 +1250,7 @@ function list_tags_for_resource(
         "/v20190125/tags",
         Dict{String,Any}("resourceArn" => resourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags_for_resource(
@@ -1194,6 +1265,7 @@ function list_tags_for_resource(
             mergewith(_merge, Dict{String,Any}("resourceArn" => resourceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1223,7 +1295,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function list_virtual_gateways(meshName; aws_config::AbstractAWSConfig=global_aws_config())
     return app_mesh(
-        "GET", "/v20190125/meshes/$(meshName)/virtualGateways"; aws_config=aws_config
+        "GET",
+        "/v20190125/meshes/$(meshName)/virtualGateways";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_virtual_gateways(
@@ -1236,6 +1311,7 @@ function list_virtual_gateways(
         "/v20190125/meshes/$(meshName)/virtualGateways",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1265,7 +1341,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function list_virtual_nodes(meshName; aws_config::AbstractAWSConfig=global_aws_config())
     return app_mesh(
-        "GET", "/v20190125/meshes/$(meshName)/virtualNodes"; aws_config=aws_config
+        "GET",
+        "/v20190125/meshes/$(meshName)/virtualNodes";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_virtual_nodes(
@@ -1274,7 +1353,11 @@ function list_virtual_nodes(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return app_mesh(
-        "GET", "/v20190125/meshes/$(meshName)/virtualNodes", params; aws_config=aws_config
+        "GET",
+        "/v20190125/meshes/$(meshName)/virtualNodes",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1304,7 +1387,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function list_virtual_routers(meshName; aws_config::AbstractAWSConfig=global_aws_config())
     return app_mesh(
-        "GET", "/v20190125/meshes/$(meshName)/virtualRouters"; aws_config=aws_config
+        "GET",
+        "/v20190125/meshes/$(meshName)/virtualRouters";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_virtual_routers(
@@ -1313,7 +1399,11 @@ function list_virtual_routers(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return app_mesh(
-        "GET", "/v20190125/meshes/$(meshName)/virtualRouters", params; aws_config=aws_config
+        "GET",
+        "/v20190125/meshes/$(meshName)/virtualRouters",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1343,7 +1433,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function list_virtual_services(meshName; aws_config::AbstractAWSConfig=global_aws_config())
     return app_mesh(
-        "GET", "/v20190125/meshes/$(meshName)/virtualServices"; aws_config=aws_config
+        "GET",
+        "/v20190125/meshes/$(meshName)/virtualServices";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_virtual_services(
@@ -1356,6 +1449,7 @@ function list_virtual_services(
         "/v20190125/meshes/$(meshName)/virtualServices",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1380,6 +1474,7 @@ function tag_resource(resourceArn, tags; aws_config::AbstractAWSConfig=global_aw
         "/v20190125/tag",
         Dict{String,Any}("resourceArn" => resourceArn, "tags" => tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -1399,6 +1494,7 @@ function tag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1421,6 +1517,7 @@ function untag_resource(
         "/v20190125/untag",
         Dict{String,Any}("resourceArn" => resourceArn, "tagKeys" => tagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -1440,6 +1537,7 @@ function untag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1477,6 +1575,7 @@ function update_gateway_route(
         "/v20190125/meshes/$(meshName)/virtualGateway/$(virtualGatewayName)/gatewayRoutes/$(gatewayRouteName)",
         Dict{String,Any}("spec" => spec, "clientToken" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_gateway_route(
@@ -1498,6 +1597,7 @@ function update_gateway_route(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1522,6 +1622,7 @@ function update_mesh(meshName; aws_config::AbstractAWSConfig=global_aws_config()
         "/v20190125/meshes/$(meshName)",
         Dict{String,Any}("clientToken" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_mesh(
@@ -1536,6 +1637,7 @@ function update_mesh(
             mergewith(_merge, Dict{String,Any}("clientToken" => string(uuid4())), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1571,6 +1673,7 @@ function update_route(
         "/v20190125/meshes/$(meshName)/virtualRouter/$(virtualRouterName)/routes/$(routeName)",
         Dict{String,Any}("spec" => spec, "clientToken" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_route(
@@ -1592,6 +1695,7 @@ function update_route(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1622,6 +1726,7 @@ function update_virtual_gateway(
         "/v20190125/meshes/$(meshName)/virtualGateways/$(virtualGatewayName)",
         Dict{String,Any}("spec" => spec, "clientToken" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_virtual_gateway(
@@ -1642,6 +1747,7 @@ function update_virtual_gateway(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1672,6 +1778,7 @@ function update_virtual_node(
         "/v20190125/meshes/$(meshName)/virtualNodes/$(virtualNodeName)",
         Dict{String,Any}("spec" => spec, "clientToken" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_virtual_node(
@@ -1692,6 +1799,7 @@ function update_virtual_node(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1722,6 +1830,7 @@ function update_virtual_router(
         "/v20190125/meshes/$(meshName)/virtualRouters/$(virtualRouterName)",
         Dict{String,Any}("spec" => spec, "clientToken" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_virtual_router(
@@ -1742,6 +1851,7 @@ function update_virtual_router(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1772,6 +1882,7 @@ function update_virtual_service(
         "/v20190125/meshes/$(meshName)/virtualServices/$(virtualServiceName)",
         Dict{String,Any}("spec" => spec, "clientToken" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_virtual_service(
@@ -1792,5 +1903,6 @@ function update_virtual_service(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/appconfig.jl
+++ b/src/services/appconfig.jl
@@ -25,7 +25,11 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function create_application(Name; aws_config::AbstractAWSConfig=global_aws_config())
     return appconfig(
-        "POST", "/applications", Dict{String,Any}("Name" => Name); aws_config=aws_config
+        "POST",
+        "/applications",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_application(
@@ -36,6 +40,7 @@ function create_application(
         "/applications",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -82,6 +87,7 @@ function create_configuration_profile(
         "/applications/$(ApplicationId)/configurationprofiles",
         Dict{String,Any}("LocationUri" => LocationUri, "Name" => Name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_configuration_profile(
@@ -102,6 +108,7 @@ function create_configuration_profile(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -161,6 +168,7 @@ function create_deployment_strategy(
             "ReplicateTo" => ReplicateTo,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_deployment_strategy(
@@ -187,6 +195,7 @@ function create_deployment_strategy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -221,6 +230,7 @@ function create_environment(
         "/applications/$(ApplicationId)/environments",
         Dict{String,Any}("Name" => Name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_environment(
@@ -234,6 +244,7 @@ function create_environment(
         "/applications/$(ApplicationId)/environments",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -273,6 +284,7 @@ function create_hosted_configuration_version(
             "headers" => Dict{String,Any}("Content-Type" => Content_Type),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_hosted_configuration_version(
@@ -297,6 +309,7 @@ function create_hosted_configuration_version(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -313,7 +326,12 @@ Delete an application. Deleting an application does not delete a configuration f
 function delete_application(
     ApplicationId; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return appconfig("DELETE", "/applications/$(ApplicationId)"; aws_config=aws_config)
+    return appconfig(
+        "DELETE",
+        "/applications/$(ApplicationId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_application(
     ApplicationId,
@@ -321,7 +339,11 @@ function delete_application(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return appconfig(
-        "DELETE", "/applications/$(ApplicationId)", params; aws_config=aws_config
+        "DELETE",
+        "/applications/$(ApplicationId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -345,6 +367,7 @@ function delete_configuration_profile(
         "DELETE",
         "/applications/$(ApplicationId)/configurationprofiles/$(ConfigurationProfileId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_configuration_profile(
@@ -358,6 +381,7 @@ function delete_configuration_profile(
         "/applications/$(ApplicationId)/configurationprofiles/$(ConfigurationProfileId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -376,7 +400,10 @@ function delete_deployment_strategy(
     DeploymentStrategyId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return appconfig(
-        "DELETE", "/deployementstrategies/$(DeploymentStrategyId)"; aws_config=aws_config
+        "DELETE",
+        "/deployementstrategies/$(DeploymentStrategyId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_deployment_strategy(
@@ -389,6 +416,7 @@ function delete_deployment_strategy(
         "/deployementstrategies/$(DeploymentStrategyId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -410,6 +438,7 @@ function delete_environment(
         "DELETE",
         "/applications/$(ApplicationId)/environments/$(EnvironmentId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_environment(
@@ -423,6 +452,7 @@ function delete_environment(
         "/applications/$(ApplicationId)/environments/$(EnvironmentId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -448,6 +478,7 @@ function delete_hosted_configuration_version(
         "DELETE",
         "/applications/$(ApplicationId)/configurationprofiles/$(ConfigurationProfileId)/hostedconfigurationversions/$(VersionNumber)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_hosted_configuration_version(
@@ -462,6 +493,7 @@ function delete_hosted_configuration_version(
         "/applications/$(ApplicationId)/configurationprofiles/$(ConfigurationProfileId)/hostedconfigurationversions/$(VersionNumber)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -476,14 +508,25 @@ Retrieve information about an application.
 
 """
 function get_application(ApplicationId; aws_config::AbstractAWSConfig=global_aws_config())
-    return appconfig("GET", "/applications/$(ApplicationId)"; aws_config=aws_config)
+    return appconfig(
+        "GET",
+        "/applications/$(ApplicationId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_application(
     ApplicationId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return appconfig("GET", "/applications/$(ApplicationId)", params; aws_config=aws_config)
+    return appconfig(
+        "GET",
+        "/applications/$(ApplicationId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -534,6 +577,7 @@ function get_configuration(
         "/applications/$(Application)/environments/$(Environment)/configurations/$(Configuration)",
         Dict{String,Any}("client_id" => client_id);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_configuration(
@@ -551,6 +595,7 @@ function get_configuration(
             mergewith(_merge, Dict{String,Any}("client_id" => client_id), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -573,6 +618,7 @@ function get_configuration_profile(
         "GET",
         "/applications/$(ApplicationId)/configurationprofiles/$(ConfigurationProfileId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_configuration_profile(
@@ -586,6 +632,7 @@ function get_configuration_profile(
         "/applications/$(ApplicationId)/configurationprofiles/$(ConfigurationProfileId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -611,6 +658,7 @@ function get_deployment(
         "GET",
         "/applications/$(ApplicationId)/environments/$(EnvironmentId)/deployments/$(DeploymentNumber)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_deployment(
@@ -625,6 +673,7 @@ function get_deployment(
         "/applications/$(ApplicationId)/environments/$(EnvironmentId)/deployments/$(DeploymentNumber)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -646,7 +695,10 @@ function get_deployment_strategy(
     DeploymentStrategyId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return appconfig(
-        "GET", "/deploymentstrategies/$(DeploymentStrategyId)"; aws_config=aws_config
+        "GET",
+        "/deploymentstrategies/$(DeploymentStrategyId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_deployment_strategy(
@@ -659,6 +711,7 @@ function get_deployment_strategy(
         "/deploymentstrategies/$(DeploymentStrategyId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -684,6 +737,7 @@ function get_environment(
         "GET",
         "/applications/$(ApplicationId)/environments/$(EnvironmentId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_environment(
@@ -697,6 +751,7 @@ function get_environment(
         "/applications/$(ApplicationId)/environments/$(EnvironmentId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -722,6 +777,7 @@ function get_hosted_configuration_version(
         "GET",
         "/applications/$(ApplicationId)/configurationprofiles/$(ConfigurationProfileId)/hostedconfigurationversions/$(VersionNumber)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_hosted_configuration_version(
@@ -736,6 +792,7 @@ function get_hosted_configuration_version(
         "/applications/$(ApplicationId)/configurationprofiles/$(ConfigurationProfileId)/hostedconfigurationversions/$(VersionNumber)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -752,12 +809,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"next_token"`: A token to start the list. Use this token to get the next set of results.
 """
 function list_applications(; aws_config::AbstractAWSConfig=global_aws_config())
-    return appconfig("GET", "/applications"; aws_config=aws_config)
+    return appconfig(
+        "GET", "/applications"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_applications(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return appconfig("GET", "/applications", params; aws_config=aws_config)
+    return appconfig(
+        "GET",
+        "/applications",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -779,7 +844,10 @@ function list_configuration_profiles(
     ApplicationId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return appconfig(
-        "GET", "/applications/$(ApplicationId)/configurationprofiles"; aws_config=aws_config
+        "GET",
+        "/applications/$(ApplicationId)/configurationprofiles";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_configuration_profiles(
@@ -792,6 +860,7 @@ function list_configuration_profiles(
         "/applications/$(ApplicationId)/configurationprofiles",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -808,12 +877,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"next_token"`: A token to start the list. Use this token to get the next set of results.
 """
 function list_deployment_strategies(; aws_config::AbstractAWSConfig=global_aws_config())
-    return appconfig("GET", "/deploymentstrategies"; aws_config=aws_config)
+    return appconfig(
+        "GET",
+        "/deploymentstrategies";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_deployment_strategies(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return appconfig("GET", "/deploymentstrategies", params; aws_config=aws_config)
+    return appconfig(
+        "GET",
+        "/deploymentstrategies",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -839,6 +919,7 @@ function list_deployments(
         "GET",
         "/applications/$(ApplicationId)/environments/$(EnvironmentId)/deployments";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_deployments(
@@ -852,6 +933,7 @@ function list_deployments(
         "/applications/$(ApplicationId)/environments/$(EnvironmentId)/deployments",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -872,7 +954,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function list_environments(ApplicationId; aws_config::AbstractAWSConfig=global_aws_config())
     return appconfig(
-        "GET", "/applications/$(ApplicationId)/environments"; aws_config=aws_config
+        "GET",
+        "/applications/$(ApplicationId)/environments";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_environments(
@@ -881,7 +966,11 @@ function list_environments(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return appconfig(
-        "GET", "/applications/$(ApplicationId)/environments", params; aws_config=aws_config
+        "GET",
+        "/applications/$(ApplicationId)/environments",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -908,6 +997,7 @@ function list_hosted_configuration_versions(
         "GET",
         "/applications/$(ApplicationId)/configurationprofiles/$(ConfigurationProfileId)/hostedconfigurationversions";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_hosted_configuration_versions(
@@ -921,6 +1011,7 @@ function list_hosted_configuration_versions(
         "/applications/$(ApplicationId)/configurationprofiles/$(ConfigurationProfileId)/hostedconfigurationversions",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -937,14 +1028,25 @@ Retrieves the list of key-value tags assigned to the resource.
 function list_tags_for_resource(
     ResourceArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return appconfig("GET", "/tags/$(ResourceArn)"; aws_config=aws_config)
+    return appconfig(
+        "GET",
+        "/tags/$(ResourceArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_tags_for_resource(
     ResourceArn,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return appconfig("GET", "/tags/$(ResourceArn)", params; aws_config=aws_config)
+    return appconfig(
+        "GET",
+        "/tags/$(ResourceArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -984,6 +1086,7 @@ function start_deployment(
             "DeploymentStrategyId" => DeploymentStrategyId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_deployment(
@@ -1010,6 +1113,7 @@ function start_deployment(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1036,6 +1140,7 @@ function stop_deployment(
         "DELETE",
         "/applications/$(ApplicationId)/environments/$(EnvironmentId)/deployments/$(DeploymentNumber)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function stop_deployment(
@@ -1050,6 +1155,7 @@ function stop_deployment(
         "/applications/$(ApplicationId)/environments/$(EnvironmentId)/deployments/$(DeploymentNumber)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1074,6 +1180,7 @@ function tag_resource(ResourceArn, Tags; aws_config::AbstractAWSConfig=global_aw
         "/tags/$(ResourceArn)",
         Dict{String,Any}("Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -1087,6 +1194,7 @@ function tag_resource(
         "/tags/$(ResourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Tags" => Tags), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1109,6 +1217,7 @@ function untag_resource(
         "/tags/$(ResourceArn)",
         Dict{String,Any}("tagKeys" => tagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -1122,6 +1231,7 @@ function untag_resource(
         "/tags/$(ResourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tagKeys" => tagKeys), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1142,7 +1252,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function update_application(
     ApplicationId; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return appconfig("PATCH", "/applications/$(ApplicationId)"; aws_config=aws_config)
+    return appconfig(
+        "PATCH",
+        "/applications/$(ApplicationId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function update_application(
     ApplicationId,
@@ -1150,7 +1265,11 @@ function update_application(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return appconfig(
-        "PATCH", "/applications/$(ApplicationId)", params; aws_config=aws_config
+        "PATCH",
+        "/applications/$(ApplicationId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1179,6 +1298,7 @@ function update_configuration_profile(
         "PATCH",
         "/applications/$(ApplicationId)/configurationprofiles/$(ConfigurationProfileId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_configuration_profile(
@@ -1192,6 +1312,7 @@ function update_configuration_profile(
         "/applications/$(ApplicationId)/configurationprofiles/$(ConfigurationProfileId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1231,7 +1352,10 @@ function update_deployment_strategy(
     DeploymentStrategyId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return appconfig(
-        "PATCH", "/deploymentstrategies/$(DeploymentStrategyId)"; aws_config=aws_config
+        "PATCH",
+        "/deploymentstrategies/$(DeploymentStrategyId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_deployment_strategy(
@@ -1244,6 +1368,7 @@ function update_deployment_strategy(
         "/deploymentstrategies/$(DeploymentStrategyId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1270,6 +1395,7 @@ function update_environment(
         "PATCH",
         "/applications/$(ApplicationId)/environments/$(EnvironmentId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_environment(
@@ -1283,6 +1409,7 @@ function update_environment(
         "/applications/$(ApplicationId)/environments/$(EnvironmentId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1309,6 +1436,7 @@ function validate_configuration(
         "/applications/$(ApplicationId)/configurationprofiles/$(ConfigurationProfileId)/validators",
         Dict{String,Any}("configuration_version" => configuration_version);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function validate_configuration(
@@ -1329,5 +1457,6 @@ function validate_configuration(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/appflow.jl
+++ b/src/services/appflow.jl
@@ -47,6 +47,7 @@ function create_connector_profile(
             "connectorType" => connectorType,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_connector_profile(
@@ -73,6 +74,7 @@ function create_connector_profile(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -125,6 +127,7 @@ function create_flow(
             "triggerConfig" => triggerConfig,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_flow(
@@ -153,6 +156,7 @@ function create_flow(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -179,6 +183,7 @@ function delete_connector_profile(
         "/delete-connector-profile",
         Dict{String,Any}("connectorProfileName" => connectorProfileName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_connector_profile(
@@ -197,6 +202,7 @@ function delete_connector_profile(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -223,6 +229,7 @@ function delete_flow(flowName; aws_config::AbstractAWSConfig=global_aws_config()
         "/delete-flow",
         Dict{String,Any}("flowName" => flowName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_flow(
@@ -237,6 +244,7 @@ function delete_flow(
             mergewith(_merge, Dict{String,Any}("flowName" => flowName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -265,6 +273,7 @@ function describe_connector_entity(
         "/describe-connector-entity",
         Dict{String,Any}("connectorEntityName" => connectorEntityName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_connector_entity(
@@ -283,6 +292,7 @@ function describe_connector_entity(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -305,12 +315,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`:  The pagination token for the next page of data.
 """
 function describe_connector_profiles(; aws_config::AbstractAWSConfig=global_aws_config())
-    return appflow("POST", "/describe-connector-profiles"; aws_config=aws_config)
+    return appflow(
+        "POST",
+        "/describe-connector-profiles";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_connector_profiles(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return appflow("POST", "/describe-connector-profiles", params; aws_config=aws_config)
+    return appflow(
+        "POST",
+        "/describe-connector-profiles",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -329,12 +350,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`:  The pagination token for the next page of data.
 """
 function describe_connectors(; aws_config::AbstractAWSConfig=global_aws_config())
-    return appflow("POST", "/describe-connectors"; aws_config=aws_config)
+    return appflow(
+        "POST",
+        "/describe-connectors";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_connectors(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return appflow("POST", "/describe-connectors", params; aws_config=aws_config)
+    return appflow(
+        "POST",
+        "/describe-connectors",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -354,6 +386,7 @@ function describe_flow(flowName; aws_config::AbstractAWSConfig=global_aws_config
         "/describe-flow",
         Dict{String,Any}("flowName" => flowName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_flow(
@@ -368,6 +401,7 @@ function describe_flow(
             mergewith(_merge, Dict{String,Any}("flowName" => flowName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -395,6 +429,7 @@ function describe_flow_execution_records(
         "/describe-flow-execution-records",
         Dict{String,Any}("flowName" => flowName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_flow_execution_records(
@@ -409,6 +444,7 @@ function describe_flow_execution_records(
             mergewith(_merge, Dict{String,Any}("flowName" => flowName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -433,12 +469,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   roots. Otherwise, this request returns all entities supported by the provider.
 """
 function list_connector_entities(; aws_config::AbstractAWSConfig=global_aws_config())
-    return appflow("POST", "/list-connector-entities"; aws_config=aws_config)
+    return appflow(
+        "POST",
+        "/list-connector-entities";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_connector_entities(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return appflow("POST", "/list-connector-entities", params; aws_config=aws_config)
+    return appflow(
+        "POST",
+        "/list-connector-entities",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -454,12 +501,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`:  The pagination token for next page of data.
 """
 function list_flows(; aws_config::AbstractAWSConfig=global_aws_config())
-    return appflow("POST", "/list-flows"; aws_config=aws_config)
+    return appflow(
+        "POST", "/list-flows"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_flows(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return appflow("POST", "/list-flows", params; aws_config=aws_config)
+    return appflow(
+        "POST",
+        "/list-flows",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -475,14 +530,25 @@ end
 function list_tags_for_resource(
     resourceArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return appflow("GET", "/tags/$(resourceArn)"; aws_config=aws_config)
+    return appflow(
+        "GET",
+        "/tags/$(resourceArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_tags_for_resource(
     resourceArn,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return appflow("GET", "/tags/$(resourceArn)", params; aws_config=aws_config)
+    return appflow(
+        "GET",
+        "/tags/$(resourceArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -503,6 +569,7 @@ function start_flow(flowName; aws_config::AbstractAWSConfig=global_aws_config())
         "/start-flow",
         Dict{String,Any}("flowName" => flowName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_flow(
@@ -517,6 +584,7 @@ function start_flow(
             mergewith(_merge, Dict{String,Any}("flowName" => flowName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -539,6 +607,7 @@ function stop_flow(flowName; aws_config::AbstractAWSConfig=global_aws_config())
         "/stop-flow",
         Dict{String,Any}("flowName" => flowName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function stop_flow(
@@ -553,6 +622,7 @@ function stop_flow(
             mergewith(_merge, Dict{String,Any}("flowName" => flowName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -573,6 +643,7 @@ function tag_resource(resourceArn, tags; aws_config::AbstractAWSConfig=global_aw
         "/tags/$(resourceArn)",
         Dict{String,Any}("tags" => tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -586,6 +657,7 @@ function tag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tags" => tags), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -608,6 +680,7 @@ function untag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}("tagKeys" => tagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -621,6 +694,7 @@ function untag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tagKeys" => tagKeys), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -653,6 +727,7 @@ function update_connector_profile(
             "connectorProfileName" => connectorProfileName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_connector_profile(
@@ -677,6 +752,7 @@ function update_connector_profile(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -719,6 +795,7 @@ function update_flow(
             "triggerConfig" => triggerConfig,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_flow(
@@ -747,5 +824,6 @@ function update_flow(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/appintegrations.jl
+++ b/src/services/appintegrations.jl
@@ -5,6 +5,55 @@ using AWS.Compat
 using AWS.UUIDs
 
 """
+    create_data_integration(name)
+    create_data_integration(name, params::Dict{String,<:Any})
+
+Creates and persists a DataIntegration resource.  You cannot create a DataIntegration
+association for a DataIntegration that has been previously associated. Use a different
+DataIntegration, or recreate the DataIntegration using the CreateDataIntegration API.
+
+# Arguments
+- `name`: The name of the DataIntegration.
+
+# Optional Parameters
+Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys are:
+- `"ClientToken"`: A unique, case-sensitive identifier that you provide to ensure the
+  idempotency of the request.
+- `"Description"`: A description of the DataIntegration.
+- `"KmsKey"`: The KMS key for the DataIntegration.
+- `"ScheduleConfig"`: The name of the data and how often it should be pulled from the
+  source.
+- `"SourceURI"`: The URI of the data source.
+- `"Tags"`: One or more tags.
+"""
+function create_data_integration(Name; aws_config::AbstractAWSConfig=global_aws_config())
+    return appintegrations(
+        "POST",
+        "/dataIntegrations",
+        Dict{String,Any}("Name" => Name, "ClientToken" => string(uuid4()));
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
+end
+function create_data_integration(
+    Name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
+)
+    return appintegrations(
+        "POST",
+        "/dataIntegrations",
+        Dict{String,Any}(
+            mergewith(
+                _merge,
+                Dict{String,Any}("Name" => Name, "ClientToken" => string(uuid4())),
+                params,
+            ),
+        );
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
+end
+
+"""
     create_event_integration(event_bridge_bus, event_filter, name)
     create_event_integration(event_bridge_bus, event_filter, name, params::Dict{String,<:Any})
 
@@ -38,6 +87,7 @@ function create_event_integration(
             "ClientToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_event_integration(
@@ -63,6 +113,46 @@ function create_event_integration(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
+end
+
+"""
+    delete_data_integration(identifier)
+    delete_data_integration(identifier, params::Dict{String,<:Any})
+
+Deletes the DataIntegration. Only DataIntegrations that don't have any
+DataIntegrationAssociations can be deleted. Deleting a DataIntegration also deletes the
+underlying Amazon AppFlow flow and service linked role.   You cannot create a
+DataIntegration association for a DataIntegration that has been previously associated. Use
+a different DataIntegration, or recreate the DataIntegration using the
+CreateDataIntegration API.
+
+# Arguments
+- `identifier`: A unique identifier for the DataIntegration.
+
+"""
+function delete_data_integration(
+    Identifier; aws_config::AbstractAWSConfig=global_aws_config()
+)
+    return appintegrations(
+        "DELETE",
+        "/dataIntegrations/$(Identifier)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
+end
+function delete_data_integration(
+    Identifier,
+    params::AbstractDict{String};
+    aws_config::AbstractAWSConfig=global_aws_config(),
+)
+    return appintegrations(
+        "DELETE",
+        "/dataIntegrations/$(Identifier)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -78,13 +168,56 @@ with clients, the request is rejected.
 
 """
 function delete_event_integration(Name; aws_config::AbstractAWSConfig=global_aws_config())
-    return appintegrations("DELETE", "/eventIntegrations/$(Name)"; aws_config=aws_config)
+    return appintegrations(
+        "DELETE",
+        "/eventIntegrations/$(Name)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_event_integration(
     Name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return appintegrations(
-        "DELETE", "/eventIntegrations/$(Name)", params; aws_config=aws_config
+        "DELETE",
+        "/eventIntegrations/$(Name)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
+end
+
+"""
+    get_data_integration(identifier)
+    get_data_integration(identifier, params::Dict{String,<:Any})
+
+Returns information about the DataIntegration.  You cannot create a DataIntegration
+association for a DataIntegration that has been previously associated. Use a different
+DataIntegration, or recreate the DataIntegration using the CreateDataIntegration API.
+
+# Arguments
+- `identifier`: A unique identifier.
+
+"""
+function get_data_integration(Identifier; aws_config::AbstractAWSConfig=global_aws_config())
+    return appintegrations(
+        "GET",
+        "/dataIntegrations/$(Identifier)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
+end
+function get_data_integration(
+    Identifier,
+    params::AbstractDict{String};
+    aws_config::AbstractAWSConfig=global_aws_config(),
+)
+    return appintegrations(
+        "GET",
+        "/dataIntegrations/$(Identifier)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -92,20 +225,103 @@ end
     get_event_integration(name)
     get_event_integration(name, params::Dict{String,<:Any})
 
-Return information about the event integration.
+Returns information about the event integration.
 
 # Arguments
 - `name`: The name of the event integration.
 
 """
 function get_event_integration(Name; aws_config::AbstractAWSConfig=global_aws_config())
-    return appintegrations("GET", "/eventIntegrations/$(Name)"; aws_config=aws_config)
+    return appintegrations(
+        "GET",
+        "/eventIntegrations/$(Name)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_event_integration(
     Name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return appintegrations(
-        "GET", "/eventIntegrations/$(Name)", params; aws_config=aws_config
+        "GET",
+        "/eventIntegrations/$(Name)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
+end
+
+"""
+    list_data_integration_associations(identifier)
+    list_data_integration_associations(identifier, params::Dict{String,<:Any})
+
+Returns a paginated list of DataIntegration associations in the account.  You cannot create
+a DataIntegration association for a DataIntegration that has been previously associated.
+Use a different DataIntegration, or recreate the DataIntegration using the
+CreateDataIntegration API.
+
+# Arguments
+- `identifier`: A unique identifier for the DataIntegration.
+
+# Optional Parameters
+Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys are:
+- `"maxResults"`: The maximum number of results to return per page.
+- `"nextToken"`: The token for the next set of results. Use the value returned in the
+  previous response in the next request to retrieve the next set of results.
+"""
+function list_data_integration_associations(
+    Identifier; aws_config::AbstractAWSConfig=global_aws_config()
+)
+    return appintegrations(
+        "GET",
+        "/dataIntegrations/$(Identifier)/associations";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
+end
+function list_data_integration_associations(
+    Identifier,
+    params::AbstractDict{String};
+    aws_config::AbstractAWSConfig=global_aws_config(),
+)
+    return appintegrations(
+        "GET",
+        "/dataIntegrations/$(Identifier)/associations",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
+end
+
+"""
+    list_data_integrations()
+    list_data_integrations(params::Dict{String,<:Any})
+
+Returns a paginated list of DataIntegrations in the account.  You cannot create a
+DataIntegration association for a DataIntegration that has been previously associated. Use
+a different DataIntegration, or recreate the DataIntegration using the
+CreateDataIntegration API.
+
+# Optional Parameters
+Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys are:
+- `"maxResults"`: The maximum number of results to return per page.
+- `"nextToken"`: The token for the next set of results. Use the value returned in the
+  previous response in the next request to retrieve the next set of results.
+"""
+function list_data_integrations(; aws_config::AbstractAWSConfig=global_aws_config())
+    return appintegrations(
+        "GET", "/dataIntegrations"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
+end
+function list_data_integrations(
+    params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
+)
+    return appintegrations(
+        "GET",
+        "/dataIntegrations",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -128,14 +344,21 @@ function list_event_integration_associations(
     Name; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return appintegrations(
-        "GET", "/eventIntegrations/$(Name)/associations"; aws_config=aws_config
+        "GET",
+        "/eventIntegrations/$(Name)/associations";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_event_integration_associations(
     Name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return appintegrations(
-        "GET", "/eventIntegrations/$(Name)/associations", params; aws_config=aws_config
+        "GET",
+        "/eventIntegrations/$(Name)/associations",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -152,12 +375,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   previous response in the next request to retrieve the next set of results.
 """
 function list_event_integrations(; aws_config::AbstractAWSConfig=global_aws_config())
-    return appintegrations("GET", "/eventIntegrations"; aws_config=aws_config)
+    return appintegrations(
+        "GET", "/eventIntegrations"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_event_integrations(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return appintegrations("GET", "/eventIntegrations", params; aws_config=aws_config)
+    return appintegrations(
+        "GET",
+        "/eventIntegrations",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -173,14 +404,25 @@ Lists the tags for the specified resource.
 function list_tags_for_resource(
     resourceArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return appintegrations("GET", "/tags/$(resourceArn)"; aws_config=aws_config)
+    return appintegrations(
+        "GET",
+        "/tags/$(resourceArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_tags_for_resource(
     resourceArn,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return appintegrations("GET", "/tags/$(resourceArn)", params; aws_config=aws_config)
+    return appintegrations(
+        "GET",
+        "/tags/$(resourceArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -200,6 +442,7 @@ function tag_resource(resourceArn, tags; aws_config::AbstractAWSConfig=global_aw
         "/tags/$(resourceArn)",
         Dict{String,Any}("tags" => tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -213,6 +456,7 @@ function tag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tags" => tags), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -235,6 +479,7 @@ function untag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}("tagKeys" => tagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -248,6 +493,47 @@ function untag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tagKeys" => tagKeys), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
+end
+
+"""
+    update_data_integration(identifier)
+    update_data_integration(identifier, params::Dict{String,<:Any})
+
+Updates the description of a DataIntegration.  You cannot create a DataIntegration
+association for a DataIntegration that has been previously associated. Use a different
+DataIntegration, or recreate the DataIntegration using the CreateDataIntegration API.
+
+# Arguments
+- `identifier`: A unique identifier for the DataIntegration.
+
+# Optional Parameters
+Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys are:
+- `"Description"`: A description of the DataIntegration.
+- `"Name"`: The name of the DataIntegration.
+"""
+function update_data_integration(
+    Identifier; aws_config::AbstractAWSConfig=global_aws_config()
+)
+    return appintegrations(
+        "PATCH",
+        "/dataIntegrations/$(Identifier)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
+end
+function update_data_integration(
+    Identifier,
+    params::AbstractDict{String};
+    aws_config::AbstractAWSConfig=global_aws_config(),
+)
+    return appintegrations(
+        "PATCH",
+        "/dataIntegrations/$(Identifier)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -265,12 +551,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"Description"`: The description of the event inegration.
 """
 function update_event_integration(Name; aws_config::AbstractAWSConfig=global_aws_config())
-    return appintegrations("PATCH", "/eventIntegrations/$(Name)"; aws_config=aws_config)
+    return appintegrations(
+        "PATCH",
+        "/eventIntegrations/$(Name)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function update_event_integration(
     Name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return appintegrations(
-        "PATCH", "/eventIntegrations/$(Name)", params; aws_config=aws_config
+        "PATCH",
+        "/eventIntegrations/$(Name)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/application_auto_scaling.jl
+++ b/src/services/application_auto_scaling.jl
@@ -98,6 +98,7 @@ function delete_scaling_policy(
             "ServiceNamespace" => ServiceNamespace,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_scaling_policy(
@@ -123,6 +124,7 @@ function delete_scaling_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -217,6 +219,7 @@ function delete_scheduled_action(
             "ServiceNamespace" => ServiceNamespace,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_scheduled_action(
@@ -242,6 +245,7 @@ function delete_scheduled_action(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -336,6 +340,7 @@ function deregister_scalable_target(
             "ServiceNamespace" => ServiceNamespace,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function deregister_scalable_target(
@@ -359,6 +364,7 @@ function deregister_scalable_target(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -453,6 +459,7 @@ function describe_scalable_targets(
         "DescribeScalableTargets",
         Dict{String,Any}("ServiceNamespace" => ServiceNamespace);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_scalable_targets(
@@ -468,6 +475,7 @@ function describe_scalable_targets(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -562,6 +570,7 @@ function describe_scaling_activities(
         "DescribeScalingActivities",
         Dict{String,Any}("ServiceNamespace" => ServiceNamespace);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_scaling_activities(
@@ -577,6 +586,7 @@ function describe_scaling_activities(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -673,6 +683,7 @@ function describe_scaling_policies(
         "DescribeScalingPolicies",
         Dict{String,Any}("ServiceNamespace" => ServiceNamespace);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_scaling_policies(
@@ -688,6 +699,7 @@ function describe_scaling_policies(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -784,6 +796,7 @@ function describe_scheduled_actions(
         "DescribeScheduledActions",
         Dict{String,Any}("ServiceNamespace" => ServiceNamespace);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_scheduled_actions(
@@ -799,6 +812,7 @@ function describe_scheduled_actions(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -925,6 +939,7 @@ function put_scaling_policy(
             "ServiceNamespace" => ServiceNamespace,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_scaling_policy(
@@ -950,6 +965,7 @@ function put_scaling_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1076,6 +1092,7 @@ function put_scheduled_action(
             "ServiceNamespace" => ServiceNamespace,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_scheduled_action(
@@ -1101,6 +1118,7 @@ function put_scheduled_action(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1238,6 +1256,7 @@ function register_scalable_target(
             "ServiceNamespace" => ServiceNamespace,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function register_scalable_target(
@@ -1261,5 +1280,6 @@ function register_scalable_target(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/application_discovery_service.jl
+++ b/src/services/application_discovery_service.jl
@@ -29,6 +29,7 @@ function associate_configuration_items_to_application(
             "configurationIds" => configurationIds,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_configuration_items_to_application(
@@ -50,6 +51,7 @@ function associate_configuration_items_to_application(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -76,6 +78,7 @@ function batch_delete_import_data(
         "BatchDeleteImportData",
         Dict{String,Any}("importTaskIds" => importTaskIds);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_delete_import_data(
@@ -89,6 +92,7 @@ function batch_delete_import_data(
             mergewith(_merge, Dict{String,Any}("importTaskIds" => importTaskIds), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -107,7 +111,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function create_application(name; aws_config::AbstractAWSConfig=global_aws_config())
     return application_discovery_service(
-        "CreateApplication", Dict{String,Any}("name" => name); aws_config=aws_config
+        "CreateApplication",
+        Dict{String,Any}("name" => name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_application(
@@ -117,6 +124,7 @@ function create_application(
         "CreateApplication",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("name" => name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -141,6 +149,7 @@ function create_tags(
         "CreateTags",
         Dict{String,Any}("configurationIds" => configurationIds, "tags" => tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_tags(
@@ -159,6 +168,7 @@ function create_tags(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -179,6 +189,7 @@ function delete_applications(
         "DeleteApplications",
         Dict{String,Any}("configurationIds" => configurationIds);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_applications(
@@ -194,6 +205,7 @@ function delete_applications(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -218,6 +230,7 @@ function delete_tags(configurationIds; aws_config::AbstractAWSConfig=global_aws_
         "DeleteTags",
         Dict{String,Any}("configurationIds" => configurationIds);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_tags(
@@ -233,6 +246,7 @@ function delete_tags(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -259,12 +273,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   get the next set of 10.
 """
 function describe_agents(; aws_config::AbstractAWSConfig=global_aws_config())
-    return application_discovery_service("DescribeAgents"; aws_config=aws_config)
+    return application_discovery_service(
+        "DescribeAgents"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_agents(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return application_discovery_service("DescribeAgents", params; aws_config=aws_config)
+    return application_discovery_service(
+        "DescribeAgents", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -290,6 +308,7 @@ function describe_configurations(
         "DescribeConfigurations",
         Dict{String,Any}("configurationIds" => configurationIds);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_configurations(
@@ -305,6 +324,7 @@ function describe_configurations(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -323,13 +343,18 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: The token from the previous call to DescribeExportTasks.
 """
 function describe_continuous_exports(; aws_config::AbstractAWSConfig=global_aws_config())
-    return application_discovery_service("DescribeContinuousExports"; aws_config=aws_config)
+    return application_discovery_service(
+        "DescribeContinuousExports"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_continuous_exports(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return application_discovery_service(
-        "DescribeContinuousExports", params; aws_config=aws_config
+        "DescribeContinuousExports",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -348,14 +373,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function describe_export_configurations(; aws_config::AbstractAWSConfig=global_aws_config())
     return application_discovery_service(
-        "DescribeExportConfigurations"; aws_config=aws_config
+        "DescribeExportConfigurations";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_export_configurations(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return application_discovery_service(
-        "DescribeExportConfigurations", params; aws_config=aws_config
+        "DescribeExportConfigurations",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -381,13 +411,18 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   value. This value is null when there are no more results to return.
 """
 function describe_export_tasks(; aws_config::AbstractAWSConfig=global_aws_config())
-    return application_discovery_service("DescribeExportTasks"; aws_config=aws_config)
+    return application_discovery_service(
+        "DescribeExportTasks"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_export_tasks(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return application_discovery_service(
-        "DescribeExportTasks", params; aws_config=aws_config
+        "DescribeExportTasks",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -408,13 +443,18 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: The token to request a specific page of results.
 """
 function describe_import_tasks(; aws_config::AbstractAWSConfig=global_aws_config())
-    return application_discovery_service("DescribeImportTasks"; aws_config=aws_config)
+    return application_discovery_service(
+        "DescribeImportTasks"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_import_tasks(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return application_discovery_service(
-        "DescribeImportTasks", params; aws_config=aws_config
+        "DescribeImportTasks",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -438,12 +478,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: A token to start the list. Use this token to get the next set of results.
 """
 function describe_tags(; aws_config::AbstractAWSConfig=global_aws_config())
-    return application_discovery_service("DescribeTags"; aws_config=aws_config)
+    return application_discovery_service(
+        "DescribeTags"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_tags(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return application_discovery_service("DescribeTags", params; aws_config=aws_config)
+    return application_discovery_service(
+        "DescribeTags", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -471,6 +515,7 @@ function disassociate_configuration_items_from_application(
             "configurationIds" => configurationIds,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disassociate_configuration_items_from_application(
@@ -492,6 +537,7 @@ function disassociate_configuration_items_from_application(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -508,13 +554,18 @@ in six hours.
 
 """
 function export_configurations(; aws_config::AbstractAWSConfig=global_aws_config())
-    return application_discovery_service("ExportConfigurations"; aws_config=aws_config)
+    return application_discovery_service(
+        "ExportConfigurations"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function export_configurations(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return application_discovery_service(
-        "ExportConfigurations", params; aws_config=aws_config
+        "ExportConfigurations",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -527,13 +578,18 @@ parameters and is called as is at the command prompt as shown in the example.
 
 """
 function get_discovery_summary(; aws_config::AbstractAWSConfig=global_aws_config())
-    return application_discovery_service("GetDiscoverySummary"; aws_config=aws_config)
+    return application_discovery_service(
+        "GetDiscoverySummary"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_discovery_summary(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return application_discovery_service(
-        "GetDiscoverySummary", params; aws_config=aws_config
+        "GetDiscoverySummary",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -569,6 +625,7 @@ function list_configurations(
         "ListConfigurations",
         Dict{String,Any}("configurationType" => configurationType);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_configurations(
@@ -584,6 +641,7 @@ function list_configurations(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -614,6 +672,7 @@ function list_server_neighbors(
         "ListServerNeighbors",
         Dict{String,Any}("configurationId" => configurationId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_server_neighbors(
@@ -629,6 +688,7 @@ function list_server_neighbors(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -640,13 +700,18 @@ Start the continuous flow of agent's discovered data into Amazon Athena.
 
 """
 function start_continuous_export(; aws_config::AbstractAWSConfig=global_aws_config())
-    return application_discovery_service("StartContinuousExport"; aws_config=aws_config)
+    return application_discovery_service(
+        "StartContinuousExport"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function start_continuous_export(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return application_discovery_service(
-        "StartContinuousExport", params; aws_config=aws_config
+        "StartContinuousExport",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -672,6 +737,7 @@ function start_data_collection_by_agent_ids(
         "StartDataCollectionByAgentIds",
         Dict{String,Any}("agentIds" => agentIds);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_data_collection_by_agent_ids(
@@ -685,6 +751,7 @@ function start_data_collection_by_agent_ids(
             mergewith(_merge, Dict{String,Any}("agentIds" => agentIds), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -718,12 +785,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   starting from the first data collected by the agent.
 """
 function start_export_task(; aws_config::AbstractAWSConfig=global_aws_config())
-    return application_discovery_service("StartExportTask"; aws_config=aws_config)
+    return application_discovery_service(
+        "StartExportTask"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function start_export_task(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return application_discovery_service("StartExportTask", params; aws_config=aws_config)
+    return application_discovery_service(
+        "StartExportTask", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -774,6 +845,7 @@ function start_import_task(
             "clientRequestToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_import_task(
@@ -796,6 +868,7 @@ function start_import_task(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -814,6 +887,7 @@ function stop_continuous_export(exportId; aws_config::AbstractAWSConfig=global_a
         "StopContinuousExport",
         Dict{String,Any}("exportId" => exportId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function stop_continuous_export(
@@ -827,6 +901,7 @@ function stop_continuous_export(
             mergewith(_merge, Dict{String,Any}("exportId" => exportId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -847,6 +922,7 @@ function stop_data_collection_by_agent_ids(
         "StopDataCollectionByAgentIds",
         Dict{String,Any}("agentIds" => agentIds);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function stop_data_collection_by_agent_ids(
@@ -860,6 +936,7 @@ function stop_data_collection_by_agent_ids(
             mergewith(_merge, Dict{String,Any}("agentIds" => agentIds), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -884,6 +961,7 @@ function update_application(
         "UpdateApplication",
         Dict{String,Any}("configurationId" => configurationId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_application(
@@ -899,5 +977,6 @@ function update_application(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/application_insights.jl
+++ b/src/services/application_insights.jl
@@ -34,6 +34,7 @@ function create_application(
         "CreateApplication",
         Dict{String,Any}("ResourceGroupName" => ResourceGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_application(
@@ -49,6 +50,7 @@ function create_application(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -78,6 +80,7 @@ function create_component(
             "ResourceList" => ResourceList,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_component(
@@ -101,6 +104,7 @@ function create_component(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -143,6 +147,7 @@ function create_log_pattern(
             "ResourceGroupName" => ResourceGroupName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_log_pattern(
@@ -170,6 +175,7 @@ function create_log_pattern(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -190,6 +196,7 @@ function delete_application(
         "DeleteApplication",
         Dict{String,Any}("ResourceGroupName" => ResourceGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_application(
@@ -205,6 +212,7 @@ function delete_application(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -230,6 +238,7 @@ function delete_component(
             "ComponentName" => ComponentName, "ResourceGroupName" => ResourceGroupName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_component(
@@ -251,6 +260,7 @@ function delete_component(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -280,6 +290,7 @@ function delete_log_pattern(
             "ResourceGroupName" => ResourceGroupName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_log_pattern(
@@ -303,6 +314,7 @@ function delete_log_pattern(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -323,6 +335,7 @@ function describe_application(
         "DescribeApplication",
         Dict{String,Any}("ResourceGroupName" => ResourceGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_application(
@@ -338,6 +351,7 @@ function describe_application(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -361,6 +375,7 @@ function describe_component(
             "ComponentName" => ComponentName, "ResourceGroupName" => ResourceGroupName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_component(
@@ -382,6 +397,7 @@ function describe_component(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -405,6 +421,7 @@ function describe_component_configuration(
             "ComponentName" => ComponentName, "ResourceGroupName" => ResourceGroupName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_component_configuration(
@@ -426,6 +443,7 @@ function describe_component_configuration(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -456,6 +474,7 @@ function describe_component_configuration_recommendation(
             "Tier" => Tier,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_component_configuration_recommendation(
@@ -479,6 +498,7 @@ function describe_component_configuration_recommendation(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -508,6 +528,7 @@ function describe_log_pattern(
             "ResourceGroupName" => ResourceGroupName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_log_pattern(
@@ -531,6 +552,7 @@ function describe_log_pattern(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -551,6 +573,7 @@ function describe_observation(
         "DescribeObservation",
         Dict{String,Any}("ObservationId" => ObservationId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_observation(
@@ -564,6 +587,7 @@ function describe_observation(
             mergewith(_merge, Dict{String,Any}("ObservationId" => ObservationId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -579,7 +603,10 @@ Describes an application problem.
 """
 function describe_problem(ProblemId; aws_config::AbstractAWSConfig=global_aws_config())
     return application_insights(
-        "DescribeProblem", Dict{String,Any}("ProblemId" => ProblemId); aws_config=aws_config
+        "DescribeProblem",
+        Dict{String,Any}("ProblemId" => ProblemId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_problem(
@@ -593,6 +620,7 @@ function describe_problem(
             mergewith(_merge, Dict{String,Any}("ProblemId" => ProblemId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -613,6 +641,7 @@ function describe_problem_observations(
         "DescribeProblemObservations",
         Dict{String,Any}("ProblemId" => ProblemId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_problem_observations(
@@ -626,6 +655,7 @@ function describe_problem_observations(
             mergewith(_merge, Dict{String,Any}("ProblemId" => ProblemId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -642,12 +672,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`: The token to request the next page of results.
 """
 function list_applications(; aws_config::AbstractAWSConfig=global_aws_config())
-    return application_insights("ListApplications"; aws_config=aws_config)
+    return application_insights(
+        "ListApplications"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_applications(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return application_insights("ListApplications", params; aws_config=aws_config)
+    return application_insights(
+        "ListApplications", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -672,6 +706,7 @@ function list_components(
         "ListComponents",
         Dict{String,Any}("ResourceGroupName" => ResourceGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_components(
@@ -687,6 +722,7 @@ function list_components(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -719,12 +755,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"StartTime"`: The start time of the event.
 """
 function list_configuration_history(; aws_config::AbstractAWSConfig=global_aws_config())
-    return application_insights("ListConfigurationHistory"; aws_config=aws_config)
+    return application_insights(
+        "ListConfigurationHistory"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_configuration_history(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return application_insights("ListConfigurationHistory", params; aws_config=aws_config)
+    return application_insights(
+        "ListConfigurationHistory",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -749,6 +792,7 @@ function list_log_pattern_sets(
         "ListLogPatternSets",
         Dict{String,Any}("ResourceGroupName" => ResourceGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_log_pattern_sets(
@@ -764,6 +808,7 @@ function list_log_pattern_sets(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -790,6 +835,7 @@ function list_log_patterns(
         "ListLogPatterns",
         Dict{String,Any}("ResourceGroupName" => ResourceGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_log_patterns(
@@ -805,6 +851,7 @@ function list_log_patterns(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -826,12 +873,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   specify a time frame for the request, problems within the past seven days are returned.
 """
 function list_problems(; aws_config::AbstractAWSConfig=global_aws_config())
-    return application_insights("ListProblems"; aws_config=aws_config)
+    return application_insights(
+        "ListProblems"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_problems(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return application_insights("ListProblems", params; aws_config=aws_config)
+    return application_insights(
+        "ListProblems", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -856,6 +907,7 @@ function list_tags_for_resource(
         "ListTagsForResource",
         Dict{String,Any}("ResourceARN" => ResourceARN);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags_for_resource(
@@ -869,6 +921,7 @@ function list_tags_for_resource(
             mergewith(_merge, Dict{String,Any}("ResourceARN" => ResourceARN), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -896,6 +949,7 @@ function tag_resource(ResourceARN, Tags; aws_config::AbstractAWSConfig=global_aw
         "TagResource",
         Dict{String,Any}("ResourceARN" => ResourceARN, "Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -914,6 +968,7 @@ function tag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -939,6 +994,7 @@ function untag_resource(
         "UntagResource",
         Dict{String,Any}("ResourceARN" => ResourceARN, "TagKeys" => TagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -957,6 +1013,7 @@ function untag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -989,6 +1046,7 @@ function update_application(
         "UpdateApplication",
         Dict{String,Any}("ResourceGroupName" => ResourceGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_application(
@@ -1004,6 +1062,7 @@ function update_application(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1031,6 +1090,7 @@ function update_component(
             "ComponentName" => ComponentName, "ResourceGroupName" => ResourceGroupName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_component(
@@ -1052,6 +1112,7 @@ function update_component(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1087,6 +1148,7 @@ function update_component_configuration(
             "ComponentName" => ComponentName, "ResourceGroupName" => ResourceGroupName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_component_configuration(
@@ -1108,6 +1170,7 @@ function update_component_configuration(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1148,6 +1211,7 @@ function update_log_pattern(
             "ResourceGroupName" => ResourceGroupName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_log_pattern(
@@ -1171,5 +1235,6 @@ function update_log_pattern(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/applicationcostprofiler.jl
+++ b/src/services/applicationcostprofiler.jl
@@ -19,7 +19,10 @@ function delete_report_definition(
     reportId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return applicationcostprofiler(
-        "DELETE", "/reportDefinition/$(reportId)"; aws_config=aws_config
+        "DELETE",
+        "/reportDefinition/$(reportId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_report_definition(
@@ -28,7 +31,11 @@ function delete_report_definition(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return applicationcostprofiler(
-        "DELETE", "/reportDefinition/$(reportId)", params; aws_config=aws_config
+        "DELETE",
+        "/reportDefinition/$(reportId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -44,7 +51,10 @@ Retrieves the definition of a report already configured in AWS Application Cost 
 """
 function get_report_definition(reportId; aws_config::AbstractAWSConfig=global_aws_config())
     return applicationcostprofiler(
-        "GET", "/reportDefinition/$(reportId)"; aws_config=aws_config
+        "GET",
+        "/reportDefinition/$(reportId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_report_definition(
@@ -53,7 +63,11 @@ function get_report_definition(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return applicationcostprofiler(
-        "GET", "/reportDefinition/$(reportId)", params; aws_config=aws_config
+        "GET",
+        "/reportDefinition/$(reportId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -78,6 +92,7 @@ function import_application_usage(
         "/importApplicationUsage",
         Dict{String,Any}("sourceS3Location" => sourceS3Location);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function import_application_usage(
@@ -94,6 +109,7 @@ function import_application_usage(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -110,13 +126,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: The token value from a previous call to access the next page of results.
 """
 function list_report_definitions(; aws_config::AbstractAWSConfig=global_aws_config())
-    return applicationcostprofiler("GET", "/reportDefinition"; aws_config=aws_config)
+    return applicationcostprofiler(
+        "GET", "/reportDefinition"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_report_definitions(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return applicationcostprofiler(
-        "GET", "/reportDefinition", params; aws_config=aws_config
+        "GET",
+        "/reportDefinition",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -155,6 +177,7 @@ function put_report_definition(
             "reportId" => reportId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_report_definition(
@@ -183,6 +206,7 @@ function put_report_definition(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -219,6 +243,7 @@ function update_report_definition(
             "reportFrequency" => reportFrequency,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_report_definition(
@@ -246,5 +271,6 @@ function update_report_definition(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/apprunner.jl
+++ b/src/services/apprunner.jl
@@ -35,6 +35,7 @@ function associate_custom_domain(
         "AssociateCustomDomain",
         Dict{String,Any}("DomainName" => DomainName, "ServiceArn" => ServiceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_custom_domain(
@@ -53,6 +54,7 @@ function associate_custom_domain(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -101,6 +103,7 @@ function create_auto_scaling_configuration(
         "CreateAutoScalingConfiguration",
         Dict{String,Any}("AutoScalingConfigurationName" => AutoScalingConfigurationName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_auto_scaling_configuration(
@@ -120,6 +123,7 @@ function create_auto_scaling_configuration(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -152,6 +156,7 @@ function create_connection(
             "ConnectionName" => ConnectionName, "ProviderType" => ProviderType
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_connection(
@@ -172,6 +177,7 @@ function create_connection(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -215,6 +221,7 @@ function create_service(
             "ServiceName" => ServiceName, "SourceConfiguration" => SourceConfiguration
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_service(
@@ -236,6 +243,7 @@ function create_service(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -261,6 +269,7 @@ function delete_auto_scaling_configuration(
         "DeleteAutoScalingConfiguration",
         Dict{String,Any}("AutoScalingConfigurationArn" => AutoScalingConfigurationArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_auto_scaling_configuration(
@@ -280,6 +289,7 @@ function delete_auto_scaling_configuration(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -301,6 +311,7 @@ function delete_connection(ConnectionArn; aws_config::AbstractAWSConfig=global_a
         "DeleteConnection",
         Dict{String,Any}("ConnectionArn" => ConnectionArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_connection(
@@ -314,6 +325,7 @@ function delete_connection(
             mergewith(_merge, Dict{String,Any}("ConnectionArn" => ConnectionArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -332,7 +344,10 @@ progress.
 """
 function delete_service(ServiceArn; aws_config::AbstractAWSConfig=global_aws_config())
     return apprunner(
-        "DeleteService", Dict{String,Any}("ServiceArn" => ServiceArn); aws_config=aws_config
+        "DeleteService",
+        Dict{String,Any}("ServiceArn" => ServiceArn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_service(
@@ -346,6 +361,7 @@ function delete_service(
             mergewith(_merge, Dict{String,Any}("ServiceArn" => ServiceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -369,6 +385,7 @@ function describe_auto_scaling_configuration(
         "DescribeAutoScalingConfiguration",
         Dict{String,Any}("AutoScalingConfigurationArn" => AutoScalingConfigurationArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_auto_scaling_configuration(
@@ -388,6 +405,7 @@ function describe_auto_scaling_configuration(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -419,6 +437,7 @@ function describe_custom_domains(
         "DescribeCustomDomains",
         Dict{String,Any}("ServiceArn" => ServiceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_custom_domains(
@@ -432,6 +451,7 @@ function describe_custom_domains(
             mergewith(_merge, Dict{String,Any}("ServiceArn" => ServiceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -451,6 +471,7 @@ function describe_service(ServiceArn; aws_config::AbstractAWSConfig=global_aws_c
         "DescribeService",
         Dict{String,Any}("ServiceArn" => ServiceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_service(
@@ -464,6 +485,7 @@ function describe_service(
             mergewith(_merge, Dict{String,Any}("ServiceArn" => ServiceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -489,6 +511,7 @@ function disassociate_custom_domain(
         "DisassociateCustomDomain",
         Dict{String,Any}("DomainName" => DomainName, "ServiceArn" => ServiceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disassociate_custom_domain(
@@ -507,6 +530,7 @@ function disassociate_custom_domain(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -538,12 +562,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function list_auto_scaling_configurations(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return apprunner("ListAutoScalingConfigurations"; aws_config=aws_config)
+    return apprunner(
+        "ListAutoScalingConfigurations";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_auto_scaling_configurations(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return apprunner("ListAutoScalingConfigurations", params; aws_config=aws_config)
+    return apprunner(
+        "ListAutoScalingConfigurations",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -565,12 +598,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   retrieves the first result page.
 """
 function list_connections(; aws_config::AbstractAWSConfig=global_aws_config())
-    return apprunner("ListConnections"; aws_config=aws_config)
+    return apprunner(
+        "ListConnections"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_connections(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return apprunner("ListConnections", params; aws_config=aws_config)
+    return apprunner(
+        "ListConnections", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -600,6 +637,7 @@ function list_operations(ServiceArn; aws_config::AbstractAWSConfig=global_aws_co
         "ListOperations",
         Dict{String,Any}("ServiceArn" => ServiceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_operations(
@@ -613,6 +651,7 @@ function list_operations(
             mergewith(_merge, Dict{String,Any}("ServiceArn" => ServiceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -633,12 +672,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   retrieves the first result page.
 """
 function list_services(; aws_config::AbstractAWSConfig=global_aws_config())
-    return apprunner("ListServices"; aws_config=aws_config)
+    return apprunner("ListServices"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_services(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return apprunner("ListServices", params; aws_config=aws_config)
+    return apprunner(
+        "ListServices", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -660,6 +701,7 @@ function list_tags_for_resource(
         "ListTagsForResource",
         Dict{String,Any}("ResourceArn" => ResourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags_for_resource(
@@ -673,6 +715,7 @@ function list_tags_for_resource(
             mergewith(_merge, Dict{String,Any}("ResourceArn" => ResourceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -692,7 +735,10 @@ ListOperations call to track the operation's progress.
 """
 function pause_service(ServiceArn; aws_config::AbstractAWSConfig=global_aws_config())
     return apprunner(
-        "PauseService", Dict{String,Any}("ServiceArn" => ServiceArn); aws_config=aws_config
+        "PauseService",
+        Dict{String,Any}("ServiceArn" => ServiceArn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function pause_service(
@@ -706,6 +752,7 @@ function pause_service(
             mergewith(_merge, Dict{String,Any}("ServiceArn" => ServiceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -724,7 +771,10 @@ OperationId and the ListOperations call to track the operation's progress.
 """
 function resume_service(ServiceArn; aws_config::AbstractAWSConfig=global_aws_config())
     return apprunner(
-        "ResumeService", Dict{String,Any}("ServiceArn" => ServiceArn); aws_config=aws_config
+        "ResumeService",
+        Dict{String,Any}("ServiceArn" => ServiceArn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function resume_service(
@@ -738,6 +788,7 @@ function resume_service(
             mergewith(_merge, Dict{String,Any}("ServiceArn" => ServiceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -763,6 +814,7 @@ function start_deployment(ServiceArn; aws_config::AbstractAWSConfig=global_aws_c
         "StartDeployment",
         Dict{String,Any}("ServiceArn" => ServiceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_deployment(
@@ -776,6 +828,7 @@ function start_deployment(
             mergewith(_merge, Dict{String,Any}("ServiceArn" => ServiceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -798,6 +851,7 @@ function tag_resource(ResourceArn, Tags; aws_config::AbstractAWSConfig=global_aw
         "TagResource",
         Dict{String,Any}("ResourceArn" => ResourceArn, "Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -816,6 +870,7 @@ function tag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -838,6 +893,7 @@ function untag_resource(
         "UntagResource",
         Dict{String,Any}("ResourceArn" => ResourceArn, "TagKeys" => TagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -856,6 +912,7 @@ function untag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -893,7 +950,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function update_service(ServiceArn; aws_config::AbstractAWSConfig=global_aws_config())
     return apprunner(
-        "UpdateService", Dict{String,Any}("ServiceArn" => ServiceArn); aws_config=aws_config
+        "UpdateService",
+        Dict{String,Any}("ServiceArn" => ServiceArn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_service(
@@ -907,5 +967,6 @@ function update_service(
             mergewith(_merge, Dict{String,Any}("ServiceArn" => ServiceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/appstream.jl
+++ b/src/services/appstream.jl
@@ -22,6 +22,7 @@ function associate_fleet(
         "AssociateFleet",
         Dict{String,Any}("FleetName" => FleetName, "StackName" => StackName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_fleet(
@@ -40,6 +41,7 @@ function associate_fleet(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -61,6 +63,7 @@ function batch_associate_user_stack(
         "BatchAssociateUserStack",
         Dict{String,Any}("UserStackAssociations" => UserStackAssociations);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_associate_user_stack(
@@ -78,6 +81,7 @@ function batch_associate_user_stack(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -98,6 +102,7 @@ function batch_disassociate_user_stack(
         "BatchDisassociateUserStack",
         Dict{String,Any}("UserStackAssociations" => UserStackAssociations);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_disassociate_user_stack(
@@ -115,6 +120,7 @@ function batch_disassociate_user_stack(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -151,6 +157,7 @@ function copy_image(
             "SourceImageName" => SourceImageName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function copy_image(
@@ -174,6 +181,7 @@ function copy_image(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -208,6 +216,7 @@ function create_directory_config(
             "OrganizationalUnitDistinguishedNames" => OrganizationalUnitDistinguishedNames,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_directory_config(
@@ -230,6 +239,7 @@ function create_directory_config(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -328,6 +338,7 @@ function create_fleet(
             "Name" => Name,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_fleet(
@@ -351,6 +362,7 @@ function create_fleet(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -414,6 +426,7 @@ function create_image_builder(
         "CreateImageBuilder",
         Dict{String,Any}("InstanceType" => InstanceType, "Name" => Name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_image_builder(
@@ -432,6 +445,7 @@ function create_image_builder(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -456,6 +470,7 @@ function create_image_builder_streaming_url(
         "CreateImageBuilderStreamingURL",
         Dict{String,Any}("Name" => Name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_image_builder_streaming_url(
@@ -465,6 +480,7 @@ function create_image_builder_streaming_url(
         "CreateImageBuilderStreamingURL",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -504,7 +520,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   streaming sessions. By default, these actions are enabled.
 """
 function create_stack(Name; aws_config::AbstractAWSConfig=global_aws_config())
-    return appstream("CreateStack", Dict{String,Any}("Name" => Name); aws_config=aws_config)
+    return appstream(
+        "CreateStack",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function create_stack(
     Name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -513,6 +534,7 @@ function create_stack(
         "CreateStack",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -548,6 +570,7 @@ function create_streaming_url(
             "FleetName" => FleetName, "StackName" => StackName, "UserId" => UserId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_streaming_url(
@@ -569,6 +592,7 @@ function create_streaming_url(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -611,6 +635,7 @@ function create_updated_image(
             "existingImageName" => existingImageName, "newImageName" => newImageName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_updated_image(
@@ -631,6 +656,7 @@ function create_updated_image(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -644,12 +670,21 @@ Creates a usage report subscription. Usage reports are generated daily.
 function create_usage_report_subscription(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return appstream("CreateUsageReportSubscription"; aws_config=aws_config)
+    return appstream(
+        "CreateUsageReportSubscription";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function create_usage_report_subscription(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return appstream("CreateUsageReportSubscription", params; aws_config=aws_config)
+    return appstream(
+        "CreateUsageReportSubscription",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -685,6 +720,7 @@ function create_user(
             "AuthenticationType" => AuthenticationType, "UserName" => UserName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_user(
@@ -705,6 +741,7 @@ function create_user(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -726,6 +763,7 @@ function delete_directory_config(
         "DeleteDirectoryConfig",
         Dict{String,Any}("DirectoryName" => DirectoryName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_directory_config(
@@ -739,6 +777,7 @@ function delete_directory_config(
             mergewith(_merge, Dict{String,Any}("DirectoryName" => DirectoryName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -753,7 +792,12 @@ Deletes the specified fleet.
 
 """
 function delete_fleet(Name; aws_config::AbstractAWSConfig=global_aws_config())
-    return appstream("DeleteFleet", Dict{String,Any}("Name" => Name); aws_config=aws_config)
+    return appstream(
+        "DeleteFleet",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_fleet(
     Name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -762,6 +806,7 @@ function delete_fleet(
         "DeleteFleet",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -777,7 +822,12 @@ an image, you cannot provision new capacity using the image.
 
 """
 function delete_image(Name; aws_config::AbstractAWSConfig=global_aws_config())
-    return appstream("DeleteImage", Dict{String,Any}("Name" => Name); aws_config=aws_config)
+    return appstream(
+        "DeleteImage",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_image(
     Name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -786,6 +836,7 @@ function delete_image(
         "DeleteImage",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -801,7 +852,10 @@ Deletes the specified image builder and releases the capacity.
 """
 function delete_image_builder(Name; aws_config::AbstractAWSConfig=global_aws_config())
     return appstream(
-        "DeleteImageBuilder", Dict{String,Any}("Name" => Name); aws_config=aws_config
+        "DeleteImageBuilder",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_image_builder(
@@ -811,6 +865,7 @@ function delete_image_builder(
         "DeleteImageBuilder",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -835,6 +890,7 @@ function delete_image_permissions(
         "DeleteImagePermissions",
         Dict{String,Any}("Name" => Name, "SharedAccountId" => SharedAccountId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_image_permissions(
@@ -853,6 +909,7 @@ function delete_image_permissions(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -869,7 +926,12 @@ made for application streaming sessions for the stack are released.
 
 """
 function delete_stack(Name; aws_config::AbstractAWSConfig=global_aws_config())
-    return appstream("DeleteStack", Dict{String,Any}("Name" => Name); aws_config=aws_config)
+    return appstream(
+        "DeleteStack",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_stack(
     Name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -878,6 +940,7 @@ function delete_stack(
         "DeleteStack",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -891,12 +954,21 @@ Disables usage report generation.
 function delete_usage_report_subscription(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return appstream("DeleteUsageReportSubscription"; aws_config=aws_config)
+    return appstream(
+        "DeleteUsageReportSubscription";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_usage_report_subscription(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return appstream("DeleteUsageReportSubscription", params; aws_config=aws_config)
+    return appstream(
+        "DeleteUsageReportSubscription",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -919,6 +991,7 @@ function delete_user(
             "AuthenticationType" => AuthenticationType, "UserName" => UserName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_user(
@@ -939,6 +1012,7 @@ function delete_user(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -961,12 +1035,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   operation. If this value is null, it retrieves the first page.
 """
 function describe_directory_configs(; aws_config::AbstractAWSConfig=global_aws_config())
-    return appstream("DescribeDirectoryConfigs"; aws_config=aws_config)
+    return appstream(
+        "DescribeDirectoryConfigs"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_directory_configs(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return appstream("DescribeDirectoryConfigs", params; aws_config=aws_config)
+    return appstream(
+        "DescribeDirectoryConfigs",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -983,12 +1064,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   operation. If this value is null, it retrieves the first page.
 """
 function describe_fleets(; aws_config::AbstractAWSConfig=global_aws_config())
-    return appstream("DescribeFleets"; aws_config=aws_config)
+    return appstream(
+        "DescribeFleets"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_fleets(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return appstream("DescribeFleets", params; aws_config=aws_config)
+    return appstream(
+        "DescribeFleets", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1006,12 +1091,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   operation. If this value is null, it retrieves the first page.
 """
 function describe_image_builders(; aws_config::AbstractAWSConfig=global_aws_config())
-    return appstream("DescribeImageBuilders"; aws_config=aws_config)
+    return appstream(
+        "DescribeImageBuilders"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_image_builders(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return appstream("DescribeImageBuilders", params; aws_config=aws_config)
+    return appstream(
+        "DescribeImageBuilders",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1035,7 +1127,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function describe_image_permissions(Name; aws_config::AbstractAWSConfig=global_aws_config())
     return appstream(
-        "DescribeImagePermissions", Dict{String,Any}("Name" => Name); aws_config=aws_config
+        "DescribeImagePermissions",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_image_permissions(
@@ -1045,6 +1140,7 @@ function describe_image_permissions(
         "DescribeImagePermissions",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1065,12 +1161,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"Type"`: The type of image (public, private, or shared) to describe.
 """
 function describe_images(; aws_config::AbstractAWSConfig=global_aws_config())
-    return appstream("DescribeImages"; aws_config=aws_config)
+    return appstream(
+        "DescribeImages"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_images(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return appstream("DescribeImages", params; aws_config=aws_config)
+    return appstream(
+        "DescribeImages", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1105,6 +1205,7 @@ function describe_sessions(
         "DescribeSessions",
         Dict{String,Any}("FleetName" => FleetName, "StackName" => StackName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_sessions(
@@ -1123,6 +1224,7 @@ function describe_sessions(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1140,12 +1242,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   operation. If this value is null, it retrieves the first page.
 """
 function describe_stacks(; aws_config::AbstractAWSConfig=global_aws_config())
-    return appstream("DescribeStacks"; aws_config=aws_config)
+    return appstream(
+        "DescribeStacks"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_stacks(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return appstream("DescribeStacks", params; aws_config=aws_config)
+    return appstream(
+        "DescribeStacks", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1163,12 +1269,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_usage_report_subscriptions(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return appstream("DescribeUsageReportSubscriptions"; aws_config=aws_config)
+    return appstream(
+        "DescribeUsageReportSubscriptions";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_usage_report_subscriptions(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return appstream("DescribeUsageReportSubscriptions", params; aws_config=aws_config)
+    return appstream(
+        "DescribeUsageReportSubscriptions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1193,12 +1308,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_user_stack_associations(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return appstream("DescribeUserStackAssociations"; aws_config=aws_config)
+    return appstream(
+        "DescribeUserStackAssociations";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_user_stack_associations(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return appstream("DescribeUserStackAssociations", params; aws_config=aws_config)
+    return appstream(
+        "DescribeUserStackAssociations",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1224,6 +1348,7 @@ function describe_users(
         "DescribeUsers",
         Dict{String,Any}("AuthenticationType" => AuthenticationType);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_users(
@@ -1239,6 +1364,7 @@ function describe_users(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1263,6 +1389,7 @@ function disable_user(
             "AuthenticationType" => AuthenticationType, "UserName" => UserName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disable_user(
@@ -1283,6 +1410,7 @@ function disable_user(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1304,6 +1432,7 @@ function disassociate_fleet(
         "DisassociateFleet",
         Dict{String,Any}("FleetName" => FleetName, "StackName" => StackName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disassociate_fleet(
@@ -1322,6 +1451,7 @@ function disassociate_fleet(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1349,6 +1479,7 @@ function enable_user(
             "AuthenticationType" => AuthenticationType, "UserName" => UserName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function enable_user(
@@ -1369,6 +1500,7 @@ function enable_user(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1384,7 +1516,10 @@ Immediately stops the specified streaming session.
 """
 function expire_session(SessionId; aws_config::AbstractAWSConfig=global_aws_config())
     return appstream(
-        "ExpireSession", Dict{String,Any}("SessionId" => SessionId); aws_config=aws_config
+        "ExpireSession",
+        Dict{String,Any}("SessionId" => SessionId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function expire_session(
@@ -1398,6 +1533,7 @@ function expire_session(
             mergewith(_merge, Dict{String,Any}("SessionId" => SessionId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1422,6 +1558,7 @@ function list_associated_fleets(
         "ListAssociatedFleets",
         Dict{String,Any}("StackName" => StackName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_associated_fleets(
@@ -1435,6 +1572,7 @@ function list_associated_fleets(
             mergewith(_merge, Dict{String,Any}("StackName" => StackName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1459,6 +1597,7 @@ function list_associated_stacks(
         "ListAssociatedStacks",
         Dict{String,Any}("FleetName" => FleetName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_associated_stacks(
@@ -1472,6 +1611,7 @@ function list_associated_stacks(
             mergewith(_merge, Dict{String,Any}("FleetName" => FleetName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1494,6 +1634,7 @@ function list_tags_for_resource(
         "ListTagsForResource",
         Dict{String,Any}("ResourceArn" => ResourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags_for_resource(
@@ -1507,6 +1648,7 @@ function list_tags_for_resource(
             mergewith(_merge, Dict{String,Any}("ResourceArn" => ResourceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1521,7 +1663,12 @@ Starts the specified fleet.
 
 """
 function start_fleet(Name; aws_config::AbstractAWSConfig=global_aws_config())
-    return appstream("StartFleet", Dict{String,Any}("Name" => Name); aws_config=aws_config)
+    return appstream(
+        "StartFleet",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function start_fleet(
     Name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -1530,6 +1677,7 @@ function start_fleet(
         "StartFleet",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1549,7 +1697,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function start_image_builder(Name; aws_config::AbstractAWSConfig=global_aws_config())
     return appstream(
-        "StartImageBuilder", Dict{String,Any}("Name" => Name); aws_config=aws_config
+        "StartImageBuilder",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_image_builder(
@@ -1559,6 +1710,7 @@ function start_image_builder(
         "StartImageBuilder",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1573,7 +1725,12 @@ Stops the specified fleet.
 
 """
 function stop_fleet(Name; aws_config::AbstractAWSConfig=global_aws_config())
-    return appstream("StopFleet", Dict{String,Any}("Name" => Name); aws_config=aws_config)
+    return appstream(
+        "StopFleet",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function stop_fleet(
     Name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -1582,6 +1739,7 @@ function stop_fleet(
         "StopFleet",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1597,7 +1755,10 @@ Stops the specified image builder.
 """
 function stop_image_builder(Name; aws_config::AbstractAWSConfig=global_aws_config())
     return appstream(
-        "StopImageBuilder", Dict{String,Any}("Name" => Name); aws_config=aws_config
+        "StopImageBuilder",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function stop_image_builder(
@@ -1607,6 +1768,7 @@ function stop_image_builder(
         "StopImageBuilder",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1635,6 +1797,7 @@ function tag_resource(ResourceArn, Tags; aws_config::AbstractAWSConfig=global_aw
         "TagResource",
         Dict{String,Any}("ResourceArn" => ResourceArn, "Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -1653,6 +1816,7 @@ function tag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1676,6 +1840,7 @@ function untag_resource(
         "UntagResource",
         Dict{String,Any}("ResourceArn" => ResourceArn, "TagKeys" => TagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -1694,6 +1859,7 @@ function untag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1722,6 +1888,7 @@ function update_directory_config(
         "UpdateDirectoryConfig",
         Dict{String,Any}("DirectoryName" => DirectoryName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_directory_config(
@@ -1735,6 +1902,7 @@ function update_directory_config(
             mergewith(_merge, Dict{String,Any}("DirectoryName" => DirectoryName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1816,12 +1984,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"VpcConfig"`: The VPC configuration for the fleet.
 """
 function update_fleet(; aws_config::AbstractAWSConfig=global_aws_config())
-    return appstream("UpdateFleet"; aws_config=aws_config)
+    return appstream("UpdateFleet"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function update_fleet(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return appstream("UpdateFleet", params; aws_config=aws_config)
+    return appstream(
+        "UpdateFleet", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1851,6 +2021,7 @@ function update_image_permissions(
             "SharedAccountId" => SharedAccountId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_image_permissions(
@@ -1874,6 +2045,7 @@ function update_image_permissions(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1909,7 +2081,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   streaming sessions. By default, these actions are enabled.
 """
 function update_stack(Name; aws_config::AbstractAWSConfig=global_aws_config())
-    return appstream("UpdateStack", Dict{String,Any}("Name" => Name); aws_config=aws_config)
+    return appstream(
+        "UpdateStack",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function update_stack(
     Name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -1918,5 +2095,6 @@ function update_stack(
         "UpdateStack",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/appsync.jl
+++ b/src/services/appsync.jl
@@ -41,6 +41,7 @@ function create_api_cache(
             "apiCachingBehavior" => apiCachingBehavior, "ttl" => ttl, "type" => type
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_api_cache(
@@ -64,6 +65,7 @@ function create_api_cache(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -84,12 +86,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   for this parameter is 7 days from creation time. For more information, see .
 """
 function create_api_key(apiId; aws_config::AbstractAWSConfig=global_aws_config())
-    return appsync("POST", "/v1/apis/$(apiId)/apikeys"; aws_config=aws_config)
+    return appsync(
+        "POST",
+        "/v1/apis/$(apiId)/apikeys";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function create_api_key(
     apiId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return appsync("POST", "/v1/apis/$(apiId)/apikeys", params; aws_config=aws_config)
+    return appsync(
+        "POST",
+        "/v1/apis/$(apiId)/apikeys",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -126,6 +139,7 @@ function create_data_source(
         "/v1/apis/$(apiId)/datasources",
         Dict{String,Any}("name" => name, "type" => type);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_data_source(
@@ -142,6 +156,7 @@ function create_data_source(
             mergewith(_merge, Dict{String,Any}("name" => name, "type" => type), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -183,6 +198,7 @@ function create_function(
             "name" => name,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_function(
@@ -208,6 +224,7 @@ function create_function(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -242,6 +259,7 @@ function create_graphql_api(
         "/v1/apis",
         Dict{String,Any}("authenticationType" => authenticationType, "name" => name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_graphql_api(
@@ -263,6 +281,7 @@ function create_graphql_api(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -305,6 +324,7 @@ function create_resolver(
         "/v1/apis/$(apiId)/types/$(typeName)/resolvers",
         Dict{String,Any}("fieldName" => fieldName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_resolver(
@@ -321,6 +341,7 @@ function create_resolver(
             mergewith(_merge, Dict{String,Any}("fieldName" => fieldName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -345,6 +366,7 @@ function create_type(
         "/v1/apis/$(apiId)/types",
         Dict{String,Any}("definition" => definition, "format" => format);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_type(
@@ -365,6 +387,7 @@ function create_type(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -379,12 +402,23 @@ Deletes an ApiCache object.
 
 """
 function delete_api_cache(apiId; aws_config::AbstractAWSConfig=global_aws_config())
-    return appsync("DELETE", "/v1/apis/$(apiId)/ApiCaches"; aws_config=aws_config)
+    return appsync(
+        "DELETE",
+        "/v1/apis/$(apiId)/ApiCaches";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_api_cache(
     apiId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return appsync("DELETE", "/v1/apis/$(apiId)/ApiCaches", params; aws_config=aws_config)
+    return appsync(
+        "DELETE",
+        "/v1/apis/$(apiId)/ApiCaches",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -399,7 +433,12 @@ Deletes an API key.
 
 """
 function delete_api_key(apiId, id; aws_config::AbstractAWSConfig=global_aws_config())
-    return appsync("DELETE", "/v1/apis/$(apiId)/apikeys/$(id)"; aws_config=aws_config)
+    return appsync(
+        "DELETE",
+        "/v1/apis/$(apiId)/apikeys/$(id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_api_key(
     apiId,
@@ -408,7 +447,11 @@ function delete_api_key(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return appsync(
-        "DELETE", "/v1/apis/$(apiId)/apikeys/$(id)", params; aws_config=aws_config
+        "DELETE",
+        "/v1/apis/$(apiId)/apikeys/$(id)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -424,7 +467,12 @@ Deletes a DataSource object.
 
 """
 function delete_data_source(apiId, name; aws_config::AbstractAWSConfig=global_aws_config())
-    return appsync("DELETE", "/v1/apis/$(apiId)/datasources/$(name)"; aws_config=aws_config)
+    return appsync(
+        "DELETE",
+        "/v1/apis/$(apiId)/datasources/$(name)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_data_source(
     apiId,
@@ -433,7 +481,11 @@ function delete_data_source(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return appsync(
-        "DELETE", "/v1/apis/$(apiId)/datasources/$(name)", params; aws_config=aws_config
+        "DELETE",
+        "/v1/apis/$(apiId)/datasources/$(name)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -452,7 +504,10 @@ function delete_function(
     apiId, functionId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return appsync(
-        "DELETE", "/v1/apis/$(apiId)/functions/$(functionId)"; aws_config=aws_config
+        "DELETE",
+        "/v1/apis/$(apiId)/functions/$(functionId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_function(
@@ -462,7 +517,11 @@ function delete_function(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return appsync(
-        "DELETE", "/v1/apis/$(apiId)/functions/$(functionId)", params; aws_config=aws_config
+        "DELETE",
+        "/v1/apis/$(apiId)/functions/$(functionId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -477,12 +536,23 @@ Deletes a GraphqlApi object.
 
 """
 function delete_graphql_api(apiId; aws_config::AbstractAWSConfig=global_aws_config())
-    return appsync("DELETE", "/v1/apis/$(apiId)"; aws_config=aws_config)
+    return appsync(
+        "DELETE",
+        "/v1/apis/$(apiId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_graphql_api(
     apiId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return appsync("DELETE", "/v1/apis/$(apiId)", params; aws_config=aws_config)
+    return appsync(
+        "DELETE",
+        "/v1/apis/$(apiId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -504,6 +574,7 @@ function delete_resolver(
         "DELETE",
         "/v1/apis/$(apiId)/types/$(typeName)/resolvers/$(fieldName)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_resolver(
@@ -518,6 +589,7 @@ function delete_resolver(
         "/v1/apis/$(apiId)/types/$(typeName)/resolvers/$(fieldName)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -533,7 +605,12 @@ Deletes a Type object.
 
 """
 function delete_type(apiId, typeName; aws_config::AbstractAWSConfig=global_aws_config())
-    return appsync("DELETE", "/v1/apis/$(apiId)/types/$(typeName)"; aws_config=aws_config)
+    return appsync(
+        "DELETE",
+        "/v1/apis/$(apiId)/types/$(typeName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_type(
     apiId,
@@ -542,7 +619,11 @@ function delete_type(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return appsync(
-        "DELETE", "/v1/apis/$(apiId)/types/$(typeName)", params; aws_config=aws_config
+        "DELETE",
+        "/v1/apis/$(apiId)/types/$(typeName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -557,12 +638,23 @@ Flushes an ApiCache object.
 
 """
 function flush_api_cache(apiId; aws_config::AbstractAWSConfig=global_aws_config())
-    return appsync("DELETE", "/v1/apis/$(apiId)/FlushCache"; aws_config=aws_config)
+    return appsync(
+        "DELETE",
+        "/v1/apis/$(apiId)/FlushCache";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function flush_api_cache(
     apiId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return appsync("DELETE", "/v1/apis/$(apiId)/FlushCache", params; aws_config=aws_config)
+    return appsync(
+        "DELETE",
+        "/v1/apis/$(apiId)/FlushCache",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -576,12 +668,23 @@ Retrieves an ApiCache object.
 
 """
 function get_api_cache(apiId; aws_config::AbstractAWSConfig=global_aws_config())
-    return appsync("GET", "/v1/apis/$(apiId)/ApiCaches"; aws_config=aws_config)
+    return appsync(
+        "GET",
+        "/v1/apis/$(apiId)/ApiCaches";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_api_cache(
     apiId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return appsync("GET", "/v1/apis/$(apiId)/ApiCaches", params; aws_config=aws_config)
+    return appsync(
+        "GET",
+        "/v1/apis/$(apiId)/ApiCaches",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -596,7 +699,12 @@ Retrieves a DataSource object.
 
 """
 function get_data_source(apiId, name; aws_config::AbstractAWSConfig=global_aws_config())
-    return appsync("GET", "/v1/apis/$(apiId)/datasources/$(name)"; aws_config=aws_config)
+    return appsync(
+        "GET",
+        "/v1/apis/$(apiId)/datasources/$(name)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_data_source(
     apiId,
@@ -605,7 +713,11 @@ function get_data_source(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return appsync(
-        "GET", "/v1/apis/$(apiId)/datasources/$(name)", params; aws_config=aws_config
+        "GET",
+        "/v1/apis/$(apiId)/datasources/$(name)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -622,7 +734,10 @@ Get a Function.
 """
 function get_function(apiId, functionId; aws_config::AbstractAWSConfig=global_aws_config())
     return appsync(
-        "GET", "/v1/apis/$(apiId)/functions/$(functionId)"; aws_config=aws_config
+        "GET",
+        "/v1/apis/$(apiId)/functions/$(functionId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_function(
@@ -632,7 +747,11 @@ function get_function(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return appsync(
-        "GET", "/v1/apis/$(apiId)/functions/$(functionId)", params; aws_config=aws_config
+        "GET",
+        "/v1/apis/$(apiId)/functions/$(functionId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -647,12 +766,20 @@ Retrieves a GraphqlApi object.
 
 """
 function get_graphql_api(apiId; aws_config::AbstractAWSConfig=global_aws_config())
-    return appsync("GET", "/v1/apis/$(apiId)"; aws_config=aws_config)
+    return appsync(
+        "GET", "/v1/apis/$(apiId)"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_graphql_api(
     apiId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return appsync("GET", "/v1/apis/$(apiId)", params; aws_config=aws_config)
+    return appsync(
+        "GET",
+        "/v1/apis/$(apiId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -678,6 +805,7 @@ function get_introspection_schema(
         "/v1/apis/$(apiId)/schema",
         Dict{String,Any}("format" => format);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_introspection_schema(
@@ -691,6 +819,7 @@ function get_introspection_schema(
         "/v1/apis/$(apiId)/schema",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("format" => format), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -713,6 +842,7 @@ function get_resolver(
         "GET",
         "/v1/apis/$(apiId)/types/$(typeName)/resolvers/$(fieldName)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_resolver(
@@ -727,6 +857,7 @@ function get_resolver(
         "/v1/apis/$(apiId)/types/$(typeName)/resolvers/$(fieldName)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -743,12 +874,23 @@ Retrieves the current status of a schema creation operation.
 function get_schema_creation_status(
     apiId; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return appsync("GET", "/v1/apis/$(apiId)/schemacreation"; aws_config=aws_config)
+    return appsync(
+        "GET",
+        "/v1/apis/$(apiId)/schemacreation";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_schema_creation_status(
     apiId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return appsync("GET", "/v1/apis/$(apiId)/schemacreation", params; aws_config=aws_config)
+    return appsync(
+        "GET",
+        "/v1/apis/$(apiId)/schemacreation",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -771,6 +913,7 @@ function get_type(
         "/v1/apis/$(apiId)/types/$(typeName)",
         Dict{String,Any}("format" => format);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_type(
@@ -785,6 +928,7 @@ function get_type(
         "/v1/apis/$(apiId)/types/$(typeName)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("format" => format), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -807,12 +951,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   which can be used to return the next set of items in the list.
 """
 function list_api_keys(apiId; aws_config::AbstractAWSConfig=global_aws_config())
-    return appsync("GET", "/v1/apis/$(apiId)/apikeys"; aws_config=aws_config)
+    return appsync(
+        "GET",
+        "/v1/apis/$(apiId)/apikeys";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_api_keys(
     apiId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return appsync("GET", "/v1/apis/$(apiId)/apikeys", params; aws_config=aws_config)
+    return appsync(
+        "GET",
+        "/v1/apis/$(apiId)/apikeys",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -831,12 +986,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   which can be used to return the next set of items in the list.
 """
 function list_data_sources(apiId; aws_config::AbstractAWSConfig=global_aws_config())
-    return appsync("GET", "/v1/apis/$(apiId)/datasources"; aws_config=aws_config)
+    return appsync(
+        "GET",
+        "/v1/apis/$(apiId)/datasources";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_data_sources(
     apiId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return appsync("GET", "/v1/apis/$(apiId)/datasources", params; aws_config=aws_config)
+    return appsync(
+        "GET",
+        "/v1/apis/$(apiId)/datasources",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -855,12 +1021,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   which can be used to return the next set of items in the list.
 """
 function list_functions(apiId; aws_config::AbstractAWSConfig=global_aws_config())
-    return appsync("GET", "/v1/apis/$(apiId)/functions"; aws_config=aws_config)
+    return appsync(
+        "GET",
+        "/v1/apis/$(apiId)/functions";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_functions(
     apiId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return appsync("GET", "/v1/apis/$(apiId)/functions", params; aws_config=aws_config)
+    return appsync(
+        "GET",
+        "/v1/apis/$(apiId)/functions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -876,12 +1053,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   which can be used to return the next set of items in the list.
 """
 function list_graphql_apis(; aws_config::AbstractAWSConfig=global_aws_config())
-    return appsync("GET", "/v1/apis"; aws_config=aws_config)
+    return appsync(
+        "GET", "/v1/apis"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_graphql_apis(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return appsync("GET", "/v1/apis", params; aws_config=aws_config)
+    return appsync(
+        "GET", "/v1/apis", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -902,7 +1083,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function list_resolvers(apiId, typeName; aws_config::AbstractAWSConfig=global_aws_config())
     return appsync(
-        "GET", "/v1/apis/$(apiId)/types/$(typeName)/resolvers"; aws_config=aws_config
+        "GET",
+        "/v1/apis/$(apiId)/types/$(typeName)/resolvers";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_resolvers(
@@ -916,6 +1100,7 @@ function list_resolvers(
         "/v1/apis/$(apiId)/types/$(typeName)/resolvers",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -939,7 +1124,10 @@ function list_resolvers_by_function(
     apiId, functionId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return appsync(
-        "GET", "/v1/apis/$(apiId)/functions/$(functionId)/resolvers"; aws_config=aws_config
+        "GET",
+        "/v1/apis/$(apiId)/functions/$(functionId)/resolvers";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_resolvers_by_function(
@@ -953,6 +1141,7 @@ function list_resolvers_by_function(
         "/v1/apis/$(apiId)/functions/$(functionId)/resolvers",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -969,14 +1158,25 @@ Lists the tags for a resource.
 function list_tags_for_resource(
     resourceArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return appsync("GET", "/v1/tags/$(resourceArn)"; aws_config=aws_config)
+    return appsync(
+        "GET",
+        "/v1/tags/$(resourceArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_tags_for_resource(
     resourceArn,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return appsync("GET", "/v1/tags/$(resourceArn)", params; aws_config=aws_config)
+    return appsync(
+        "GET",
+        "/v1/tags/$(resourceArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1001,6 +1201,7 @@ function list_types(apiId, format; aws_config::AbstractAWSConfig=global_aws_conf
         "/v1/apis/$(apiId)/types",
         Dict{String,Any}("format" => format);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_types(
@@ -1014,6 +1215,7 @@ function list_types(
         "/v1/apis/$(apiId)/types",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("format" => format), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1037,6 +1239,7 @@ function start_schema_creation(
         "/v1/apis/$(apiId)/schemacreation",
         Dict{String,Any}("definition" => definition);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_schema_creation(
@@ -1052,6 +1255,7 @@ function start_schema_creation(
             mergewith(_merge, Dict{String,Any}("definition" => definition), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1072,6 +1276,7 @@ function tag_resource(resourceArn, tags; aws_config::AbstractAWSConfig=global_aw
         "/v1/tags/$(resourceArn)",
         Dict{String,Any}("tags" => tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -1085,6 +1290,7 @@ function tag_resource(
         "/v1/tags/$(resourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tags" => tags), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1107,6 +1313,7 @@ function untag_resource(
         "/v1/tags/$(resourceArn)",
         Dict{String,Any}("tagKeys" => tagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -1120,6 +1327,7 @@ function untag_resource(
         "/v1/tags/$(resourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tagKeys" => tagKeys), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1154,6 +1362,7 @@ function update_api_cache(
             "apiCachingBehavior" => apiCachingBehavior, "ttl" => ttl, "type" => type
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_api_cache(
@@ -1177,6 +1386,7 @@ function update_api_cache(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1197,7 +1407,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   represented as seconds since the epoch. For more information, see .
 """
 function update_api_key(apiId, id; aws_config::AbstractAWSConfig=global_aws_config())
-    return appsync("POST", "/v1/apis/$(apiId)/apikeys/$(id)"; aws_config=aws_config)
+    return appsync(
+        "POST",
+        "/v1/apis/$(apiId)/apikeys/$(id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function update_api_key(
     apiId,
@@ -1205,7 +1420,13 @@ function update_api_key(
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return appsync("POST", "/v1/apis/$(apiId)/apikeys/$(id)", params; aws_config=aws_config)
+    return appsync(
+        "POST",
+        "/v1/apis/$(apiId)/apikeys/$(id)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1241,6 +1462,7 @@ function update_data_source(
         "/v1/apis/$(apiId)/datasources/$(name)",
         Dict{String,Any}("type" => type);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_data_source(
@@ -1255,6 +1477,7 @@ function update_data_source(
         "/v1/apis/$(apiId)/datasources/$(name)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("type" => type), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1297,6 +1520,7 @@ function update_function(
             "name" => name,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_function(
@@ -1323,6 +1547,7 @@ function update_function(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1351,7 +1576,11 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function update_graphql_api(apiId, name; aws_config::AbstractAWSConfig=global_aws_config())
     return appsync(
-        "POST", "/v1/apis/$(apiId)", Dict{String,Any}("name" => name); aws_config=aws_config
+        "POST",
+        "/v1/apis/$(apiId)",
+        Dict{String,Any}("name" => name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_graphql_api(
@@ -1365,6 +1594,7 @@ function update_graphql_api(
         "/v1/apis/$(apiId)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("name" => name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1404,6 +1634,7 @@ function update_resolver(
         "POST",
         "/v1/apis/$(apiId)/types/$(typeName)/resolvers/$(fieldName)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_resolver(
@@ -1418,6 +1649,7 @@ function update_resolver(
         "/v1/apis/$(apiId)/types/$(typeName)/resolvers/$(fieldName)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1444,6 +1676,7 @@ function update_type(
         "/v1/apis/$(apiId)/types/$(typeName)",
         Dict{String,Any}("format" => format);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_type(
@@ -1458,5 +1691,6 @@ function update_type(
         "/v1/apis/$(apiId)/types/$(typeName)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("format" => format), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/athena.jl
+++ b/src/services/athena.jl
@@ -28,6 +28,7 @@ function batch_get_named_query(
         "BatchGetNamedQuery",
         Dict{String,Any}("NamedQueryIds" => NamedQueryIds);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_get_named_query(
@@ -41,6 +42,7 @@ function batch_get_named_query(
             mergewith(_merge, Dict{String,Any}("NamedQueryIds" => NamedQueryIds), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -65,6 +67,7 @@ function batch_get_query_execution(
         "BatchGetQueryExecution",
         Dict{String,Any}("QueryExecutionIds" => QueryExecutionIds);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_get_query_execution(
@@ -80,6 +83,7 @@ function batch_get_query_execution(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -125,6 +129,7 @@ function create_data_catalog(Name, Type; aws_config::AbstractAWSConfig=global_aw
         "CreateDataCatalog",
         Dict{String,Any}("Name" => Name, "Type" => Type);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_data_catalog(
@@ -139,6 +144,7 @@ function create_data_catalog(
             mergewith(_merge, Dict{String,Any}("Name" => Name, "Type" => Type), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -179,6 +185,7 @@ function create_named_query(
             "ClientRequestToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_named_query(
@@ -203,6 +210,7 @@ function create_named_query(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -235,6 +243,7 @@ function create_prepared_statement(
             "WorkGroup" => WorkGroup,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_prepared_statement(
@@ -258,6 +267,7 @@ function create_prepared_statement(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -284,7 +294,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function create_work_group(Name; aws_config::AbstractAWSConfig=global_aws_config())
     return athena(
-        "CreateWorkGroup", Dict{String,Any}("Name" => Name); aws_config=aws_config
+        "CreateWorkGroup",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_work_group(
@@ -294,6 +307,7 @@ function create_work_group(
         "CreateWorkGroup",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -309,7 +323,10 @@ Deletes a data catalog.
 """
 function delete_data_catalog(Name; aws_config::AbstractAWSConfig=global_aws_config())
     return athena(
-        "DeleteDataCatalog", Dict{String,Any}("Name" => Name); aws_config=aws_config
+        "DeleteDataCatalog",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_data_catalog(
@@ -319,6 +336,7 @@ function delete_data_catalog(
         "DeleteDataCatalog",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -339,6 +357,7 @@ function delete_named_query(NamedQueryId; aws_config::AbstractAWSConfig=global_a
         "DeleteNamedQuery",
         Dict{String,Any}("NamedQueryId" => NamedQueryId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_named_query(
@@ -352,6 +371,7 @@ function delete_named_query(
             mergewith(_merge, Dict{String,Any}("NamedQueryId" => NamedQueryId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -373,6 +393,7 @@ function delete_prepared_statement(
         "DeletePreparedStatement",
         Dict{String,Any}("StatementName" => StatementName, "WorkGroup" => WorkGroup);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_prepared_statement(
@@ -393,6 +414,7 @@ function delete_prepared_statement(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -412,7 +434,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function delete_work_group(WorkGroup; aws_config::AbstractAWSConfig=global_aws_config())
     return athena(
-        "DeleteWorkGroup", Dict{String,Any}("WorkGroup" => WorkGroup); aws_config=aws_config
+        "DeleteWorkGroup",
+        Dict{String,Any}("WorkGroup" => WorkGroup);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_work_group(
@@ -426,6 +451,7 @@ function delete_work_group(
             mergewith(_merge, Dict{String,Any}("WorkGroup" => WorkGroup), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -440,7 +466,12 @@ Returns the specified data catalog.
 
 """
 function get_data_catalog(Name; aws_config::AbstractAWSConfig=global_aws_config())
-    return athena("GetDataCatalog", Dict{String,Any}("Name" => Name); aws_config=aws_config)
+    return athena(
+        "GetDataCatalog",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_data_catalog(
     Name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -449,6 +480,7 @@ function get_data_catalog(
         "GetDataCatalog",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -470,6 +502,7 @@ function get_database(
         "GetDatabase",
         Dict{String,Any}("CatalogName" => CatalogName, "DatabaseName" => DatabaseName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_database(
@@ -490,6 +523,7 @@ function get_database(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -509,6 +543,7 @@ function get_named_query(NamedQueryId; aws_config::AbstractAWSConfig=global_aws_
         "GetNamedQuery",
         Dict{String,Any}("NamedQueryId" => NamedQueryId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_named_query(
@@ -522,6 +557,7 @@ function get_named_query(
             mergewith(_merge, Dict{String,Any}("NamedQueryId" => NamedQueryId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -543,6 +579,7 @@ function get_prepared_statement(
         "GetPreparedStatement",
         Dict{String,Any}("StatementName" => StatementName, "WorkGroup" => WorkGroup);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_prepared_statement(
@@ -563,6 +600,7 @@ function get_prepared_statement(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -585,6 +623,7 @@ function get_query_execution(
         "GetQueryExecution",
         Dict{String,Any}("QueryExecutionId" => QueryExecutionId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_query_execution(
@@ -600,6 +639,7 @@ function get_query_execution(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -635,6 +675,7 @@ function get_query_results(
         "GetQueryResults",
         Dict{String,Any}("QueryExecutionId" => QueryExecutionId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_query_results(
@@ -650,6 +691,7 @@ function get_query_results(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -677,6 +719,7 @@ function get_table_metadata(
             "TableName" => TableName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_table_metadata(
@@ -700,6 +743,7 @@ function get_table_metadata(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -715,7 +759,10 @@ Returns information about the workgroup with the specified name.
 """
 function get_work_group(WorkGroup; aws_config::AbstractAWSConfig=global_aws_config())
     return athena(
-        "GetWorkGroup", Dict{String,Any}("WorkGroup" => WorkGroup); aws_config=aws_config
+        "GetWorkGroup",
+        Dict{String,Any}("WorkGroup" => WorkGroup);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_work_group(
@@ -729,6 +776,7 @@ function get_work_group(
             mergewith(_merge, Dict{String,Any}("WorkGroup" => WorkGroup), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -746,12 +794,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   the NextToken from the response object of the previous page call.
 """
 function list_data_catalogs(; aws_config::AbstractAWSConfig=global_aws_config())
-    return athena("ListDataCatalogs"; aws_config=aws_config)
+    return athena(
+        "ListDataCatalogs"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_data_catalogs(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return athena("ListDataCatalogs", params; aws_config=aws_config)
+    return athena(
+        "ListDataCatalogs", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -775,6 +827,7 @@ function list_databases(CatalogName; aws_config::AbstractAWSConfig=global_aws_co
         "ListDatabases",
         Dict{String,Any}("CatalogName" => CatalogName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_databases(
@@ -788,6 +841,7 @@ function list_databases(
             mergewith(_merge, Dict{String,Any}("CatalogName" => CatalogName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -806,12 +860,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   the NextToken from the response object of the previous page call.
 """
 function list_engine_versions(; aws_config::AbstractAWSConfig=global_aws_config())
-    return athena("ListEngineVersions"; aws_config=aws_config)
+    return athena(
+        "ListEngineVersions"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_engine_versions(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return athena("ListEngineVersions", params; aws_config=aws_config)
+    return athena(
+        "ListEngineVersions", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -833,12 +891,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   If a workgroup is not specified, the saved queries for the primary workgroup are returned.
 """
 function list_named_queries(; aws_config::AbstractAWSConfig=global_aws_config())
-    return athena("ListNamedQueries"; aws_config=aws_config)
+    return athena(
+        "ListNamedQueries"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_named_queries(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return athena("ListNamedQueries", params; aws_config=aws_config)
+    return athena(
+        "ListNamedQueries", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -864,6 +926,7 @@ function list_prepared_statements(
         "ListPreparedStatements",
         Dict{String,Any}("WorkGroup" => WorkGroup);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_prepared_statements(
@@ -877,6 +940,7 @@ function list_prepared_statements(
             mergewith(_merge, Dict{String,Any}("WorkGroup" => WorkGroup), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -901,12 +965,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   primary workgroup is returned.
 """
 function list_query_executions(; aws_config::AbstractAWSConfig=global_aws_config())
-    return athena("ListQueryExecutions"; aws_config=aws_config)
+    return athena(
+        "ListQueryExecutions"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_query_executions(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return athena("ListQueryExecutions", params; aws_config=aws_config)
+    return athena(
+        "ListQueryExecutions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -935,6 +1006,7 @@ function list_table_metadata(
         "ListTableMetadata",
         Dict{String,Any}("CatalogName" => CatalogName, "DatabaseName" => DatabaseName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_table_metadata(
@@ -955,6 +1027,7 @@ function list_table_metadata(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -982,6 +1055,7 @@ function list_tags_for_resource(
         "ListTagsForResource",
         Dict{String,Any}("ResourceARN" => ResourceARN);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags_for_resource(
@@ -995,6 +1069,7 @@ function list_tags_for_resource(
             mergewith(_merge, Dict{String,Any}("ResourceARN" => ResourceARN), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1012,12 +1087,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   the NextToken from the response object of the previous page call.
 """
 function list_work_groups(; aws_config::AbstractAWSConfig=global_aws_config())
-    return athena("ListWorkGroups"; aws_config=aws_config)
+    return athena("ListWorkGroups"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_work_groups(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return athena("ListWorkGroups", params; aws_config=aws_config)
+    return athena(
+        "ListWorkGroups", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1058,6 +1135,7 @@ function start_query_execution(
             "QueryString" => QueryString, "ClientRequestToken" => string(uuid4())
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_query_execution(
@@ -1077,6 +1155,7 @@ function start_query_execution(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1099,6 +1178,7 @@ function stop_query_execution(
         "StopQueryExecution",
         Dict{String,Any}("QueryExecutionId" => QueryExecutionId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function stop_query_execution(
@@ -1114,6 +1194,7 @@ function stop_query_execution(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1144,6 +1225,7 @@ function tag_resource(ResourceARN, Tags; aws_config::AbstractAWSConfig=global_aw
         "TagResource",
         Dict{String,Any}("ResourceARN" => ResourceARN, "Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -1162,6 +1244,7 @@ function tag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1184,6 +1267,7 @@ function untag_resource(
         "UntagResource",
         Dict{String,Any}("ResourceARN" => ResourceARN, "TagKeys" => TagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -1202,6 +1286,7 @@ function untag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1238,6 +1323,7 @@ function update_data_catalog(Name, Type; aws_config::AbstractAWSConfig=global_aw
         "UpdateDataCatalog",
         Dict{String,Any}("Name" => Name, "Type" => Type);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_data_catalog(
@@ -1252,6 +1338,7 @@ function update_data_catalog(
             mergewith(_merge, Dict{String,Any}("Name" => Name, "Type" => Type), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1284,6 +1371,7 @@ function update_prepared_statement(
             "WorkGroup" => WorkGroup,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_prepared_statement(
@@ -1307,6 +1395,7 @@ function update_prepared_statement(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1328,7 +1417,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function update_work_group(WorkGroup; aws_config::AbstractAWSConfig=global_aws_config())
     return athena(
-        "UpdateWorkGroup", Dict{String,Any}("WorkGroup" => WorkGroup); aws_config=aws_config
+        "UpdateWorkGroup",
+        Dict{String,Any}("WorkGroup" => WorkGroup);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_work_group(
@@ -1342,5 +1434,6 @@ function update_work_group(
             mergewith(_merge, Dict{String,Any}("WorkGroup" => WorkGroup), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/auditmanager.jl
+++ b/src/services/auditmanager.jl
@@ -23,6 +23,7 @@ function associate_assessment_report_evidence_folder(
         "/assessments/$(assessmentId)/associateToAssessmentReport",
         Dict{String,Any}("evidenceFolderId" => evidenceFolderId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_assessment_report_evidence_folder(
@@ -40,6 +41,7 @@ function associate_assessment_report_evidence_folder(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -68,6 +70,7 @@ function batch_associate_assessment_report_evidence(
             "evidenceFolderId" => evidenceFolderId, "evidenceIds" => evidenceIds
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_associate_assessment_report_evidence(
@@ -90,6 +93,7 @@ function batch_associate_assessment_report_evidence(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -115,6 +119,7 @@ function batch_create_delegation_by_assessment(
         "/assessments/$(assessmentId)/delegations",
         Dict{String,Any}("createDelegationRequests" => createDelegationRequests);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_create_delegation_by_assessment(
@@ -134,6 +139,7 @@ function batch_create_delegation_by_assessment(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -156,6 +162,7 @@ function batch_delete_delegation_by_assessment(
         "/assessments/$(assessmentId)/delegations",
         Dict{String,Any}("delegationIds" => delegationIds);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_delete_delegation_by_assessment(
@@ -171,6 +178,7 @@ function batch_delete_delegation_by_assessment(
             mergewith(_merge, Dict{String,Any}("delegationIds" => delegationIds), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -199,6 +207,7 @@ function batch_disassociate_assessment_report_evidence(
             "evidenceFolderId" => evidenceFolderId, "evidenceIds" => evidenceIds
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_disassociate_assessment_report_evidence(
@@ -221,6 +230,7 @@ function batch_disassociate_assessment_report_evidence(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -250,6 +260,7 @@ function batch_import_evidence_to_assessment_control(
         "/assessments/$(assessmentId)/controlSets/$(controlSetId)/controls/$(controlId)/evidence",
         Dict{String,Any}("manualEvidence" => manualEvidence);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_import_evidence_to_assessment_control(
@@ -267,6 +278,7 @@ function batch_import_evidence_to_assessment_control(
             mergewith(_merge, Dict{String,Any}("manualEvidence" => manualEvidence), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -308,6 +320,7 @@ function create_assessment(
             "scope" => scope,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_assessment(
@@ -336,6 +349,7 @@ function create_assessment(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -364,6 +378,7 @@ function create_assessment_framework(
         "/assessmentFrameworks",
         Dict{String,Any}("controlSets" => controlSets, "name" => name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_assessment_framework(
@@ -383,6 +398,7 @@ function create_assessment_framework(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -408,6 +424,7 @@ function create_assessment_report(
         "/assessments/$(assessmentId)/reports",
         Dict{String,Any}("name" => name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_assessment_report(
@@ -421,6 +438,7 @@ function create_assessment_report(
         "/assessments/$(assessmentId)/reports",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("name" => name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -452,6 +470,7 @@ function create_control(
         "/controls",
         Dict{String,Any}("controlMappingSources" => controlMappingSources, "name" => name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_control(
@@ -473,6 +492,7 @@ function create_control(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -487,7 +507,12 @@ end
 
 """
 function delete_assessment(assessmentId; aws_config::AbstractAWSConfig=global_aws_config())
-    return auditmanager("DELETE", "/assessments/$(assessmentId)"; aws_config=aws_config)
+    return auditmanager(
+        "DELETE",
+        "/assessments/$(assessmentId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_assessment(
     assessmentId,
@@ -495,7 +520,11 @@ function delete_assessment(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return auditmanager(
-        "DELETE", "/assessments/$(assessmentId)", params; aws_config=aws_config
+        "DELETE",
+        "/assessments/$(assessmentId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -513,7 +542,10 @@ function delete_assessment_framework(
     frameworkId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return auditmanager(
-        "DELETE", "/assessmentFrameworks/$(frameworkId)"; aws_config=aws_config
+        "DELETE",
+        "/assessmentFrameworks/$(frameworkId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_assessment_framework(
@@ -522,7 +554,11 @@ function delete_assessment_framework(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return auditmanager(
-        "DELETE", "/assessmentFrameworks/$(frameworkId)", params; aws_config=aws_config
+        "DELETE",
+        "/assessmentFrameworks/$(frameworkId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -544,6 +580,7 @@ function delete_assessment_report(
         "DELETE",
         "/assessments/$(assessmentId)/reports/$(assessmentReportId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_assessment_report(
@@ -557,6 +594,7 @@ function delete_assessment_report(
         "/assessments/$(assessmentId)/reports/$(assessmentReportId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -571,14 +609,25 @@ end
 
 """
 function delete_control(controlId; aws_config::AbstractAWSConfig=global_aws_config())
-    return auditmanager("DELETE", "/controls/$(controlId)"; aws_config=aws_config)
+    return auditmanager(
+        "DELETE",
+        "/controls/$(controlId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_control(
     controlId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return auditmanager("DELETE", "/controls/$(controlId)", params; aws_config=aws_config)
+    return auditmanager(
+        "DELETE",
+        "/controls/$(controlId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -589,12 +638,23 @@ end
 
 """
 function deregister_account(; aws_config::AbstractAWSConfig=global_aws_config())
-    return auditmanager("POST", "/account/deregisterAccount"; aws_config=aws_config)
+    return auditmanager(
+        "POST",
+        "/account/deregisterAccount";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function deregister_account(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return auditmanager("POST", "/account/deregisterAccount", params; aws_config=aws_config)
+    return auditmanager(
+        "POST",
+        "/account/deregisterAccount",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -615,14 +675,21 @@ function deregister_organization_admin_account(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
     return auditmanager(
-        "POST", "/account/deregisterOrganizationAdminAccount"; aws_config=aws_config
+        "POST",
+        "/account/deregisterOrganizationAdminAccount";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function deregister_organization_admin_account(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return auditmanager(
-        "POST", "/account/deregisterOrganizationAdminAccount", params; aws_config=aws_config
+        "POST",
+        "/account/deregisterOrganizationAdminAccount",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -645,6 +712,7 @@ function disassociate_assessment_report_evidence_folder(
         "/assessments/$(assessmentId)/disassociateFromAssessmentReport",
         Dict{String,Any}("evidenceFolderId" => evidenceFolderId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disassociate_assessment_report_evidence_folder(
@@ -662,6 +730,7 @@ function disassociate_assessment_report_evidence_folder(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -673,12 +742,20 @@ end
 
 """
 function get_account_status(; aws_config::AbstractAWSConfig=global_aws_config())
-    return auditmanager("GET", "/account/status"; aws_config=aws_config)
+    return auditmanager(
+        "GET", "/account/status"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_account_status(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return auditmanager("GET", "/account/status", params; aws_config=aws_config)
+    return auditmanager(
+        "GET",
+        "/account/status",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -692,7 +769,12 @@ end
 
 """
 function get_assessment(assessmentId; aws_config::AbstractAWSConfig=global_aws_config())
-    return auditmanager("GET", "/assessments/$(assessmentId)"; aws_config=aws_config)
+    return auditmanager(
+        "GET",
+        "/assessments/$(assessmentId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_assessment(
     assessmentId,
@@ -700,7 +782,11 @@ function get_assessment(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return auditmanager(
-        "GET", "/assessments/$(assessmentId)", params; aws_config=aws_config
+        "GET",
+        "/assessments/$(assessmentId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -718,7 +804,10 @@ function get_assessment_framework(
     frameworkId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return auditmanager(
-        "GET", "/assessmentFrameworks/$(frameworkId)"; aws_config=aws_config
+        "GET",
+        "/assessmentFrameworks/$(frameworkId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_assessment_framework(
@@ -727,7 +816,11 @@ function get_assessment_framework(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return auditmanager(
-        "GET", "/assessmentFrameworks/$(frameworkId)", params; aws_config=aws_config
+        "GET",
+        "/assessmentFrameworks/$(frameworkId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -749,6 +842,7 @@ function get_assessment_report_url(
         "GET",
         "/assessments/$(assessmentId)/reports/$(assessmentReportId)/url";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_assessment_report_url(
@@ -762,6 +856,7 @@ function get_assessment_report_url(
         "/assessments/$(assessmentId)/reports/$(assessmentReportId)/url",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -784,7 +879,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function get_change_logs(assessmentId; aws_config::AbstractAWSConfig=global_aws_config())
     return auditmanager(
-        "GET", "/assessments/$(assessmentId)/changelogs"; aws_config=aws_config
+        "GET",
+        "/assessments/$(assessmentId)/changelogs";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_change_logs(
@@ -793,7 +891,11 @@ function get_change_logs(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return auditmanager(
-        "GET", "/assessments/$(assessmentId)/changelogs", params; aws_config=aws_config
+        "GET",
+        "/assessments/$(assessmentId)/changelogs",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -808,14 +910,25 @@ end
 
 """
 function get_control(controlId; aws_config::AbstractAWSConfig=global_aws_config())
-    return auditmanager("GET", "/controls/$(controlId)"; aws_config=aws_config)
+    return auditmanager(
+        "GET",
+        "/controls/$(controlId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_control(
     controlId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return auditmanager("GET", "/controls/$(controlId)", params; aws_config=aws_config)
+    return auditmanager(
+        "GET",
+        "/controls/$(controlId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -831,12 +944,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`:  The pagination token used to fetch the next set of results.
 """
 function get_delegations(; aws_config::AbstractAWSConfig=global_aws_config())
-    return auditmanager("GET", "/delegations"; aws_config=aws_config)
+    return auditmanager(
+        "GET", "/delegations"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_delegations(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return auditmanager("GET", "/delegations", params; aws_config=aws_config)
+    return auditmanager(
+        "GET",
+        "/delegations",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -863,6 +984,7 @@ function get_evidence(
         "GET",
         "/assessments/$(assessmentId)/controlSets/$(controlSetId)/evidenceFolders/$(evidenceFolderId)/evidence/$(evidenceId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_evidence(
@@ -878,6 +1000,7 @@ function get_evidence(
         "/assessments/$(assessmentId)/controlSets/$(controlSetId)/evidenceFolders/$(evidenceFolderId)/evidence/$(evidenceId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -909,6 +1032,7 @@ function get_evidence_by_evidence_folder(
         "GET",
         "/assessments/$(assessmentId)/controlSets/$(controlSetId)/evidenceFolders/$(evidenceFolderId)/evidence";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_evidence_by_evidence_folder(
@@ -923,6 +1047,7 @@ function get_evidence_by_evidence_folder(
         "/assessments/$(assessmentId)/controlSets/$(controlSetId)/evidenceFolders/$(evidenceFolderId)/evidence",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -948,6 +1073,7 @@ function get_evidence_folder(
         "GET",
         "/assessments/$(assessmentId)/controlSets/$(controlSetId)/evidenceFolders/$(evidenceFolderId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_evidence_folder(
@@ -962,6 +1088,7 @@ function get_evidence_folder(
         "/assessments/$(assessmentId)/controlSets/$(controlSetId)/evidenceFolders/$(evidenceFolderId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -984,7 +1111,10 @@ function get_evidence_folders_by_assessment(
     assessmentId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return auditmanager(
-        "GET", "/assessments/$(assessmentId)/evidenceFolders"; aws_config=aws_config
+        "GET",
+        "/assessments/$(assessmentId)/evidenceFolders";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_evidence_folders_by_assessment(
@@ -993,7 +1123,11 @@ function get_evidence_folders_by_assessment(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return auditmanager(
-        "GET", "/assessments/$(assessmentId)/evidenceFolders", params; aws_config=aws_config
+        "GET",
+        "/assessments/$(assessmentId)/evidenceFolders",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1022,6 +1156,7 @@ function get_evidence_folders_by_assessment_control(
         "GET",
         "/assessments/$(assessmentId)/evidenceFolders-by-assessment-control/$(controlSetId)/$(controlId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_evidence_folders_by_assessment_control(
@@ -1036,6 +1171,7 @@ function get_evidence_folders_by_assessment_control(
         "/assessments/$(assessmentId)/evidenceFolders-by-assessment-control/$(controlSetId)/$(controlId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1048,13 +1184,22 @@ organization.
 
 """
 function get_organization_admin_account(; aws_config::AbstractAWSConfig=global_aws_config())
-    return auditmanager("GET", "/account/organizationAdminAccount"; aws_config=aws_config)
+    return auditmanager(
+        "GET",
+        "/account/organizationAdminAccount";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_organization_admin_account(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return auditmanager(
-        "GET", "/account/organizationAdminAccount", params; aws_config=aws_config
+        "GET",
+        "/account/organizationAdminAccount",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1066,12 +1211,16 @@ end
 
 """
 function get_services_in_scope(; aws_config::AbstractAWSConfig=global_aws_config())
-    return auditmanager("GET", "/services"; aws_config=aws_config)
+    return auditmanager(
+        "GET", "/services"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_services_in_scope(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return auditmanager("GET", "/services", params; aws_config=aws_config)
+    return auditmanager(
+        "GET", "/services", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1085,14 +1234,25 @@ end
 
 """
 function get_settings(attribute; aws_config::AbstractAWSConfig=global_aws_config())
-    return auditmanager("GET", "/settings/$(attribute)"; aws_config=aws_config)
+    return auditmanager(
+        "GET",
+        "/settings/$(attribute)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_settings(
     attribute,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return auditmanager("GET", "/settings/$(attribute)", params; aws_config=aws_config)
+    return auditmanager(
+        "GET",
+        "/settings/$(attribute)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1118,6 +1278,7 @@ function list_assessment_frameworks(
         "/assessmentFrameworks",
         Dict{String,Any}("frameworkType" => frameworkType);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_assessment_frameworks(
@@ -1132,6 +1293,7 @@ function list_assessment_frameworks(
             mergewith(_merge, Dict{String,Any}("frameworkType" => frameworkType), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1148,12 +1310,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`:  The pagination token used to fetch the next set of results.
 """
 function list_assessment_reports(; aws_config::AbstractAWSConfig=global_aws_config())
-    return auditmanager("GET", "/assessmentReports"; aws_config=aws_config)
+    return auditmanager(
+        "GET", "/assessmentReports"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_assessment_reports(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return auditmanager("GET", "/assessmentReports", params; aws_config=aws_config)
+    return auditmanager(
+        "GET",
+        "/assessmentReports",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1169,12 +1339,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`:  The pagination token used to fetch the next set of results.
 """
 function list_assessments(; aws_config::AbstractAWSConfig=global_aws_config())
-    return auditmanager("GET", "/assessments"; aws_config=aws_config)
+    return auditmanager(
+        "GET", "/assessments"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_assessments(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return auditmanager("GET", "/assessments", params; aws_config=aws_config)
+    return auditmanager(
+        "GET",
+        "/assessments",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1198,6 +1376,7 @@ function list_controls(controlType; aws_config::AbstractAWSConfig=global_aws_con
         "/controls",
         Dict{String,Any}("controlType" => controlType);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_controls(
@@ -1212,6 +1391,7 @@ function list_controls(
             mergewith(_merge, Dict{String,Any}("controlType" => controlType), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1238,6 +1418,7 @@ function list_keywords_for_data_source(
         "/dataSourceKeywords",
         Dict{String,Any}("source" => source);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_keywords_for_data_source(
@@ -1248,6 +1429,7 @@ function list_keywords_for_data_source(
         "/dataSourceKeywords",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("source" => source), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1264,12 +1446,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`:  The pagination token used to fetch the next set of results.
 """
 function list_notifications(; aws_config::AbstractAWSConfig=global_aws_config())
-    return auditmanager("GET", "/notifications"; aws_config=aws_config)
+    return auditmanager(
+        "GET", "/notifications"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_notifications(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return auditmanager("GET", "/notifications", params; aws_config=aws_config)
+    return auditmanager(
+        "GET",
+        "/notifications",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1285,14 +1475,25 @@ end
 function list_tags_for_resource(
     resourceArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return auditmanager("GET", "/tags/$(resourceArn)"; aws_config=aws_config)
+    return auditmanager(
+        "GET",
+        "/tags/$(resourceArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_tags_for_resource(
     resourceArn,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return auditmanager("GET", "/tags/$(resourceArn)", params; aws_config=aws_config)
+    return auditmanager(
+        "GET",
+        "/tags/$(resourceArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1307,12 +1508,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"kmsKey"`:  The KMS key details.
 """
 function register_account(; aws_config::AbstractAWSConfig=global_aws_config())
-    return auditmanager("POST", "/account/registerAccount"; aws_config=aws_config)
+    return auditmanager(
+        "POST",
+        "/account/registerAccount";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function register_account(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return auditmanager("POST", "/account/registerAccount", params; aws_config=aws_config)
+    return auditmanager(
+        "POST",
+        "/account/registerAccount",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1334,6 +1546,7 @@ function register_organization_admin_account(
         "/account/registerOrganizationAdminAccount",
         Dict{String,Any}("adminAccountId" => adminAccountId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function register_organization_admin_account(
@@ -1348,6 +1561,7 @@ function register_organization_admin_account(
             mergewith(_merge, Dict{String,Any}("adminAccountId" => adminAccountId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1368,6 +1582,7 @@ function tag_resource(resourceArn, tags; aws_config::AbstractAWSConfig=global_aw
         "/tags/$(resourceArn)",
         Dict{String,Any}("tags" => tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -1381,6 +1596,7 @@ function tag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tags" => tags), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1403,6 +1619,7 @@ function untag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}("tagKeys" => tagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -1416,6 +1633,7 @@ function untag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tagKeys" => tagKeys), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1445,6 +1663,7 @@ function update_assessment(
         "/assessments/$(assessmentId)",
         Dict{String,Any}("scope" => scope);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_assessment(
@@ -1458,6 +1677,7 @@ function update_assessment(
         "/assessments/$(assessmentId)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("scope" => scope), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1484,6 +1704,7 @@ function update_assessment_control(
         "PUT",
         "/assessments/$(assessmentId)/controlSets/$(controlSetId)/controls/$(controlId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_assessment_control(
@@ -1498,6 +1719,7 @@ function update_assessment_control(
         "/assessments/$(assessmentId)/controlSets/$(controlSetId)/controls/$(controlId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1526,6 +1748,7 @@ function update_assessment_control_set_status(
         "/assessments/$(assessmentId)/controlSets/$(controlSetId)/status",
         Dict{String,Any}("comment" => comment, "status" => status);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_assessment_control_set_status(
@@ -1545,6 +1768,7 @@ function update_assessment_control_set_status(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1573,6 +1797,7 @@ function update_assessment_framework(
         "/assessmentFrameworks/$(frameworkId)",
         Dict{String,Any}("controlSets" => controlSets, "name" => name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_assessment_framework(
@@ -1593,6 +1818,7 @@ function update_assessment_framework(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1615,6 +1841,7 @@ function update_assessment_status(
         "/assessments/$(assessmentId)/status",
         Dict{String,Any}("status" => status);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_assessment_status(
@@ -1628,6 +1855,7 @@ function update_assessment_status(
         "/assessments/$(assessmentId)/status",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("status" => status), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1662,6 +1890,7 @@ function update_control(
         "/controls/$(controlId)",
         Dict{String,Any}("controlMappingSources" => controlMappingSources, "name" => name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_control(
@@ -1684,6 +1913,7 @@ function update_control(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1703,12 +1933,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Manager sends notifications.
 """
 function update_settings(; aws_config::AbstractAWSConfig=global_aws_config())
-    return auditmanager("PUT", "/settings"; aws_config=aws_config)
+    return auditmanager(
+        "PUT", "/settings"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function update_settings(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return auditmanager("PUT", "/settings", params; aws_config=aws_config)
+    return auditmanager(
+        "PUT", "/settings", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1730,6 +1964,7 @@ function validate_assessment_report_integrity(
         "/assessmentReports/integrity",
         Dict{String,Any}("s3RelativePath" => s3RelativePath);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function validate_assessment_report_integrity(
@@ -1744,5 +1979,6 @@ function validate_assessment_report_integrity(
             mergewith(_merge, Dict{String,Any}("s3RelativePath" => s3RelativePath), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/auto_scaling.jl
+++ b/src/services/auto_scaling.jl
@@ -32,6 +32,7 @@ function attach_instances(
         "AttachInstances",
         Dict{String,Any}("AutoScalingGroupName" => AutoScalingGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function attach_instances(
@@ -49,6 +50,7 @@ function attach_instances(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -83,6 +85,7 @@ function attach_load_balancer_target_groups(
             "TargetGroupARNs" => TargetGroupARNs,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function attach_load_balancer_target_groups(
@@ -104,6 +107,7 @@ function attach_load_balancer_target_groups(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -137,6 +141,7 @@ function attach_load_balancers(
             "LoadBalancerNames" => LoadBalancerNames,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function attach_load_balancers(
@@ -158,6 +163,7 @@ function attach_load_balancers(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -185,6 +191,7 @@ function batch_delete_scheduled_action(
             "ScheduledActionNames" => ScheduledActionNames,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_delete_scheduled_action(
@@ -206,6 +213,7 @@ function batch_delete_scheduled_action(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -233,6 +241,7 @@ function batch_put_scheduled_update_group_action(
             "ScheduledUpdateGroupActions" => ScheduledUpdateGroupActions,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_put_scheduled_update_group_action(
@@ -254,6 +263,7 @@ function batch_put_scheduled_update_group_action(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -278,6 +288,7 @@ function cancel_instance_refresh(
         "CancelInstanceRefresh",
         Dict{String,Any}("AutoScalingGroupName" => AutoScalingGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function cancel_instance_refresh(
@@ -295,6 +306,7 @@ function cancel_instance_refresh(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -341,6 +353,7 @@ function complete_lifecycle_action(
             "LifecycleHookName" => LifecycleHookName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function complete_lifecycle_action(
@@ -364,6 +377,7 @@ function complete_lifecycle_action(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -510,6 +524,7 @@ function create_auto_scaling_group(
             "MinSize" => MinSize,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_auto_scaling_group(
@@ -533,6 +548,7 @@ function create_auto_scaling_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -642,6 +658,7 @@ function create_launch_configuration(
         "CreateLaunchConfiguration",
         Dict{String,Any}("LaunchConfigurationName" => LaunchConfigurationName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_launch_configuration(
@@ -659,6 +676,7 @@ function create_launch_configuration(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -677,7 +695,10 @@ instances in the Amazon EC2 Auto Scaling User Guide.
 """
 function create_or_update_tags(Tags; aws_config::AbstractAWSConfig=global_aws_config())
     return auto_scaling(
-        "CreateOrUpdateTags", Dict{String,Any}("Tags" => Tags); aws_config=aws_config
+        "CreateOrUpdateTags",
+        Dict{String,Any}("Tags" => Tags);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_or_update_tags(
@@ -687,6 +708,7 @@ function create_or_update_tags(
         "CreateOrUpdateTags",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Tags" => Tags), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -720,6 +742,7 @@ function delete_auto_scaling_group(
         "DeleteAutoScalingGroup",
         Dict{String,Any}("AutoScalingGroupName" => AutoScalingGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_auto_scaling_group(
@@ -737,6 +760,7 @@ function delete_auto_scaling_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -759,6 +783,7 @@ function delete_launch_configuration(
         "DeleteLaunchConfiguration",
         Dict{String,Any}("LaunchConfigurationName" => LaunchConfigurationName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_launch_configuration(
@@ -776,6 +801,7 @@ function delete_launch_configuration(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -803,6 +829,7 @@ function delete_lifecycle_hook(
             "LifecycleHookName" => LifecycleHookName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_lifecycle_hook(
@@ -824,6 +851,7 @@ function delete_lifecycle_hook(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -848,6 +876,7 @@ function delete_notification_configuration(
             "AutoScalingGroupName" => AutoScalingGroupName, "TopicARN" => TopicARN
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_notification_configuration(
@@ -868,6 +897,7 @@ function delete_notification_configuration(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -889,7 +919,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function delete_policy(PolicyName; aws_config::AbstractAWSConfig=global_aws_config())
     return auto_scaling(
-        "DeletePolicy", Dict{String,Any}("PolicyName" => PolicyName); aws_config=aws_config
+        "DeletePolicy",
+        Dict{String,Any}("PolicyName" => PolicyName);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_policy(
@@ -903,6 +936,7 @@ function delete_policy(
             mergewith(_merge, Dict{String,Any}("PolicyName" => PolicyName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -929,6 +963,7 @@ function delete_scheduled_action(
             "ScheduledActionName" => ScheduledActionName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_scheduled_action(
@@ -950,6 +985,7 @@ function delete_scheduled_action(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -965,7 +1001,10 @@ Deletes the specified tags.
 """
 function delete_tags(Tags; aws_config::AbstractAWSConfig=global_aws_config())
     return auto_scaling(
-        "DeleteTags", Dict{String,Any}("Tags" => Tags); aws_config=aws_config
+        "DeleteTags",
+        Dict{String,Any}("Tags" => Tags);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_tags(
@@ -975,6 +1014,7 @@ function delete_tags(
         "DeleteTags",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Tags" => Tags), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1001,6 +1041,7 @@ function delete_warm_pool(
         "DeleteWarmPool",
         Dict{String,Any}("AutoScalingGroupName" => AutoScalingGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_warm_pool(
@@ -1018,6 +1059,7 @@ function delete_warm_pool(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1033,12 +1075,19 @@ Guide.
 
 """
 function describe_account_limits(; aws_config::AbstractAWSConfig=global_aws_config())
-    return auto_scaling("DescribeAccountLimits"; aws_config=aws_config)
+    return auto_scaling(
+        "DescribeAccountLimits"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_account_limits(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return auto_scaling("DescribeAccountLimits", params; aws_config=aws_config)
+    return auto_scaling(
+        "DescribeAccountLimits",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1051,12 +1100,19 @@ PercentChangeInCapacity
 
 """
 function describe_adjustment_types(; aws_config::AbstractAWSConfig=global_aws_config())
-    return auto_scaling("DescribeAdjustmentTypes"; aws_config=aws_config)
+    return auto_scaling(
+        "DescribeAdjustmentTypes"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_adjustment_types(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return auto_scaling("DescribeAdjustmentTypes", params; aws_config=aws_config)
+    return auto_scaling(
+        "DescribeAdjustmentTypes",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1078,12 +1134,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   from a previous call.)
 """
 function describe_auto_scaling_groups(; aws_config::AbstractAWSConfig=global_aws_config())
-    return auto_scaling("DescribeAutoScalingGroups"; aws_config=aws_config)
+    return auto_scaling(
+        "DescribeAutoScalingGroups"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_auto_scaling_groups(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return auto_scaling("DescribeAutoScalingGroups", params; aws_config=aws_config)
+    return auto_scaling(
+        "DescribeAutoScalingGroups",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1105,12 +1168,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_auto_scaling_instances(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return auto_scaling("DescribeAutoScalingInstances"; aws_config=aws_config)
+    return auto_scaling(
+        "DescribeAutoScalingInstances";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_auto_scaling_instances(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return auto_scaling("DescribeAutoScalingInstances", params; aws_config=aws_config)
+    return auto_scaling(
+        "DescribeAutoScalingInstances",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1123,13 +1195,20 @@ Describes the notification types that are supported by Amazon EC2 Auto Scaling.
 function describe_auto_scaling_notification_types(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return auto_scaling("DescribeAutoScalingNotificationTypes"; aws_config=aws_config)
+    return auto_scaling(
+        "DescribeAutoScalingNotificationTypes";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_auto_scaling_notification_types(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return auto_scaling(
-        "DescribeAutoScalingNotificationTypes", params; aws_config=aws_config
+        "DescribeAutoScalingNotificationTypes",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1170,6 +1249,7 @@ function describe_instance_refreshes(
         "DescribeInstanceRefreshes",
         Dict{String,Any}("AutoScalingGroupName" => AutoScalingGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_instance_refreshes(
@@ -1187,6 +1267,7 @@ function describe_instance_refreshes(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1206,12 +1287,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   from a previous call.)
 """
 function describe_launch_configurations(; aws_config::AbstractAWSConfig=global_aws_config())
-    return auto_scaling("DescribeLaunchConfigurations"; aws_config=aws_config)
+    return auto_scaling(
+        "DescribeLaunchConfigurations";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_launch_configurations(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return auto_scaling("DescribeLaunchConfigurations", params; aws_config=aws_config)
+    return auto_scaling(
+        "DescribeLaunchConfigurations",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1223,12 +1313,19 @@ Describes the available types of lifecycle hooks. The following hook types are s
 
 """
 function describe_lifecycle_hook_types(; aws_config::AbstractAWSConfig=global_aws_config())
-    return auto_scaling("DescribeLifecycleHookTypes"; aws_config=aws_config)
+    return auto_scaling(
+        "DescribeLifecycleHookTypes"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_lifecycle_hook_types(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return auto_scaling("DescribeLifecycleHookTypes", params; aws_config=aws_config)
+    return auto_scaling(
+        "DescribeLifecycleHookTypes",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1252,6 +1349,7 @@ function describe_lifecycle_hooks(
         "DescribeLifecycleHooks",
         Dict{String,Any}("AutoScalingGroupName" => AutoScalingGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_lifecycle_hooks(
@@ -1269,6 +1367,7 @@ function describe_lifecycle_hooks(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1310,6 +1409,7 @@ function describe_load_balancer_target_groups(
         "DescribeLoadBalancerTargetGroups",
         Dict{String,Any}("AutoScalingGroupName" => AutoScalingGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_load_balancer_target_groups(
@@ -1327,6 +1427,7 @@ function describe_load_balancer_target_groups(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1370,6 +1471,7 @@ function describe_load_balancers(
         "DescribeLoadBalancers",
         Dict{String,Any}("AutoScalingGroupName" => AutoScalingGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_load_balancers(
@@ -1387,6 +1489,7 @@ function describe_load_balancers(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1402,12 +1505,21 @@ metric when calling the EnableMetricsCollection API.
 function describe_metric_collection_types(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return auto_scaling("DescribeMetricCollectionTypes"; aws_config=aws_config)
+    return auto_scaling(
+        "DescribeMetricCollectionTypes";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_metric_collection_types(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return auto_scaling("DescribeMetricCollectionTypes", params; aws_config=aws_config)
+    return auto_scaling(
+        "DescribeMetricCollectionTypes",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1428,12 +1540,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_notification_configurations(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return auto_scaling("DescribeNotificationConfigurations"; aws_config=aws_config)
+    return auto_scaling(
+        "DescribeNotificationConfigurations";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_notification_configurations(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return auto_scaling("DescribeNotificationConfigurations", params; aws_config=aws_config)
+    return auto_scaling(
+        "DescribeNotificationConfigurations",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1457,12 +1578,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   StepScaling, TargetTrackingScaling, and PredictiveScaling.
 """
 function describe_policies(; aws_config::AbstractAWSConfig=global_aws_config())
-    return auto_scaling("DescribePolicies"; aws_config=aws_config)
+    return auto_scaling(
+        "DescribePolicies"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_policies(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return auto_scaling("DescribePolicies", params; aws_config=aws_config)
+    return auto_scaling(
+        "DescribePolicies", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1493,12 +1618,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   from a previous call.)
 """
 function describe_scaling_activities(; aws_config::AbstractAWSConfig=global_aws_config())
-    return auto_scaling("DescribeScalingActivities"; aws_config=aws_config)
+    return auto_scaling(
+        "DescribeScalingActivities"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_scaling_activities(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return auto_scaling("DescribeScalingActivities", params; aws_config=aws_config)
+    return auto_scaling(
+        "DescribeScalingActivities",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1510,12 +1642,21 @@ APIs.
 
 """
 function describe_scaling_process_types(; aws_config::AbstractAWSConfig=global_aws_config())
-    return auto_scaling("DescribeScalingProcessTypes"; aws_config=aws_config)
+    return auto_scaling(
+        "DescribeScalingProcessTypes";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_scaling_process_types(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return auto_scaling("DescribeScalingProcessTypes", params; aws_config=aws_config)
+    return auto_scaling(
+        "DescribeScalingProcessTypes",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1542,12 +1683,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   provided, this parameter is ignored.
 """
 function describe_scheduled_actions(; aws_config::AbstractAWSConfig=global_aws_config())
-    return auto_scaling("DescribeScheduledActions"; aws_config=aws_config)
+    return auto_scaling(
+        "DescribeScheduledActions"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_scheduled_actions(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return auto_scaling("DescribeScheduledActions", params; aws_config=aws_config)
+    return auto_scaling(
+        "DescribeScheduledActions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1572,12 +1720,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   from a previous call.)
 """
 function describe_tags(; aws_config::AbstractAWSConfig=global_aws_config())
-    return auto_scaling("DescribeTags"; aws_config=aws_config)
+    return auto_scaling(
+        "DescribeTags"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_tags(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return auto_scaling("DescribeTags", params; aws_config=aws_config)
+    return auto_scaling(
+        "DescribeTags", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1592,12 +1744,21 @@ Amazon EC2 Auto Scaling User Guide.
 function describe_termination_policy_types(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return auto_scaling("DescribeTerminationPolicyTypes"; aws_config=aws_config)
+    return auto_scaling(
+        "DescribeTerminationPolicyTypes";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_termination_policy_types(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return auto_scaling("DescribeTerminationPolicyTypes", params; aws_config=aws_config)
+    return auto_scaling(
+        "DescribeTerminationPolicyTypes",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1624,6 +1785,7 @@ function describe_warm_pool(
         "DescribeWarmPool",
         Dict{String,Any}("AutoScalingGroupName" => AutoScalingGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_warm_pool(
@@ -1641,6 +1803,7 @@ function describe_warm_pool(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1678,6 +1841,7 @@ function detach_instances(
             "ShouldDecrementDesiredCapacity" => ShouldDecrementDesiredCapacity,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function detach_instances(
@@ -1699,6 +1863,7 @@ function detach_instances(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1724,6 +1889,7 @@ function detach_load_balancer_target_groups(
             "TargetGroupARNs" => TargetGroupARNs,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function detach_load_balancer_target_groups(
@@ -1745,6 +1911,7 @@ function detach_load_balancer_target_groups(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1778,6 +1945,7 @@ function detach_load_balancers(
             "LoadBalancerNames" => LoadBalancerNames,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function detach_load_balancers(
@@ -1799,6 +1967,7 @@ function detach_load_balancers(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1829,6 +1998,7 @@ function disable_metrics_collection(
         "DisableMetricsCollection",
         Dict{String,Any}("AutoScalingGroupName" => AutoScalingGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disable_metrics_collection(
@@ -1846,6 +2016,7 @@ function disable_metrics_collection(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1884,6 +2055,7 @@ function enable_metrics_collection(
             "AutoScalingGroupName" => AutoScalingGroupName, "Granularity" => Granularity
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function enable_metrics_collection(
@@ -1905,6 +2077,7 @@ function enable_metrics_collection(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1941,6 +2114,7 @@ function enter_standby(
             "ShouldDecrementDesiredCapacity" => ShouldDecrementDesiredCapacity,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function enter_standby(
@@ -1962,6 +2136,7 @@ function enter_standby(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1993,7 +2168,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function execute_policy(PolicyName; aws_config::AbstractAWSConfig=global_aws_config())
     return auto_scaling(
-        "ExecutePolicy", Dict{String,Any}("PolicyName" => PolicyName); aws_config=aws_config
+        "ExecutePolicy",
+        Dict{String,Any}("PolicyName" => PolicyName);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function execute_policy(
@@ -2007,6 +2185,7 @@ function execute_policy(
             mergewith(_merge, Dict{String,Any}("PolicyName" => PolicyName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2032,6 +2211,7 @@ function exit_standby(
         "ExitStandby",
         Dict{String,Any}("AutoScalingGroupName" => AutoScalingGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function exit_standby(
@@ -2049,6 +2229,7 @@ function exit_standby(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2092,6 +2273,7 @@ function get_predictive_scaling_forecast(
             "StartTime" => StartTime,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_predictive_scaling_forecast(
@@ -2117,6 +2299,7 @@ function get_predictive_scaling_forecast(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2187,6 +2370,7 @@ function put_lifecycle_hook(
             "LifecycleHookName" => LifecycleHookName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_lifecycle_hook(
@@ -2208,6 +2392,7 @@ function put_lifecycle_hook(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2245,6 +2430,7 @@ function put_notification_configuration(
             "TopicARN" => TopicARN,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_notification_configuration(
@@ -2268,6 +2454,7 @@ function put_notification_configuration(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2352,6 +2539,7 @@ function put_scaling_policy(
             "AutoScalingGroupName" => AutoScalingGroupName, "PolicyName" => PolicyName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_scaling_policy(
@@ -2373,6 +2561,7 @@ function put_scaling_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2427,6 +2616,7 @@ function put_scheduled_update_group_action(
             "ScheduledActionName" => ScheduledActionName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_scheduled_update_group_action(
@@ -2448,6 +2638,7 @@ function put_scheduled_update_group_action(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2497,6 +2688,7 @@ function put_warm_pool(
         "PutWarmPool",
         Dict{String,Any}("AutoScalingGroupName" => AutoScalingGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_warm_pool(
@@ -2514,6 +2706,7 @@ function put_warm_pool(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2558,6 +2751,7 @@ function record_lifecycle_action_heartbeat(
             "LifecycleHookName" => LifecycleHookName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function record_lifecycle_action_heartbeat(
@@ -2579,6 +2773,7 @@ function record_lifecycle_action_heartbeat(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2607,6 +2802,7 @@ function resume_processes(
         "ResumeProcesses",
         Dict{String,Any}("AutoScalingGroupName" => AutoScalingGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function resume_processes(
@@ -2624,6 +2820,7 @@ function resume_processes(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2658,6 +2855,7 @@ function set_desired_capacity(
             "DesiredCapacity" => DesiredCapacity,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function set_desired_capacity(
@@ -2679,6 +2877,7 @@ function set_desired_capacity(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2710,6 +2909,7 @@ function set_instance_health(
         "SetInstanceHealth",
         Dict{String,Any}("HealthStatus" => HealthStatus, "InstanceId" => InstanceId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function set_instance_health(
@@ -2730,6 +2930,7 @@ function set_instance_health(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2764,6 +2965,7 @@ function set_instance_protection(
             "ProtectedFromScaleIn" => ProtectedFromScaleIn,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function set_instance_protection(
@@ -2787,6 +2989,7 @@ function set_instance_protection(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2837,6 +3040,7 @@ function start_instance_refresh(
         "StartInstanceRefresh",
         Dict{String,Any}("AutoScalingGroupName" => AutoScalingGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_instance_refresh(
@@ -2854,6 +3058,7 @@ function start_instance_refresh(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2884,6 +3089,7 @@ function suspend_processes(
         "SuspendProcesses",
         Dict{String,Any}("AutoScalingGroupName" => AutoScalingGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function suspend_processes(
@@ -2901,6 +3107,7 @@ function suspend_processes(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2938,6 +3145,7 @@ function terminate_instance_in_auto_scaling_group(
             "ShouldDecrementDesiredCapacity" => ShouldDecrementDesiredCapacity,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function terminate_instance_in_auto_scaling_group(
@@ -2959,6 +3167,7 @@ function terminate_instance_in_auto_scaling_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3067,6 +3276,7 @@ function update_auto_scaling_group(
         "UpdateAutoScalingGroup",
         Dict{String,Any}("AutoScalingGroupName" => AutoScalingGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_auto_scaling_group(
@@ -3084,5 +3294,6 @@ function update_auto_scaling_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/auto_scaling_plans.jl
+++ b/src/services/auto_scaling_plans.jl
@@ -34,6 +34,7 @@ function create_scaling_plan(
             "ScalingPlanName" => ScalingPlanName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_scaling_plan(
@@ -57,6 +58,7 @@ function create_scaling_plan(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -84,6 +86,7 @@ function delete_scaling_plan(
             "ScalingPlanName" => ScalingPlanName, "ScalingPlanVersion" => ScalingPlanVersion
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_scaling_plan(
@@ -105,6 +108,7 @@ function delete_scaling_plan(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -134,6 +138,7 @@ function describe_scaling_plan_resources(
             "ScalingPlanName" => ScalingPlanName, "ScalingPlanVersion" => ScalingPlanVersion
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_scaling_plan_resources(
@@ -155,6 +160,7 @@ function describe_scaling_plan_resources(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -178,12 +184,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   name.
 """
 function describe_scaling_plans(; aws_config::AbstractAWSConfig=global_aws_config())
-    return auto_scaling_plans("DescribeScalingPlans"; aws_config=aws_config)
+    return auto_scaling_plans(
+        "DescribeScalingPlans"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_scaling_plans(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return auto_scaling_plans("DescribeScalingPlans", params; aws_config=aws_config)
+    return auto_scaling_plans(
+        "DescribeScalingPlans",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -245,6 +258,7 @@ function get_scaling_plan_resource_forecast_data(
             "StartTime" => StartTime,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_scaling_plan_resource_forecast_data(
@@ -278,6 +292,7 @@ function get_scaling_plan_resource_forecast_data(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -309,6 +324,7 @@ function update_scaling_plan(
             "ScalingPlanName" => ScalingPlanName, "ScalingPlanVersion" => ScalingPlanVersion
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_scaling_plan(
@@ -330,5 +346,6 @@ function update_scaling_plan(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/backup.jl
+++ b/src/services/backup.jl
@@ -32,6 +32,7 @@ function create_backup_plan(BackupPlan; aws_config::AbstractAWSConfig=global_aws
         "/backup/plans/",
         Dict{String,Any}("BackupPlan" => BackupPlan);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_backup_plan(
@@ -46,6 +47,7 @@ function create_backup_plan(
             mergewith(_merge, Dict{String,Any}("BackupPlan" => BackupPlan), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -85,6 +87,7 @@ function create_backup_selection(
         "/backup/plans/$(backupPlanId)/selections/",
         Dict{String,Any}("BackupSelection" => BackupSelection);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_backup_selection(
@@ -102,6 +105,7 @@ function create_backup_selection(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -132,14 +136,25 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function create_backup_vault(
     backupVaultName; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return backup("PUT", "/backup-vaults/$(backupVaultName)"; aws_config=aws_config)
+    return backup(
+        "PUT",
+        "/backup-vaults/$(backupVaultName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function create_backup_vault(
     backupVaultName,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return backup("PUT", "/backup-vaults/$(backupVaultName)", params; aws_config=aws_config)
+    return backup(
+        "PUT",
+        "/backup-vaults/$(backupVaultName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -181,6 +196,7 @@ function create_framework(
             "IdempotencyToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_framework(
@@ -204,6 +220,7 @@ function create_framework(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -252,6 +269,7 @@ function create_report_plan(
             "IdempotencyToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_report_plan(
@@ -277,6 +295,7 @@ function create_report_plan(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -293,14 +312,25 @@ plan. Previous versions, if any, will still exist.
 
 """
 function delete_backup_plan(backupPlanId; aws_config::AbstractAWSConfig=global_aws_config())
-    return backup("DELETE", "/backup/plans/$(backupPlanId)"; aws_config=aws_config)
+    return backup(
+        "DELETE",
+        "/backup/plans/$(backupPlanId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_backup_plan(
     backupPlanId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return backup("DELETE", "/backup/plans/$(backupPlanId)", params; aws_config=aws_config)
+    return backup(
+        "DELETE",
+        "/backup/plans/$(backupPlanId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -323,6 +353,7 @@ function delete_backup_selection(
         "DELETE",
         "/backup/plans/$(backupPlanId)/selections/$(selectionId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_backup_selection(
@@ -336,6 +367,7 @@ function delete_backup_selection(
         "/backup/plans/$(backupPlanId)/selections/$(selectionId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -355,7 +387,12 @@ Deletes the backup vault identified by its name. A vault can be deleted only if 
 function delete_backup_vault(
     backupVaultName; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return backup("DELETE", "/backup-vaults/$(backupVaultName)"; aws_config=aws_config)
+    return backup(
+        "DELETE",
+        "/backup-vaults/$(backupVaultName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_backup_vault(
     backupVaultName,
@@ -363,7 +400,11 @@ function delete_backup_vault(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return backup(
-        "DELETE", "/backup-vaults/$(backupVaultName)", params; aws_config=aws_config
+        "DELETE",
+        "/backup-vaults/$(backupVaultName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -384,7 +425,10 @@ function delete_backup_vault_access_policy(
     backupVaultName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return backup(
-        "DELETE", "/backup-vaults/$(backupVaultName)/access-policy"; aws_config=aws_config
+        "DELETE",
+        "/backup-vaults/$(backupVaultName)/access-policy";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_backup_vault_access_policy(
@@ -397,6 +441,7 @@ function delete_backup_vault_access_policy(
         "/backup-vaults/$(backupVaultName)/access-policy",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -419,6 +464,7 @@ function delete_backup_vault_notifications(
         "DELETE",
         "/backup-vaults/$(backupVaultName)/notification-configuration";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_backup_vault_notifications(
@@ -431,6 +477,7 @@ function delete_backup_vault_notifications(
         "/backup-vaults/$(backupVaultName)/notification-configuration",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -445,7 +492,12 @@ Deletes the framework specified by a framework name.
 
 """
 function delete_framework(frameworkName; aws_config::AbstractAWSConfig=global_aws_config())
-    return backup("DELETE", "/audit/frameworks/$(frameworkName)"; aws_config=aws_config)
+    return backup(
+        "DELETE",
+        "/audit/frameworks/$(frameworkName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_framework(
     frameworkName,
@@ -453,7 +505,11 @@ function delete_framework(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return backup(
-        "DELETE", "/audit/frameworks/$(frameworkName)", params; aws_config=aws_config
+        "DELETE",
+        "/audit/frameworks/$(frameworkName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -482,6 +538,7 @@ function delete_recovery_point(
         "DELETE",
         "/backup-vaults/$(backupVaultName)/recovery-points/$(recoveryPointArn)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_recovery_point(
@@ -495,6 +552,7 @@ function delete_recovery_point(
         "/backup-vaults/$(backupVaultName)/recovery-points/$(recoveryPointArn)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -511,7 +569,12 @@ Deletes the report plan specified by a report plan name.
 function delete_report_plan(
     reportPlanName; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return backup("DELETE", "/audit/report-plans/$(reportPlanName)"; aws_config=aws_config)
+    return backup(
+        "DELETE",
+        "/audit/report-plans/$(reportPlanName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_report_plan(
     reportPlanName,
@@ -519,7 +582,11 @@ function delete_report_plan(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return backup(
-        "DELETE", "/audit/report-plans/$(reportPlanName)", params; aws_config=aws_config
+        "DELETE",
+        "/audit/report-plans/$(reportPlanName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -534,14 +601,25 @@ Returns backup job details for the specified BackupJobId.
 
 """
 function describe_backup_job(backupJobId; aws_config::AbstractAWSConfig=global_aws_config())
-    return backup("GET", "/backup-jobs/$(backupJobId)"; aws_config=aws_config)
+    return backup(
+        "GET",
+        "/backup-jobs/$(backupJobId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_backup_job(
     backupJobId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return backup("GET", "/backup-jobs/$(backupJobId)", params; aws_config=aws_config)
+    return backup(
+        "GET",
+        "/backup-jobs/$(backupJobId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -560,14 +638,25 @@ Returns metadata about a backup vault specified by its name.
 function describe_backup_vault(
     backupVaultName; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return backup("GET", "/backup-vaults/$(backupVaultName)"; aws_config=aws_config)
+    return backup(
+        "GET",
+        "/backup-vaults/$(backupVaultName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_backup_vault(
     backupVaultName,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return backup("GET", "/backup-vaults/$(backupVaultName)", params; aws_config=aws_config)
+    return backup(
+        "GET",
+        "/backup-vaults/$(backupVaultName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -581,14 +670,25 @@ Returns metadata associated with creating a copy of a resource.
 
 """
 function describe_copy_job(copyJobId; aws_config::AbstractAWSConfig=global_aws_config())
-    return backup("GET", "/copy-jobs/$(copyJobId)"; aws_config=aws_config)
+    return backup(
+        "GET",
+        "/copy-jobs/$(copyJobId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_copy_job(
     copyJobId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return backup("GET", "/copy-jobs/$(copyJobId)", params; aws_config=aws_config)
+    return backup(
+        "GET",
+        "/copy-jobs/$(copyJobId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -604,7 +704,12 @@ Returns the framework details for the specified FrameworkName.
 function describe_framework(
     frameworkName; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return backup("GET", "/audit/frameworks/$(frameworkName)"; aws_config=aws_config)
+    return backup(
+        "GET",
+        "/audit/frameworks/$(frameworkName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_framework(
     frameworkName,
@@ -612,7 +717,11 @@ function describe_framework(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return backup(
-        "GET", "/audit/frameworks/$(frameworkName)", params; aws_config=aws_config
+        "GET",
+        "/audit/frameworks/$(frameworkName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -626,12 +735,20 @@ describe-global-settings --region us-west-2
 
 """
 function describe_global_settings(; aws_config::AbstractAWSConfig=global_aws_config())
-    return backup("GET", "/global-settings"; aws_config=aws_config)
+    return backup(
+        "GET", "/global-settings"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_global_settings(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return backup("GET", "/global-settings", params; aws_config=aws_config)
+    return backup(
+        "GET",
+        "/global-settings",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -649,14 +766,25 @@ Amazon Resource Name (ARN), and the Amazon Web Services service type of the save
 function describe_protected_resource(
     resourceArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return backup("GET", "/resources/$(resourceArn)"; aws_config=aws_config)
+    return backup(
+        "GET",
+        "/resources/$(resourceArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_protected_resource(
     resourceArn,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return backup("GET", "/resources/$(resourceArn)", params; aws_config=aws_config)
+    return backup(
+        "GET",
+        "/resources/$(resourceArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -683,6 +811,7 @@ function describe_recovery_point(
         "GET",
         "/backup-vaults/$(backupVaultName)/recovery-points/$(recoveryPointArn)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_recovery_point(
@@ -696,6 +825,7 @@ function describe_recovery_point(
         "/backup-vaults/$(backupVaultName)/recovery-points/$(recoveryPointArn)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -710,12 +840,20 @@ does not try to protect that service's resources in this Region.
 
 """
 function describe_region_settings(; aws_config::AbstractAWSConfig=global_aws_config())
-    return backup("GET", "/account-settings"; aws_config=aws_config)
+    return backup(
+        "GET", "/account-settings"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_region_settings(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return backup("GET", "/account-settings", params; aws_config=aws_config)
+    return backup(
+        "GET",
+        "/account-settings",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -730,14 +868,25 @@ Returns the details associated with creating a report as specified by its Report
 
 """
 function describe_report_job(reportJobId; aws_config::AbstractAWSConfig=global_aws_config())
-    return backup("GET", "/audit/report-jobs/$(reportJobId)"; aws_config=aws_config)
+    return backup(
+        "GET",
+        "/audit/report-jobs/$(reportJobId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_report_job(
     reportJobId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return backup("GET", "/audit/report-jobs/$(reportJobId)", params; aws_config=aws_config)
+    return backup(
+        "GET",
+        "/audit/report-jobs/$(reportJobId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -754,7 +903,12 @@ Services Region.
 function describe_report_plan(
     reportPlanName; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return backup("GET", "/audit/report-plans/$(reportPlanName)"; aws_config=aws_config)
+    return backup(
+        "GET",
+        "/audit/report-plans/$(reportPlanName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_report_plan(
     reportPlanName,
@@ -762,7 +916,11 @@ function describe_report_plan(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return backup(
-        "GET", "/audit/report-plans/$(reportPlanName)", params; aws_config=aws_config
+        "GET",
+        "/audit/report-plans/$(reportPlanName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -779,14 +937,25 @@ Returns metadata associated with a restore job that is specified by a job ID.
 function describe_restore_job(
     restoreJobId; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return backup("GET", "/restore-jobs/$(restoreJobId)"; aws_config=aws_config)
+    return backup(
+        "GET",
+        "/restore-jobs/$(restoreJobId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_restore_job(
     restoreJobId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return backup("GET", "/restore-jobs/$(restoreJobId)", params; aws_config=aws_config)
+    return backup(
+        "GET",
+        "/restore-jobs/$(restoreJobId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -811,6 +980,7 @@ function disassociate_recovery_point(
         "POST",
         "/backup-vaults/$(backupVaultName)/recovery-points/$(recoveryPointArn)/disassociate";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disassociate_recovery_point(
@@ -824,6 +994,7 @@ function disassociate_recovery_point(
         "/backup-vaults/$(backupVaultName)/recovery-points/$(recoveryPointArn)/disassociate",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -840,7 +1011,12 @@ Returns the backup plan that is specified by the plan ID as a backup template.
 function export_backup_plan_template(
     backupPlanId; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return backup("GET", "/backup/plans/$(backupPlanId)/toTemplate/"; aws_config=aws_config)
+    return backup(
+        "GET",
+        "/backup/plans/$(backupPlanId)/toTemplate/";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function export_backup_plan_template(
     backupPlanId,
@@ -848,7 +1024,11 @@ function export_backup_plan_template(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return backup(
-        "GET", "/backup/plans/$(backupPlanId)/toTemplate/", params; aws_config=aws_config
+        "GET",
+        "/backup/plans/$(backupPlanId)/toTemplate/",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -868,14 +1048,25 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   most 1,024 bytes long. Version IDs cannot be edited.
 """
 function get_backup_plan(backupPlanId; aws_config::AbstractAWSConfig=global_aws_config())
-    return backup("GET", "/backup/plans/$(backupPlanId)/"; aws_config=aws_config)
+    return backup(
+        "GET",
+        "/backup/plans/$(backupPlanId)/";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_backup_plan(
     backupPlanId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return backup("GET", "/backup/plans/$(backupPlanId)/", params; aws_config=aws_config)
+    return backup(
+        "GET",
+        "/backup/plans/$(backupPlanId)/",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -896,6 +1087,7 @@ function get_backup_plan_from_json(
         "/backup/template/json/toPlan",
         Dict{String,Any}("BackupPlanTemplateJson" => BackupPlanTemplateJson);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_backup_plan_from_json(
@@ -914,6 +1106,7 @@ function get_backup_plan_from_json(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -931,7 +1124,10 @@ function get_backup_plan_from_template(
     templateId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return backup(
-        "GET", "/backup/template/plans/$(templateId)/toPlan"; aws_config=aws_config
+        "GET",
+        "/backup/template/plans/$(templateId)/toPlan";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_backup_plan_from_template(
@@ -940,7 +1136,11 @@ function get_backup_plan_from_template(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return backup(
-        "GET", "/backup/template/plans/$(templateId)/toPlan", params; aws_config=aws_config
+        "GET",
+        "/backup/template/plans/$(templateId)/toPlan",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -964,6 +1164,7 @@ function get_backup_selection(
         "GET",
         "/backup/plans/$(backupPlanId)/selections/$(selectionId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_backup_selection(
@@ -977,6 +1178,7 @@ function get_backup_selection(
         "/backup/plans/$(backupPlanId)/selections/$(selectionId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -997,7 +1199,10 @@ function get_backup_vault_access_policy(
     backupVaultName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return backup(
-        "GET", "/backup-vaults/$(backupVaultName)/access-policy"; aws_config=aws_config
+        "GET",
+        "/backup-vaults/$(backupVaultName)/access-policy";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_backup_vault_access_policy(
@@ -1010,6 +1215,7 @@ function get_backup_vault_access_policy(
         "/backup-vaults/$(backupVaultName)/access-policy",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1033,6 +1239,7 @@ function get_backup_vault_notifications(
         "GET",
         "/backup-vaults/$(backupVaultName)/notification-configuration";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_backup_vault_notifications(
@@ -1045,6 +1252,7 @@ function get_backup_vault_notifications(
         "/backup-vaults/$(backupVaultName)/notification-configuration",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1071,6 +1279,7 @@ function get_recovery_point_restore_metadata(
         "GET",
         "/backup-vaults/$(backupVaultName)/recovery-points/$(recoveryPointArn)/restore-metadata";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_recovery_point_restore_metadata(
@@ -1084,6 +1293,7 @@ function get_recovery_point_restore_metadata(
         "/backup-vaults/$(backupVaultName)/recovery-points/$(recoveryPointArn)/restore-metadata",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1095,12 +1305,23 @@ Returns the Amazon Web Services resource types supported by Backup.
 
 """
 function get_supported_resource_types(; aws_config::AbstractAWSConfig=global_aws_config())
-    return backup("GET", "/supported-resource-types"; aws_config=aws_config)
+    return backup(
+        "GET",
+        "/supported-resource-types";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_supported_resource_types(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return backup("GET", "/supported-resource-types", params; aws_config=aws_config)
+    return backup(
+        "GET",
+        "/supported-resource-types",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1134,12 +1355,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"state"`: Returns only backup jobs that are in the specified state.
 """
 function list_backup_jobs(; aws_config::AbstractAWSConfig=global_aws_config())
-    return backup("GET", "/backup-jobs/"; aws_config=aws_config)
+    return backup(
+        "GET", "/backup-jobs/"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_backup_jobs(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return backup("GET", "/backup-jobs/", params; aws_config=aws_config)
+    return backup(
+        "GET",
+        "/backup-jobs/",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1157,12 +1386,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   items in your list starting at the location pointed to by the next token.
 """
 function list_backup_plan_templates(; aws_config::AbstractAWSConfig=global_aws_config())
-    return backup("GET", "/backup/template/plans"; aws_config=aws_config)
+    return backup(
+        "GET",
+        "/backup/template/plans";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_backup_plan_templates(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return backup("GET", "/backup/template/plans", params; aws_config=aws_config)
+    return backup(
+        "GET",
+        "/backup/template/plans",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1185,7 +1425,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function list_backup_plan_versions(
     backupPlanId; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return backup("GET", "/backup/plans/$(backupPlanId)/versions/"; aws_config=aws_config)
+    return backup(
+        "GET",
+        "/backup/plans/$(backupPlanId)/versions/";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_backup_plan_versions(
     backupPlanId,
@@ -1193,7 +1438,11 @@ function list_backup_plan_versions(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return backup(
-        "GET", "/backup/plans/$(backupPlanId)/versions/", params; aws_config=aws_config
+        "GET",
+        "/backup/plans/$(backupPlanId)/versions/",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1215,12 +1464,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   items in your list starting at the location pointed to by the next token.
 """
 function list_backup_plans(; aws_config::AbstractAWSConfig=global_aws_config())
-    return backup("GET", "/backup/plans/"; aws_config=aws_config)
+    return backup(
+        "GET", "/backup/plans/"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_backup_plans(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return backup("GET", "/backup/plans/", params; aws_config=aws_config)
+    return backup(
+        "GET",
+        "/backup/plans/",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1243,7 +1500,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function list_backup_selections(
     backupPlanId; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return backup("GET", "/backup/plans/$(backupPlanId)/selections/"; aws_config=aws_config)
+    return backup(
+        "GET",
+        "/backup/plans/$(backupPlanId)/selections/";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_backup_selections(
     backupPlanId,
@@ -1251,7 +1513,11 @@ function list_backup_selections(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return backup(
-        "GET", "/backup/plans/$(backupPlanId)/selections/", params; aws_config=aws_config
+        "GET",
+        "/backup/plans/$(backupPlanId)/selections/",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1269,12 +1535,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   items in your list starting at the location pointed to by the next token.
 """
 function list_backup_vaults(; aws_config::AbstractAWSConfig=global_aws_config())
-    return backup("GET", "/backup-vaults/"; aws_config=aws_config)
+    return backup(
+        "GET", "/backup-vaults/"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_backup_vaults(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return backup("GET", "/backup-vaults/", params; aws_config=aws_config)
+    return backup(
+        "GET",
+        "/backup-vaults/",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1305,12 +1579,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"state"`: Returns only copy jobs that are in the specified state.
 """
 function list_copy_jobs(; aws_config::AbstractAWSConfig=global_aws_config())
-    return backup("GET", "/copy-jobs/"; aws_config=aws_config)
+    return backup(
+        "GET", "/copy-jobs/"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_copy_jobs(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return backup("GET", "/copy-jobs/", params; aws_config=aws_config)
+    return backup(
+        "GET", "/copy-jobs/", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1328,12 +1606,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   which can be used to return the next set of items in the list.
 """
 function list_frameworks(; aws_config::AbstractAWSConfig=global_aws_config())
-    return backup("GET", "/audit/frameworks"; aws_config=aws_config)
+    return backup(
+        "GET", "/audit/frameworks"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_frameworks(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return backup("GET", "/audit/frameworks", params; aws_config=aws_config)
+    return backup(
+        "GET",
+        "/audit/frameworks",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1351,12 +1637,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   items in your list starting at the location pointed to by the next token.
 """
 function list_protected_resources(; aws_config::AbstractAWSConfig=global_aws_config())
-    return backup("GET", "/resources/"; aws_config=aws_config)
+    return backup(
+        "GET", "/resources/"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_protected_resources(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return backup("GET", "/resources/", params; aws_config=aws_config)
+    return backup(
+        "GET", "/resources/", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1391,7 +1681,10 @@ function list_recovery_points_by_backup_vault(
     backupVaultName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return backup(
-        "GET", "/backup-vaults/$(backupVaultName)/recovery-points/"; aws_config=aws_config
+        "GET",
+        "/backup-vaults/$(backupVaultName)/recovery-points/";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_recovery_points_by_backup_vault(
@@ -1404,6 +1697,7 @@ function list_recovery_points_by_backup_vault(
         "/backup-vaults/$(backupVaultName)/recovery-points/",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1431,7 +1725,10 @@ function list_recovery_points_by_resource(
     resourceArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return backup(
-        "GET", "/resources/$(resourceArn)/recovery-points/"; aws_config=aws_config
+        "GET",
+        "/resources/$(resourceArn)/recovery-points/";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_recovery_points_by_resource(
@@ -1440,7 +1737,11 @@ function list_recovery_points_by_resource(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return backup(
-        "GET", "/resources/$(resourceArn)/recovery-points/", params; aws_config=aws_config
+        "GET",
+        "/resources/$(resourceArn)/recovery-points/",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1467,12 +1768,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   CREATED | RUNNING | COMPLETED | FAILED
 """
 function list_report_jobs(; aws_config::AbstractAWSConfig=global_aws_config())
-    return backup("GET", "/audit/report-jobs"; aws_config=aws_config)
+    return backup(
+        "GET", "/audit/report-jobs"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_report_jobs(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return backup("GET", "/audit/report-jobs", params; aws_config=aws_config)
+    return backup(
+        "GET",
+        "/audit/report-jobs",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1490,12 +1799,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   which can be used to return the next set of items in the list.
 """
 function list_report_plans(; aws_config::AbstractAWSConfig=global_aws_config())
-    return backup("GET", "/audit/report-plans"; aws_config=aws_config)
+    return backup(
+        "GET", "/audit/report-plans"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_report_plans(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return backup("GET", "/audit/report-plans", params; aws_config=aws_config)
+    return backup(
+        "GET",
+        "/audit/report-plans",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1518,12 +1835,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"status"`: Returns only restore jobs associated with the specified job status.
 """
 function list_restore_jobs(; aws_config::AbstractAWSConfig=global_aws_config())
-    return backup("GET", "/restore-jobs/"; aws_config=aws_config)
+    return backup(
+        "GET", "/restore-jobs/"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_restore_jobs(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return backup("GET", "/restore-jobs/", params; aws_config=aws_config)
+    return backup(
+        "GET",
+        "/restore-jobs/",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1546,14 +1871,25 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   items in your list starting at the location pointed to by the next token.
 """
 function list_tags(resourceArn; aws_config::AbstractAWSConfig=global_aws_config())
-    return backup("GET", "/tags/$(resourceArn)/"; aws_config=aws_config)
+    return backup(
+        "GET",
+        "/tags/$(resourceArn)/";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_tags(
     resourceArn,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return backup("GET", "/tags/$(resourceArn)/", params; aws_config=aws_config)
+    return backup(
+        "GET",
+        "/tags/$(resourceArn)/",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1577,7 +1913,10 @@ function put_backup_vault_access_policy(
     backupVaultName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return backup(
-        "PUT", "/backup-vaults/$(backupVaultName)/access-policy"; aws_config=aws_config
+        "PUT",
+        "/backup-vaults/$(backupVaultName)/access-policy";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_backup_vault_access_policy(
@@ -1590,6 +1929,7 @@ function put_backup_vault_access_policy(
         "/backup-vaults/$(backupVaultName)/access-policy",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1627,6 +1967,7 @@ function put_backup_vault_notifications(
             "BackupVaultEvents" => BackupVaultEvents, "SNSTopicArn" => SNSTopicArn
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_backup_vault_notifications(
@@ -1649,6 +1990,7 @@ function put_backup_vault_notifications(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1711,6 +2053,7 @@ function start_backup_job(
             "ResourceArn" => ResourceArn,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_backup_job(
@@ -1735,6 +2078,7 @@ function start_backup_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1783,6 +2127,7 @@ function start_copy_job(
             "SourceBackupVaultName" => SourceBackupVaultName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_copy_job(
@@ -1809,6 +2154,7 @@ function start_copy_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1833,6 +2179,7 @@ function start_report_job(reportPlanName; aws_config::AbstractAWSConfig=global_a
         "/audit/report-jobs/$(reportPlanName)",
         Dict{String,Any}("IdempotencyToken" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_report_job(
@@ -1849,6 +2196,7 @@ function start_report_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1909,6 +2257,7 @@ function start_restore_job(
             "RecoveryPointArn" => RecoveryPointArn,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_restore_job(
@@ -1933,6 +2282,7 @@ function start_restore_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1947,14 +2297,25 @@ Attempts to cancel a job to create a one-time backup of a resource.
 
 """
 function stop_backup_job(backupJobId; aws_config::AbstractAWSConfig=global_aws_config())
-    return backup("POST", "/backup-jobs/$(backupJobId)"; aws_config=aws_config)
+    return backup(
+        "POST",
+        "/backup-jobs/$(backupJobId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function stop_backup_job(
     backupJobId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return backup("POST", "/backup-jobs/$(backupJobId)", params; aws_config=aws_config)
+    return backup(
+        "POST",
+        "/backup-jobs/$(backupJobId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1977,6 +2338,7 @@ function tag_resource(Tags, resourceArn; aws_config::AbstractAWSConfig=global_aw
         "/tags/$(resourceArn)",
         Dict{String,Any}("Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -1990,6 +2352,7 @@ function tag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Tags" => Tags), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2014,6 +2377,7 @@ function untag_resource(
         "/untag/$(resourceArn)",
         Dict{String,Any}("TagKeyList" => TagKeyList);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -2029,6 +2393,7 @@ function untag_resource(
             mergewith(_merge, Dict{String,Any}("TagKeyList" => TagKeyList), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2053,6 +2418,7 @@ function update_backup_plan(
         "/backup/plans/$(backupPlanId)",
         Dict{String,Any}("BackupPlan" => BackupPlan);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_backup_plan(
@@ -2068,6 +2434,7 @@ function update_backup_plan(
             mergewith(_merge, Dict{String,Any}("BackupPlan" => BackupPlan), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2099,6 +2466,7 @@ function update_framework(frameworkName; aws_config::AbstractAWSConfig=global_aw
         "/audit/frameworks/$(frameworkName)",
         Dict{String,Any}("IdempotencyToken" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_framework(
@@ -2115,6 +2483,7 @@ function update_framework(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2133,12 +2502,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   us-west-2.
 """
 function update_global_settings(; aws_config::AbstractAWSConfig=global_aws_config())
-    return backup("PUT", "/global-settings"; aws_config=aws_config)
+    return backup(
+        "PUT", "/global-settings"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function update_global_settings(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return backup("PUT", "/global-settings", params; aws_config=aws_config)
+    return backup(
+        "PUT",
+        "/global-settings",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2181,6 +2558,7 @@ function update_recovery_point_lifecycle(
         "POST",
         "/backup-vaults/$(backupVaultName)/recovery-points/$(recoveryPointArn)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_recovery_point_lifecycle(
@@ -2194,6 +2572,7 @@ function update_recovery_point_lifecycle(
         "/backup-vaults/$(backupVaultName)/recovery-points/$(recoveryPointArn)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2213,12 +2592,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   preferences for the Region.
 """
 function update_region_settings(; aws_config::AbstractAWSConfig=global_aws_config())
-    return backup("PUT", "/account-settings"; aws_config=aws_config)
+    return backup(
+        "PUT", "/account-settings"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function update_region_settings(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return backup("PUT", "/account-settings", params; aws_config=aws_config)
+    return backup(
+        "PUT",
+        "/account-settings",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2255,6 +2642,7 @@ function update_report_plan(
         "/audit/report-plans/$(reportPlanName)",
         Dict{String,Any}("IdempotencyToken" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_report_plan(
@@ -2271,5 +2659,6 @@ function update_report_plan(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/batch.jl
+++ b/src/services/batch.jl
@@ -26,6 +26,7 @@ function cancel_job(jobId, reason; aws_config::AbstractAWSConfig=global_aws_conf
         "/v1/canceljob",
         Dict{String,Any}("jobId" => jobId, "reason" => reason);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function cancel_job(
@@ -43,6 +44,7 @@ function cancel_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -129,6 +131,7 @@ function create_compute_environment(
             "computeEnvironmentName" => computeEnvironmentName, "type" => type
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_compute_environment(
@@ -150,6 +153,7 @@ function create_compute_environment(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -207,6 +211,7 @@ function create_job_queue(
             "priority" => priority,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_job_queue(
@@ -231,6 +236,7 @@ function create_job_queue(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -258,6 +264,7 @@ function delete_compute_environment(
         "/v1/deletecomputeenvironment",
         Dict{String,Any}("computeEnvironment" => computeEnvironment);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_compute_environment(
@@ -274,6 +281,7 @@ function delete_compute_environment(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -297,6 +305,7 @@ function delete_job_queue(jobQueue; aws_config::AbstractAWSConfig=global_aws_con
         "/v1/deletejobqueue",
         Dict{String,Any}("jobQueue" => jobQueue);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_job_queue(
@@ -311,6 +320,7 @@ function delete_job_queue(
             mergewith(_merge, Dict{String,Any}("jobQueue" => jobQueue), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -333,6 +343,7 @@ function deregister_job_definition(
         "/v1/deregisterjobdefinition",
         Dict{String,Any}("jobDefinition" => jobDefinition);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function deregister_job_definition(
@@ -347,6 +358,7 @@ function deregister_job_definition(
             mergewith(_merge, Dict{String,Any}("jobDefinition" => jobDefinition), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -377,12 +389,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   items in a list and not for other programmatic purposes.
 """
 function describe_compute_environments(; aws_config::AbstractAWSConfig=global_aws_config())
-    return batch("POST", "/v1/describecomputeenvironments"; aws_config=aws_config)
+    return batch(
+        "POST",
+        "/v1/describecomputeenvironments";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_compute_environments(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return batch("POST", "/v1/describecomputeenvironments", params; aws_config=aws_config)
+    return batch(
+        "POST",
+        "/v1/describecomputeenvironments",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -415,12 +438,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"status"`: The status used to filter job definitions.
 """
 function describe_job_definitions(; aws_config::AbstractAWSConfig=global_aws_config())
-    return batch("POST", "/v1/describejobdefinitions"; aws_config=aws_config)
+    return batch(
+        "POST",
+        "/v1/describejobdefinitions";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_job_definitions(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return batch("POST", "/v1/describejobdefinitions", params; aws_config=aws_config)
+    return batch(
+        "POST",
+        "/v1/describejobdefinitions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -447,12 +481,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   not for other programmatic purposes.
 """
 function describe_job_queues(; aws_config::AbstractAWSConfig=global_aws_config())
-    return batch("POST", "/v1/describejobqueues"; aws_config=aws_config)
+    return batch(
+        "POST",
+        "/v1/describejobqueues";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_job_queues(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return batch("POST", "/v1/describejobqueues", params; aws_config=aws_config)
+    return batch(
+        "POST",
+        "/v1/describejobqueues",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -467,7 +512,11 @@ Describes a list of Batch jobs.
 """
 function describe_jobs(jobs; aws_config::AbstractAWSConfig=global_aws_config())
     return batch(
-        "POST", "/v1/describejobs", Dict{String,Any}("jobs" => jobs); aws_config=aws_config
+        "POST",
+        "/v1/describejobs",
+        Dict{String,Any}("jobs" => jobs);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_jobs(
@@ -478,6 +527,7 @@ function describe_jobs(
         "/v1/describejobs",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("jobs" => jobs), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -541,12 +591,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   programmatic purposes.
 """
 function list_jobs(; aws_config::AbstractAWSConfig=global_aws_config())
-    return batch("POST", "/v1/listjobs"; aws_config=aws_config)
+    return batch(
+        "POST", "/v1/listjobs"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_jobs(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return batch("POST", "/v1/listjobs", params; aws_config=aws_config)
+    return batch(
+        "POST",
+        "/v1/listjobs",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -567,14 +625,25 @@ multi-node parallel (MNP) jobs are not supported.
 function list_tags_for_resource(
     resourceArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return batch("GET", "/v1/tags/$(resourceArn)"; aws_config=aws_config)
+    return batch(
+        "GET",
+        "/v1/tags/$(resourceArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_tags_for_resource(
     resourceArn,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return batch("GET", "/v1/tags/$(resourceArn)", params; aws_config=aws_config)
+    return batch(
+        "GET",
+        "/v1/tags/$(resourceArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -635,6 +704,7 @@ function register_job_definition(
         "/v1/registerjobdefinition",
         Dict{String,Any}("jobDefinitionName" => jobDefinitionName, "type" => type);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function register_job_definition(
@@ -654,6 +724,7 @@ function register_job_definition(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -733,6 +804,7 @@ function submit_job(
             "jobDefinition" => jobDefinition, "jobName" => jobName, "jobQueue" => jobQueue
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function submit_job(
@@ -757,6 +829,7 @@ function submit_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -785,6 +858,7 @@ function tag_resource(resourceArn, tags; aws_config::AbstractAWSConfig=global_aw
         "/v1/tags/$(resourceArn)",
         Dict{String,Any}("tags" => tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -798,6 +872,7 @@ function tag_resource(
         "/v1/tags/$(resourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tags" => tags), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -822,6 +897,7 @@ function terminate_job(jobId, reason; aws_config::AbstractAWSConfig=global_aws_c
         "/v1/terminatejob",
         Dict{String,Any}("jobId" => jobId, "reason" => reason);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function terminate_job(
@@ -839,6 +915,7 @@ function terminate_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -863,6 +940,7 @@ function untag_resource(
         "/v1/tags/$(resourceArn)",
         Dict{String,Any}("tagKeys" => tagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -876,6 +954,7 @@ function untag_resource(
         "/v1/tags/$(resourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tagKeys" => tagKeys), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -923,6 +1002,7 @@ function update_compute_environment(
         "/v1/updatecomputeenvironment",
         Dict{String,Any}("computeEnvironment" => computeEnvironment);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_compute_environment(
@@ -939,6 +1019,7 @@ function update_compute_environment(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -977,6 +1058,7 @@ function update_job_queue(jobQueue; aws_config::AbstractAWSConfig=global_aws_con
         "/v1/updatejobqueue",
         Dict{String,Any}("jobQueue" => jobQueue);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_job_queue(
@@ -991,5 +1073,6 @@ function update_job_queue(
             mergewith(_merge, Dict{String,Any}("jobQueue" => jobQueue), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/braket.jl
+++ b/src/services/braket.jl
@@ -23,6 +23,7 @@ function cancel_quantum_task(
         "/quantum-task/$(quantumTaskArn)/cancel",
         Dict{String,Any}("clientToken" => clientToken);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function cancel_quantum_task(
@@ -38,6 +39,7 @@ function cancel_quantum_task(
             mergewith(_merge, Dict{String,Any}("clientToken" => clientToken), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -82,6 +84,7 @@ function create_quantum_task(
             "shots" => shots,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_quantum_task(
@@ -112,6 +115,7 @@ function create_quantum_task(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -126,14 +130,25 @@ Retrieves the devices available in Amazon Braket.
 
 """
 function get_device(deviceArn; aws_config::AbstractAWSConfig=global_aws_config())
-    return braket("GET", "/device/$(deviceArn)"; aws_config=aws_config)
+    return braket(
+        "GET",
+        "/device/$(deviceArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_device(
     deviceArn,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return braket("GET", "/device/$(deviceArn)", params; aws_config=aws_config)
+    return braket(
+        "GET",
+        "/device/$(deviceArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -147,14 +162,25 @@ Retrieves the specified quantum task.
 
 """
 function get_quantum_task(quantumTaskArn; aws_config::AbstractAWSConfig=global_aws_config())
-    return braket("GET", "/quantum-task/$(quantumTaskArn)"; aws_config=aws_config)
+    return braket(
+        "GET",
+        "/quantum-task/$(quantumTaskArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_quantum_task(
     quantumTaskArn,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return braket("GET", "/quantum-task/$(quantumTaskArn)", params; aws_config=aws_config)
+    return braket(
+        "GET",
+        "/quantum-task/$(quantumTaskArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -170,14 +196,25 @@ Shows the tags associated with this resource.
 function list_tags_for_resource(
     resourceArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return braket("GET", "/tags/$(resourceArn)"; aws_config=aws_config)
+    return braket(
+        "GET",
+        "/tags/$(resourceArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_tags_for_resource(
     resourceArn,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return braket("GET", "/tags/$(resourceArn)", params; aws_config=aws_config)
+    return braket(
+        "GET",
+        "/tags/$(resourceArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -197,7 +234,11 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function search_devices(filters; aws_config::AbstractAWSConfig=global_aws_config())
     return braket(
-        "POST", "/devices", Dict{String,Any}("filters" => filters); aws_config=aws_config
+        "POST",
+        "/devices",
+        Dict{String,Any}("filters" => filters);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function search_devices(
@@ -208,6 +249,7 @@ function search_devices(
         "/devices",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("filters" => filters), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -232,6 +274,7 @@ function search_quantum_tasks(filters; aws_config::AbstractAWSConfig=global_aws_
         "/quantum-tasks",
         Dict{String,Any}("filters" => filters);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function search_quantum_tasks(
@@ -242,6 +285,7 @@ function search_quantum_tasks(
         "/quantum-tasks",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("filters" => filters), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -262,6 +306,7 @@ function tag_resource(resourceArn, tags; aws_config::AbstractAWSConfig=global_aw
         "/tags/$(resourceArn)",
         Dict{String,Any}("tags" => tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -275,6 +320,7 @@ function tag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tags" => tags), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -297,6 +343,7 @@ function untag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}("tagKeys" => tagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -310,5 +357,6 @@ function untag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tagKeys" => tagKeys), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/budgets.jl
+++ b/src/services/budgets.jl
@@ -29,6 +29,7 @@ function create_budget(AccountId, Budget; aws_config::AbstractAWSConfig=global_a
         "CreateBudget",
         Dict{String,Any}("AccountId" => AccountId, "Budget" => Budget);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_budget(
@@ -47,6 +48,7 @@ function create_budget(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -96,6 +98,7 @@ function create_budget_action(
             "Subscribers" => Subscribers,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_budget_action(
@@ -131,6 +134,7 @@ function create_budget_action(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -167,6 +171,7 @@ function create_notification(
             "Subscribers" => Subscribers,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_notification(
@@ -192,6 +197,7 @@ function create_notification(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -227,6 +233,7 @@ function create_subscriber(
             "Subscriber" => Subscriber,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_subscriber(
@@ -252,6 +259,7 @@ function create_subscriber(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -274,6 +282,7 @@ function delete_budget(
         "DeleteBudget",
         Dict{String,Any}("AccountId" => AccountId, "BudgetName" => BudgetName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_budget(
@@ -292,6 +301,7 @@ function delete_budget(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -316,6 +326,7 @@ function delete_budget_action(
             "AccountId" => AccountId, "ActionId" => ActionId, "BudgetName" => BudgetName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_budget_action(
@@ -339,6 +350,7 @@ function delete_budget_action(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -367,6 +379,7 @@ function delete_notification(
             "Notification" => Notification,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_notification(
@@ -390,6 +403,7 @@ function delete_notification(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -424,6 +438,7 @@ function delete_subscriber(
             "Subscriber" => Subscriber,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_subscriber(
@@ -449,6 +464,7 @@ function delete_subscriber(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -472,6 +488,7 @@ function describe_budget(
         "DescribeBudget",
         Dict{String,Any}("AccountId" => AccountId, "BudgetName" => BudgetName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_budget(
@@ -490,6 +507,7 @@ function describe_budget(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -514,6 +532,7 @@ function describe_budget_action(
             "AccountId" => AccountId, "ActionId" => ActionId, "BudgetName" => BudgetName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_budget_action(
@@ -537,6 +556,7 @@ function describe_budget_action(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -566,6 +586,7 @@ function describe_budget_action_histories(
             "AccountId" => AccountId, "ActionId" => ActionId, "BudgetName" => BudgetName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_budget_action_histories(
@@ -589,6 +610,7 @@ function describe_budget_action_histories(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -613,6 +635,7 @@ function describe_budget_actions_for_account(
         "DescribeBudgetActionsForAccount",
         Dict{String,Any}("AccountId" => AccountId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_budget_actions_for_account(
@@ -626,6 +649,7 @@ function describe_budget_actions_for_account(
             mergewith(_merge, Dict{String,Any}("AccountId" => AccountId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -651,6 +675,7 @@ function describe_budget_actions_for_budget(
         "DescribeBudgetActionsForBudget",
         Dict{String,Any}("AccountId" => AccountId, "BudgetName" => BudgetName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_budget_actions_for_budget(
@@ -669,6 +694,7 @@ function describe_budget_actions_for_budget(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -697,6 +723,7 @@ function describe_budget_performance_history(
         "DescribeBudgetPerformanceHistory",
         Dict{String,Any}("AccountId" => AccountId, "BudgetName" => BudgetName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_budget_performance_history(
@@ -715,6 +742,7 @@ function describe_budget_performance_history(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -738,7 +766,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function describe_budgets(AccountId; aws_config::AbstractAWSConfig=global_aws_config())
     return budgets(
-        "DescribeBudgets", Dict{String,Any}("AccountId" => AccountId); aws_config=aws_config
+        "DescribeBudgets",
+        Dict{String,Any}("AccountId" => AccountId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_budgets(
@@ -752,6 +783,7 @@ function describe_budgets(
             mergewith(_merge, Dict{String,Any}("AccountId" => AccountId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -780,6 +812,7 @@ function describe_notifications_for_budget(
         "DescribeNotificationsForBudget",
         Dict{String,Any}("AccountId" => AccountId, "BudgetName" => BudgetName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_notifications_for_budget(
@@ -798,6 +831,7 @@ function describe_notifications_for_budget(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -831,6 +865,7 @@ function describe_subscribers_for_notification(
             "Notification" => Notification,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_subscribers_for_notification(
@@ -854,6 +889,7 @@ function describe_subscribers_for_notification(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -886,6 +922,7 @@ function execute_budget_action(
             "ExecutionType" => ExecutionType,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function execute_budget_action(
@@ -911,6 +948,7 @@ function execute_budget_action(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -937,6 +975,7 @@ function update_budget(
         "UpdateBudget",
         Dict{String,Any}("AccountId" => AccountId, "NewBudget" => NewBudget);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_budget(
@@ -955,6 +994,7 @@ function update_budget(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -988,6 +1028,7 @@ function update_budget_action(
             "AccountId" => AccountId, "ActionId" => ActionId, "BudgetName" => BudgetName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_budget_action(
@@ -1011,6 +1052,7 @@ function update_budget_action(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1044,6 +1086,7 @@ function update_notification(
             "OldNotification" => OldNotification,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_notification(
@@ -1069,6 +1112,7 @@ function update_notification(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1105,6 +1149,7 @@ function update_subscriber(
             "OldSubscriber" => OldSubscriber,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_subscriber(
@@ -1132,5 +1177,6 @@ function update_subscriber(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/chime.jl
+++ b/src/services/chime.jl
@@ -24,6 +24,7 @@ function associate_phone_number_with_user(
         "/accounts/$(accountId)/users/$(userId)?operation=associate-phone-number",
         Dict{String,Any}("E164PhoneNumber" => E164PhoneNumber);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_phone_number_with_user(
@@ -42,6 +43,7 @@ function associate_phone_number_with_user(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -69,6 +71,7 @@ function associate_phone_numbers_with_voice_connector(
         "/voice-connectors/$(voiceConnectorId)?operation=associate-phone-numbers",
         Dict{String,Any}("E164PhoneNumbers" => E164PhoneNumbers);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_phone_numbers_with_voice_connector(
@@ -86,6 +89,7 @@ function associate_phone_numbers_with_voice_connector(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -115,6 +119,7 @@ function associate_phone_numbers_with_voice_connector_group(
         "/voice-connector-groups/$(voiceConnectorGroupId)?operation=associate-phone-numbers",
         Dict{String,Any}("E164PhoneNumbers" => E164PhoneNumbers);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_phone_numbers_with_voice_connector_group(
@@ -132,6 +137,7 @@ function associate_phone_numbers_with_voice_connector_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -154,6 +160,7 @@ function associate_signin_delegate_groups_with_account(
         "/accounts/$(accountId)?operation=associate-signin-delegate-groups",
         Dict{String,Any}("SigninDelegateGroups" => SigninDelegateGroups);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_signin_delegate_groups_with_account(
@@ -173,6 +180,7 @@ function associate_signin_delegate_groups_with_account(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -197,6 +205,7 @@ function batch_create_attendee(
         "/meetings/$(meetingId)/attendees?operation=batch-create",
         Dict{String,Any}("Attendees" => Attendees);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_create_attendee(
@@ -212,6 +221,7 @@ function batch_create_attendee(
             mergewith(_merge, Dict{String,Any}("Attendees" => Attendees), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -241,6 +251,7 @@ function batch_create_channel_membership(
         "/channels/$(channelArn)/memberships?operation=batch-create",
         Dict{String,Any}("MemberArns" => MemberArns);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_create_channel_membership(
@@ -256,6 +267,7 @@ function batch_create_channel_membership(
             mergewith(_merge, Dict{String,Any}("MemberArns" => MemberArns), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -281,6 +293,7 @@ function batch_create_room_membership(
         "/accounts/$(accountId)/rooms/$(roomId)/memberships?operation=batch-create",
         Dict{String,Any}("MembershipItemList" => MembershipItemList);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_create_room_membership(
@@ -299,6 +312,7 @@ function batch_create_room_membership(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -322,6 +336,7 @@ function batch_delete_phone_number(
         "/phone-numbers?operation=batch-delete",
         Dict{String,Any}("PhoneNumberIds" => PhoneNumberIds);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_delete_phone_number(
@@ -336,6 +351,7 @@ function batch_delete_phone_number(
             mergewith(_merge, Dict{String,Any}("PhoneNumberIds" => PhoneNumberIds), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -366,6 +382,7 @@ function batch_suspend_user(
         "/accounts/$(accountId)/users?operation=suspend",
         Dict{String,Any}("UserIdList" => UserIdList);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_suspend_user(
@@ -381,6 +398,7 @@ function batch_suspend_user(
             mergewith(_merge, Dict{String,Any}("UserIdList" => UserIdList), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -408,6 +426,7 @@ function batch_unsuspend_user(
         "/accounts/$(accountId)/users?operation=unsuspend",
         Dict{String,Any}("UserIdList" => UserIdList);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_unsuspend_user(
@@ -423,6 +442,7 @@ function batch_unsuspend_user(
             mergewith(_merge, Dict{String,Any}("UserIdList" => UserIdList), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -451,6 +471,7 @@ function batch_update_phone_number(
         "/phone-numbers?operation=batch-update",
         Dict{String,Any}("UpdatePhoneNumberRequestItems" => UpdatePhoneNumberRequestItems);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_update_phone_number(
@@ -471,6 +492,7 @@ function batch_update_phone_number(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -495,6 +517,7 @@ function batch_update_user(
         "/accounts/$(accountId)/users",
         Dict{String,Any}("UpdateUserRequestItems" => UpdateUserRequestItems);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_update_user(
@@ -514,6 +537,7 @@ function batch_update_user(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -531,7 +555,11 @@ types, see Managing Your Amazon Chime Accounts in the Amazon Chime Administratio
 """
 function create_account(Name; aws_config::AbstractAWSConfig=global_aws_config())
     return chime(
-        "POST", "/accounts", Dict{String,Any}("Name" => Name); aws_config=aws_config
+        "POST",
+        "/accounts",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_account(
@@ -542,6 +570,7 @@ function create_account(
         "/accounts",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -570,6 +599,7 @@ function create_app_instance(
         "/app-instances",
         Dict{String,Any}("ClientRequestToken" => ClientRequestToken, "Name" => Name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_app_instance(
@@ -591,6 +621,7 @@ function create_app_instance(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -616,6 +647,7 @@ function create_app_instance_admin(
         "/app-instances/$(appInstanceArn)/admins",
         Dict{String,Any}("AppInstanceAdminArn" => AppInstanceAdminArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_app_instance_admin(
@@ -635,6 +667,7 @@ function create_app_instance_admin(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -673,6 +706,7 @@ function create_app_instance_user(
             "Name" => Name,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_app_instance_user(
@@ -699,6 +733,7 @@ function create_app_instance_user(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -726,6 +761,7 @@ function create_attendee(
         "/meetings/$(meetingId)/attendees",
         Dict{String,Any}("ExternalUserId" => ExternalUserId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_attendee(
@@ -741,6 +777,7 @@ function create_attendee(
             mergewith(_merge, Dict{String,Any}("ExternalUserId" => ExternalUserId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -766,6 +803,7 @@ function create_bot(
         "/accounts/$(accountId)/bots",
         Dict{String,Any}("DisplayName" => DisplayName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_bot(
@@ -781,6 +819,7 @@ function create_bot(
             mergewith(_merge, Dict{String,Any}("DisplayName" => DisplayName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -824,6 +863,7 @@ function create_channel(
             "Name" => Name,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_channel(
@@ -848,6 +888,7 @@ function create_channel(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -878,6 +919,7 @@ function create_channel_ban(
         "/channels/$(channelArn)/bans",
         Dict{String,Any}("MemberArn" => MemberArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_channel_ban(
@@ -893,6 +935,7 @@ function create_channel_ban(
             mergewith(_merge, Dict{String,Any}("MemberArn" => MemberArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -928,6 +971,7 @@ function create_channel_membership(
         "/channels/$(channelArn)/memberships",
         Dict{String,Any}("MemberArn" => MemberArn, "Type" => Type);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_channel_membership(
@@ -946,6 +990,7 @@ function create_channel_membership(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -975,6 +1020,7 @@ function create_channel_moderator(
         "/channels/$(channelArn)/moderators",
         Dict{String,Any}("ChannelModeratorArn" => ChannelModeratorArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_channel_moderator(
@@ -994,6 +1040,7 @@ function create_channel_moderator(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1033,6 +1080,7 @@ function create_media_capture_pipeline(
             "ClientRequestToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_media_capture_pipeline(
@@ -1060,6 +1108,7 @@ function create_media_capture_pipeline(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1097,6 +1146,7 @@ function create_meeting(
         "/meetings",
         Dict{String,Any}("ClientRequestToken" => ClientRequestToken);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_meeting(
@@ -1113,6 +1163,7 @@ function create_meeting(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1151,6 +1202,7 @@ function create_meeting_dial_out(
             "ToPhoneNumber" => ToPhoneNumber,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_meeting_dial_out(
@@ -1176,6 +1228,7 @@ function create_meeting_dial_out(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1213,6 +1266,7 @@ function create_meeting_with_attendees(
         "/meetings?operation=create-attendees",
         Dict{String,Any}("ClientRequestToken" => ClientRequestToken);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_meeting_with_attendees(
@@ -1229,6 +1283,7 @@ function create_meeting_with_attendees(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1255,6 +1310,7 @@ function create_phone_number_order(
             "E164PhoneNumbers" => E164PhoneNumbers, "ProductType" => ProductType
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_phone_number_order(
@@ -1276,6 +1332,7 @@ function create_phone_number_order(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1315,6 +1372,7 @@ function create_proxy_session(
             "ParticipantPhoneNumbers" => ParticipantPhoneNumbers,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_proxy_session(
@@ -1338,6 +1396,7 @@ function create_proxy_session(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1361,6 +1420,7 @@ function create_room(Name, accountId; aws_config::AbstractAWSConfig=global_aws_c
         "/accounts/$(accountId)/rooms",
         Dict{String,Any}("Name" => Name, "ClientRequestToken" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_room(
@@ -1380,6 +1440,7 @@ function create_room(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1408,6 +1469,7 @@ function create_room_membership(
         "/accounts/$(accountId)/rooms/$(roomId)/memberships",
         Dict{String,Any}("MemberId" => MemberId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_room_membership(
@@ -1424,6 +1486,7 @@ function create_room_membership(
             mergewith(_merge, Dict{String,Any}("MemberId" => MemberId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1450,6 +1513,7 @@ function create_sip_media_application(
             "AwsRegion" => AwsRegion, "Endpoints" => Endpoints, "Name" => Name
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_sip_media_application(
@@ -1472,6 +1536,7 @@ function create_sip_media_application(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1505,6 +1570,7 @@ function create_sip_media_application_call(
             "FromPhoneNumber" => FromPhoneNumber, "ToPhoneNumber" => ToPhoneNumber
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_sip_media_application_call(
@@ -1527,6 +1593,7 @@ function create_sip_media_application_call(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1572,6 +1639,7 @@ function create_sip_rule(
             "TriggerValue" => TriggerValue,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_sip_rule(
@@ -1598,6 +1666,7 @@ function create_sip_rule(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1618,7 +1687,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function create_user(accountId; aws_config::AbstractAWSConfig=global_aws_config())
     return chime(
-        "POST", "/accounts/$(accountId)/users?operation=create"; aws_config=aws_config
+        "POST",
+        "/accounts/$(accountId)/users?operation=create";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_user(
@@ -1631,6 +1703,7 @@ function create_user(
         "/accounts/$(accountId)/users?operation=create",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1662,6 +1735,7 @@ function create_voice_connector(
         "/voice-connectors",
         Dict{String,Any}("Name" => Name, "RequireEncryption" => RequireEncryption);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_voice_connector(
@@ -1681,6 +1755,7 @@ function create_voice_connector(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1709,6 +1784,7 @@ function create_voice_connector_group(
         "/voice-connector-groups",
         Dict{String,Any}("Name" => Name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_voice_connector_group(
@@ -1719,6 +1795,7 @@ function create_voice_connector_group(
         "/voice-connector-groups",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1739,14 +1816,25 @@ days, deleted accounts are permanently removed from your Disabled accounts list.
 
 """
 function delete_account(accountId; aws_config::AbstractAWSConfig=global_aws_config())
-    return chime("DELETE", "/accounts/$(accountId)"; aws_config=aws_config)
+    return chime(
+        "DELETE",
+        "/accounts/$(accountId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_account(
     accountId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return chime("DELETE", "/accounts/$(accountId)", params; aws_config=aws_config)
+    return chime(
+        "DELETE",
+        "/accounts/$(accountId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1762,7 +1850,12 @@ Deletes an AppInstance and all associated data asynchronously.
 function delete_app_instance(
     appInstanceArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return chime("DELETE", "/app-instances/$(appInstanceArn)"; aws_config=aws_config)
+    return chime(
+        "DELETE",
+        "/app-instances/$(appInstanceArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_app_instance(
     appInstanceArn,
@@ -1770,7 +1863,11 @@ function delete_app_instance(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return chime(
-        "DELETE", "/app-instances/$(appInstanceArn)", params; aws_config=aws_config
+        "DELETE",
+        "/app-instances/$(appInstanceArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1792,6 +1889,7 @@ function delete_app_instance_admin(
         "DELETE",
         "/app-instances/$(appInstanceArn)/admins/$(appInstanceAdminArn)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_app_instance_admin(
@@ -1805,6 +1903,7 @@ function delete_app_instance_admin(
         "/app-instances/$(appInstanceArn)/admins/$(appInstanceAdminArn)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1825,6 +1924,7 @@ function delete_app_instance_streaming_configurations(
         "DELETE",
         "/app-instances/$(appInstanceArn)/streaming-configurations";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_app_instance_streaming_configurations(
@@ -1837,6 +1937,7 @@ function delete_app_instance_streaming_configurations(
         "/app-instances/$(appInstanceArn)/streaming-configurations",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1854,7 +1955,10 @@ function delete_app_instance_user(
     appInstanceUserArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return chime(
-        "DELETE", "/app-instance-users/$(appInstanceUserArn)"; aws_config=aws_config
+        "DELETE",
+        "/app-instance-users/$(appInstanceUserArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_app_instance_user(
@@ -1863,7 +1967,11 @@ function delete_app_instance_user(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return chime(
-        "DELETE", "/app-instance-users/$(appInstanceUserArn)", params; aws_config=aws_config
+        "DELETE",
+        "/app-instance-users/$(appInstanceUserArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1885,7 +1993,10 @@ function delete_attendee(
     attendeeId, meetingId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return chime(
-        "DELETE", "/meetings/$(meetingId)/attendees/$(attendeeId)"; aws_config=aws_config
+        "DELETE",
+        "/meetings/$(meetingId)/attendees/$(attendeeId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_attendee(
@@ -1899,6 +2010,7 @@ function delete_attendee(
         "/meetings/$(meetingId)/attendees/$(attendeeId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1918,14 +2030,25 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"x-amz-chime-bearer"`: The AppInstanceUserArn of the user that makes the API call.
 """
 function delete_channel(channelArn; aws_config::AbstractAWSConfig=global_aws_config())
-    return chime("DELETE", "/channels/$(channelArn)"; aws_config=aws_config)
+    return chime(
+        "DELETE",
+        "/channels/$(channelArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_channel(
     channelArn,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return chime("DELETE", "/channels/$(channelArn)", params; aws_config=aws_config)
+    return chime(
+        "DELETE",
+        "/channels/$(channelArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1948,7 +2071,10 @@ function delete_channel_ban(
     channelArn, memberArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return chime(
-        "DELETE", "/channels/$(channelArn)/bans/$(memberArn)"; aws_config=aws_config
+        "DELETE",
+        "/channels/$(channelArn)/bans/$(memberArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_channel_ban(
@@ -1958,7 +2084,11 @@ function delete_channel_ban(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return chime(
-        "DELETE", "/channels/$(channelArn)/bans/$(memberArn)", params; aws_config=aws_config
+        "DELETE",
+        "/channels/$(channelArn)/bans/$(memberArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1981,7 +2111,10 @@ function delete_channel_membership(
     channelArn, memberArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return chime(
-        "DELETE", "/channels/$(channelArn)/memberships/$(memberArn)"; aws_config=aws_config
+        "DELETE",
+        "/channels/$(channelArn)/memberships/$(memberArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_channel_membership(
@@ -1995,6 +2128,7 @@ function delete_channel_membership(
         "/channels/$(channelArn)/memberships/$(memberArn)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2019,7 +2153,10 @@ function delete_channel_message(
     channelArn, messageId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return chime(
-        "DELETE", "/channels/$(channelArn)/messages/$(messageId)"; aws_config=aws_config
+        "DELETE",
+        "/channels/$(channelArn)/messages/$(messageId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_channel_message(
@@ -2033,6 +2170,7 @@ function delete_channel_message(
         "/channels/$(channelArn)/messages/$(messageId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2058,6 +2196,7 @@ function delete_channel_moderator(
         "DELETE",
         "/channels/$(channelArn)/moderators/$(channelModeratorArn)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_channel_moderator(
@@ -2071,6 +2210,7 @@ function delete_channel_moderator(
         "/channels/$(channelArn)/moderators/$(channelModeratorArn)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2092,6 +2232,7 @@ function delete_events_configuration(
         "DELETE",
         "/accounts/$(accountId)/bots/$(botId)/events-configuration";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_events_configuration(
@@ -2105,6 +2246,7 @@ function delete_events_configuration(
         "/accounts/$(accountId)/bots/$(botId)/events-configuration",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2122,7 +2264,10 @@ function delete_media_capture_pipeline(
     mediaPipelineId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return chime(
-        "DELETE", "/media-capture-pipelines/$(mediaPipelineId)"; aws_config=aws_config
+        "DELETE",
+        "/media-capture-pipelines/$(mediaPipelineId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_media_capture_pipeline(
@@ -2135,6 +2280,7 @@ function delete_media_capture_pipeline(
         "/media-capture-pipelines/$(mediaPipelineId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2152,14 +2298,25 @@ Developer Guide.
 
 """
 function delete_meeting(meetingId; aws_config::AbstractAWSConfig=global_aws_config())
-    return chime("DELETE", "/meetings/$(meetingId)"; aws_config=aws_config)
+    return chime(
+        "DELETE",
+        "/meetings/$(meetingId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_meeting(
     meetingId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return chime("DELETE", "/meetings/$(meetingId)", params; aws_config=aws_config)
+    return chime(
+        "DELETE",
+        "/meetings/$(meetingId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2178,14 +2335,25 @@ permanently.
 function delete_phone_number(
     phoneNumberId; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return chime("DELETE", "/phone-numbers/$(phoneNumberId)"; aws_config=aws_config)
+    return chime(
+        "DELETE",
+        "/phone-numbers/$(phoneNumberId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_phone_number(
     phoneNumberId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return chime("DELETE", "/phone-numbers/$(phoneNumberId)", params; aws_config=aws_config)
+    return chime(
+        "DELETE",
+        "/phone-numbers/$(phoneNumberId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2206,6 +2374,7 @@ function delete_proxy_session(
         "DELETE",
         "/voice-connectors/$(voiceConnectorId)/proxy-sessions/$(proxySessionId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_proxy_session(
@@ -2219,6 +2388,7 @@ function delete_proxy_session(
         "/voice-connectors/$(voiceConnectorId)/proxy-sessions/$(proxySessionId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2234,7 +2404,12 @@ Deletes a chat room in an Amazon Chime Enterprise account.
 
 """
 function delete_room(accountId, roomId; aws_config::AbstractAWSConfig=global_aws_config())
-    return chime("DELETE", "/accounts/$(accountId)/rooms/$(roomId)"; aws_config=aws_config)
+    return chime(
+        "DELETE",
+        "/accounts/$(accountId)/rooms/$(roomId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_room(
     accountId,
@@ -2243,7 +2418,11 @@ function delete_room(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return chime(
-        "DELETE", "/accounts/$(accountId)/rooms/$(roomId)", params; aws_config=aws_config
+        "DELETE",
+        "/accounts/$(accountId)/rooms/$(roomId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2266,6 +2445,7 @@ function delete_room_membership(
         "DELETE",
         "/accounts/$(accountId)/rooms/$(roomId)/memberships/$(memberId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_room_membership(
@@ -2280,6 +2460,7 @@ function delete_room_membership(
         "/accounts/$(accountId)/rooms/$(roomId)/memberships/$(memberId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2297,7 +2478,10 @@ function delete_sip_media_application(
     sipMediaApplicationId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return chime(
-        "DELETE", "/sip-media-applications/$(sipMediaApplicationId)"; aws_config=aws_config
+        "DELETE",
+        "/sip-media-applications/$(sipMediaApplicationId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_sip_media_application(
@@ -2310,6 +2494,7 @@ function delete_sip_media_application(
         "/sip-media-applications/$(sipMediaApplicationId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2324,14 +2509,25 @@ Deletes a SIP rule. You must disable a SIP rule before you can delete it.
 
 """
 function delete_sip_rule(sipRuleId; aws_config::AbstractAWSConfig=global_aws_config())
-    return chime("DELETE", "/sip-rules/$(sipRuleId)"; aws_config=aws_config)
+    return chime(
+        "DELETE",
+        "/sip-rules/$(sipRuleId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_sip_rule(
     sipRuleId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return chime("DELETE", "/sip-rules/$(sipRuleId)", params; aws_config=aws_config)
+    return chime(
+        "DELETE",
+        "/sip-rules/$(sipRuleId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2348,7 +2544,12 @@ Amazon Chime Voice Connector must be disassociated from it before it can be dele
 function delete_voice_connector(
     voiceConnectorId; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return chime("DELETE", "/voice-connectors/$(voiceConnectorId)"; aws_config=aws_config)
+    return chime(
+        "DELETE",
+        "/voice-connectors/$(voiceConnectorId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_voice_connector(
     voiceConnectorId,
@@ -2356,7 +2557,11 @@ function delete_voice_connector(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return chime(
-        "DELETE", "/voice-connectors/$(voiceConnectorId)", params; aws_config=aws_config
+        "DELETE",
+        "/voice-connectors/$(voiceConnectorId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2378,6 +2583,7 @@ function delete_voice_connector_emergency_calling_configuration(
         "DELETE",
         "/voice-connectors/$(voiceConnectorId)/emergency-calling-configuration";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_voice_connector_emergency_calling_configuration(
@@ -2390,6 +2596,7 @@ function delete_voice_connector_emergency_calling_configuration(
         "/voice-connectors/$(voiceConnectorId)/emergency-calling-configuration",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2408,7 +2615,10 @@ function delete_voice_connector_group(
     voiceConnectorGroupId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return chime(
-        "DELETE", "/voice-connector-groups/$(voiceConnectorGroupId)"; aws_config=aws_config
+        "DELETE",
+        "/voice-connector-groups/$(voiceConnectorGroupId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_voice_connector_group(
@@ -2421,6 +2631,7 @@ function delete_voice_connector_group(
         "/voice-connector-groups/$(voiceConnectorGroupId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2440,7 +2651,10 @@ function delete_voice_connector_origination(
     voiceConnectorId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return chime(
-        "DELETE", "/voice-connectors/$(voiceConnectorId)/origination"; aws_config=aws_config
+        "DELETE",
+        "/voice-connectors/$(voiceConnectorId)/origination";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_voice_connector_origination(
@@ -2453,6 +2667,7 @@ function delete_voice_connector_origination(
         "/voice-connectors/$(voiceConnectorId)/origination",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2473,6 +2688,7 @@ function delete_voice_connector_proxy(
         "DELETE",
         "/voice-connectors/$(voiceConnectorId)/programmable-numbers/proxy";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_voice_connector_proxy(
@@ -2485,6 +2701,7 @@ function delete_voice_connector_proxy(
         "/voice-connectors/$(voiceConnectorId)/programmable-numbers/proxy",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2505,6 +2722,7 @@ function delete_voice_connector_streaming_configuration(
         "DELETE",
         "/voice-connectors/$(voiceConnectorId)/streaming-configuration";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_voice_connector_streaming_configuration(
@@ -2517,6 +2735,7 @@ function delete_voice_connector_streaming_configuration(
         "/voice-connectors/$(voiceConnectorId)/streaming-configuration",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2536,7 +2755,10 @@ function delete_voice_connector_termination(
     voiceConnectorId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return chime(
-        "DELETE", "/voice-connectors/$(voiceConnectorId)/termination"; aws_config=aws_config
+        "DELETE",
+        "/voice-connectors/$(voiceConnectorId)/termination";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_voice_connector_termination(
@@ -2549,6 +2771,7 @@ function delete_voice_connector_termination(
         "/voice-connectors/$(voiceConnectorId)/termination",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2573,6 +2796,7 @@ function delete_voice_connector_termination_credentials(
         "/voice-connectors/$(voiceConnectorId)/termination/credentials?operation=delete",
         Dict{String,Any}("Usernames" => Usernames);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_voice_connector_termination_credentials(
@@ -2588,6 +2812,7 @@ function delete_voice_connector_termination_credentials(
             mergewith(_merge, Dict{String,Any}("Usernames" => Usernames), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2604,14 +2829,25 @@ Returns the full details of an AppInstance.
 function describe_app_instance(
     appInstanceArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return chime("GET", "/app-instances/$(appInstanceArn)"; aws_config=aws_config)
+    return chime(
+        "GET",
+        "/app-instances/$(appInstanceArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_app_instance(
     appInstanceArn,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return chime("GET", "/app-instances/$(appInstanceArn)", params; aws_config=aws_config)
+    return chime(
+        "GET",
+        "/app-instances/$(appInstanceArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2632,6 +2868,7 @@ function describe_app_instance_admin(
         "GET",
         "/app-instances/$(appInstanceArn)/admins/$(appInstanceAdminArn)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_app_instance_admin(
@@ -2645,6 +2882,7 @@ function describe_app_instance_admin(
         "/app-instances/$(appInstanceArn)/admins/$(appInstanceAdminArn)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2661,7 +2899,12 @@ Returns the full details of an AppInstanceUser.
 function describe_app_instance_user(
     appInstanceUserArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return chime("GET", "/app-instance-users/$(appInstanceUserArn)"; aws_config=aws_config)
+    return chime(
+        "GET",
+        "/app-instance-users/$(appInstanceUserArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_app_instance_user(
     appInstanceUserArn,
@@ -2669,7 +2912,11 @@ function describe_app_instance_user(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return chime(
-        "GET", "/app-instance-users/$(appInstanceUserArn)", params; aws_config=aws_config
+        "GET",
+        "/app-instance-users/$(appInstanceUserArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2689,14 +2936,25 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"x-amz-chime-bearer"`: The AppInstanceUserArn of the user that makes the API call.
 """
 function describe_channel(channelArn; aws_config::AbstractAWSConfig=global_aws_config())
-    return chime("GET", "/channels/$(channelArn)"; aws_config=aws_config)
+    return chime(
+        "GET",
+        "/channels/$(channelArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_channel(
     channelArn,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return chime("GET", "/channels/$(channelArn)", params; aws_config=aws_config)
+    return chime(
+        "GET",
+        "/channels/$(channelArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2718,7 +2976,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_channel_ban(
     channelArn, memberArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return chime("GET", "/channels/$(channelArn)/bans/$(memberArn)"; aws_config=aws_config)
+    return chime(
+        "GET",
+        "/channels/$(channelArn)/bans/$(memberArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_channel_ban(
     channelArn,
@@ -2727,7 +2990,11 @@ function describe_channel_ban(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return chime(
-        "GET", "/channels/$(channelArn)/bans/$(memberArn)", params; aws_config=aws_config
+        "GET",
+        "/channels/$(channelArn)/bans/$(memberArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2751,7 +3018,10 @@ function describe_channel_membership(
     channelArn, memberArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return chime(
-        "GET", "/channels/$(channelArn)/memberships/$(memberArn)"; aws_config=aws_config
+        "GET",
+        "/channels/$(channelArn)/memberships/$(memberArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_channel_membership(
@@ -2765,6 +3035,7 @@ function describe_channel_membership(
         "/channels/$(channelArn)/memberships/$(memberArn)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2792,6 +3063,7 @@ function describe_channel_membership_for_app_instance_user(
         "/channels/$(channelArn)?scope=app-instance-user-membership",
         Dict{String,Any}("app-instance-user-arn" => app_instance_user_arn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_channel_membership_for_app_instance_user(
@@ -2811,6 +3083,7 @@ function describe_channel_membership_for_app_instance_user(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2838,6 +3111,7 @@ function describe_channel_moderated_by_app_instance_user(
         "/channels/$(channelArn)?scope=app-instance-user-moderated-channel",
         Dict{String,Any}("app-instance-user-arn" => app_instance_user_arn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_channel_moderated_by_app_instance_user(
@@ -2857,6 +3131,7 @@ function describe_channel_moderated_by_app_instance_user(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2883,6 +3158,7 @@ function describe_channel_moderator(
         "GET",
         "/channels/$(channelArn)/moderators/$(channelModeratorArn)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_channel_moderator(
@@ -2896,6 +3172,7 @@ function describe_channel_moderator(
         "/channels/$(channelArn)/moderators/$(channelModeratorArn)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2917,6 +3194,7 @@ function disassociate_phone_number_from_user(
         "POST",
         "/accounts/$(accountId)/users/$(userId)?operation=disassociate-phone-number";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disassociate_phone_number_from_user(
@@ -2930,6 +3208,7 @@ function disassociate_phone_number_from_user(
         "/accounts/$(accountId)/users/$(userId)?operation=disassociate-phone-number",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2952,6 +3231,7 @@ function disassociate_phone_numbers_from_voice_connector(
         "/voice-connectors/$(voiceConnectorId)?operation=disassociate-phone-numbers",
         Dict{String,Any}("E164PhoneNumbers" => E164PhoneNumbers);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disassociate_phone_numbers_from_voice_connector(
@@ -2969,6 +3249,7 @@ function disassociate_phone_numbers_from_voice_connector(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2994,6 +3275,7 @@ function disassociate_phone_numbers_from_voice_connector_group(
         "/voice-connector-groups/$(voiceConnectorGroupId)?operation=disassociate-phone-numbers",
         Dict{String,Any}("E164PhoneNumbers" => E164PhoneNumbers);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disassociate_phone_numbers_from_voice_connector_group(
@@ -3011,6 +3293,7 @@ function disassociate_phone_numbers_from_voice_connector_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3033,6 +3316,7 @@ function disassociate_signin_delegate_groups_from_account(
         "/accounts/$(accountId)?operation=disassociate-signin-delegate-groups",
         Dict{String,Any}("GroupNames" => GroupNames);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disassociate_signin_delegate_groups_from_account(
@@ -3048,6 +3332,7 @@ function disassociate_signin_delegate_groups_from_account(
             mergewith(_merge, Dict{String,Any}("GroupNames" => GroupNames), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3063,14 +3348,25 @@ supported licenses.
 
 """
 function get_account(accountId; aws_config::AbstractAWSConfig=global_aws_config())
-    return chime("GET", "/accounts/$(accountId)"; aws_config=aws_config)
+    return chime(
+        "GET",
+        "/accounts/$(accountId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_account(
     accountId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return chime("GET", "/accounts/$(accountId)", params; aws_config=aws_config)
+    return chime(
+        "GET",
+        "/accounts/$(accountId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -3086,14 +3382,25 @@ Policies Page in the Amazon Chime Administration Guide.
 
 """
 function get_account_settings(accountId; aws_config::AbstractAWSConfig=global_aws_config())
-    return chime("GET", "/accounts/$(accountId)/settings"; aws_config=aws_config)
+    return chime(
+        "GET",
+        "/accounts/$(accountId)/settings";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_account_settings(
     accountId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return chime("GET", "/accounts/$(accountId)/settings", params; aws_config=aws_config)
+    return chime(
+        "GET",
+        "/accounts/$(accountId)/settings",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -3110,7 +3417,10 @@ function get_app_instance_retention_settings(
     appInstanceArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return chime(
-        "GET", "/app-instances/$(appInstanceArn)/retention-settings"; aws_config=aws_config
+        "GET",
+        "/app-instances/$(appInstanceArn)/retention-settings";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_app_instance_retention_settings(
@@ -3123,6 +3433,7 @@ function get_app_instance_retention_settings(
         "/app-instances/$(appInstanceArn)/retention-settings",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3143,6 +3454,7 @@ function get_app_instance_streaming_configurations(
         "GET",
         "/app-instances/$(appInstanceArn)/streaming-configurations";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_app_instance_streaming_configurations(
@@ -3155,6 +3467,7 @@ function get_app_instance_streaming_configurations(
         "/app-instances/$(appInstanceArn)/streaming-configurations",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3175,7 +3488,10 @@ function get_attendee(
     attendeeId, meetingId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return chime(
-        "GET", "/meetings/$(meetingId)/attendees/$(attendeeId)"; aws_config=aws_config
+        "GET",
+        "/meetings/$(meetingId)/attendees/$(attendeeId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_attendee(
@@ -3189,6 +3505,7 @@ function get_attendee(
         "/meetings/$(meetingId)/attendees/$(attendeeId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3205,7 +3522,12 @@ display name.
 
 """
 function get_bot(accountId, botId; aws_config::AbstractAWSConfig=global_aws_config())
-    return chime("GET", "/accounts/$(accountId)/bots/$(botId)"; aws_config=aws_config)
+    return chime(
+        "GET",
+        "/accounts/$(accountId)/bots/$(botId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_bot(
     accountId,
@@ -3214,7 +3536,11 @@ function get_bot(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return chime(
-        "GET", "/accounts/$(accountId)/bots/$(botId)", params; aws_config=aws_config
+        "GET",
+        "/accounts/$(accountId)/bots/$(botId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3238,7 +3564,10 @@ function get_channel_message(
     channelArn, messageId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return chime(
-        "GET", "/channels/$(channelArn)/messages/$(messageId)"; aws_config=aws_config
+        "GET",
+        "/channels/$(channelArn)/messages/$(messageId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_channel_message(
@@ -3252,6 +3581,7 @@ function get_channel_message(
         "/channels/$(channelArn)/messages/$(messageId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3274,6 +3604,7 @@ function get_events_configuration(
         "GET",
         "/accounts/$(accountId)/bots/$(botId)/events-configuration";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_events_configuration(
@@ -3287,6 +3618,7 @@ function get_events_configuration(
         "/accounts/$(accountId)/bots/$(botId)/events-configuration",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3299,12 +3631,14 @@ Business Calling and Amazon Chime Voice Connector settings.
 
 """
 function get_global_settings(; aws_config::AbstractAWSConfig=global_aws_config())
-    return chime("GET", "/settings"; aws_config=aws_config)
+    return chime("GET", "/settings"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function get_global_settings(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return chime("GET", "/settings", params; aws_config=aws_config)
+    return chime(
+        "GET", "/settings", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -3321,7 +3655,10 @@ function get_media_capture_pipeline(
     mediaPipelineId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return chime(
-        "GET", "/media-capture-pipelines/$(mediaPipelineId)"; aws_config=aws_config
+        "GET",
+        "/media-capture-pipelines/$(mediaPipelineId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_media_capture_pipeline(
@@ -3330,7 +3667,11 @@ function get_media_capture_pipeline(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return chime(
-        "GET", "/media-capture-pipelines/$(mediaPipelineId)", params; aws_config=aws_config
+        "GET",
+        "/media-capture-pipelines/$(mediaPipelineId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3347,14 +3688,25 @@ Developer Guide .
 
 """
 function get_meeting(meetingId; aws_config::AbstractAWSConfig=global_aws_config())
-    return chime("GET", "/meetings/$(meetingId)"; aws_config=aws_config)
+    return chime(
+        "GET",
+        "/meetings/$(meetingId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_meeting(
     meetingId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return chime("GET", "/meetings/$(meetingId)", params; aws_config=aws_config)
+    return chime(
+        "GET",
+        "/meetings/$(meetingId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -3365,12 +3717,23 @@ The details of the endpoint for the messaging session.
 
 """
 function get_messaging_session_endpoint(; aws_config::AbstractAWSConfig=global_aws_config())
-    return chime("GET", "/endpoints/messaging-session"; aws_config=aws_config)
+    return chime(
+        "GET",
+        "/endpoints/messaging-session";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_messaging_session_endpoint(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return chime("GET", "/endpoints/messaging-session", params; aws_config=aws_config)
+    return chime(
+        "GET",
+        "/endpoints/messaging-session",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -3385,14 +3748,25 @@ and product type.
 
 """
 function get_phone_number(phoneNumberId; aws_config::AbstractAWSConfig=global_aws_config())
-    return chime("GET", "/phone-numbers/$(phoneNumberId)"; aws_config=aws_config)
+    return chime(
+        "GET",
+        "/phone-numbers/$(phoneNumberId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_phone_number(
     phoneNumberId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return chime("GET", "/phone-numbers/$(phoneNumberId)", params; aws_config=aws_config)
+    return chime(
+        "GET",
+        "/phone-numbers/$(phoneNumberId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -3409,7 +3783,12 @@ timestamp, phone numbers in E.164 format, product type, and order status.
 function get_phone_number_order(
     phoneNumberOrderId; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return chime("GET", "/phone-number-orders/$(phoneNumberOrderId)"; aws_config=aws_config)
+    return chime(
+        "GET",
+        "/phone-number-orders/$(phoneNumberOrderId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_phone_number_order(
     phoneNumberOrderId,
@@ -3417,7 +3796,11 @@ function get_phone_number_order(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return chime(
-        "GET", "/phone-number-orders/$(phoneNumberOrderId)", params; aws_config=aws_config
+        "GET",
+        "/phone-number-orders/$(phoneNumberOrderId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3430,12 +3813,23 @@ default outbound calling name.
 
 """
 function get_phone_number_settings(; aws_config::AbstractAWSConfig=global_aws_config())
-    return chime("GET", "/settings/phone-number"; aws_config=aws_config)
+    return chime(
+        "GET",
+        "/settings/phone-number";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_phone_number_settings(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return chime("GET", "/settings/phone-number", params; aws_config=aws_config)
+    return chime(
+        "GET",
+        "/settings/phone-number",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -3456,6 +3850,7 @@ function get_proxy_session(
         "GET",
         "/voice-connectors/$(voiceConnectorId)/proxy-sessions/$(proxySessionId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_proxy_session(
@@ -3469,6 +3864,7 @@ function get_proxy_session(
         "/voice-connectors/$(voiceConnectorId)/proxy-sessions/$(proxySessionId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3487,7 +3883,12 @@ Chime Administration Guide.
 function get_retention_settings(
     accountId; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return chime("GET", "/accounts/$(accountId)/retention-settings"; aws_config=aws_config)
+    return chime(
+        "GET",
+        "/accounts/$(accountId)/retention-settings";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_retention_settings(
     accountId,
@@ -3495,7 +3896,11 @@ function get_retention_settings(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return chime(
-        "GET", "/accounts/$(accountId)/retention-settings", params; aws_config=aws_config
+        "GET",
+        "/accounts/$(accountId)/retention-settings",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3512,7 +3917,12 @@ account.
 
 """
 function get_room(accountId, roomId; aws_config::AbstractAWSConfig=global_aws_config())
-    return chime("GET", "/accounts/$(accountId)/rooms/$(roomId)"; aws_config=aws_config)
+    return chime(
+        "GET",
+        "/accounts/$(accountId)/rooms/$(roomId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_room(
     accountId,
@@ -3521,7 +3931,11 @@ function get_room(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return chime(
-        "GET", "/accounts/$(accountId)/rooms/$(roomId)", params; aws_config=aws_config
+        "GET",
+        "/accounts/$(accountId)/rooms/$(roomId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3540,7 +3954,10 @@ function get_sip_media_application(
     sipMediaApplicationId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return chime(
-        "GET", "/sip-media-applications/$(sipMediaApplicationId)"; aws_config=aws_config
+        "GET",
+        "/sip-media-applications/$(sipMediaApplicationId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_sip_media_application(
@@ -3553,6 +3970,7 @@ function get_sip_media_application(
         "/sip-media-applications/$(sipMediaApplicationId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3573,6 +3991,7 @@ function get_sip_media_application_logging_configuration(
         "GET",
         "/sip-media-applications/$(sipMediaApplicationId)/logging-configuration";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_sip_media_application_logging_configuration(
@@ -3585,6 +4004,7 @@ function get_sip_media_application_logging_configuration(
         "/sip-media-applications/$(sipMediaApplicationId)/logging-configuration",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3600,14 +4020,25 @@ endpoints.
 
 """
 function get_sip_rule(sipRuleId; aws_config::AbstractAWSConfig=global_aws_config())
-    return chime("GET", "/sip-rules/$(sipRuleId)"; aws_config=aws_config)
+    return chime(
+        "GET",
+        "/sip-rules/$(sipRuleId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_sip_rule(
     sipRuleId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return chime("GET", "/sip-rules/$(sipRuleId)", params; aws_config=aws_config)
+    return chime(
+        "GET",
+        "/sip-rules/$(sipRuleId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -3624,7 +4055,12 @@ user ID, use the ListUsers action, and then filter by email address.
 
 """
 function get_user(accountId, userId; aws_config::AbstractAWSConfig=global_aws_config())
-    return chime("GET", "/accounts/$(accountId)/users/$(userId)"; aws_config=aws_config)
+    return chime(
+        "GET",
+        "/accounts/$(accountId)/users/$(userId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_user(
     accountId,
@@ -3633,7 +4069,11 @@ function get_user(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return chime(
-        "GET", "/accounts/$(accountId)/users/$(userId)", params; aws_config=aws_config
+        "GET",
+        "/accounts/$(accountId)/users/$(userId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3652,7 +4092,10 @@ function get_user_settings(
     accountId, userId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return chime(
-        "GET", "/accounts/$(accountId)/users/$(userId)/settings"; aws_config=aws_config
+        "GET",
+        "/accounts/$(accountId)/users/$(userId)/settings";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_user_settings(
@@ -3666,6 +4109,7 @@ function get_user_settings(
         "/accounts/$(accountId)/users/$(userId)/settings",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3683,7 +4127,12 @@ outbound host, and encryption requirements.
 function get_voice_connector(
     voiceConnectorId; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return chime("GET", "/voice-connectors/$(voiceConnectorId)"; aws_config=aws_config)
+    return chime(
+        "GET",
+        "/voice-connectors/$(voiceConnectorId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_voice_connector(
     voiceConnectorId,
@@ -3691,7 +4140,11 @@ function get_voice_connector(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return chime(
-        "GET", "/voice-connectors/$(voiceConnectorId)", params; aws_config=aws_config
+        "GET",
+        "/voice-connectors/$(voiceConnectorId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3713,6 +4166,7 @@ function get_voice_connector_emergency_calling_configuration(
         "GET",
         "/voice-connectors/$(voiceConnectorId)/emergency-calling-configuration";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_voice_connector_emergency_calling_configuration(
@@ -3725,6 +4179,7 @@ function get_voice_connector_emergency_calling_configuration(
         "/voice-connectors/$(voiceConnectorId)/emergency-calling-configuration",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3743,7 +4198,10 @@ function get_voice_connector_group(
     voiceConnectorGroupId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return chime(
-        "GET", "/voice-connector-groups/$(voiceConnectorGroupId)"; aws_config=aws_config
+        "GET",
+        "/voice-connector-groups/$(voiceConnectorGroupId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_voice_connector_group(
@@ -3756,6 +4214,7 @@ function get_voice_connector_group(
         "/voice-connector-groups/$(voiceConnectorGroupId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3777,6 +4236,7 @@ function get_voice_connector_logging_configuration(
         "GET",
         "/voice-connectors/$(voiceConnectorId)/logging-configuration";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_voice_connector_logging_configuration(
@@ -3789,6 +4249,7 @@ function get_voice_connector_logging_configuration(
         "/voice-connectors/$(voiceConnectorId)/logging-configuration",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3806,7 +4267,10 @@ function get_voice_connector_origination(
     voiceConnectorId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return chime(
-        "GET", "/voice-connectors/$(voiceConnectorId)/origination"; aws_config=aws_config
+        "GET",
+        "/voice-connectors/$(voiceConnectorId)/origination";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_voice_connector_origination(
@@ -3819,6 +4283,7 @@ function get_voice_connector_origination(
         "/voice-connectors/$(voiceConnectorId)/origination",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3839,6 +4304,7 @@ function get_voice_connector_proxy(
         "GET",
         "/voice-connectors/$(voiceConnectorId)/programmable-numbers/proxy";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_voice_connector_proxy(
@@ -3851,6 +4317,7 @@ function get_voice_connector_proxy(
         "/voice-connectors/$(voiceConnectorId)/programmable-numbers/proxy",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3873,6 +4340,7 @@ function get_voice_connector_streaming_configuration(
         "GET",
         "/voice-connectors/$(voiceConnectorId)/streaming-configuration";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_voice_connector_streaming_configuration(
@@ -3885,6 +4353,7 @@ function get_voice_connector_streaming_configuration(
         "/voice-connectors/$(voiceConnectorId)/streaming-configuration",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3902,7 +4371,10 @@ function get_voice_connector_termination(
     voiceConnectorId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return chime(
-        "GET", "/voice-connectors/$(voiceConnectorId)/termination"; aws_config=aws_config
+        "GET",
+        "/voice-connectors/$(voiceConnectorId)/termination";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_voice_connector_termination(
@@ -3915,6 +4387,7 @@ function get_voice_connector_termination(
         "/voice-connectors/$(voiceConnectorId)/termination",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3936,6 +4409,7 @@ function get_voice_connector_termination_health(
         "GET",
         "/voice-connectors/$(voiceConnectorId)/termination/health";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_voice_connector_termination_health(
@@ -3948,6 +4422,7 @@ function get_voice_connector_termination_health(
         "/voice-connectors/$(voiceConnectorId)/termination/health",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3974,6 +4449,7 @@ function invite_users(
         "/accounts/$(accountId)/users?operation=add",
         Dict{String,Any}("UserEmailList" => UserEmailList);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function invite_users(
@@ -3989,6 +4465,7 @@ function invite_users(
             mergewith(_merge, Dict{String,Any}("UserEmailList" => UserEmailList), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4009,12 +4486,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"user-email"`: User email address with which to filter results.
 """
 function list_accounts(; aws_config::AbstractAWSConfig=global_aws_config())
-    return chime("GET", "/accounts"; aws_config=aws_config)
+    return chime("GET", "/accounts"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_accounts(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return chime("GET", "/accounts", params; aws_config=aws_config)
+    return chime(
+        "GET", "/accounts", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -4035,7 +4514,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function list_app_instance_admins(
     appInstanceArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return chime("GET", "/app-instances/$(appInstanceArn)/admins"; aws_config=aws_config)
+    return chime(
+        "GET",
+        "/app-instances/$(appInstanceArn)/admins";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_app_instance_admins(
     appInstanceArn,
@@ -4043,7 +4527,11 @@ function list_app_instance_admins(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return chime(
-        "GET", "/app-instances/$(appInstanceArn)/admins", params; aws_config=aws_config
+        "GET",
+        "/app-instances/$(appInstanceArn)/admins",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4070,6 +4558,7 @@ function list_app_instance_users(
         "/app-instance-users",
         Dict{String,Any}("app-instance-arn" => app_instance_arn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_app_instance_users(
@@ -4086,6 +4575,7 @@ function list_app_instance_users(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4102,12 +4592,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   number of AppInstances.
 """
 function list_app_instances(; aws_config::AbstractAWSConfig=global_aws_config())
-    return chime("GET", "/app-instances"; aws_config=aws_config)
+    return chime(
+        "GET", "/app-instances"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_app_instances(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return chime("GET", "/app-instances", params; aws_config=aws_config)
+    return chime(
+        "GET",
+        "/app-instances",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -4125,7 +4623,10 @@ function list_attendee_tags(
     attendeeId, meetingId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return chime(
-        "GET", "/meetings/$(meetingId)/attendees/$(attendeeId)/tags"; aws_config=aws_config
+        "GET",
+        "/meetings/$(meetingId)/attendees/$(attendeeId)/tags";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_attendee_tags(
@@ -4139,6 +4640,7 @@ function list_attendee_tags(
         "/meetings/$(meetingId)/attendees/$(attendeeId)/tags",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4158,14 +4660,25 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"next-token"`: The token to use to retrieve the next page of results.
 """
 function list_attendees(meetingId; aws_config::AbstractAWSConfig=global_aws_config())
-    return chime("GET", "/meetings/$(meetingId)/attendees"; aws_config=aws_config)
+    return chime(
+        "GET",
+        "/meetings/$(meetingId)/attendees";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_attendees(
     meetingId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return chime("GET", "/meetings/$(meetingId)/attendees", params; aws_config=aws_config)
+    return chime(
+        "GET",
+        "/meetings/$(meetingId)/attendees",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -4184,14 +4697,25 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"next-token"`: The token to use to retrieve the next page of results.
 """
 function list_bots(accountId; aws_config::AbstractAWSConfig=global_aws_config())
-    return chime("GET", "/accounts/$(accountId)/bots"; aws_config=aws_config)
+    return chime(
+        "GET",
+        "/accounts/$(accountId)/bots";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_bots(
     accountId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return chime("GET", "/accounts/$(accountId)/bots", params; aws_config=aws_config)
+    return chime(
+        "GET",
+        "/accounts/$(accountId)/bots",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -4213,14 +4737,25 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"x-amz-chime-bearer"`: The AppInstanceUserArn of the user that makes the API call.
 """
 function list_channel_bans(channelArn; aws_config::AbstractAWSConfig=global_aws_config())
-    return chime("GET", "/channels/$(channelArn)/bans"; aws_config=aws_config)
+    return chime(
+        "GET",
+        "/channels/$(channelArn)/bans";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_channel_bans(
     channelArn,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return chime("GET", "/channels/$(channelArn)/bans", params; aws_config=aws_config)
+    return chime(
+        "GET",
+        "/channels/$(channelArn)/bans",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -4247,7 +4782,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function list_channel_memberships(
     channelArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return chime("GET", "/channels/$(channelArn)/memberships"; aws_config=aws_config)
+    return chime(
+        "GET",
+        "/channels/$(channelArn)/memberships";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_channel_memberships(
     channelArn,
@@ -4255,7 +4795,11 @@ function list_channel_memberships(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return chime(
-        "GET", "/channels/$(channelArn)/memberships", params; aws_config=aws_config
+        "GET",
+        "/channels/$(channelArn)/memberships",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4280,7 +4824,10 @@ function list_channel_memberships_for_app_instance_user(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
     return chime(
-        "GET", "/channels?scope=app-instance-user-memberships"; aws_config=aws_config
+        "GET",
+        "/channels?scope=app-instance-user-memberships";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_channel_memberships_for_app_instance_user(
@@ -4291,6 +4838,7 @@ function list_channel_memberships_for_app_instance_user(
         "/channels?scope=app-instance-user-memberships",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4322,14 +4870,25 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function list_channel_messages(
     channelArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return chime("GET", "/channels/$(channelArn)/messages"; aws_config=aws_config)
+    return chime(
+        "GET",
+        "/channels/$(channelArn)/messages";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_channel_messages(
     channelArn,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return chime("GET", "/channels/$(channelArn)/messages", params; aws_config=aws_config)
+    return chime(
+        "GET",
+        "/channels/$(channelArn)/messages",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -4353,14 +4912,25 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function list_channel_moderators(
     channelArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return chime("GET", "/channels/$(channelArn)/moderators"; aws_config=aws_config)
+    return chime(
+        "GET",
+        "/channels/$(channelArn)/moderators";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_channel_moderators(
     channelArn,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return chime("GET", "/channels/$(channelArn)/moderators", params; aws_config=aws_config)
+    return chime(
+        "GET",
+        "/channels/$(channelArn)/moderators",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -4392,6 +4962,7 @@ function list_channels(app_instance_arn; aws_config::AbstractAWSConfig=global_aw
         "/channels",
         Dict{String,Any}("app-instance-arn" => app_instance_arn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_channels(
@@ -4408,6 +4979,7 @@ function list_channels(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4431,7 +5003,10 @@ function list_channels_moderated_by_app_instance_user(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
     return chime(
-        "GET", "/channels?scope=app-instance-user-moderated-channels"; aws_config=aws_config
+        "GET",
+        "/channels?scope=app-instance-user-moderated-channels";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_channels_moderated_by_app_instance_user(
@@ -4442,6 +5017,7 @@ function list_channels_moderated_by_app_instance_user(
         "/channels?scope=app-instance-user-moderated-channels",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4458,12 +5034,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"next-token"`: The token used to retrieve the next page of results.
 """
 function list_media_capture_pipelines(; aws_config::AbstractAWSConfig=global_aws_config())
-    return chime("GET", "/media-capture-pipelines"; aws_config=aws_config)
+    return chime(
+        "GET",
+        "/media-capture-pipelines";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_media_capture_pipelines(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return chime("GET", "/media-capture-pipelines", params; aws_config=aws_config)
+    return chime(
+        "GET",
+        "/media-capture-pipelines",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -4477,14 +5064,25 @@ Lists the tags applied to an Amazon Chime SDK meeting resource.
 
 """
 function list_meeting_tags(meetingId; aws_config::AbstractAWSConfig=global_aws_config())
-    return chime("GET", "/meetings/$(meetingId)/tags"; aws_config=aws_config)
+    return chime(
+        "GET",
+        "/meetings/$(meetingId)/tags";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_meeting_tags(
     meetingId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return chime("GET", "/meetings/$(meetingId)/tags", params; aws_config=aws_config)
+    return chime(
+        "GET",
+        "/meetings/$(meetingId)/tags",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -4500,12 +5098,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"next-token"`: The token to use to retrieve the next page of results.
 """
 function list_meetings(; aws_config::AbstractAWSConfig=global_aws_config())
-    return chime("GET", "/meetings"; aws_config=aws_config)
+    return chime("GET", "/meetings"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_meetings(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return chime("GET", "/meetings", params; aws_config=aws_config)
+    return chime(
+        "GET", "/meetings", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -4520,12 +5120,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"next-token"`: The token to use to retrieve the next page of results.
 """
 function list_phone_number_orders(; aws_config::AbstractAWSConfig=global_aws_config())
-    return chime("GET", "/phone-number-orders"; aws_config=aws_config)
+    return chime(
+        "GET",
+        "/phone-number-orders";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_phone_number_orders(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return chime("GET", "/phone-number-orders", params; aws_config=aws_config)
+    return chime(
+        "GET",
+        "/phone-number-orders",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -4545,12 +5156,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"status"`: The phone number status.
 """
 function list_phone_numbers(; aws_config::AbstractAWSConfig=global_aws_config())
-    return chime("GET", "/phone-numbers"; aws_config=aws_config)
+    return chime(
+        "GET", "/phone-numbers"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_phone_numbers(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return chime("GET", "/phone-numbers", params; aws_config=aws_config)
+    return chime(
+        "GET",
+        "/phone-numbers",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -4572,7 +5191,10 @@ function list_proxy_sessions(
     voiceConnectorId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return chime(
-        "GET", "/voice-connectors/$(voiceConnectorId)/proxy-sessions"; aws_config=aws_config
+        "GET",
+        "/voice-connectors/$(voiceConnectorId)/proxy-sessions";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_proxy_sessions(
@@ -4585,6 +5207,7 @@ function list_proxy_sessions(
         "/voice-connectors/$(voiceConnectorId)/proxy-sessions",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4608,7 +5231,10 @@ function list_room_memberships(
     accountId, roomId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return chime(
-        "GET", "/accounts/$(accountId)/rooms/$(roomId)/memberships"; aws_config=aws_config
+        "GET",
+        "/accounts/$(accountId)/rooms/$(roomId)/memberships";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_room_memberships(
@@ -4622,6 +5248,7 @@ function list_room_memberships(
         "/accounts/$(accountId)/rooms/$(roomId)/memberships",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4643,14 +5270,25 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"next-token"`: The token to use to retrieve the next page of results.
 """
 function list_rooms(accountId; aws_config::AbstractAWSConfig=global_aws_config())
-    return chime("GET", "/accounts/$(accountId)/rooms"; aws_config=aws_config)
+    return chime(
+        "GET",
+        "/accounts/$(accountId)/rooms";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_rooms(
     accountId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return chime("GET", "/accounts/$(accountId)/rooms", params; aws_config=aws_config)
+    return chime(
+        "GET",
+        "/accounts/$(accountId)/rooms",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -4666,12 +5304,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"next-token"`: The token to use to retrieve the next page of results.
 """
 function list_sip_media_applications(; aws_config::AbstractAWSConfig=global_aws_config())
-    return chime("GET", "/sip-media-applications"; aws_config=aws_config)
+    return chime(
+        "GET",
+        "/sip-media-applications";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_sip_media_applications(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return chime("GET", "/sip-media-applications", params; aws_config=aws_config)
+    return chime(
+        "GET",
+        "/sip-media-applications",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -4688,12 +5337,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"sip-media-application"`: The SIP media application ID.
 """
 function list_sip_rules(; aws_config::AbstractAWSConfig=global_aws_config())
-    return chime("GET", "/sip-rules"; aws_config=aws_config)
+    return chime(
+        "GET", "/sip-rules"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_sip_rules(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return chime("GET", "/sip-rules", params; aws_config=aws_config)
+    return chime(
+        "GET", "/sip-rules", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -4714,6 +5367,7 @@ function list_supported_phone_number_countries(
         "/phone-number-countries",
         Dict{String,Any}("product-type" => product_type);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_supported_phone_number_countries(
@@ -4728,6 +5382,7 @@ function list_supported_phone_number_countries(
             mergewith(_merge, Dict{String,Any}("product-type" => product_type), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4742,7 +5397,13 @@ Lists the tags applied to an Amazon Chime SDK meeting resource.
 
 """
 function list_tags_for_resource(arn; aws_config::AbstractAWSConfig=global_aws_config())
-    return chime("GET", "/tags", Dict{String,Any}("arn" => arn); aws_config=aws_config)
+    return chime(
+        "GET",
+        "/tags",
+        Dict{String,Any}("arn" => arn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_tags_for_resource(
     arn, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -4752,6 +5413,7 @@ function list_tags_for_resource(
         "/tags",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("arn" => arn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4774,14 +5436,25 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"user-type"`: The user type.
 """
 function list_users(accountId; aws_config::AbstractAWSConfig=global_aws_config())
-    return chime("GET", "/accounts/$(accountId)/users"; aws_config=aws_config)
+    return chime(
+        "GET",
+        "/accounts/$(accountId)/users";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_users(
     accountId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return chime("GET", "/accounts/$(accountId)/users", params; aws_config=aws_config)
+    return chime(
+        "GET",
+        "/accounts/$(accountId)/users",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -4796,12 +5469,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"next-token"`: The token to use to retrieve the next page of results.
 """
 function list_voice_connector_groups(; aws_config::AbstractAWSConfig=global_aws_config())
-    return chime("GET", "/voice-connector-groups"; aws_config=aws_config)
+    return chime(
+        "GET",
+        "/voice-connector-groups";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_voice_connector_groups(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return chime("GET", "/voice-connector-groups", params; aws_config=aws_config)
+    return chime(
+        "GET",
+        "/voice-connector-groups",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -4821,6 +5505,7 @@ function list_voice_connector_termination_credentials(
         "GET",
         "/voice-connectors/$(voiceConnectorId)/termination/credentials";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_voice_connector_termination_credentials(
@@ -4833,6 +5518,7 @@ function list_voice_connector_termination_credentials(
         "/voice-connectors/$(voiceConnectorId)/termination/credentials",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4848,12 +5534,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"next-token"`: The token to use to retrieve the next page of results.
 """
 function list_voice_connectors(; aws_config::AbstractAWSConfig=global_aws_config())
-    return chime("GET", "/voice-connectors"; aws_config=aws_config)
+    return chime(
+        "GET", "/voice-connectors"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_voice_connectors(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return chime("GET", "/voice-connectors", params; aws_config=aws_config)
+    return chime(
+        "GET",
+        "/voice-connectors",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -4872,6 +5566,7 @@ function logout_user(accountId, userId; aws_config::AbstractAWSConfig=global_aws
         "POST",
         "/accounts/$(accountId)/users/$(userId)?operation=logout";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function logout_user(
@@ -4885,6 +5580,7 @@ function logout_user(
         "/accounts/$(accountId)/users/$(userId)?operation=logout",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4909,6 +5605,7 @@ function put_app_instance_retention_settings(
         "/app-instances/$(appInstanceArn)/retention-settings",
         Dict{String,Any}("AppInstanceRetentionSettings" => AppInstanceRetentionSettings);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_app_instance_retention_settings(
@@ -4930,6 +5627,7 @@ function put_app_instance_retention_settings(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4957,6 +5655,7 @@ function put_app_instance_streaming_configurations(
             "AppInstanceStreamingConfigurations" => AppInstanceStreamingConfigurations
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_app_instance_streaming_configurations(
@@ -4979,6 +5678,7 @@ function put_app_instance_streaming_configurations(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5007,6 +5707,7 @@ function put_events_configuration(
         "PUT",
         "/accounts/$(accountId)/bots/$(botId)/events-configuration";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_events_configuration(
@@ -5020,6 +5721,7 @@ function put_events_configuration(
         "/accounts/$(accountId)/bots/$(botId)/events-configuration",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5048,6 +5750,7 @@ function put_retention_settings(
         "/accounts/$(accountId)/retention-settings",
         Dict{String,Any}("RetentionSettings" => RetentionSettings);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_retention_settings(
@@ -5065,6 +5768,7 @@ function put_retention_settings(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5088,6 +5792,7 @@ function put_sip_media_application_logging_configuration(
         "PUT",
         "/sip-media-applications/$(sipMediaApplicationId)/logging-configuration";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_sip_media_application_logging_configuration(
@@ -5100,6 +5805,7 @@ function put_sip_media_application_logging_configuration(
         "/sip-media-applications/$(sipMediaApplicationId)/logging-configuration",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5127,6 +5833,7 @@ function put_voice_connector_emergency_calling_configuration(
         "/voice-connectors/$(voiceConnectorId)/emergency-calling-configuration",
         Dict{String,Any}("EmergencyCallingConfiguration" => EmergencyCallingConfiguration);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_voice_connector_emergency_calling_configuration(
@@ -5148,6 +5855,7 @@ function put_voice_connector_emergency_calling_configuration(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5174,6 +5882,7 @@ function put_voice_connector_logging_configuration(
         "/voice-connectors/$(voiceConnectorId)/logging-configuration",
         Dict{String,Any}("LoggingConfiguration" => LoggingConfiguration);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_voice_connector_logging_configuration(
@@ -5193,6 +5902,7 @@ function put_voice_connector_logging_configuration(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5217,6 +5927,7 @@ function put_voice_connector_origination(
         "/voice-connectors/$(voiceConnectorId)/origination",
         Dict{String,Any}("Origination" => Origination);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_voice_connector_origination(
@@ -5232,6 +5943,7 @@ function put_voice_connector_origination(
             mergewith(_merge, Dict{String,Any}("Origination" => Origination), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5267,6 +5979,7 @@ function put_voice_connector_proxy(
             "PhoneNumberPoolCountries" => PhoneNumberPoolCountries,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_voice_connector_proxy(
@@ -5290,6 +6003,7 @@ function put_voice_connector_proxy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5316,6 +6030,7 @@ function put_voice_connector_streaming_configuration(
         "/voice-connectors/$(voiceConnectorId)/streaming-configuration",
         Dict{String,Any}("StreamingConfiguration" => StreamingConfiguration);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_voice_connector_streaming_configuration(
@@ -5335,6 +6050,7 @@ function put_voice_connector_streaming_configuration(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5359,6 +6075,7 @@ function put_voice_connector_termination(
         "/voice-connectors/$(voiceConnectorId)/termination",
         Dict{String,Any}("Termination" => Termination);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_voice_connector_termination(
@@ -5374,6 +6091,7 @@ function put_voice_connector_termination(
             mergewith(_merge, Dict{String,Any}("Termination" => Termination), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5397,6 +6115,7 @@ function put_voice_connector_termination_credentials(
         "POST",
         "/voice-connectors/$(voiceConnectorId)/termination/credentials?operation=put";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_voice_connector_termination_credentials(
@@ -5409,6 +6128,7 @@ function put_voice_connector_termination_credentials(
         "/voice-connectors/$(voiceConnectorId)/termination/credentials?operation=put",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5436,6 +6156,7 @@ function redact_channel_message(
         "POST",
         "/channels/$(channelArn)/messages/$(messageId)?operation=redact";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function redact_channel_message(
@@ -5449,6 +6170,7 @@ function redact_channel_message(
         "/channels/$(channelArn)/messages/$(messageId)?operation=redact",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5471,6 +6193,7 @@ function redact_conversation_message(
         "POST",
         "/accounts/$(accountId)/conversations/$(conversationId)/messages/$(messageId)?operation=redact";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function redact_conversation_message(
@@ -5485,6 +6208,7 @@ function redact_conversation_message(
         "/accounts/$(accountId)/conversations/$(conversationId)/messages/$(messageId)?operation=redact",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5507,6 +6231,7 @@ function redact_room_message(
         "POST",
         "/accounts/$(accountId)/rooms/$(roomId)/messages/$(messageId)?operation=redact";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function redact_room_message(
@@ -5521,6 +6246,7 @@ function redact_room_message(
         "/accounts/$(accountId)/rooms/$(roomId)/messages/$(messageId)?operation=redact",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5542,6 +6268,7 @@ function regenerate_security_token(
         "POST",
         "/accounts/$(accountId)/bots/$(botId)?operation=regenerate-security-token";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function regenerate_security_token(
@@ -5555,6 +6282,7 @@ function regenerate_security_token(
         "/accounts/$(accountId)/bots/$(botId)?operation=regenerate-security-token",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5577,6 +6305,7 @@ function reset_personal_pin(
         "POST",
         "/accounts/$(accountId)/users/$(userId)?operation=reset-personal-pin";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function reset_personal_pin(
@@ -5590,6 +6319,7 @@ function reset_personal_pin(
         "/accounts/$(accountId)/users/$(userId)?operation=reset-personal-pin",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5607,7 +6337,10 @@ function restore_phone_number(
     phoneNumberId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return chime(
-        "POST", "/phone-numbers/$(phoneNumberId)?operation=restore"; aws_config=aws_config
+        "POST",
+        "/phone-numbers/$(phoneNumberId)?operation=restore";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function restore_phone_number(
@@ -5620,6 +6353,7 @@ function restore_phone_number(
         "/phone-numbers/$(phoneNumberId)?operation=restore",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5648,12 +6382,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   to the US.
 """
 function search_available_phone_numbers(; aws_config::AbstractAWSConfig=global_aws_config())
-    return chime("GET", "/search?type=phone-numbers"; aws_config=aws_config)
+    return chime(
+        "GET",
+        "/search?type=phone-numbers";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function search_available_phone_numbers(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return chime("GET", "/search?type=phone-numbers", params; aws_config=aws_config)
+    return chime(
+        "GET",
+        "/search?type=phone-numbers",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -5697,6 +6442,7 @@ function send_channel_message(
             "Type" => Type,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function send_channel_message(
@@ -5724,6 +6470,7 @@ function send_channel_message(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5747,6 +6494,7 @@ function start_meeting_transcription(
         "/meetings/$(meetingId)/transcription?operation=start",
         Dict{String,Any}("TranscriptionConfiguration" => TranscriptionConfiguration);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_meeting_transcription(
@@ -5768,6 +6516,7 @@ function start_meeting_transcription(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5785,7 +6534,10 @@ function stop_meeting_transcription(
     meetingId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return chime(
-        "POST", "/meetings/$(meetingId)/transcription?operation=stop"; aws_config=aws_config
+        "POST",
+        "/meetings/$(meetingId)/transcription?operation=stop";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function stop_meeting_transcription(
@@ -5798,6 +6550,7 @@ function stop_meeting_transcription(
         "/meetings/$(meetingId)/transcription?operation=stop",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5821,6 +6574,7 @@ function tag_attendee(
         "/meetings/$(meetingId)/attendees/$(attendeeId)/tags?operation=add",
         Dict{String,Any}("Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_attendee(
@@ -5835,6 +6589,7 @@ function tag_attendee(
         "/meetings/$(meetingId)/attendees/$(attendeeId)/tags?operation=add",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Tags" => Tags), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5855,6 +6610,7 @@ function tag_meeting(Tags, meetingId; aws_config::AbstractAWSConfig=global_aws_c
         "/meetings/$(meetingId)/tags?operation=add",
         Dict{String,Any}("Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_meeting(
@@ -5868,6 +6624,7 @@ function tag_meeting(
         "/meetings/$(meetingId)/tags?operation=add",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Tags" => Tags), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5888,6 +6645,7 @@ function tag_resource(ResourceARN, Tags; aws_config::AbstractAWSConfig=global_aw
         "/tags?operation=tag-resource",
         Dict{String,Any}("ResourceARN" => ResourceARN, "Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -5907,6 +6665,7 @@ function tag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5930,6 +6689,7 @@ function untag_attendee(
         "/meetings/$(meetingId)/attendees/$(attendeeId)/tags?operation=delete",
         Dict{String,Any}("TagKeys" => TagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_attendee(
@@ -5944,6 +6704,7 @@ function untag_attendee(
         "/meetings/$(meetingId)/attendees/$(attendeeId)/tags?operation=delete",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("TagKeys" => TagKeys), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5966,6 +6727,7 @@ function untag_meeting(
         "/meetings/$(meetingId)/tags?operation=delete",
         Dict{String,Any}("TagKeys" => TagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_meeting(
@@ -5979,6 +6741,7 @@ function untag_meeting(
         "/meetings/$(meetingId)/tags?operation=delete",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("TagKeys" => TagKeys), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6001,6 +6764,7 @@ function untag_resource(
         "/tags?operation=untag-resource",
         Dict{String,Any}("ResourceARN" => ResourceARN, "TagKeys" => TagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -6020,6 +6784,7 @@ function untag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6040,14 +6805,25 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"Name"`: The new name for the specified Amazon Chime account.
 """
 function update_account(accountId; aws_config::AbstractAWSConfig=global_aws_config())
-    return chime("POST", "/accounts/$(accountId)"; aws_config=aws_config)
+    return chime(
+        "POST",
+        "/accounts/$(accountId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function update_account(
     accountId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return chime("POST", "/accounts/$(accountId)", params; aws_config=aws_config)
+    return chime(
+        "POST",
+        "/accounts/$(accountId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -6071,6 +6847,7 @@ function update_account_settings(
         "/accounts/$(accountId)/settings",
         Dict{String,Any}("AccountSettings" => AccountSettings);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_account_settings(
@@ -6088,6 +6865,7 @@ function update_account_settings(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6113,6 +6891,7 @@ function update_app_instance(
         "/app-instances/$(appInstanceArn)",
         Dict{String,Any}("Name" => Name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_app_instance(
@@ -6126,6 +6905,7 @@ function update_app_instance(
         "/app-instances/$(appInstanceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6151,6 +6931,7 @@ function update_app_instance_user(
         "/app-instance-users/$(appInstanceUserArn)",
         Dict{String,Any}("Name" => Name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_app_instance_user(
@@ -6164,6 +6945,7 @@ function update_app_instance_user(
         "/app-instance-users/$(appInstanceUserArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6183,7 +6965,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"Disabled"`: When true, stops the specified bot from running in your account.
 """
 function update_bot(accountId, botId; aws_config::AbstractAWSConfig=global_aws_config())
-    return chime("POST", "/accounts/$(accountId)/bots/$(botId)"; aws_config=aws_config)
+    return chime(
+        "POST",
+        "/accounts/$(accountId)/bots/$(botId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function update_bot(
     accountId,
@@ -6192,7 +6979,11 @@ function update_bot(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return chime(
-        "POST", "/accounts/$(accountId)/bots/$(botId)", params; aws_config=aws_config
+        "POST",
+        "/accounts/$(accountId)/bots/$(botId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6222,6 +7013,7 @@ function update_channel(
         "/channels/$(channelArn)",
         Dict{String,Any}("Mode" => Mode, "Name" => Name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_channel(
@@ -6238,6 +7030,7 @@ function update_channel(
             mergewith(_merge, Dict{String,Any}("Mode" => Mode, "Name" => Name), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6262,7 +7055,10 @@ function update_channel_message(
     channelArn, messageId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return chime(
-        "PUT", "/channels/$(channelArn)/messages/$(messageId)"; aws_config=aws_config
+        "PUT",
+        "/channels/$(channelArn)/messages/$(messageId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_channel_message(
@@ -6276,6 +7072,7 @@ function update_channel_message(
         "/channels/$(channelArn)/messages/$(messageId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6297,14 +7094,25 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function update_channel_read_marker(
     channelArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return chime("PUT", "/channels/$(channelArn)/readMarker"; aws_config=aws_config)
+    return chime(
+        "PUT",
+        "/channels/$(channelArn)/readMarker";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function update_channel_read_marker(
     channelArn,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return chime("PUT", "/channels/$(channelArn)/readMarker", params; aws_config=aws_config)
+    return chime(
+        "PUT",
+        "/channels/$(channelArn)/readMarker",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -6329,6 +7137,7 @@ function update_global_settings(
             "BusinessCalling" => BusinessCalling, "VoiceConnector" => VoiceConnector
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_global_settings(
@@ -6350,6 +7159,7 @@ function update_global_settings(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6376,14 +7186,25 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function update_phone_number(
     phoneNumberId; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return chime("POST", "/phone-numbers/$(phoneNumberId)"; aws_config=aws_config)
+    return chime(
+        "POST",
+        "/phone-numbers/$(phoneNumberId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function update_phone_number(
     phoneNumberId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return chime("POST", "/phone-numbers/$(phoneNumberId)", params; aws_config=aws_config)
+    return chime(
+        "POST",
+        "/phone-numbers/$(phoneNumberId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -6406,6 +7227,7 @@ function update_phone_number_settings(
         "/settings/phone-number",
         Dict{String,Any}("CallingName" => CallingName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_phone_number_settings(
@@ -6420,6 +7242,7 @@ function update_phone_number_settings(
             mergewith(_merge, Dict{String,Any}("CallingName" => CallingName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6449,6 +7272,7 @@ function update_proxy_session(
         "/voice-connectors/$(voiceConnectorId)/proxy-sessions/$(proxySessionId)",
         Dict{String,Any}("Capabilities" => Capabilities);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_proxy_session(
@@ -6465,6 +7289,7 @@ function update_proxy_session(
             mergewith(_merge, Dict{String,Any}("Capabilities" => Capabilities), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6484,7 +7309,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"Name"`: The room name.
 """
 function update_room(accountId, roomId; aws_config::AbstractAWSConfig=global_aws_config())
-    return chime("POST", "/accounts/$(accountId)/rooms/$(roomId)"; aws_config=aws_config)
+    return chime(
+        "POST",
+        "/accounts/$(accountId)/rooms/$(roomId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function update_room(
     accountId,
@@ -6493,7 +7323,11 @@ function update_room(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return chime(
-        "POST", "/accounts/$(accountId)/rooms/$(roomId)", params; aws_config=aws_config
+        "POST",
+        "/accounts/$(accountId)/rooms/$(roomId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6522,6 +7356,7 @@ function update_room_membership(
         "POST",
         "/accounts/$(accountId)/rooms/$(roomId)/memberships/$(memberId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_room_membership(
@@ -6536,6 +7371,7 @@ function update_room_membership(
         "/accounts/$(accountId)/rooms/$(roomId)/memberships/$(memberId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6557,7 +7393,10 @@ function update_sip_media_application(
     sipMediaApplicationId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return chime(
-        "PUT", "/sip-media-applications/$(sipMediaApplicationId)"; aws_config=aws_config
+        "PUT",
+        "/sip-media-applications/$(sipMediaApplicationId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_sip_media_application(
@@ -6570,6 +7409,7 @@ function update_sip_media_application(
         "/sip-media-applications/$(sipMediaApplicationId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6598,6 +7438,7 @@ function update_sip_media_application_call(
         "/sip-media-applications/$(sipMediaApplicationId)/calls/$(transactionId)",
         Dict{String,Any}("Arguments" => Arguments);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_sip_media_application_call(
@@ -6614,6 +7455,7 @@ function update_sip_media_application_call(
             mergewith(_merge, Dict{String,Any}("Arguments" => Arguments), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6638,6 +7480,7 @@ function update_sip_rule(Name, sipRuleId; aws_config::AbstractAWSConfig=global_a
         "/sip-rules/$(sipRuleId)",
         Dict{String,Any}("Name" => Name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_sip_rule(
@@ -6651,6 +7494,7 @@ function update_sip_rule(
         "/sip-rules/$(sipRuleId)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6673,7 +7517,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"UserType"`: The user type.
 """
 function update_user(accountId, userId; aws_config::AbstractAWSConfig=global_aws_config())
-    return chime("POST", "/accounts/$(accountId)/users/$(userId)"; aws_config=aws_config)
+    return chime(
+        "POST",
+        "/accounts/$(accountId)/users/$(userId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function update_user(
     accountId,
@@ -6682,7 +7531,11 @@ function update_user(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return chime(
-        "POST", "/accounts/$(accountId)/users/$(userId)", params; aws_config=aws_config
+        "POST",
+        "/accounts/$(accountId)/users/$(userId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6706,6 +7559,7 @@ function update_user_settings(
         "/accounts/$(accountId)/users/$(userId)/settings",
         Dict{String,Any}("UserSettings" => UserSettings);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_user_settings(
@@ -6722,6 +7576,7 @@ function update_user_settings(
             mergewith(_merge, Dict{String,Any}("UserSettings" => UserSettings), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6749,6 +7604,7 @@ function update_voice_connector(
         "/voice-connectors/$(voiceConnectorId)",
         Dict{String,Any}("Name" => Name, "RequireEncryption" => RequireEncryption);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_voice_connector(
@@ -6769,6 +7625,7 @@ function update_voice_connector(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6796,6 +7653,7 @@ function update_voice_connector_group(
         "/voice-connector-groups/$(voiceConnectorGroupId)",
         Dict{String,Any}("Name" => Name, "VoiceConnectorItems" => VoiceConnectorItems);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_voice_connector_group(
@@ -6818,5 +7676,6 @@ function update_voice_connector_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/chime_sdk_identity.jl
+++ b/src/services/chime_sdk_identity.jl
@@ -29,6 +29,7 @@ function create_app_instance(
         "/app-instances",
         Dict{String,Any}("ClientRequestToken" => ClientRequestToken, "Name" => Name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_app_instance(
@@ -50,6 +51,7 @@ function create_app_instance(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -75,6 +77,7 @@ function create_app_instance_admin(
         "/app-instances/$(appInstanceArn)/admins",
         Dict{String,Any}("AppInstanceAdminArn" => AppInstanceAdminArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_app_instance_admin(
@@ -94,6 +97,7 @@ function create_app_instance_admin(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -132,6 +136,7 @@ function create_app_instance_user(
             "Name" => Name,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_app_instance_user(
@@ -158,6 +163,7 @@ function create_app_instance_user(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -175,7 +181,10 @@ function delete_app_instance(
     appInstanceArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return chime_sdk_identity(
-        "DELETE", "/app-instances/$(appInstanceArn)"; aws_config=aws_config
+        "DELETE",
+        "/app-instances/$(appInstanceArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_app_instance(
@@ -184,7 +193,11 @@ function delete_app_instance(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return chime_sdk_identity(
-        "DELETE", "/app-instances/$(appInstanceArn)", params; aws_config=aws_config
+        "DELETE",
+        "/app-instances/$(appInstanceArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -206,6 +219,7 @@ function delete_app_instance_admin(
         "DELETE",
         "/app-instances/$(appInstanceArn)/admins/$(appInstanceAdminArn)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_app_instance_admin(
@@ -219,6 +233,7 @@ function delete_app_instance_admin(
         "/app-instances/$(appInstanceArn)/admins/$(appInstanceAdminArn)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -236,7 +251,10 @@ function delete_app_instance_user(
     appInstanceUserArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return chime_sdk_identity(
-        "DELETE", "/app-instance-users/$(appInstanceUserArn)"; aws_config=aws_config
+        "DELETE",
+        "/app-instance-users/$(appInstanceUserArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_app_instance_user(
@@ -245,7 +263,11 @@ function delete_app_instance_user(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return chime_sdk_identity(
-        "DELETE", "/app-instance-users/$(appInstanceUserArn)", params; aws_config=aws_config
+        "DELETE",
+        "/app-instance-users/$(appInstanceUserArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -263,7 +285,10 @@ function describe_app_instance(
     appInstanceArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return chime_sdk_identity(
-        "GET", "/app-instances/$(appInstanceArn)"; aws_config=aws_config
+        "GET",
+        "/app-instances/$(appInstanceArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_app_instance(
@@ -272,7 +297,11 @@ function describe_app_instance(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return chime_sdk_identity(
-        "GET", "/app-instances/$(appInstanceArn)", params; aws_config=aws_config
+        "GET",
+        "/app-instances/$(appInstanceArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -294,6 +323,7 @@ function describe_app_instance_admin(
         "GET",
         "/app-instances/$(appInstanceArn)/admins/$(appInstanceAdminArn)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_app_instance_admin(
@@ -307,6 +337,7 @@ function describe_app_instance_admin(
         "/app-instances/$(appInstanceArn)/admins/$(appInstanceAdminArn)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -324,7 +355,10 @@ function describe_app_instance_user(
     appInstanceUserArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return chime_sdk_identity(
-        "GET", "/app-instance-users/$(appInstanceUserArn)"; aws_config=aws_config
+        "GET",
+        "/app-instance-users/$(appInstanceUserArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_app_instance_user(
@@ -333,7 +367,11 @@ function describe_app_instance_user(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return chime_sdk_identity(
-        "GET", "/app-instance-users/$(appInstanceUserArn)", params; aws_config=aws_config
+        "GET",
+        "/app-instance-users/$(appInstanceUserArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -351,7 +389,10 @@ function get_app_instance_retention_settings(
     appInstanceArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return chime_sdk_identity(
-        "GET", "/app-instances/$(appInstanceArn)/retention-settings"; aws_config=aws_config
+        "GET",
+        "/app-instances/$(appInstanceArn)/retention-settings";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_app_instance_retention_settings(
@@ -364,6 +405,7 @@ function get_app_instance_retention_settings(
         "/app-instances/$(appInstanceArn)/retention-settings",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -386,7 +428,10 @@ function list_app_instance_admins(
     appInstanceArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return chime_sdk_identity(
-        "GET", "/app-instances/$(appInstanceArn)/admins"; aws_config=aws_config
+        "GET",
+        "/app-instances/$(appInstanceArn)/admins";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_app_instance_admins(
@@ -395,7 +440,11 @@ function list_app_instance_admins(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return chime_sdk_identity(
-        "GET", "/app-instances/$(appInstanceArn)/admins", params; aws_config=aws_config
+        "GET",
+        "/app-instances/$(appInstanceArn)/admins",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -422,6 +471,7 @@ function list_app_instance_users(
         "/app-instance-users",
         Dict{String,Any}("app-instance-arn" => app_instance_arn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_app_instance_users(
@@ -438,6 +488,7 @@ function list_app_instance_users(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -454,12 +505,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   number of AppInstances.
 """
 function list_app_instances(; aws_config::AbstractAWSConfig=global_aws_config())
-    return chime_sdk_identity("GET", "/app-instances"; aws_config=aws_config)
+    return chime_sdk_identity(
+        "GET", "/app-instances"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_app_instances(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return chime_sdk_identity("GET", "/app-instances", params; aws_config=aws_config)
+    return chime_sdk_identity(
+        "GET",
+        "/app-instances",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -483,6 +542,7 @@ function put_app_instance_retention_settings(
         "/app-instances/$(appInstanceArn)/retention-settings",
         Dict{String,Any}("AppInstanceRetentionSettings" => AppInstanceRetentionSettings);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_app_instance_retention_settings(
@@ -504,6 +564,7 @@ function put_app_instance_retention_settings(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -527,6 +588,7 @@ function update_app_instance(
         "/app-instances/$(appInstanceArn)",
         Dict{String,Any}("Metadata" => Metadata, "Name" => Name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_app_instance(
@@ -545,6 +607,7 @@ function update_app_instance(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -568,6 +631,7 @@ function update_app_instance_user(
         "/app-instance-users/$(appInstanceUserArn)",
         Dict{String,Any}("Metadata" => Metadata, "Name" => Name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_app_instance_user(
@@ -586,5 +650,6 @@ function update_app_instance_user(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/chime_sdk_messaging.jl
+++ b/src/services/chime_sdk_messaging.jl
@@ -36,6 +36,7 @@ function batch_create_channel_membership(
             "headers" => Dict{String,Any}("x-amz-chime-bearer" => x_amz_chime_bearer),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_create_channel_membership(
@@ -60,6 +61,7 @@ function batch_create_channel_membership(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -105,6 +107,7 @@ function create_channel(
             "headers" => Dict{String,Any}("x-amz-chime-bearer" => x_amz_chime_bearer),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_channel(
@@ -132,6 +135,7 @@ function create_channel(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -166,6 +170,7 @@ function create_channel_ban(
             "headers" => Dict{String,Any}("x-amz-chime-bearer" => x_amz_chime_bearer),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_channel_ban(
@@ -190,6 +195,7 @@ function create_channel_ban(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -231,6 +237,7 @@ function create_channel_membership(
             "headers" => Dict{String,Any}("x-amz-chime-bearer" => x_amz_chime_bearer),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_channel_membership(
@@ -257,6 +264,7 @@ function create_channel_membership(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -290,6 +298,7 @@ function create_channel_moderator(
             "headers" => Dict{String,Any}("x-amz-chime-bearer" => x_amz_chime_bearer),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_channel_moderator(
@@ -314,6 +323,7 @@ function create_channel_moderator(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -340,6 +350,7 @@ function delete_channel(
             "headers" => Dict{String,Any}("x-amz-chime-bearer" => x_amz_chime_bearer)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_channel(
@@ -362,6 +373,7 @@ function delete_channel(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -392,6 +404,7 @@ function delete_channel_ban(
             "headers" => Dict{String,Any}("x-amz-chime-bearer" => x_amz_chime_bearer)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_channel_ban(
@@ -415,6 +428,7 @@ function delete_channel_ban(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -444,6 +458,7 @@ function delete_channel_membership(
             "headers" => Dict{String,Any}("x-amz-chime-bearer" => x_amz_chime_bearer)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_channel_membership(
@@ -467,6 +482,7 @@ function delete_channel_membership(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -498,6 +514,7 @@ function delete_channel_message(
             "headers" => Dict{String,Any}("x-amz-chime-bearer" => x_amz_chime_bearer)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_channel_message(
@@ -521,6 +538,7 @@ function delete_channel_message(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -550,6 +568,7 @@ function delete_channel_moderator(
             "headers" => Dict{String,Any}("x-amz-chime-bearer" => x_amz_chime_bearer)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_channel_moderator(
@@ -573,6 +592,7 @@ function delete_channel_moderator(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -599,6 +619,7 @@ function describe_channel(
             "headers" => Dict{String,Any}("x-amz-chime-bearer" => x_amz_chime_bearer)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_channel(
@@ -621,6 +642,7 @@ function describe_channel(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -651,6 +673,7 @@ function describe_channel_ban(
             "headers" => Dict{String,Any}("x-amz-chime-bearer" => x_amz_chime_bearer)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_channel_ban(
@@ -674,6 +697,7 @@ function describe_channel_ban(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -704,6 +728,7 @@ function describe_channel_membership(
             "headers" => Dict{String,Any}("x-amz-chime-bearer" => x_amz_chime_bearer)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_channel_membership(
@@ -727,6 +752,7 @@ function describe_channel_membership(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -758,6 +784,7 @@ function describe_channel_membership_for_app_instance_user(
             "headers" => Dict{String,Any}("x-amz-chime-bearer" => x_amz_chime_bearer),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_channel_membership_for_app_instance_user(
@@ -782,6 +809,7 @@ function describe_channel_membership_for_app_instance_user(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -813,6 +841,7 @@ function describe_channel_moderated_by_app_instance_user(
             "headers" => Dict{String,Any}("x-amz-chime-bearer" => x_amz_chime_bearer),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_channel_moderated_by_app_instance_user(
@@ -837,6 +866,7 @@ function describe_channel_moderated_by_app_instance_user(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -867,6 +897,7 @@ function describe_channel_moderator(
             "headers" => Dict{String,Any}("x-amz-chime-bearer" => x_amz_chime_bearer)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_channel_moderator(
@@ -890,6 +921,7 @@ function describe_channel_moderator(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -920,6 +952,7 @@ function get_channel_message(
             "headers" => Dict{String,Any}("x-amz-chime-bearer" => x_amz_chime_bearer)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_channel_message(
@@ -943,6 +976,7 @@ function get_channel_message(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -954,13 +988,22 @@ The details of the endpoint for the messaging session.
 
 """
 function get_messaging_session_endpoint(; aws_config::AbstractAWSConfig=global_aws_config())
-    return chime_sdk_messaging("GET", "/endpoints/messaging-session"; aws_config=aws_config)
+    return chime_sdk_messaging(
+        "GET",
+        "/endpoints/messaging-session";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_messaging_session_endpoint(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return chime_sdk_messaging(
-        "GET", "/endpoints/messaging-session", params; aws_config=aws_config
+        "GET",
+        "/endpoints/messaging-session",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -992,6 +1035,7 @@ function list_channel_bans(
             "headers" => Dict{String,Any}("x-amz-chime-bearer" => x_amz_chime_bearer)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_channel_bans(
@@ -1014,6 +1058,7 @@ function list_channel_bans(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1048,6 +1093,7 @@ function list_channel_memberships(
             "headers" => Dict{String,Any}("x-amz-chime-bearer" => x_amz_chime_bearer)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_channel_memberships(
@@ -1070,6 +1116,7 @@ function list_channel_memberships(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1102,6 +1149,7 @@ function list_channel_memberships_for_app_instance_user(
             "headers" => Dict{String,Any}("x-amz-chime-bearer" => x_amz_chime_bearer)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_channel_memberships_for_app_instance_user(
@@ -1123,6 +1171,7 @@ function list_channel_memberships_for_app_instance_user(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1161,6 +1210,7 @@ function list_channel_messages(
             "headers" => Dict{String,Any}("x-amz-chime-bearer" => x_amz_chime_bearer)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_channel_messages(
@@ -1183,6 +1233,7 @@ function list_channel_messages(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1214,6 +1265,7 @@ function list_channel_moderators(
             "headers" => Dict{String,Any}("x-amz-chime-bearer" => x_amz_chime_bearer)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_channel_moderators(
@@ -1236,6 +1288,7 @@ function list_channel_moderators(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1273,6 +1326,7 @@ function list_channels(
             "headers" => Dict{String,Any}("x-amz-chime-bearer" => x_amz_chime_bearer),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_channels(
@@ -1296,6 +1350,7 @@ function list_channels(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1327,6 +1382,7 @@ function list_channels_moderated_by_app_instance_user(
             "headers" => Dict{String,Any}("x-amz-chime-bearer" => x_amz_chime_bearer)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_channels_moderated_by_app_instance_user(
@@ -1348,6 +1404,7 @@ function list_channels_moderated_by_app_instance_user(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1379,6 +1436,7 @@ function redact_channel_message(
             "headers" => Dict{String,Any}("x-amz-chime-bearer" => x_amz_chime_bearer)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function redact_channel_message(
@@ -1402,6 +1460,7 @@ function redact_channel_message(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1448,6 +1507,7 @@ function send_channel_message(
             "headers" => Dict{String,Any}("x-amz-chime-bearer" => x_amz_chime_bearer),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function send_channel_message(
@@ -1478,6 +1538,7 @@ function send_channel_message(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1515,6 +1576,7 @@ function update_channel(
             "headers" => Dict{String,Any}("x-amz-chime-bearer" => x_amz_chime_bearer),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_channel(
@@ -1541,6 +1603,7 @@ function update_channel(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1574,6 +1637,7 @@ function update_channel_message(
             "headers" => Dict{String,Any}("x-amz-chime-bearer" => x_amz_chime_bearer)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_channel_message(
@@ -1597,6 +1661,7 @@ function update_channel_message(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1623,6 +1688,7 @@ function update_channel_read_marker(
             "headers" => Dict{String,Any}("x-amz-chime-bearer" => x_amz_chime_bearer)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_channel_read_marker(
@@ -1645,5 +1711,6 @@ function update_channel_read_marker(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/cloud9.jl
+++ b/src/services/cloud9.jl
@@ -58,6 +58,7 @@ function create_environment_ec2(
         "CreateEnvironmentEC2",
         Dict{String,Any}("instanceType" => instanceType, "name" => name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_environment_ec2(
@@ -76,6 +77,7 @@ function create_environment_ec2(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -105,6 +107,7 @@ function create_environment_membership(
             "userArn" => userArn,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_environment_membership(
@@ -128,6 +131,7 @@ function create_environment_membership(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -149,6 +153,7 @@ function delete_environment(
         "DeleteEnvironment",
         Dict{String,Any}("environmentId" => environmentId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_environment(
@@ -162,6 +167,7 @@ function delete_environment(
             mergewith(_merge, Dict{String,Any}("environmentId" => environmentId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -184,6 +190,7 @@ function delete_environment_membership(
         "DeleteEnvironmentMembership",
         Dict{String,Any}("environmentId" => environmentId, "userArn" => userArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_environment_membership(
@@ -202,6 +209,7 @@ function delete_environment_membership(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -231,12 +239,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_environment_memberships(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return cloud9("DescribeEnvironmentMemberships"; aws_config=aws_config)
+    return cloud9(
+        "DescribeEnvironmentMemberships";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_environment_memberships(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return cloud9("DescribeEnvironmentMemberships", params; aws_config=aws_config)
+    return cloud9(
+        "DescribeEnvironmentMemberships",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -256,6 +273,7 @@ function describe_environment_status(
         "DescribeEnvironmentStatus",
         Dict{String,Any}("environmentId" => environmentId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_environment_status(
@@ -269,6 +287,7 @@ function describe_environment_status(
             mergewith(_merge, Dict{String,Any}("environmentId" => environmentId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -289,6 +308,7 @@ function describe_environments(
         "DescribeEnvironments",
         Dict{String,Any}("environmentIds" => environmentIds);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_environments(
@@ -302,6 +322,7 @@ function describe_environments(
             mergewith(_merge, Dict{String,Any}("environmentIds" => environmentIds), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -321,12 +342,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   next token that is returned, until no more next tokens are returned.
 """
 function list_environments(; aws_config::AbstractAWSConfig=global_aws_config())
-    return cloud9("ListEnvironments"; aws_config=aws_config)
+    return cloud9(
+        "ListEnvironments"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_environments(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return cloud9("ListEnvironments", params; aws_config=aws_config)
+    return cloud9(
+        "ListEnvironments", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -347,6 +372,7 @@ function list_tags_for_resource(
         "ListTagsForResource",
         Dict{String,Any}("ResourceARN" => ResourceARN);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags_for_resource(
@@ -360,6 +386,7 @@ function list_tags_for_resource(
             mergewith(_merge, Dict{String,Any}("ResourceARN" => ResourceARN), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -381,6 +408,7 @@ function tag_resource(ResourceARN, Tags; aws_config::AbstractAWSConfig=global_aw
         "TagResource",
         Dict{String,Any}("ResourceARN" => ResourceARN, "Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -399,6 +427,7 @@ function tag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -422,6 +451,7 @@ function untag_resource(
         "UntagResource",
         Dict{String,Any}("ResourceARN" => ResourceARN, "TagKeys" => TagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -440,6 +470,7 @@ function untag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -470,6 +501,7 @@ function update_environment(
         "UpdateEnvironment",
         Dict{String,Any}("environmentId" => environmentId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_environment(
@@ -483,6 +515,7 @@ function update_environment(
             mergewith(_merge, Dict{String,Any}("environmentId" => environmentId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -515,6 +548,7 @@ function update_environment_membership(
             "userArn" => userArn,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_environment_membership(
@@ -538,5 +572,6 @@ function update_environment_membership(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/clouddirectory.jl
+++ b/src/services/clouddirectory.jl
@@ -36,6 +36,7 @@ function add_facet_to_object(
             "headers" => Dict{String,Any}("x-amz-data-partition" => x_amz_data_partition),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function add_facet_to_object(
@@ -61,6 +62,7 @@ function add_facet_to_object(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -91,6 +93,7 @@ function apply_schema(
             "headers" => Dict{String,Any}("x-amz-data-partition" => x_amz_data_partition),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function apply_schema(
@@ -114,6 +117,7 @@ function apply_schema(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -149,6 +153,7 @@ function attach_object(
             "headers" => Dict{String,Any}("x-amz-data-partition" => x_amz_data_partition),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function attach_object(
@@ -176,6 +181,7 @@ function attach_object(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -209,6 +215,7 @@ function attach_policy(
             "headers" => Dict{String,Any}("x-amz-data-partition" => x_amz_data_partition),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function attach_policy(
@@ -234,6 +241,7 @@ function attach_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -265,6 +273,7 @@ function attach_to_index(
             "headers" => Dict{String,Any}("x-amz-data-partition" => x_amz_data_partition),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function attach_to_index(
@@ -290,6 +299,7 @@ function attach_to_index(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -331,6 +341,7 @@ function attach_typed_link(
             "headers" => Dict{String,Any}("x-amz-data-partition" => x_amz_data_partition),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function attach_typed_link(
@@ -360,6 +371,7 @@ function attach_typed_link(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -391,6 +403,7 @@ function batch_read(
             "headers" => Dict{String,Any}("x-amz-data-partition" => x_amz_data_partition),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_read(
@@ -414,6 +427,7 @@ function batch_read(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -440,6 +454,7 @@ function batch_write(
             "headers" => Dict{String,Any}("x-amz-data-partition" => x_amz_data_partition),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_write(
@@ -463,6 +478,7 @@ function batch_write(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -492,6 +508,7 @@ function create_directory(
             "headers" => Dict{String,Any}("x-amz-data-partition" => x_amz_data_partition),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_directory(
@@ -515,6 +532,7 @@ function create_directory(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -553,6 +571,7 @@ function create_facet(
             "headers" => Dict{String,Any}("x-amz-data-partition" => x_amz_data_partition),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_facet(
@@ -576,6 +595,7 @@ function create_facet(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -612,6 +632,7 @@ function create_index(
             "headers" => Dict{String,Any}("x-amz-data-partition" => x_amz_data_partition),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_index(
@@ -637,6 +658,7 @@ function create_index(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -674,6 +696,7 @@ function create_object(
             "headers" => Dict{String,Any}("x-amz-data-partition" => x_amz_data_partition),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_object(
@@ -697,6 +720,7 @@ function create_object(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -723,6 +747,7 @@ function create_schema(Name; aws_config::AbstractAWSConfig=global_aws_config())
         "/amazonclouddirectory/2017-01-11/schema/create",
         Dict{String,Any}("Name" => Name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_schema(
@@ -733,6 +758,7 @@ function create_schema(
         "/amazonclouddirectory/2017-01-11/schema/create",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -759,6 +785,7 @@ function create_typed_link_facet(
             "headers" => Dict{String,Any}("x-amz-data-partition" => x_amz_data_partition),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_typed_link_facet(
@@ -782,6 +809,7 @@ function create_typed_link_facet(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -806,6 +834,7 @@ function delete_directory(
             "headers" => Dict{String,Any}("x-amz-data-partition" => x_amz_data_partition)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_directory(
@@ -827,6 +856,7 @@ function delete_directory(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -854,6 +884,7 @@ function delete_facet(
             "headers" => Dict{String,Any}("x-amz-data-partition" => x_amz_data_partition),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_facet(
@@ -877,6 +908,7 @@ function delete_facet(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -905,6 +937,7 @@ function delete_object(
             "headers" => Dict{String,Any}("x-amz-data-partition" => x_amz_data_partition),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_object(
@@ -928,6 +961,7 @@ function delete_object(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -952,6 +986,7 @@ function delete_schema(
             "headers" => Dict{String,Any}("x-amz-data-partition" => x_amz_data_partition)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_schema(
@@ -973,6 +1008,7 @@ function delete_schema(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -999,6 +1035,7 @@ function delete_typed_link_facet(
             "headers" => Dict{String,Any}("x-amz-data-partition" => x_amz_data_partition),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_typed_link_facet(
@@ -1022,6 +1059,7 @@ function delete_typed_link_facet(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1053,6 +1091,7 @@ function detach_from_index(
             "headers" => Dict{String,Any}("x-amz-data-partition" => x_amz_data_partition),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function detach_from_index(
@@ -1078,6 +1117,7 @@ function detach_from_index(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1111,6 +1151,7 @@ function detach_object(
             "headers" => Dict{String,Any}("x-amz-data-partition" => x_amz_data_partition),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function detach_object(
@@ -1136,6 +1177,7 @@ function detach_object(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1168,6 +1210,7 @@ function detach_policy(
             "headers" => Dict{String,Any}("x-amz-data-partition" => x_amz_data_partition),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function detach_policy(
@@ -1193,6 +1236,7 @@ function detach_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1222,6 +1266,7 @@ function detach_typed_link(
             "headers" => Dict{String,Any}("x-amz-data-partition" => x_amz_data_partition),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function detach_typed_link(
@@ -1245,6 +1290,7 @@ function detach_typed_link(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1269,6 +1315,7 @@ function disable_directory(
             "headers" => Dict{String,Any}("x-amz-data-partition" => x_amz_data_partition)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disable_directory(
@@ -1290,6 +1337,7 @@ function disable_directory(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1314,6 +1362,7 @@ function enable_directory(
             "headers" => Dict{String,Any}("x-amz-data-partition" => x_amz_data_partition)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function enable_directory(
@@ -1335,6 +1384,7 @@ function enable_directory(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1356,6 +1406,7 @@ function get_applied_schema_version(
         "/amazonclouddirectory/2017-01-11/schema/getappliedschema",
         Dict{String,Any}("SchemaArn" => SchemaArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_applied_schema_version(
@@ -1370,6 +1421,7 @@ function get_applied_schema_version(
             mergewith(_merge, Dict{String,Any}("SchemaArn" => SchemaArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1393,6 +1445,7 @@ function get_directory(
             "headers" => Dict{String,Any}("x-amz-data-partition" => x_amz_data_partition)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_directory(
@@ -1414,6 +1467,7 @@ function get_directory(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1441,6 +1495,7 @@ function get_facet(
             "headers" => Dict{String,Any}("x-amz-data-partition" => x_amz_data_partition),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_facet(
@@ -1464,6 +1519,7 @@ function get_facet(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1499,6 +1555,7 @@ function get_link_attributes(
             "headers" => Dict{String,Any}("x-amz-data-partition" => x_amz_data_partition),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_link_attributes(
@@ -1524,6 +1581,7 @@ function get_link_attributes(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1564,6 +1622,7 @@ function get_object_attributes(
             "headers" => Dict{String,Any}("x-amz-data-partition" => x_amz_data_partition),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_object_attributes(
@@ -1591,6 +1650,7 @@ function get_object_attributes(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1620,6 +1680,7 @@ function get_object_information(
             "headers" => Dict{String,Any}("x-amz-data-partition" => x_amz_data_partition),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_object_information(
@@ -1643,6 +1704,7 @@ function get_object_information(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1666,6 +1728,7 @@ function get_schema_as_json(
             "headers" => Dict{String,Any}("x-amz-data-partition" => x_amz_data_partition)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_schema_as_json(
@@ -1687,6 +1750,7 @@ function get_schema_as_json(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1714,6 +1778,7 @@ function get_typed_link_facet_information(
             "headers" => Dict{String,Any}("x-amz-data-partition" => x_amz_data_partition),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_typed_link_facet_information(
@@ -1737,6 +1802,7 @@ function get_typed_link_facet_information(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1765,6 +1831,7 @@ function list_applied_schema_arns(
         "/amazonclouddirectory/2017-01-11/schema/applied",
         Dict{String,Any}("DirectoryArn" => DirectoryArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_applied_schema_arns(
@@ -1779,6 +1846,7 @@ function list_applied_schema_arns(
             mergewith(_merge, Dict{String,Any}("DirectoryArn" => DirectoryArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1809,6 +1877,7 @@ function list_attached_indices(
             "headers" => Dict{String,Any}("x-amz-data-partition" => x_amz_data_partition),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_attached_indices(
@@ -1832,6 +1901,7 @@ function list_attached_indices(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1848,7 +1918,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function list_development_schema_arns(; aws_config::AbstractAWSConfig=global_aws_config())
     return clouddirectory(
-        "POST", "/amazonclouddirectory/2017-01-11/schema/development"; aws_config=aws_config
+        "POST",
+        "/amazonclouddirectory/2017-01-11/schema/development";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_development_schema_arns(
@@ -1859,6 +1932,7 @@ function list_development_schema_arns(
         "/amazonclouddirectory/2017-01-11/schema/development",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1877,7 +1951,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function list_directories(; aws_config::AbstractAWSConfig=global_aws_config())
     return clouddirectory(
-        "POST", "/amazonclouddirectory/2017-01-11/directory/list"; aws_config=aws_config
+        "POST",
+        "/amazonclouddirectory/2017-01-11/directory/list";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_directories(
@@ -1888,6 +1965,7 @@ function list_directories(
         "/amazonclouddirectory/2017-01-11/directory/list",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1917,6 +1995,7 @@ function list_facet_attributes(
             "headers" => Dict{String,Any}("x-amz-data-partition" => x_amz_data_partition),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_facet_attributes(
@@ -1940,6 +2019,7 @@ function list_facet_attributes(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1967,6 +2047,7 @@ function list_facet_names(
             "headers" => Dict{String,Any}("x-amz-data-partition" => x_amz_data_partition)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_facet_names(
@@ -1988,6 +2069,7 @@ function list_facet_names(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2026,6 +2108,7 @@ function list_incoming_typed_links(
             "headers" => Dict{String,Any}("x-amz-data-partition" => x_amz_data_partition),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_incoming_typed_links(
@@ -2049,6 +2132,7 @@ function list_incoming_typed_links(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2081,6 +2165,7 @@ function list_index(
             "headers" => Dict{String,Any}("x-amz-data-partition" => x_amz_data_partition),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_index(
@@ -2104,6 +2189,7 @@ function list_index(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2123,7 +2209,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function list_managed_schema_arns(; aws_config::AbstractAWSConfig=global_aws_config())
     return clouddirectory(
-        "POST", "/amazonclouddirectory/2017-01-11/schema/managed"; aws_config=aws_config
+        "POST",
+        "/amazonclouddirectory/2017-01-11/schema/managed";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_managed_schema_arns(
@@ -2134,6 +2223,7 @@ function list_managed_schema_arns(
         "/amazonclouddirectory/2017-01-11/schema/managed",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2171,6 +2261,7 @@ function list_object_attributes(
             "headers" => Dict{String,Any}("x-amz-data-partition" => x_amz_data_partition),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_object_attributes(
@@ -2194,6 +2285,7 @@ function list_object_attributes(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2229,6 +2321,7 @@ function list_object_children(
             "headers" => Dict{String,Any}("x-amz-data-partition" => x_amz_data_partition),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_object_children(
@@ -2252,6 +2345,7 @@ function list_object_children(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2290,6 +2384,7 @@ function list_object_parent_paths(
             "headers" => Dict{String,Any}("x-amz-data-partition" => x_amz_data_partition),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_object_parent_paths(
@@ -2313,6 +2408,7 @@ function list_object_parent_paths(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2351,6 +2447,7 @@ function list_object_parents(
             "headers" => Dict{String,Any}("x-amz-data-partition" => x_amz_data_partition),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_object_parents(
@@ -2374,6 +2471,7 @@ function list_object_parents(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2409,6 +2507,7 @@ function list_object_policies(
             "headers" => Dict{String,Any}("x-amz-data-partition" => x_amz_data_partition),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_object_policies(
@@ -2432,6 +2531,7 @@ function list_object_policies(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2471,6 +2571,7 @@ function list_outgoing_typed_links(
             "headers" => Dict{String,Any}("x-amz-data-partition" => x_amz_data_partition),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_outgoing_typed_links(
@@ -2494,6 +2595,7 @@ function list_outgoing_typed_links(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2528,6 +2630,7 @@ function list_policy_attachments(
             "headers" => Dict{String,Any}("x-amz-data-partition" => x_amz_data_partition),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_policy_attachments(
@@ -2551,6 +2654,7 @@ function list_policy_attachments(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2570,7 +2674,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function list_published_schema_arns(; aws_config::AbstractAWSConfig=global_aws_config())
     return clouddirectory(
-        "POST", "/amazonclouddirectory/2017-01-11/schema/published"; aws_config=aws_config
+        "POST",
+        "/amazonclouddirectory/2017-01-11/schema/published";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_published_schema_arns(
@@ -2581,6 +2688,7 @@ function list_published_schema_arns(
         "/amazonclouddirectory/2017-01-11/schema/published",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2611,6 +2719,7 @@ function list_tags_for_resource(
         "/amazonclouddirectory/2017-01-11/tags",
         Dict{String,Any}("ResourceArn" => ResourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags_for_resource(
@@ -2625,6 +2734,7 @@ function list_tags_for_resource(
             mergewith(_merge, Dict{String,Any}("ResourceArn" => ResourceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2656,6 +2766,7 @@ function list_typed_link_facet_attributes(
             "headers" => Dict{String,Any}("x-amz-data-partition" => x_amz_data_partition),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_typed_link_facet_attributes(
@@ -2679,6 +2790,7 @@ function list_typed_link_facet_attributes(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2708,6 +2820,7 @@ function list_typed_link_facet_names(
             "headers" => Dict{String,Any}("x-amz-data-partition" => x_amz_data_partition)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_typed_link_facet_names(
@@ -2729,6 +2842,7 @@ function list_typed_link_facet_names(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2765,6 +2879,7 @@ function lookup_policy(
             "headers" => Dict{String,Any}("x-amz-data-partition" => x_amz_data_partition),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function lookup_policy(
@@ -2788,6 +2903,7 @@ function lookup_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2821,6 +2937,7 @@ function publish_schema(
             "headers" => Dict{String,Any}("x-amz-data-partition" => x_amz_data_partition),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function publish_schema(
@@ -2844,6 +2961,7 @@ function publish_schema(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2870,6 +2988,7 @@ function put_schema_from_json(
             "headers" => Dict{String,Any}("x-amz-data-partition" => x_amz_data_partition),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_schema_from_json(
@@ -2893,6 +3012,7 @@ function put_schema_from_json(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2923,6 +3043,7 @@ function remove_facet_from_object(
             "headers" => Dict{String,Any}("x-amz-data-partition" => x_amz_data_partition),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function remove_facet_from_object(
@@ -2948,6 +3069,7 @@ function remove_facet_from_object(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2969,6 +3091,7 @@ function tag_resource(ResourceArn, Tags; aws_config::AbstractAWSConfig=global_aw
         "/amazonclouddirectory/2017-01-11/tags/add",
         Dict{String,Any}("ResourceArn" => ResourceArn, "Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -2988,6 +3111,7 @@ function tag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3011,6 +3135,7 @@ function untag_resource(
         "/amazonclouddirectory/2017-01-11/tags/remove",
         Dict{String,Any}("ResourceArn" => ResourceArn, "TagKeys" => TagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -3030,6 +3155,7 @@ function untag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3064,6 +3190,7 @@ function update_facet(
             "headers" => Dict{String,Any}("x-amz-data-partition" => x_amz_data_partition),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_facet(
@@ -3087,6 +3214,7 @@ function update_facet(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3120,6 +3248,7 @@ function update_link_attributes(
             "headers" => Dict{String,Any}("x-amz-data-partition" => x_amz_data_partition),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_link_attributes(
@@ -3145,6 +3274,7 @@ function update_link_attributes(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3176,6 +3306,7 @@ function update_object_attributes(
             "headers" => Dict{String,Any}("x-amz-data-partition" => x_amz_data_partition),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_object_attributes(
@@ -3201,6 +3332,7 @@ function update_object_attributes(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3227,6 +3359,7 @@ function update_schema(
             "headers" => Dict{String,Any}("x-amz-data-partition" => x_amz_data_partition),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_schema(
@@ -3250,6 +3383,7 @@ function update_schema(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3290,6 +3424,7 @@ function update_typed_link_facet(
             "headers" => Dict{String,Any}("x-amz-data-partition" => x_amz_data_partition),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_typed_link_facet(
@@ -3317,6 +3452,7 @@ function update_typed_link_facet(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3350,6 +3486,7 @@ function upgrade_applied_schema(
             "DirectoryArn" => DirectoryArn, "PublishedSchemaArn" => PublishedSchemaArn
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function upgrade_applied_schema(
@@ -3372,6 +3509,7 @@ function upgrade_applied_schema(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3411,6 +3549,7 @@ function upgrade_published_schema(
             "PublishedSchemaArn" => PublishedSchemaArn,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function upgrade_published_schema(
@@ -3435,5 +3574,6 @@ function upgrade_published_schema(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/cloudformation.jl
+++ b/src/services/cloudformation.jl
@@ -47,12 +47,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   one is available.
 """
 function activate_type(; aws_config::AbstractAWSConfig=global_aws_config())
-    return cloudformation("ActivateType"; aws_config=aws_config)
+    return cloudformation(
+        "ActivateType"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function activate_type(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return cloudformation("ActivateType", params; aws_config=aws_config)
+    return cloudformation(
+        "ActivateType", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -75,6 +79,7 @@ function batch_describe_type_configurations(
         "BatchDescribeTypeConfigurations",
         Dict{String,Any}("TypeConfigurationIdentifiers" => TypeConfigurationIdentifiers);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_describe_type_configurations(
@@ -94,6 +99,7 @@ function batch_describe_type_configurations(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -120,6 +126,7 @@ function cancel_update_stack(StackName; aws_config::AbstractAWSConfig=global_aws
         "CancelUpdateStack",
         Dict{String,Any}("StackName" => StackName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function cancel_update_stack(
@@ -133,6 +140,7 @@ function cancel_update_stack(
             mergewith(_merge, Dict{String,Any}("StackName" => StackName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -202,6 +210,7 @@ function continue_update_rollback(
         "ContinueUpdateRollback",
         Dict{String,Any}("StackName" => StackName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function continue_update_rollback(
@@ -215,6 +224,7 @@ function continue_update_rollback(
             mergewith(_merge, Dict{String,Any}("StackName" => StackName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -340,6 +350,7 @@ function create_change_set(
         "CreateChangeSet",
         Dict{String,Any}("ChangeSetName" => ChangeSetName, "StackName" => StackName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_change_set(
@@ -360,6 +371,7 @@ function create_change_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -483,7 +495,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function create_stack(StackName; aws_config::AbstractAWSConfig=global_aws_config())
     return cloudformation(
-        "CreateStack", Dict{String,Any}("StackName" => StackName); aws_config=aws_config
+        "CreateStack",
+        Dict{String,Any}("StackName" => StackName);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_stack(
@@ -497,6 +512,7 @@ function create_stack(
             mergewith(_merge, Dict{String,Any}("StackName" => StackName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -566,6 +582,7 @@ function create_stack_instances(
             "OperationId" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_stack_instances(
@@ -588,6 +605,7 @@ function create_stack_instances(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -693,6 +711,7 @@ function create_stack_set(StackSetName; aws_config::AbstractAWSConfig=global_aws
             "StackSetName" => StackSetName, "ClientRequestToken" => string(uuid4())
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_stack_set(
@@ -712,6 +731,7 @@ function create_stack_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -736,12 +756,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Conditional: You must specify either Arn, or TypeName and Type.
 """
 function deactivate_type(; aws_config::AbstractAWSConfig=global_aws_config())
-    return cloudformation("DeactivateType"; aws_config=aws_config)
+    return cloudformation(
+        "DeactivateType"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function deactivate_type(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return cloudformation("DeactivateType", params; aws_config=aws_config)
+    return cloudformation(
+        "DeactivateType", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -769,6 +793,7 @@ function delete_change_set(ChangeSetName; aws_config::AbstractAWSConfig=global_a
         "DeleteChangeSet",
         Dict{String,Any}("ChangeSetName" => ChangeSetName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_change_set(
@@ -782,6 +807,7 @@ function delete_change_set(
             mergewith(_merge, Dict{String,Any}("ChangeSetName" => ChangeSetName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -824,7 +850,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function delete_stack(StackName; aws_config::AbstractAWSConfig=global_aws_config())
     return cloudformation(
-        "DeleteStack", Dict{String,Any}("StackName" => StackName); aws_config=aws_config
+        "DeleteStack",
+        Dict{String,Any}("StackName" => StackName);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_stack(
@@ -838,6 +867,7 @@ function delete_stack(
             mergewith(_merge, Dict{String,Any}("StackName" => StackName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -892,6 +922,7 @@ function delete_stack_instances(
             "OperationId" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_stack_instances(
@@ -916,6 +947,7 @@ function delete_stack_instances(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -946,6 +978,7 @@ function delete_stack_set(StackSetName; aws_config::AbstractAWSConfig=global_aws
         "DeleteStackSet",
         Dict{String,Any}("StackSetName" => StackSetName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_stack_set(
@@ -959,6 +992,7 @@ function delete_stack_set(
             mergewith(_merge, Dict{String,Any}("StackSetName" => StackSetName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -990,12 +1024,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   registered.
 """
 function deregister_type(; aws_config::AbstractAWSConfig=global_aws_config())
-    return cloudformation("DeregisterType"; aws_config=aws_config)
+    return cloudformation(
+        "DeregisterType"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function deregister_type(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return cloudformation("DeregisterType", params; aws_config=aws_config)
+    return cloudformation(
+        "DeregisterType", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1011,12 +1049,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`: A string that identifies the next page of limits that you want to retrieve.
 """
 function describe_account_limits(; aws_config::AbstractAWSConfig=global_aws_config())
-    return cloudformation("DescribeAccountLimits"; aws_config=aws_config)
+    return cloudformation(
+        "DescribeAccountLimits"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_account_limits(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return cloudformation("DescribeAccountLimits", params; aws_config=aws_config)
+    return cloudformation(
+        "DescribeAccountLimits",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1045,6 +1090,7 @@ function describe_change_set(
         "DescribeChangeSet",
         Dict{String,Any}("ChangeSetName" => ChangeSetName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_change_set(
@@ -1058,6 +1104,7 @@ function describe_change_set(
             mergewith(_merge, Dict{String,Any}("ChangeSetName" => ChangeSetName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1078,12 +1125,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   about your own publisher account.
 """
 function describe_publisher(; aws_config::AbstractAWSConfig=global_aws_config())
-    return cloudformation("DescribePublisher"; aws_config=aws_config)
+    return cloudformation(
+        "DescribePublisher"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_publisher(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return cloudformation("DescribePublisher", params; aws_config=aws_config)
+    return cloudformation(
+        "DescribePublisher", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1115,6 +1166,7 @@ function describe_stack_drift_detection_status(
         "DescribeStackDriftDetectionStatus",
         Dict{String,Any}("StackDriftDetectionId" => StackDriftDetectionId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_stack_drift_detection_status(
@@ -1132,6 +1184,7 @@ function describe_stack_drift_detection_status(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1153,12 +1206,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   There is no default value.
 """
 function describe_stack_events(; aws_config::AbstractAWSConfig=global_aws_config())
-    return cloudformation("DescribeStackEvents"; aws_config=aws_config)
+    return cloudformation(
+        "DescribeStackEvents"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_stack_events(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return cloudformation("DescribeStackEvents", params; aws_config=aws_config)
+    return cloudformation(
+        "DescribeStackEvents",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1201,6 +1261,7 @@ function describe_stack_instance(
             "StackSetName" => StackSetName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_stack_instance(
@@ -1224,6 +1285,7 @@ function describe_stack_instance(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1253,6 +1315,7 @@ function describe_stack_resource(
             "LogicalResourceId" => LogicalResourceId, "StackName" => StackName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_stack_resource(
@@ -1273,6 +1336,7 @@ function describe_stack_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1313,6 +1377,7 @@ function describe_stack_resource_drifts(
         "DescribeStackResourceDrifts",
         Dict{String,Any}("StackName" => StackName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_stack_resource_drifts(
@@ -1326,6 +1391,7 @@ function describe_stack_resource_drifts(
             mergewith(_merge, Dict{String,Any}("StackName" => StackName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1362,12 +1428,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   specify PhysicalResourceId.
 """
 function describe_stack_resources(; aws_config::AbstractAWSConfig=global_aws_config())
-    return cloudformation("DescribeStackResources"; aws_config=aws_config)
+    return cloudformation(
+        "DescribeStackResources"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_stack_resources(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return cloudformation("DescribeStackResources", params; aws_config=aws_config)
+    return cloudformation(
+        "DescribeStackResources",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1395,6 +1468,7 @@ function describe_stack_set(StackSetName; aws_config::AbstractAWSConfig=global_a
         "DescribeStackSet",
         Dict{String,Any}("StackSetName" => StackSetName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_stack_set(
@@ -1408,6 +1482,7 @@ function describe_stack_set(
             mergewith(_merge, Dict{String,Any}("StackSetName" => StackSetName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1440,6 +1515,7 @@ function describe_stack_set_operation(
         "DescribeStackSetOperation",
         Dict{String,Any}("OperationId" => OperationId, "StackSetName" => StackSetName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_stack_set_operation(
@@ -1460,6 +1536,7 @@ function describe_stack_set_operation(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1480,12 +1557,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   There is no default value.
 """
 function describe_stacks(; aws_config::AbstractAWSConfig=global_aws_config())
-    return cloudformation("DescribeStacks"; aws_config=aws_config)
+    return cloudformation(
+        "DescribeStacks"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_stacks(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return cloudformation("DescribeStacks", params; aws_config=aws_config)
+    return cloudformation(
+        "DescribeStacks", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1514,12 +1595,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   version.
 """
 function describe_type(; aws_config::AbstractAWSConfig=global_aws_config())
-    return cloudformation("DescribeType"; aws_config=aws_config)
+    return cloudformation(
+        "DescribeType"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_type(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return cloudformation("DescribeType", params; aws_config=aws_config)
+    return cloudformation(
+        "DescribeType", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1545,6 +1630,7 @@ function describe_type_registration(
         "DescribeTypeRegistration",
         Dict{String,Any}("RegistrationToken" => RegistrationToken);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_type_registration(
@@ -1560,6 +1646,7 @@ function describe_type_registration(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1597,6 +1684,7 @@ function detect_stack_drift(StackName; aws_config::AbstractAWSConfig=global_aws_
         "DetectStackDrift",
         Dict{String,Any}("StackName" => StackName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function detect_stack_drift(
@@ -1610,6 +1698,7 @@ function detect_stack_drift(
             mergewith(_merge, Dict{String,Any}("StackName" => StackName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1643,6 +1732,7 @@ function detect_stack_resource_drift(
             "LogicalResourceId" => LogicalResourceId, "StackName" => StackName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function detect_stack_resource_drift(
@@ -1663,6 +1753,7 @@ function detect_stack_resource_drift(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1713,6 +1804,7 @@ function detect_stack_set_drift(
         "DetectStackSetDrift",
         Dict{String,Any}("StackSetName" => StackSetName, "OperationId" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function detect_stack_set_drift(
@@ -1732,6 +1824,7 @@ function detect_stack_set_drift(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1756,12 +1849,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   pass TemplateURL or TemplateBody. If both are passed, only TemplateBody is used.
 """
 function estimate_template_cost(; aws_config::AbstractAWSConfig=global_aws_config())
-    return cloudformation("EstimateTemplateCost"; aws_config=aws_config)
+    return cloudformation(
+        "EstimateTemplateCost"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function estimate_template_cost(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return cloudformation("EstimateTemplateCost", params; aws_config=aws_config)
+    return cloudformation(
+        "EstimateTemplateCost",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1799,6 +1899,7 @@ function execute_change_set(
         "ExecuteChangeSet",
         Dict{String,Any}("ChangeSetName" => ChangeSetName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function execute_change_set(
@@ -1812,6 +1913,7 @@ function execute_change_set(
             mergewith(_merge, Dict{String,Any}("ChangeSetName" => ChangeSetName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1829,7 +1931,10 @@ value is returned.
 """
 function get_stack_policy(StackName; aws_config::AbstractAWSConfig=global_aws_config())
     return cloudformation(
-        "GetStackPolicy", Dict{String,Any}("StackName" => StackName); aws_config=aws_config
+        "GetStackPolicy",
+        Dict{String,Any}("StackName" => StackName);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_stack_policy(
@@ -1843,6 +1948,7 @@ function get_stack_policy(
             mergewith(_merge, Dict{String,Any}("StackName" => StackName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1871,12 +1977,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   default, CloudFormation specifies Processed.
 """
 function get_template(; aws_config::AbstractAWSConfig=global_aws_config())
-    return cloudformation("GetTemplate"; aws_config=aws_config)
+    return cloudformation(
+        "GetTemplate"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_template(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return cloudformation("GetTemplate", params; aws_config=aws_config)
+    return cloudformation(
+        "GetTemplate", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1920,12 +2030,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   parameters: StackName, StackSetName, TemplateBody, or TemplateURL.
 """
 function get_template_summary(; aws_config::AbstractAWSConfig=global_aws_config())
-    return cloudformation("GetTemplateSummary"; aws_config=aws_config)
+    return cloudformation(
+        "GetTemplateSummary"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_template_summary(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return cloudformation("GetTemplateSummary", params; aws_config=aws_config)
+    return cloudformation(
+        "GetTemplateSummary", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1962,6 +2076,7 @@ function import_stacks_to_stack_set(
             "OperationId" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function import_stacks_to_stack_set(
@@ -1984,6 +2099,7 @@ function import_stacks_to_stack_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2005,7 +2121,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function list_change_sets(StackName; aws_config::AbstractAWSConfig=global_aws_config())
     return cloudformation(
-        "ListChangeSets", Dict{String,Any}("StackName" => StackName); aws_config=aws_config
+        "ListChangeSets",
+        Dict{String,Any}("StackName" => StackName);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_change_sets(
@@ -2019,6 +2138,7 @@ function list_change_sets(
             mergewith(_merge, Dict{String,Any}("StackName" => StackName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2037,12 +2157,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   next page of exported output values that you asked to retrieve.
 """
 function list_exports(; aws_config::AbstractAWSConfig=global_aws_config())
-    return cloudformation("ListExports"; aws_config=aws_config)
+    return cloudformation(
+        "ListExports"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_exports(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return cloudformation("ListExports", params; aws_config=aws_config)
+    return cloudformation(
+        "ListExports", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -2065,7 +2189,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function list_imports(ExportName; aws_config::AbstractAWSConfig=global_aws_config())
     return cloudformation(
-        "ListImports", Dict{String,Any}("ExportName" => ExportName); aws_config=aws_config
+        "ListImports",
+        Dict{String,Any}("ExportName" => ExportName);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_imports(
@@ -2079,6 +2206,7 @@ function list_imports(
             mergewith(_merge, Dict{String,Any}("ExportName" => ExportName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2124,6 +2252,7 @@ function list_stack_instances(
         "ListStackInstances",
         Dict{String,Any}("StackSetName" => StackSetName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_stack_instances(
@@ -2137,6 +2266,7 @@ function list_stack_instances(
             mergewith(_merge, Dict{String,Any}("StackSetName" => StackSetName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2164,6 +2294,7 @@ function list_stack_resources(StackName; aws_config::AbstractAWSConfig=global_aw
         "ListStackResources",
         Dict{String,Any}("StackName" => StackName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_stack_resources(
@@ -2177,6 +2308,7 @@ function list_stack_resources(
             mergewith(_merge, Dict{String,Any}("StackName" => StackName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2217,6 +2349,7 @@ function list_stack_set_operation_results(
         "ListStackSetOperationResults",
         Dict{String,Any}("OperationId" => OperationId, "StackSetName" => StackSetName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_stack_set_operation_results(
@@ -2237,6 +2370,7 @@ function list_stack_set_operation_results(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2276,6 +2410,7 @@ function list_stack_set_operations(
         "ListStackSetOperations",
         Dict{String,Any}("StackSetName" => StackSetName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_stack_set_operations(
@@ -2289,6 +2424,7 @@ function list_stack_set_operations(
             mergewith(_merge, Dict{String,Any}("StackSetName" => StackSetName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2327,12 +2463,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"Status"`: The status of the stack sets that you want to get summary information about.
 """
 function list_stack_sets(; aws_config::AbstractAWSConfig=global_aws_config())
-    return cloudformation("ListStackSets"; aws_config=aws_config)
+    return cloudformation(
+        "ListStackSets"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_stack_sets(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return cloudformation("ListStackSets", params; aws_config=aws_config)
+    return cloudformation(
+        "ListStackSets", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -2352,12 +2492,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   status codes, see the StackStatus parameter of the Stack data type.
 """
 function list_stacks(; aws_config::AbstractAWSConfig=global_aws_config())
-    return cloudformation("ListStacks"; aws_config=aws_config)
+    return cloudformation(
+        "ListStacks"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_stacks(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return cloudformation("ListStacks", params; aws_config=aws_config)
+    return cloudformation(
+        "ListStacks", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -2386,12 +2530,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   and Type, or Arn.
 """
 function list_type_registrations(; aws_config::AbstractAWSConfig=global_aws_config())
-    return cloudformation("ListTypeRegistrations"; aws_config=aws_config)
+    return cloudformation(
+        "ListTypeRegistrations"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_type_registrations(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return cloudformation("ListTypeRegistrations", params; aws_config=aws_config)
+    return cloudformation(
+        "ListTypeRegistrations",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2425,12 +2576,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Conditional: You must specify either TypeName and Type, or Arn.
 """
 function list_type_versions(; aws_config::AbstractAWSConfig=global_aws_config())
-    return cloudformation("ListTypeVersions"; aws_config=aws_config)
+    return cloudformation(
+        "ListTypeVersions"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_type_versions(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return cloudformation("ListTypeVersions", params; aws_config=aws_config)
+    return cloudformation(
+        "ListTypeVersions", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -2474,12 +2629,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   third-party publishers.   The default is PRIVATE.
 """
 function list_types(; aws_config::AbstractAWSConfig=global_aws_config())
-    return cloudformation("ListTypes"; aws_config=aws_config)
+    return cloudformation(
+        "ListTypes"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_types(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return cloudformation("ListTypes", params; aws_config=aws_config)
+    return cloudformation(
+        "ListTypes", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -2508,12 +2667,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   and Type.
 """
 function publish_type(; aws_config::AbstractAWSConfig=global_aws_config())
-    return cloudformation("PublishType"; aws_config=aws_config)
+    return cloudformation(
+        "PublishType"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function publish_type(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return cloudformation("PublishType", params; aws_config=aws_config)
+    return cloudformation(
+        "PublishType", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -2544,6 +2707,7 @@ function record_handler_progress(
             "BearerToken" => BearerToken, "OperationStatus" => OperationStatus
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function record_handler_progress(
@@ -2564,6 +2728,7 @@ function record_handler_progress(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2589,12 +2754,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   CloudFormation CLI User Guide.
 """
 function register_publisher(; aws_config::AbstractAWSConfig=global_aws_config())
-    return cloudformation("RegisterPublisher"; aws_config=aws_config)
+    return cloudformation(
+        "RegisterPublisher"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function register_publisher(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return cloudformation("RegisterPublisher", params; aws_config=aws_config)
+    return cloudformation(
+        "RegisterPublisher", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -2659,6 +2828,7 @@ function register_type(
             "SchemaHandlerPackage" => SchemaHandlerPackage, "TypeName" => TypeName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function register_type(
@@ -2679,6 +2849,7 @@ function register_type(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2705,7 +2876,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function rollback_stack(StackName; aws_config::AbstractAWSConfig=global_aws_config())
     return cloudformation(
-        "RollbackStack", Dict{String,Any}("StackName" => StackName); aws_config=aws_config
+        "RollbackStack",
+        Dict{String,Any}("StackName" => StackName);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function rollback_stack(
@@ -2719,6 +2893,7 @@ function rollback_stack(
             mergewith(_merge, Dict{String,Any}("StackName" => StackName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2742,7 +2917,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function set_stack_policy(StackName; aws_config::AbstractAWSConfig=global_aws_config())
     return cloudformation(
-        "SetStackPolicy", Dict{String,Any}("StackName" => StackName); aws_config=aws_config
+        "SetStackPolicy",
+        Dict{String,Any}("StackName" => StackName);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function set_stack_policy(
@@ -2756,6 +2934,7 @@ function set_stack_policy(
             mergewith(_merge, Dict{String,Any}("StackName" => StackName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2801,6 +2980,7 @@ function set_type_configuration(
         "SetTypeConfiguration",
         Dict{String,Any}("Configuration" => Configuration);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function set_type_configuration(
@@ -2814,6 +2994,7 @@ function set_type_configuration(
             mergewith(_merge, Dict{String,Any}("Configuration" => Configuration), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2837,12 +3018,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   registered.
 """
 function set_type_default_version(; aws_config::AbstractAWSConfig=global_aws_config())
-    return cloudformation("SetTypeDefaultVersion"; aws_config=aws_config)
+    return cloudformation(
+        "SetTypeDefaultVersion"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function set_type_default_version(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return cloudformation("SetTypeDefaultVersion", params; aws_config=aws_config)
+    return cloudformation(
+        "SetTypeDefaultVersion",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2884,6 +3072,7 @@ function signal_resource(
             "UniqueId" => UniqueId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function signal_resource(
@@ -2909,6 +3098,7 @@ function signal_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2941,6 +3131,7 @@ function stop_stack_set_operation(
         "StopStackSetOperation",
         Dict{String,Any}("OperationId" => OperationId, "StackSetName" => StackSetName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function stop_stack_set_operation(
@@ -2961,6 +3152,7 @@ function stop_stack_set_operation(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3001,12 +3193,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   the default version of the extension in this account and region for testing.
 """
 function test_type(; aws_config::AbstractAWSConfig=global_aws_config())
-    return cloudformation("TestType"; aws_config=aws_config)
+    return cloudformation(
+        "TestType"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function test_type(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return cloudformation("TestType", params; aws_config=aws_config)
+    return cloudformation(
+        "TestType", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -3132,7 +3328,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function update_stack(StackName; aws_config::AbstractAWSConfig=global_aws_config())
     return cloudformation(
-        "UpdateStack", Dict{String,Any}("StackName" => StackName); aws_config=aws_config
+        "UpdateStack",
+        Dict{String,Any}("StackName" => StackName);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_stack(
@@ -3146,6 +3345,7 @@ function update_stack(
             mergewith(_merge, Dict{String,Any}("StackName" => StackName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3230,6 +3430,7 @@ function update_stack_instances(
             "OperationId" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_stack_instances(
@@ -3252,6 +3453,7 @@ function update_stack_instances(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3404,6 +3606,7 @@ function update_stack_set(StackSetName; aws_config::AbstractAWSConfig=global_aws
         "UpdateStackSet",
         Dict{String,Any}("StackSetName" => StackSetName, "OperationId" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_stack_set(
@@ -3423,6 +3626,7 @@ function update_stack_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3455,6 +3659,7 @@ function update_termination_protection(
             "StackName" => StackName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_termination_protection(
@@ -3476,6 +3681,7 @@ function update_termination_protection(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3500,10 +3706,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   TemplateBody is used.
 """
 function validate_template(; aws_config::AbstractAWSConfig=global_aws_config())
-    return cloudformation("ValidateTemplate"; aws_config=aws_config)
+    return cloudformation(
+        "ValidateTemplate"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function validate_template(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return cloudformation("ValidateTemplate", params; aws_config=aws_config)
+    return cloudformation(
+        "ValidateTemplate", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end

--- a/src/services/cloudfront.jl
+++ b/src/services/cloudfront.jl
@@ -32,6 +32,7 @@ function associate_alias2020_05_31(
         "/2020-05-31/distribution/$(TargetDistributionId)/associate-alias",
         Dict{String,Any}("Alias" => Alias);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_alias2020_05_31(
@@ -45,6 +46,7 @@ function associate_alias2020_05_31(
         "/2020-05-31/distribution/$(TargetDistributionId)/associate-alias",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Alias" => Alias), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -77,6 +79,7 @@ function create_cache_policy2020_05_31(
         "/2020-05-31/cache-policy",
         Dict{String,Any}("CachePolicyConfig" => CachePolicyConfig);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_cache_policy2020_05_31(
@@ -93,6 +96,7 @@ function create_cache_policy2020_05_31(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -121,6 +125,7 @@ function create_cloud_front_origin_access_identity2020_05_31(
             "CloudFrontOriginAccessIdentityConfig" => CloudFrontOriginAccessIdentityConfig
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_cloud_front_origin_access_identity2020_05_31(
@@ -142,6 +147,7 @@ function create_cloud_front_origin_access_identity2020_05_31(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -171,6 +177,7 @@ function create_distribution2020_05_31(
         "/2020-05-31/distribution",
         Dict{String,Any}("DistributionConfig" => DistributionConfig);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_distribution2020_05_31(
@@ -187,6 +194,7 @@ function create_distribution2020_05_31(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -208,6 +216,7 @@ function create_distribution_with_tags2020_05_31(
         "/2020-05-31/distribution?WithTags",
         Dict{String,Any}("DistributionConfigWithTags" => DistributionConfigWithTags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_distribution_with_tags2020_05_31(
@@ -228,6 +237,7 @@ function create_distribution_with_tags2020_05_31(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -250,6 +260,7 @@ function create_field_level_encryption_config2020_05_31(
         "/2020-05-31/field-level-encryption",
         Dict{String,Any}("FieldLevelEncryptionConfig" => FieldLevelEncryptionConfig);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_field_level_encryption_config2020_05_31(
@@ -270,6 +281,7 @@ function create_field_level_encryption_config2020_05_31(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -294,6 +306,7 @@ function create_field_level_encryption_profile2020_05_31(
             "FieldLevelEncryptionProfileConfig" => FieldLevelEncryptionProfileConfig
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_field_level_encryption_profile2020_05_31(
@@ -314,6 +327,7 @@ function create_field_level_encryption_profile2020_05_31(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -351,6 +365,7 @@ function create_function2020_05_31(
             "Name" => Name,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_function2020_05_31(
@@ -375,6 +390,7 @@ function create_function2020_05_31(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -397,6 +413,7 @@ function create_invalidation2020_05_31(
         "/2020-05-31/distribution/$(DistributionId)/invalidation",
         Dict{String,Any}("InvalidationBatch" => InvalidationBatch);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_invalidation2020_05_31(
@@ -414,6 +431,7 @@ function create_invalidation2020_05_31(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -443,6 +461,7 @@ function create_key_group2020_05_31(
         "/2020-05-31/key-group",
         Dict{String,Any}("KeyGroupConfig" => KeyGroupConfig);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_key_group2020_05_31(
@@ -457,6 +476,7 @@ function create_key_group2020_05_31(
             mergewith(_merge, Dict{String,Any}("KeyGroupConfig" => KeyGroupConfig), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -484,6 +504,7 @@ function create_monitoring_subscription2020_05_31(
         "/2020-05-31/distributions/$(DistributionId)/monitoring-subscription",
         Dict{String,Any}("MonitoringSubscription" => MonitoringSubscription);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_monitoring_subscription2020_05_31(
@@ -503,6 +524,7 @@ function create_monitoring_subscription2020_05_31(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -536,6 +558,7 @@ function create_origin_request_policy2020_05_31(
         "/2020-05-31/origin-request-policy",
         Dict{String,Any}("OriginRequestPolicyConfig" => OriginRequestPolicyConfig);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_origin_request_policy2020_05_31(
@@ -554,6 +577,7 @@ function create_origin_request_policy2020_05_31(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -576,6 +600,7 @@ function create_public_key2020_05_31(
         "/2020-05-31/public-key",
         Dict{String,Any}("PublicKeyConfig" => PublicKeyConfig);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_public_key2020_05_31(
@@ -592,6 +617,7 @@ function create_public_key2020_05_31(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -634,6 +660,7 @@ function create_realtime_log_config2020_05_31(
             "SamplingRate" => SamplingRate,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_realtime_log_config2020_05_31(
@@ -660,6 +687,7 @@ function create_realtime_log_config2020_05_31(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -683,6 +711,7 @@ function create_streaming_distribution2020_05_31(
         "/2020-05-31/streaming-distribution",
         Dict{String,Any}("StreamingDistributionConfig" => StreamingDistributionConfig);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_streaming_distribution2020_05_31(
@@ -703,6 +732,7 @@ function create_streaming_distribution2020_05_31(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -729,6 +759,7 @@ function create_streaming_distribution_with_tags2020_05_31(
             "StreamingDistributionConfigWithTags" => StreamingDistributionConfigWithTags
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_streaming_distribution_with_tags2020_05_31(
@@ -750,6 +781,7 @@ function create_streaming_distribution_with_tags2020_05_31(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -776,13 +808,22 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function delete_cache_policy2020_05_31(
     Id; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return cloudfront("DELETE", "/2020-05-31/cache-policy/$(Id)"; aws_config=aws_config)
+    return cloudfront(
+        "DELETE",
+        "/2020-05-31/cache-policy/$(Id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_cache_policy2020_05_31(
     Id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return cloudfront(
-        "DELETE", "/2020-05-31/cache-policy/$(Id)", params; aws_config=aws_config
+        "DELETE",
+        "/2020-05-31/cache-policy/$(Id)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -807,6 +848,7 @@ function delete_cloud_front_origin_access_identity2020_05_31(
         "DELETE",
         "/2020-05-31/origin-access-identity/cloudfront/$(Id)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_cloud_front_origin_access_identity2020_05_31(
@@ -817,6 +859,7 @@ function delete_cloud_front_origin_access_identity2020_05_31(
         "/2020-05-31/origin-access-identity/cloudfront/$(Id)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -837,13 +880,22 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function delete_distribution2020_05_31(
     Id; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return cloudfront("DELETE", "/2020-05-31/distribution/$(Id)"; aws_config=aws_config)
+    return cloudfront(
+        "DELETE",
+        "/2020-05-31/distribution/$(Id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_distribution2020_05_31(
     Id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return cloudfront(
-        "DELETE", "/2020-05-31/distribution/$(Id)", params; aws_config=aws_config
+        "DELETE",
+        "/2020-05-31/distribution/$(Id)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -865,14 +917,21 @@ function delete_field_level_encryption_config2020_05_31(
     Id; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return cloudfront(
-        "DELETE", "/2020-05-31/field-level-encryption/$(Id)"; aws_config=aws_config
+        "DELETE",
+        "/2020-05-31/field-level-encryption/$(Id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_field_level_encryption_config2020_05_31(
     Id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return cloudfront(
-        "DELETE", "/2020-05-31/field-level-encryption/$(Id)", params; aws_config=aws_config
+        "DELETE",
+        "/2020-05-31/field-level-encryption/$(Id)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -894,7 +953,10 @@ function delete_field_level_encryption_profile2020_05_31(
     Id; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return cloudfront(
-        "DELETE", "/2020-05-31/field-level-encryption-profile/$(Id)"; aws_config=aws_config
+        "DELETE",
+        "/2020-05-31/field-level-encryption-profile/$(Id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_field_level_encryption_profile2020_05_31(
@@ -905,6 +967,7 @@ function delete_field_level_encryption_profile2020_05_31(
         "/2020-05-31/field-level-encryption-profile/$(Id)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -932,6 +995,7 @@ function delete_function2020_05_31(
         "/2020-05-31/function/$(Name)",
         Dict{String,Any}("headers" => Dict{String,Any}("If-Match" => If_Match));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_function2020_05_31(
@@ -951,6 +1015,7 @@ function delete_function2020_05_31(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -974,13 +1039,22 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   group’s ETag value. To get the ETag, use GetKeyGroup or GetKeyGroupConfig.
 """
 function delete_key_group2020_05_31(Id; aws_config::AbstractAWSConfig=global_aws_config())
-    return cloudfront("DELETE", "/2020-05-31/key-group/$(Id)"; aws_config=aws_config)
+    return cloudfront(
+        "DELETE",
+        "/2020-05-31/key-group/$(Id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_key_group2020_05_31(
     Id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return cloudfront(
-        "DELETE", "/2020-05-31/key-group/$(Id)", params; aws_config=aws_config
+        "DELETE",
+        "/2020-05-31/key-group/$(Id)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1001,6 +1075,7 @@ function delete_monitoring_subscription2020_05_31(
         "DELETE",
         "/2020-05-31/distributions/$(DistributionId)/monitoring-subscription";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_monitoring_subscription2020_05_31(
@@ -1013,6 +1088,7 @@ function delete_monitoring_subscription2020_05_31(
         "/2020-05-31/distributions/$(DistributionId)/monitoring-subscription",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1040,14 +1116,21 @@ function delete_origin_request_policy2020_05_31(
     Id; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return cloudfront(
-        "DELETE", "/2020-05-31/origin-request-policy/$(Id)"; aws_config=aws_config
+        "DELETE",
+        "/2020-05-31/origin-request-policy/$(Id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_origin_request_policy2020_05_31(
     Id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return cloudfront(
-        "DELETE", "/2020-05-31/origin-request-policy/$(Id)", params; aws_config=aws_config
+        "DELETE",
+        "/2020-05-31/origin-request-policy/$(Id)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1066,13 +1149,22 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   key identity to delete. For example: E2QWRUHAPOMQZL.
 """
 function delete_public_key2020_05_31(Id; aws_config::AbstractAWSConfig=global_aws_config())
-    return cloudfront("DELETE", "/2020-05-31/public-key/$(Id)"; aws_config=aws_config)
+    return cloudfront(
+        "DELETE",
+        "/2020-05-31/public-key/$(Id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_public_key2020_05_31(
     Id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return cloudfront(
-        "DELETE", "/2020-05-31/public-key/$(Id)", params; aws_config=aws_config
+        "DELETE",
+        "/2020-05-31/public-key/$(Id)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1097,14 +1189,21 @@ function delete_realtime_log_config2020_05_31(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
     return cloudfront(
-        "POST", "/2020-05-31/delete-realtime-log-config/"; aws_config=aws_config
+        "POST",
+        "/2020-05-31/delete-realtime-log-config/";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_realtime_log_config2020_05_31(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return cloudfront(
-        "POST", "/2020-05-31/delete-realtime-log-config/", params; aws_config=aws_config
+        "POST",
+        "/2020-05-31/delete-realtime-log-config/",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1144,14 +1243,21 @@ function delete_streaming_distribution2020_05_31(
     Id; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return cloudfront(
-        "DELETE", "/2020-05-31/streaming-distribution/$(Id)"; aws_config=aws_config
+        "DELETE",
+        "/2020-05-31/streaming-distribution/$(Id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_streaming_distribution2020_05_31(
     Id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return cloudfront(
-        "DELETE", "/2020-05-31/streaming-distribution/$(Id)", params; aws_config=aws_config
+        "DELETE",
+        "/2020-05-31/streaming-distribution/$(Id)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1174,13 +1280,22 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_function2020_05_31(
     Name; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return cloudfront("GET", "/2020-05-31/function/$(Name)/describe"; aws_config=aws_config)
+    return cloudfront(
+        "GET",
+        "/2020-05-31/function/$(Name)/describe";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_function2020_05_31(
     Name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return cloudfront(
-        "GET", "/2020-05-31/function/$(Name)/describe", params; aws_config=aws_config
+        "GET",
+        "/2020-05-31/function/$(Name)/describe",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1203,13 +1318,22 @@ ListCachePolicies.
 
 """
 function get_cache_policy2020_05_31(Id; aws_config::AbstractAWSConfig=global_aws_config())
-    return cloudfront("GET", "/2020-05-31/cache-policy/$(Id)"; aws_config=aws_config)
+    return cloudfront(
+        "GET",
+        "/2020-05-31/cache-policy/$(Id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_cache_policy2020_05_31(
     Id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return cloudfront(
-        "GET", "/2020-05-31/cache-policy/$(Id)", params; aws_config=aws_config
+        "GET",
+        "/2020-05-31/cache-policy/$(Id)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1233,13 +1357,22 @@ ListCachePolicies.
 function get_cache_policy_config2020_05_31(
     Id; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return cloudfront("GET", "/2020-05-31/cache-policy/$(Id)/config"; aws_config=aws_config)
+    return cloudfront(
+        "GET",
+        "/2020-05-31/cache-policy/$(Id)/config";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_cache_policy_config2020_05_31(
     Id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return cloudfront(
-        "GET", "/2020-05-31/cache-policy/$(Id)/config", params; aws_config=aws_config
+        "GET",
+        "/2020-05-31/cache-policy/$(Id)/config",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1257,7 +1390,10 @@ function get_cloud_front_origin_access_identity2020_05_31(
     Id; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return cloudfront(
-        "GET", "/2020-05-31/origin-access-identity/cloudfront/$(Id)"; aws_config=aws_config
+        "GET",
+        "/2020-05-31/origin-access-identity/cloudfront/$(Id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_cloud_front_origin_access_identity2020_05_31(
@@ -1268,6 +1404,7 @@ function get_cloud_front_origin_access_identity2020_05_31(
         "/2020-05-31/origin-access-identity/cloudfront/$(Id)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1288,6 +1425,7 @@ function get_cloud_front_origin_access_identity_config2020_05_31(
         "GET",
         "/2020-05-31/origin-access-identity/cloudfront/$(Id)/config";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_cloud_front_origin_access_identity_config2020_05_31(
@@ -1298,6 +1436,7 @@ function get_cloud_front_origin_access_identity_config2020_05_31(
         "/2020-05-31/origin-access-identity/cloudfront/$(Id)/config",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1313,13 +1452,22 @@ Get the information about a distribution.
 
 """
 function get_distribution2020_05_31(Id; aws_config::AbstractAWSConfig=global_aws_config())
-    return cloudfront("GET", "/2020-05-31/distribution/$(Id)"; aws_config=aws_config)
+    return cloudfront(
+        "GET",
+        "/2020-05-31/distribution/$(Id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_distribution2020_05_31(
     Id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return cloudfront(
-        "GET", "/2020-05-31/distribution/$(Id)", params; aws_config=aws_config
+        "GET",
+        "/2020-05-31/distribution/$(Id)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1337,13 +1485,22 @@ Get the configuration information about a distribution.
 function get_distribution_config2020_05_31(
     Id; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return cloudfront("GET", "/2020-05-31/distribution/$(Id)/config"; aws_config=aws_config)
+    return cloudfront(
+        "GET",
+        "/2020-05-31/distribution/$(Id)/config";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_distribution_config2020_05_31(
     Id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return cloudfront(
-        "GET", "/2020-05-31/distribution/$(Id)/config", params; aws_config=aws_config
+        "GET",
+        "/2020-05-31/distribution/$(Id)/config",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1361,14 +1518,21 @@ function get_field_level_encryption2020_05_31(
     Id; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return cloudfront(
-        "GET", "/2020-05-31/field-level-encryption/$(Id)"; aws_config=aws_config
+        "GET",
+        "/2020-05-31/field-level-encryption/$(Id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_field_level_encryption2020_05_31(
     Id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return cloudfront(
-        "GET", "/2020-05-31/field-level-encryption/$(Id)", params; aws_config=aws_config
+        "GET",
+        "/2020-05-31/field-level-encryption/$(Id)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1386,7 +1550,10 @@ function get_field_level_encryption_config2020_05_31(
     Id; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return cloudfront(
-        "GET", "/2020-05-31/field-level-encryption/$(Id)/config"; aws_config=aws_config
+        "GET",
+        "/2020-05-31/field-level-encryption/$(Id)/config";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_field_level_encryption_config2020_05_31(
@@ -1397,6 +1564,7 @@ function get_field_level_encryption_config2020_05_31(
         "/2020-05-31/field-level-encryption/$(Id)/config",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1414,7 +1582,10 @@ function get_field_level_encryption_profile2020_05_31(
     Id; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return cloudfront(
-        "GET", "/2020-05-31/field-level-encryption-profile/$(Id)"; aws_config=aws_config
+        "GET",
+        "/2020-05-31/field-level-encryption-profile/$(Id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_field_level_encryption_profile2020_05_31(
@@ -1425,6 +1596,7 @@ function get_field_level_encryption_profile2020_05_31(
         "/2020-05-31/field-level-encryption-profile/$(Id)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1445,6 +1617,7 @@ function get_field_level_encryption_profile_config2020_05_31(
         "GET",
         "/2020-05-31/field-level-encryption-profile/$(Id)/config";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_field_level_encryption_profile_config2020_05_31(
@@ -1455,6 +1628,7 @@ function get_field_level_encryption_profile_config2020_05_31(
         "/2020-05-31/field-level-encryption-profile/$(Id)/config",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1474,12 +1648,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"Stage"`: The function’s stage, either DEVELOPMENT or LIVE.
 """
 function get_function2020_05_31(Name; aws_config::AbstractAWSConfig=global_aws_config())
-    return cloudfront("GET", "/2020-05-31/function/$(Name)"; aws_config=aws_config)
+    return cloudfront(
+        "GET",
+        "/2020-05-31/function/$(Name)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_function2020_05_31(
     Name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return cloudfront("GET", "/2020-05-31/function/$(Name)", params; aws_config=aws_config)
+    return cloudfront(
+        "GET",
+        "/2020-05-31/function/$(Name)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1500,6 +1685,7 @@ function get_invalidation2020_05_31(
         "GET",
         "/2020-05-31/distribution/$(DistributionId)/invalidation/$(Id)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_invalidation2020_05_31(
@@ -1513,6 +1699,7 @@ function get_invalidation2020_05_31(
         "/2020-05-31/distribution/$(DistributionId)/invalidation/$(Id)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1532,12 +1719,23 @@ behavior, you can get the identifier using ListKeyGroups.
 
 """
 function get_key_group2020_05_31(Id; aws_config::AbstractAWSConfig=global_aws_config())
-    return cloudfront("GET", "/2020-05-31/key-group/$(Id)"; aws_config=aws_config)
+    return cloudfront(
+        "GET",
+        "/2020-05-31/key-group/$(Id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_key_group2020_05_31(
     Id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return cloudfront("GET", "/2020-05-31/key-group/$(Id)", params; aws_config=aws_config)
+    return cloudfront(
+        "GET",
+        "/2020-05-31/key-group/$(Id)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1558,13 +1756,22 @@ ListKeyGroups.
 function get_key_group_config2020_05_31(
     Id; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return cloudfront("GET", "/2020-05-31/key-group/$(Id)/config"; aws_config=aws_config)
+    return cloudfront(
+        "GET",
+        "/2020-05-31/key-group/$(Id)/config";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_key_group_config2020_05_31(
     Id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return cloudfront(
-        "GET", "/2020-05-31/key-group/$(Id)/config", params; aws_config=aws_config
+        "GET",
+        "/2020-05-31/key-group/$(Id)/config",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1587,6 +1794,7 @@ function get_monitoring_subscription2020_05_31(
         "GET",
         "/2020-05-31/distributions/$(DistributionId)/monitoring-subscription";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_monitoring_subscription2020_05_31(
@@ -1599,6 +1807,7 @@ function get_monitoring_subscription2020_05_31(
         "/2020-05-31/distributions/$(DistributionId)/monitoring-subscription",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1624,14 +1833,21 @@ function get_origin_request_policy2020_05_31(
     Id; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return cloudfront(
-        "GET", "/2020-05-31/origin-request-policy/$(Id)"; aws_config=aws_config
+        "GET",
+        "/2020-05-31/origin-request-policy/$(Id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_origin_request_policy2020_05_31(
     Id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return cloudfront(
-        "GET", "/2020-05-31/origin-request-policy/$(Id)", params; aws_config=aws_config
+        "GET",
+        "/2020-05-31/origin-request-policy/$(Id)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1656,7 +1872,10 @@ function get_origin_request_policy_config2020_05_31(
     Id; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return cloudfront(
-        "GET", "/2020-05-31/origin-request-policy/$(Id)/config"; aws_config=aws_config
+        "GET",
+        "/2020-05-31/origin-request-policy/$(Id)/config";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_origin_request_policy_config2020_05_31(
@@ -1667,6 +1886,7 @@ function get_origin_request_policy_config2020_05_31(
         "/2020-05-31/origin-request-policy/$(Id)/config",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1681,12 +1901,23 @@ Gets a public key.
 
 """
 function get_public_key2020_05_31(Id; aws_config::AbstractAWSConfig=global_aws_config())
-    return cloudfront("GET", "/2020-05-31/public-key/$(Id)"; aws_config=aws_config)
+    return cloudfront(
+        "GET",
+        "/2020-05-31/public-key/$(Id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_public_key2020_05_31(
     Id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return cloudfront("GET", "/2020-05-31/public-key/$(Id)", params; aws_config=aws_config)
+    return cloudfront(
+        "GET",
+        "/2020-05-31/public-key/$(Id)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1702,13 +1933,22 @@ Gets a public key configuration.
 function get_public_key_config2020_05_31(
     Id; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return cloudfront("GET", "/2020-05-31/public-key/$(Id)/config"; aws_config=aws_config)
+    return cloudfront(
+        "GET",
+        "/2020-05-31/public-key/$(Id)/config";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_public_key_config2020_05_31(
     Id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return cloudfront(
-        "GET", "/2020-05-31/public-key/$(Id)/config", params; aws_config=aws_config
+        "GET",
+        "/2020-05-31/public-key/$(Id)/config",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1729,13 +1969,22 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function get_realtime_log_config2020_05_31(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return cloudfront("POST", "/2020-05-31/get-realtime-log-config/"; aws_config=aws_config)
+    return cloudfront(
+        "POST",
+        "/2020-05-31/get-realtime-log-config/";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_realtime_log_config2020_05_31(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return cloudfront(
-        "POST", "/2020-05-31/get-realtime-log-config/", params; aws_config=aws_config
+        "POST",
+        "/2020-05-31/get-realtime-log-config/",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1754,14 +2003,21 @@ function get_streaming_distribution2020_05_31(
     Id; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return cloudfront(
-        "GET", "/2020-05-31/streaming-distribution/$(Id)"; aws_config=aws_config
+        "GET",
+        "/2020-05-31/streaming-distribution/$(Id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_streaming_distribution2020_05_31(
     Id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return cloudfront(
-        "GET", "/2020-05-31/streaming-distribution/$(Id)", params; aws_config=aws_config
+        "GET",
+        "/2020-05-31/streaming-distribution/$(Id)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1779,7 +2035,10 @@ function get_streaming_distribution_config2020_05_31(
     Id; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return cloudfront(
-        "GET", "/2020-05-31/streaming-distribution/$(Id)/config"; aws_config=aws_config
+        "GET",
+        "/2020-05-31/streaming-distribution/$(Id)/config";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_streaming_distribution_config2020_05_31(
@@ -1790,6 +2049,7 @@ function get_streaming_distribution_config2020_05_31(
         "/2020-05-31/streaming-distribution/$(Id)/config",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1817,12 +2077,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   custom – Returns only the custom policies created in your account.
 """
 function list_cache_policies2020_05_31(; aws_config::AbstractAWSConfig=global_aws_config())
-    return cloudfront("GET", "/2020-05-31/cache-policy"; aws_config=aws_config)
+    return cloudfront(
+        "GET",
+        "/2020-05-31/cache-policy";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_cache_policies2020_05_31(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return cloudfront("GET", "/2020-05-31/cache-policy", params; aws_config=aws_config)
+    return cloudfront(
+        "GET",
+        "/2020-05-31/cache-policy",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1844,7 +2115,10 @@ function list_cloud_front_origin_access_identities2020_05_31(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
     return cloudfront(
-        "GET", "/2020-05-31/origin-access-identity/cloudfront"; aws_config=aws_config
+        "GET",
+        "/2020-05-31/origin-access-identity/cloudfront";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_cloud_front_origin_access_identities2020_05_31(
@@ -1855,6 +2129,7 @@ function list_cloud_front_origin_access_identities2020_05_31(
         "/2020-05-31/origin-access-identity/cloudfront",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1904,6 +2179,7 @@ function list_conflicting_aliases2020_05_31(
         "/2020-05-31/conflicting-alias",
         Dict{String,Any}("Alias" => Alias, "DistributionId" => DistributionId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_conflicting_aliases2020_05_31(
@@ -1923,6 +2199,7 @@ function list_conflicting_aliases2020_05_31(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1941,12 +2218,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"MaxItems"`: The maximum number of distributions you want in the response body.
 """
 function list_distributions2020_05_31(; aws_config::AbstractAWSConfig=global_aws_config())
-    return cloudfront("GET", "/2020-05-31/distribution"; aws_config=aws_config)
+    return cloudfront(
+        "GET",
+        "/2020-05-31/distribution";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_distributions2020_05_31(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return cloudfront("GET", "/2020-05-31/distribution", params; aws_config=aws_config)
+    return cloudfront(
+        "GET",
+        "/2020-05-31/distribution",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1979,6 +2267,7 @@ function list_distributions_by_cache_policy_id2020_05_31(
         "GET",
         "/2020-05-31/distributionsByCachePolicyId/$(CachePolicyId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_distributions_by_cache_policy_id2020_05_31(
@@ -1991,6 +2280,7 @@ function list_distributions_by_cache_policy_id2020_05_31(
         "/2020-05-31/distributionsByCachePolicyId/$(CachePolicyId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2020,7 +2310,10 @@ function list_distributions_by_key_group2020_05_31(
     KeyGroupId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return cloudfront(
-        "GET", "/2020-05-31/distributionsByKeyGroupId/$(KeyGroupId)"; aws_config=aws_config
+        "GET",
+        "/2020-05-31/distributionsByKeyGroupId/$(KeyGroupId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_distributions_by_key_group2020_05_31(
@@ -2033,6 +2326,7 @@ function list_distributions_by_key_group2020_05_31(
         "/2020-05-31/distributionsByKeyGroupId/$(KeyGroupId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2066,6 +2360,7 @@ function list_distributions_by_origin_request_policy_id2020_05_31(
         "GET",
         "/2020-05-31/distributionsByOriginRequestPolicyId/$(OriginRequestPolicyId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_distributions_by_origin_request_policy_id2020_05_31(
@@ -2078,6 +2373,7 @@ function list_distributions_by_origin_request_policy_id2020_05_31(
         "/2020-05-31/distributionsByOriginRequestPolicyId/$(OriginRequestPolicyId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2111,7 +2407,10 @@ function list_distributions_by_realtime_log_config2020_05_31(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
     return cloudfront(
-        "POST", "/2020-05-31/distributionsByRealtimeLogConfig/"; aws_config=aws_config
+        "POST",
+        "/2020-05-31/distributionsByRealtimeLogConfig/";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_distributions_by_realtime_log_config2020_05_31(
@@ -2122,6 +2421,7 @@ function list_distributions_by_realtime_log_config2020_05_31(
         "/2020-05-31/distributionsByRealtimeLogConfig/",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2150,7 +2450,10 @@ function list_distributions_by_web_aclid2020_05_31(
     WebACLId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return cloudfront(
-        "GET", "/2020-05-31/distributionsByWebACLId/$(WebACLId)"; aws_config=aws_config
+        "GET",
+        "/2020-05-31/distributionsByWebACLId/$(WebACLId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_distributions_by_web_aclid2020_05_31(
@@ -2163,6 +2466,7 @@ function list_distributions_by_web_aclid2020_05_31(
         "/2020-05-31/distributionsByWebACLId/$(WebACLId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2185,13 +2489,22 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function list_field_level_encryption_configs2020_05_31(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return cloudfront("GET", "/2020-05-31/field-level-encryption"; aws_config=aws_config)
+    return cloudfront(
+        "GET",
+        "/2020-05-31/field-level-encryption";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_field_level_encryption_configs2020_05_31(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return cloudfront(
-        "GET", "/2020-05-31/field-level-encryption", params; aws_config=aws_config
+        "GET",
+        "/2020-05-31/field-level-encryption",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2215,14 +2528,21 @@ function list_field_level_encryption_profiles2020_05_31(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
     return cloudfront(
-        "GET", "/2020-05-31/field-level-encryption-profile"; aws_config=aws_config
+        "GET",
+        "/2020-05-31/field-level-encryption-profile";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_field_level_encryption_profiles2020_05_31(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return cloudfront(
-        "GET", "/2020-05-31/field-level-encryption-profile", params; aws_config=aws_config
+        "GET",
+        "/2020-05-31/field-level-encryption-profile",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2249,12 +2569,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   stage, either DEVELOPMENT or LIVE.
 """
 function list_functions2020_05_31(; aws_config::AbstractAWSConfig=global_aws_config())
-    return cloudfront("GET", "/2020-05-31/function"; aws_config=aws_config)
+    return cloudfront(
+        "GET",
+        "/2020-05-31/function";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_functions2020_05_31(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return cloudfront("GET", "/2020-05-31/function", params; aws_config=aws_config)
+    return cloudfront(
+        "GET",
+        "/2020-05-31/function",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2284,6 +2615,7 @@ function list_invalidations2020_05_31(
         "GET",
         "/2020-05-31/distribution/$(DistributionId)/invalidation";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_invalidations2020_05_31(
@@ -2296,6 +2628,7 @@ function list_invalidations2020_05_31(
         "/2020-05-31/distribution/$(DistributionId)/invalidation",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2318,12 +2651,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"MaxItems"`: The maximum number of key groups that you want in the response.
 """
 function list_key_groups2020_05_31(; aws_config::AbstractAWSConfig=global_aws_config())
-    return cloudfront("GET", "/2020-05-31/key-group"; aws_config=aws_config)
+    return cloudfront(
+        "GET",
+        "/2020-05-31/key-group";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_key_groups2020_05_31(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return cloudfront("GET", "/2020-05-31/key-group", params; aws_config=aws_config)
+    return cloudfront(
+        "GET",
+        "/2020-05-31/key-group",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2352,13 +2696,22 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function list_origin_request_policies2020_05_31(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return cloudfront("GET", "/2020-05-31/origin-request-policy"; aws_config=aws_config)
+    return cloudfront(
+        "GET",
+        "/2020-05-31/origin-request-policy";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_origin_request_policies2020_05_31(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return cloudfront(
-        "GET", "/2020-05-31/origin-request-policy", params; aws_config=aws_config
+        "GET",
+        "/2020-05-31/origin-request-policy",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2377,12 +2730,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"MaxItems"`: The maximum number of public keys you want in the response body.
 """
 function list_public_keys2020_05_31(; aws_config::AbstractAWSConfig=global_aws_config())
-    return cloudfront("GET", "/2020-05-31/public-key"; aws_config=aws_config)
+    return cloudfront(
+        "GET",
+        "/2020-05-31/public-key";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_public_keys2020_05_31(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return cloudfront("GET", "/2020-05-31/public-key", params; aws_config=aws_config)
+    return cloudfront(
+        "GET",
+        "/2020-05-31/public-key",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2407,13 +2771,22 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function list_realtime_log_configs2020_05_31(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return cloudfront("GET", "/2020-05-31/realtime-log-config"; aws_config=aws_config)
+    return cloudfront(
+        "GET",
+        "/2020-05-31/realtime-log-config";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_realtime_log_configs2020_05_31(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return cloudfront(
-        "GET", "/2020-05-31/realtime-log-config", params; aws_config=aws_config
+        "GET",
+        "/2020-05-31/realtime-log-config",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2431,13 +2804,22 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function list_streaming_distributions2020_05_31(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return cloudfront("GET", "/2020-05-31/streaming-distribution"; aws_config=aws_config)
+    return cloudfront(
+        "GET",
+        "/2020-05-31/streaming-distribution";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_streaming_distributions2020_05_31(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return cloudfront(
-        "GET", "/2020-05-31/streaming-distribution", params; aws_config=aws_config
+        "GET",
+        "/2020-05-31/streaming-distribution",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2459,6 +2841,7 @@ function list_tags_for_resource2020_05_31(
         "/2020-05-31/tagging",
         Dict{String,Any}("Resource" => Resource);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags_for_resource2020_05_31(
@@ -2473,6 +2856,7 @@ function list_tags_for_resource2020_05_31(
             mergewith(_merge, Dict{String,Any}("Resource" => Resource), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2502,6 +2886,7 @@ function publish_function2020_05_31(
         "/2020-05-31/function/$(Name)/publish",
         Dict{String,Any}("headers" => Dict{String,Any}("If-Match" => If_Match));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function publish_function2020_05_31(
@@ -2521,6 +2906,7 @@ function publish_function2020_05_31(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2543,6 +2929,7 @@ function tag_resource2020_05_31(
         "/2020-05-31/tagging?Operation=Tag",
         Dict{String,Any}("Resource" => Resource, "Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource2020_05_31(
@@ -2560,6 +2947,7 @@ function tag_resource2020_05_31(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2600,6 +2988,7 @@ function test_function2020_05_31(
             "headers" => Dict{String,Any}("If-Match" => If_Match),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function test_function2020_05_31(
@@ -2623,6 +3012,7 @@ function test_function2020_05_31(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2645,6 +3035,7 @@ function untag_resource2020_05_31(
         "/2020-05-31/tagging?Operation=Untag",
         Dict{String,Any}("Resource" => Resource, "TagKeys" => TagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource2020_05_31(
@@ -2664,6 +3055,7 @@ function untag_resource2020_05_31(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2698,6 +3090,7 @@ function update_cache_policy2020_05_31(
         "/2020-05-31/cache-policy/$(Id)",
         Dict{String,Any}("CachePolicyConfig" => CachePolicyConfig);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_cache_policy2020_05_31(
@@ -2715,6 +3108,7 @@ function update_cache_policy2020_05_31(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2745,6 +3139,7 @@ function update_cloud_front_origin_access_identity2020_05_31(
             "CloudFrontOriginAccessIdentityConfig" => CloudFrontOriginAccessIdentityConfig
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_cloud_front_origin_access_identity2020_05_31(
@@ -2767,6 +3162,7 @@ function update_cloud_front_origin_access_identity2020_05_31(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2825,6 +3221,7 @@ function update_distribution2020_05_31(
         "/2020-05-31/distribution/$(Id)/config",
         Dict{String,Any}("DistributionConfig" => DistributionConfig);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_distribution2020_05_31(
@@ -2842,6 +3239,7 @@ function update_distribution2020_05_31(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2869,6 +3267,7 @@ function update_field_level_encryption_config2020_05_31(
         "/2020-05-31/field-level-encryption/$(Id)/config",
         Dict{String,Any}("FieldLevelEncryptionConfig" => FieldLevelEncryptionConfig);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_field_level_encryption_config2020_05_31(
@@ -2890,6 +3289,7 @@ function update_field_level_encryption_config2020_05_31(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2919,6 +3319,7 @@ function update_field_level_encryption_profile2020_05_31(
             "FieldLevelEncryptionProfileConfig" => FieldLevelEncryptionProfileConfig
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_field_level_encryption_profile2020_05_31(
@@ -2940,6 +3341,7 @@ function update_field_level_encryption_profile2020_05_31(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2978,6 +3380,7 @@ function update_function2020_05_31(
             "headers" => Dict{String,Any}("If-Match" => If_Match),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_function2020_05_31(
@@ -3003,6 +3406,7 @@ function update_function2020_05_31(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3034,6 +3438,7 @@ function update_key_group2020_05_31(
         "/2020-05-31/key-group/$(Id)",
         Dict{String,Any}("KeyGroupConfig" => KeyGroupConfig);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_key_group2020_05_31(
@@ -3049,6 +3454,7 @@ function update_key_group2020_05_31(
             mergewith(_merge, Dict{String,Any}("KeyGroupConfig" => KeyGroupConfig), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3084,6 +3490,7 @@ function update_origin_request_policy2020_05_31(
         "/2020-05-31/origin-request-policy/$(Id)",
         Dict{String,Any}("OriginRequestPolicyConfig" => OriginRequestPolicyConfig);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_origin_request_policy2020_05_31(
@@ -3103,6 +3510,7 @@ function update_origin_request_policy2020_05_31(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3129,6 +3537,7 @@ function update_public_key2020_05_31(
         "/2020-05-31/public-key/$(Id)/config",
         Dict{String,Any}("PublicKeyConfig" => PublicKeyConfig);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_public_key2020_05_31(
@@ -3146,6 +3555,7 @@ function update_public_key2020_05_31(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3178,13 +3588,22 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function update_realtime_log_config2020_05_31(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return cloudfront("PUT", "/2020-05-31/realtime-log-config/"; aws_config=aws_config)
+    return cloudfront(
+        "PUT",
+        "/2020-05-31/realtime-log-config/";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function update_realtime_log_config2020_05_31(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return cloudfront(
-        "PUT", "/2020-05-31/realtime-log-config/", params; aws_config=aws_config
+        "PUT",
+        "/2020-05-31/realtime-log-config/",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3211,6 +3630,7 @@ function update_streaming_distribution2020_05_31(
         "/2020-05-31/streaming-distribution/$(Id)/config",
         Dict{String,Any}("StreamingDistributionConfig" => StreamingDistributionConfig);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_streaming_distribution2020_05_31(
@@ -3232,5 +3652,6 @@ function update_streaming_distribution2020_05_31(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/cloudhsm.jl
+++ b/src/services/cloudhsm.jl
@@ -27,6 +27,7 @@ function add_tags_to_resource(
         "AddTagsToResource",
         Dict{String,Any}("ResourceArn" => ResourceArn, "TagList" => TagList);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function add_tags_to_resource(
@@ -45,6 +46,7 @@ function add_tags_to_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -64,7 +66,12 @@ partitions that spans multiple physical HSMs.
 
 """
 function create_hapg(Label; aws_config::AbstractAWSConfig=global_aws_config())
-    return cloudhsm("CreateHapg", Dict{String,Any}("Label" => Label); aws_config=aws_config)
+    return cloudhsm(
+        "CreateHapg",
+        Dict{String,Any}("Label" => Label);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function create_hapg(
     Label, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -73,6 +80,7 @@ function create_hapg(
         "CreateHapg",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Label" => Label), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -124,6 +132,7 @@ function create_hsm(
             "SubscriptionType" => SubscriptionType,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_hsm(
@@ -149,6 +158,7 @@ function create_hsm(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -174,6 +184,7 @@ function create_luna_client(Certificate; aws_config::AbstractAWSConfig=global_aw
         "CreateLunaClient",
         Dict{String,Any}("Certificate" => Certificate);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_luna_client(
@@ -187,6 +198,7 @@ function create_luna_client(
             mergewith(_merge, Dict{String,Any}("Certificate" => Certificate), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -206,7 +218,10 @@ high-availability partition group.
 """
 function delete_hapg(HapgArn; aws_config::AbstractAWSConfig=global_aws_config())
     return cloudhsm(
-        "DeleteHapg", Dict{String,Any}("HapgArn" => HapgArn); aws_config=aws_config
+        "DeleteHapg",
+        Dict{String,Any}("HapgArn" => HapgArn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_hapg(
@@ -216,6 +231,7 @@ function delete_hapg(
         "DeleteHapg",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("HapgArn" => HapgArn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -235,7 +251,10 @@ completion, this operation cannot be undone and your key material cannot be reco
 """
 function delete_hsm(HsmArn; aws_config::AbstractAWSConfig=global_aws_config())
     return cloudhsm(
-        "DeleteHsm", Dict{String,Any}("HsmArn" => HsmArn); aws_config=aws_config
+        "DeleteHsm",
+        Dict{String,Any}("HsmArn" => HsmArn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_hsm(
@@ -245,6 +264,7 @@ function delete_hsm(
         "DeleteHsm",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("HsmArn" => HsmArn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -266,6 +286,7 @@ function delete_luna_client(ClientArn; aws_config::AbstractAWSConfig=global_aws_
         "DeleteLunaClient",
         Dict{String,Any}("ClientArn" => ClientArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_luna_client(
@@ -279,6 +300,7 @@ function delete_luna_client(
             mergewith(_merge, Dict{String,Any}("ClientArn" => ClientArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -298,7 +320,10 @@ about a high-availability partition group.
 """
 function describe_hapg(HapgArn; aws_config::AbstractAWSConfig=global_aws_config())
     return cloudhsm(
-        "DescribeHapg", Dict{String,Any}("HapgArn" => HapgArn); aws_config=aws_config
+        "DescribeHapg",
+        Dict{String,Any}("HapgArn" => HapgArn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_hapg(
@@ -308,6 +333,7 @@ function describe_hapg(
         "DescribeHapg",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("HapgArn" => HapgArn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -329,12 +355,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   HsmSerialNumber parameter must be specified.
 """
 function describe_hsm(; aws_config::AbstractAWSConfig=global_aws_config())
-    return cloudhsm("DescribeHsm"; aws_config=aws_config)
+    return cloudhsm("DescribeHsm"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function describe_hsm(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return cloudhsm("DescribeHsm", params; aws_config=aws_config)
+    return cloudhsm(
+        "DescribeHsm", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -353,12 +381,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"ClientArn"`: The ARN of the client.
 """
 function describe_luna_client(; aws_config::AbstractAWSConfig=global_aws_config())
-    return cloudhsm("DescribeLunaClient"; aws_config=aws_config)
+    return cloudhsm(
+        "DescribeLunaClient"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_luna_client(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return cloudhsm("DescribeLunaClient", params; aws_config=aws_config)
+    return cloudhsm(
+        "DescribeLunaClient", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -390,6 +422,7 @@ function get_config(
             "HapgList" => HapgList,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_config(
@@ -413,6 +446,7 @@ function get_config(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -428,12 +462,16 @@ Zones that have available AWS CloudHSM capacity.
 
 """
 function list_available_zones(; aws_config::AbstractAWSConfig=global_aws_config())
-    return cloudhsm("ListAvailableZones"; aws_config=aws_config)
+    return cloudhsm(
+        "ListAvailableZones"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_available_zones(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return cloudhsm("ListAvailableZones", params; aws_config=aws_config)
+    return cloudhsm(
+        "ListAvailableZones", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -455,12 +493,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   is the first call.
 """
 function list_hapgs(; aws_config::AbstractAWSConfig=global_aws_config())
-    return cloudhsm("ListHapgs"; aws_config=aws_config)
+    return cloudhsm("ListHapgs"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_hapgs(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return cloudhsm("ListHapgs", params; aws_config=aws_config)
+    return cloudhsm(
+        "ListHapgs", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -482,12 +522,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   the first call.
 """
 function list_hsms(; aws_config::AbstractAWSConfig=global_aws_config())
-    return cloudhsm("ListHsms"; aws_config=aws_config)
+    return cloudhsm("ListHsms"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_hsms(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return cloudhsm("ListHsms", params; aws_config=aws_config)
+    return cloudhsm(
+        "ListHsms", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -508,12 +550,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   this is the first call.
 """
 function list_luna_clients(; aws_config::AbstractAWSConfig=global_aws_config())
-    return cloudhsm("ListLunaClients"; aws_config=aws_config)
+    return cloudhsm(
+        "ListLunaClients"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_luna_clients(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return cloudhsm("ListLunaClients", params; aws_config=aws_config)
+    return cloudhsm(
+        "ListLunaClients", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -537,6 +583,7 @@ function list_tags_for_resource(
         "ListTagsForResource",
         Dict{String,Any}("ResourceArn" => ResourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags_for_resource(
@@ -550,6 +597,7 @@ function list_tags_for_resource(
             mergewith(_merge, Dict{String,Any}("ResourceArn" => ResourceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -574,7 +622,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function modify_hapg(HapgArn; aws_config::AbstractAWSConfig=global_aws_config())
     return cloudhsm(
-        "ModifyHapg", Dict{String,Any}("HapgArn" => HapgArn); aws_config=aws_config
+        "ModifyHapg",
+        Dict{String,Any}("HapgArn" => HapgArn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_hapg(
@@ -584,6 +635,7 @@ function modify_hapg(
         "ModifyHapg",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("HapgArn" => HapgArn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -617,7 +669,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function modify_hsm(HsmArn; aws_config::AbstractAWSConfig=global_aws_config())
     return cloudhsm(
-        "ModifyHsm", Dict{String,Any}("HsmArn" => HsmArn); aws_config=aws_config
+        "ModifyHsm",
+        Dict{String,Any}("HsmArn" => HsmArn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_hsm(
@@ -627,6 +682,7 @@ function modify_hsm(
         "ModifyHsm",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("HsmArn" => HsmArn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -653,6 +709,7 @@ function modify_luna_client(
         "ModifyLunaClient",
         Dict{String,Any}("Certificate" => Certificate, "ClientArn" => ClientArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_luna_client(
@@ -671,6 +728,7 @@ function modify_luna_client(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -698,6 +756,7 @@ function remove_tags_from_resource(
         "RemoveTagsFromResource",
         Dict{String,Any}("ResourceArn" => ResourceArn, "TagKeyList" => TagKeyList);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function remove_tags_from_resource(
@@ -716,5 +775,6 @@ function remove_tags_from_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/cloudhsm_v2.jl
+++ b/src/services/cloudhsm_v2.jl
@@ -28,6 +28,7 @@ function copy_backup_to_region(
         "CopyBackupToRegion",
         Dict{String,Any}("BackupId" => BackupId, "DestinationRegion" => DestinationRegion);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function copy_backup_to_region(
@@ -48,6 +49,7 @@ function copy_backup_to_region(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -80,6 +82,7 @@ function create_cluster(
         "CreateCluster",
         Dict{String,Any}("HsmType" => HsmType, "SubnetIds" => SubnetIds);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_cluster(
@@ -98,6 +101,7 @@ function create_cluster(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -126,6 +130,7 @@ function create_hsm(
         "CreateHsm",
         Dict{String,Any}("AvailabilityZone" => AvailabilityZone, "ClusterId" => ClusterId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_hsm(
@@ -146,6 +151,7 @@ function create_hsm(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -163,7 +169,10 @@ DeleteBackup request is made. For more information on restoring a backup, see Re
 """
 function delete_backup(BackupId; aws_config::AbstractAWSConfig=global_aws_config())
     return cloudhsm_v2(
-        "DeleteBackup", Dict{String,Any}("BackupId" => BackupId); aws_config=aws_config
+        "DeleteBackup",
+        Dict{String,Any}("BackupId" => BackupId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_backup(
@@ -177,6 +186,7 @@ function delete_backup(
             mergewith(_merge, Dict{String,Any}("BackupId" => BackupId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -195,7 +205,10 @@ DescribeClusters. To delete an HSM, use DeleteHsm.
 """
 function delete_cluster(ClusterId; aws_config::AbstractAWSConfig=global_aws_config())
     return cloudhsm_v2(
-        "DeleteCluster", Dict{String,Any}("ClusterId" => ClusterId); aws_config=aws_config
+        "DeleteCluster",
+        Dict{String,Any}("ClusterId" => ClusterId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_cluster(
@@ -209,6 +222,7 @@ function delete_cluster(
             mergewith(_merge, Dict{String,Any}("ClusterId" => ClusterId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -234,7 +248,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function delete_hsm(ClusterId; aws_config::AbstractAWSConfig=global_aws_config())
     return cloudhsm_v2(
-        "DeleteHsm", Dict{String,Any}("ClusterId" => ClusterId); aws_config=aws_config
+        "DeleteHsm",
+        Dict{String,Any}("ClusterId" => ClusterId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_hsm(
@@ -248,6 +265,7 @@ function delete_hsm(
             mergewith(_merge, Dict{String,Any}("ClusterId" => ClusterId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -281,12 +299,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   chronological order of generation.
 """
 function describe_backups(; aws_config::AbstractAWSConfig=global_aws_config())
-    return cloudhsm_v2("DescribeBackups"; aws_config=aws_config)
+    return cloudhsm_v2(
+        "DescribeBackups"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_backups(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return cloudhsm_v2("DescribeBackups", params; aws_config=aws_config)
+    return cloudhsm_v2(
+        "DescribeBackups", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -312,12 +334,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   value to get more clusters.
 """
 function describe_clusters(; aws_config::AbstractAWSConfig=global_aws_config())
-    return cloudhsm_v2("DescribeClusters"; aws_config=aws_config)
+    return cloudhsm_v2(
+        "DescribeClusters"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_clusters(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return cloudhsm_v2("DescribeClusters", params; aws_config=aws_config)
+    return cloudhsm_v2(
+        "DescribeClusters", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -353,6 +379,7 @@ function initialize_cluster(
             "TrustAnchor" => TrustAnchor,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function initialize_cluster(
@@ -376,6 +403,7 @@ function initialize_cluster(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -402,7 +430,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function list_tags(ResourceId; aws_config::AbstractAWSConfig=global_aws_config())
     return cloudhsm_v2(
-        "ListTags", Dict{String,Any}("ResourceId" => ResourceId); aws_config=aws_config
+        "ListTags",
+        Dict{String,Any}("ResourceId" => ResourceId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags(
@@ -416,6 +447,7 @@ function list_tags(
             mergewith(_merge, Dict{String,Any}("ResourceId" => ResourceId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -440,6 +472,7 @@ function modify_backup_attributes(
         "ModifyBackupAttributes",
         Dict{String,Any}("BackupId" => BackupId, "NeverExpires" => NeverExpires);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_backup_attributes(
@@ -458,6 +491,7 @@ function modify_backup_attributes(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -482,6 +516,7 @@ function modify_cluster(
             "BackupRetentionPolicy" => BackupRetentionPolicy, "ClusterId" => ClusterId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_cluster(
@@ -503,6 +538,7 @@ function modify_cluster(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -520,7 +556,10 @@ information on deleting a backup, see DeleteBackup.
 """
 function restore_backup(BackupId; aws_config::AbstractAWSConfig=global_aws_config())
     return cloudhsm_v2(
-        "RestoreBackup", Dict{String,Any}("BackupId" => BackupId); aws_config=aws_config
+        "RestoreBackup",
+        Dict{String,Any}("BackupId" => BackupId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function restore_backup(
@@ -534,6 +573,7 @@ function restore_backup(
             mergewith(_merge, Dict{String,Any}("BackupId" => BackupId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -556,6 +596,7 @@ function tag_resource(
         "TagResource",
         Dict{String,Any}("ResourceId" => ResourceId, "TagList" => TagList);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -574,6 +615,7 @@ function tag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -597,6 +639,7 @@ function untag_resource(
         "UntagResource",
         Dict{String,Any}("ResourceId" => ResourceId, "TagKeyList" => TagKeyList);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -615,5 +658,6 @@ function untag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/cloudsearch.jl
+++ b/src/services/cloudsearch.jl
@@ -20,6 +20,7 @@ function build_suggesters(DomainName; aws_config::AbstractAWSConfig=global_aws_c
         "BuildSuggesters",
         Dict{String,Any}("DomainName" => DomainName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function build_suggesters(
@@ -33,6 +34,7 @@ function build_suggesters(
             mergewith(_merge, Dict{String,Any}("DomainName" => DomainName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -51,7 +53,10 @@ Amazon CloudSearch Developer Guide.
 """
 function create_domain(DomainName; aws_config::AbstractAWSConfig=global_aws_config())
     return cloudsearch(
-        "CreateDomain", Dict{String,Any}("DomainName" => DomainName); aws_config=aws_config
+        "CreateDomain",
+        Dict{String,Any}("DomainName" => DomainName);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_domain(
@@ -65,6 +70,7 @@ function create_domain(
             mergewith(_merge, Dict{String,Any}("DomainName" => DomainName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -88,6 +94,7 @@ function define_analysis_scheme(
         "DefineAnalysisScheme",
         Dict{String,Any}("AnalysisScheme" => AnalysisScheme, "DomainName" => DomainName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function define_analysis_scheme(
@@ -108,6 +115,7 @@ function define_analysis_scheme(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -131,6 +139,7 @@ function define_expression(
         "DefineExpression",
         Dict{String,Any}("DomainName" => DomainName, "Expression" => Expression);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function define_expression(
@@ -149,6 +158,7 @@ function define_expression(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -176,6 +186,7 @@ function define_index_field(
         "DefineIndexField",
         Dict{String,Any}("DomainName" => DomainName, "IndexField" => IndexField);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function define_index_field(
@@ -194,6 +205,7 @@ function define_index_field(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -219,6 +231,7 @@ function define_suggester(
         "DefineSuggester",
         Dict{String,Any}("DomainName" => DomainName, "Suggester" => Suggester);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function define_suggester(
@@ -237,6 +250,7 @@ function define_suggester(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -261,6 +275,7 @@ function delete_analysis_scheme(
             "AnalysisSchemeName" => AnalysisSchemeName, "DomainName" => DomainName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_analysis_scheme(
@@ -281,6 +296,7 @@ function delete_analysis_scheme(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -298,7 +314,10 @@ CloudSearch Developer Guide.
 """
 function delete_domain(DomainName; aws_config::AbstractAWSConfig=global_aws_config())
     return cloudsearch(
-        "DeleteDomain", Dict{String,Any}("DomainName" => DomainName); aws_config=aws_config
+        "DeleteDomain",
+        Dict{String,Any}("DomainName" => DomainName);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_domain(
@@ -312,6 +331,7 @@ function delete_domain(
             mergewith(_merge, Dict{String,Any}("DomainName" => DomainName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -334,6 +354,7 @@ function delete_expression(
         "DeleteExpression",
         Dict{String,Any}("DomainName" => DomainName, "ExpressionName" => ExpressionName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_expression(
@@ -354,6 +375,7 @@ function delete_expression(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -377,6 +399,7 @@ function delete_index_field(
         "DeleteIndexField",
         Dict{String,Any}("DomainName" => DomainName, "IndexFieldName" => IndexFieldName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_index_field(
@@ -397,6 +420,7 @@ function delete_index_field(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -419,6 +443,7 @@ function delete_suggester(
         "DeleteSuggester",
         Dict{String,Any}("DomainName" => DomainName, "SuggesterName" => SuggesterName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_suggester(
@@ -439,6 +464,7 @@ function delete_suggester(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -469,6 +495,7 @@ function describe_analysis_schemes(
         "DescribeAnalysisSchemes",
         Dict{String,Any}("DomainName" => DomainName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_analysis_schemes(
@@ -482,6 +509,7 @@ function describe_analysis_schemes(
             mergewith(_merge, Dict{String,Any}("DomainName" => DomainName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -509,6 +537,7 @@ function describe_availability_options(
         "DescribeAvailabilityOptions",
         Dict{String,Any}("DomainName" => DomainName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_availability_options(
@@ -522,6 +551,7 @@ function describe_availability_options(
             mergewith(_merge, Dict{String,Any}("DomainName" => DomainName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -548,6 +578,7 @@ function describe_domain_endpoint_options(
         "DescribeDomainEndpointOptions",
         Dict{String,Any}("DomainName" => DomainName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_domain_endpoint_options(
@@ -561,6 +592,7 @@ function describe_domain_endpoint_options(
             mergewith(_merge, Dict{String,Any}("DomainName" => DomainName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -579,12 +611,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"DomainNames"`: The names of the domains you want to include in the response.
 """
 function describe_domains(; aws_config::AbstractAWSConfig=global_aws_config())
-    return cloudsearch("DescribeDomains"; aws_config=aws_config)
+    return cloudsearch(
+        "DescribeDomains"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_domains(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return cloudsearch("DescribeDomains", params; aws_config=aws_config)
+    return cloudsearch(
+        "DescribeDomains", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -612,6 +648,7 @@ function describe_expressions(DomainName; aws_config::AbstractAWSConfig=global_a
         "DescribeExpressions",
         Dict{String,Any}("DomainName" => DomainName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_expressions(
@@ -625,6 +662,7 @@ function describe_expressions(
             mergewith(_merge, Dict{String,Any}("DomainName" => DomainName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -655,6 +693,7 @@ function describe_index_fields(
         "DescribeIndexFields",
         Dict{String,Any}("DomainName" => DomainName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_index_fields(
@@ -668,6 +707,7 @@ function describe_index_fields(
             mergewith(_merge, Dict{String,Any}("DomainName" => DomainName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -690,6 +730,7 @@ function describe_scaling_parameters(
         "DescribeScalingParameters",
         Dict{String,Any}("DomainName" => DomainName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_scaling_parameters(
@@ -703,6 +744,7 @@ function describe_scaling_parameters(
             mergewith(_merge, Dict{String,Any}("DomainName" => DomainName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -731,6 +773,7 @@ function describe_service_access_policies(
         "DescribeServiceAccessPolicies",
         Dict{String,Any}("DomainName" => DomainName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_service_access_policies(
@@ -744,6 +787,7 @@ function describe_service_access_policies(
             mergewith(_merge, Dict{String,Any}("DomainName" => DomainName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -772,6 +816,7 @@ function describe_suggesters(DomainName; aws_config::AbstractAWSConfig=global_aw
         "DescribeSuggesters",
         Dict{String,Any}("DomainName" => DomainName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_suggesters(
@@ -785,6 +830,7 @@ function describe_suggesters(
             mergewith(_merge, Dict{String,Any}("DomainName" => DomainName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -805,6 +851,7 @@ function index_documents(DomainName; aws_config::AbstractAWSConfig=global_aws_co
         "IndexDocuments",
         Dict{String,Any}("DomainName" => DomainName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function index_documents(
@@ -818,6 +865,7 @@ function index_documents(
             mergewith(_merge, Dict{String,Any}("DomainName" => DomainName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -829,12 +877,16 @@ Lists all search domains owned by an account.
 
 """
 function list_domain_names(; aws_config::AbstractAWSConfig=global_aws_config())
-    return cloudsearch("ListDomainNames"; aws_config=aws_config)
+    return cloudsearch(
+        "ListDomainNames"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_domain_names(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return cloudsearch("ListDomainNames", params; aws_config=aws_config)
+    return cloudsearch(
+        "ListDomainNames", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -861,6 +913,7 @@ function update_availability_options(
         "UpdateAvailabilityOptions",
         Dict{String,Any}("DomainName" => DomainName, "MultiAZ" => MultiAZ);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_availability_options(
@@ -879,6 +932,7 @@ function update_availability_options(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -906,6 +960,7 @@ function update_domain_endpoint_options(
             "DomainEndpointOptions" => DomainEndpointOptions, "DomainName" => DomainName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_domain_endpoint_options(
@@ -927,6 +982,7 @@ function update_domain_endpoint_options(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -955,6 +1011,7 @@ function update_scaling_parameters(
             "DomainName" => DomainName, "ScalingParameters" => ScalingParameters
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_scaling_parameters(
@@ -975,6 +1032,7 @@ function update_scaling_parameters(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -998,6 +1056,7 @@ function update_service_access_policies(
         "UpdateServiceAccessPolicies",
         Dict{String,Any}("AccessPolicies" => AccessPolicies, "DomainName" => DomainName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_service_access_policies(
@@ -1018,5 +1077,6 @@ function update_service_access_policies(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/cloudsearch_domain.jl
+++ b/src/services/cloudsearch_domain.jl
@@ -222,6 +222,7 @@ function search(q; aws_config::AbstractAWSConfig=global_aws_config())
         "/2013-01-01/search?format=sdk&pretty=true",
         Dict{String,Any}("q" => q);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function search(
@@ -232,6 +233,7 @@ function search(
         "/2013-01-01/search?format=sdk&pretty=true",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("q" => q), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -265,6 +267,7 @@ function suggest(q, suggester; aws_config::AbstractAWSConfig=global_aws_config()
         "/2013-01-01/suggest?format=sdk&pretty=true",
         Dict{String,Any}("q" => q, "suggester" => suggester);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function suggest(
@@ -280,6 +283,7 @@ function suggest(
             mergewith(_merge, Dict{String,Any}("q" => q, "suggester" => suggester), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -321,6 +325,7 @@ function upload_documents(
             "headers" => Dict{String,Any}("Content-Type" => Content_Type),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function upload_documents(
@@ -343,5 +348,6 @@ function upload_documents(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/cloudtrail.jl
+++ b/src/services/cloudtrail.jl
@@ -25,7 +25,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function add_tags(ResourceId; aws_config::AbstractAWSConfig=global_aws_config())
     return cloudtrail(
-        "AddTags", Dict{String,Any}("ResourceId" => ResourceId); aws_config=aws_config
+        "AddTags",
+        Dict{String,Any}("ResourceId" => ResourceId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function add_tags(
@@ -39,6 +42,7 @@ function add_tags(
             mergewith(_merge, Dict{String,Any}("ResourceId" => ResourceId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -103,6 +107,7 @@ function create_trail(Name, S3BucketName; aws_config::AbstractAWSConfig=global_a
         "CreateTrail",
         Dict{String,Any}("Name" => Name, "S3BucketName" => S3BucketName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_trail(
@@ -121,6 +126,7 @@ function create_trail(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -140,7 +146,10 @@ regions) of a trail that is enabled in all regions.
 """
 function delete_trail(Name; aws_config::AbstractAWSConfig=global_aws_config())
     return cloudtrail(
-        "DeleteTrail", Dict{String,Any}("Name" => Name); aws_config=aws_config
+        "DeleteTrail",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_trail(
@@ -150,6 +159,7 @@ function delete_trail(
         "DeleteTrail",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -180,12 +190,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   trail ARN.
 """
 function describe_trails(; aws_config::AbstractAWSConfig=global_aws_config())
-    return cloudtrail("DescribeTrails"; aws_config=aws_config)
+    return cloudtrail(
+        "DescribeTrails"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_trails(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return cloudtrail("DescribeTrails", params; aws_config=aws_config)
+    return cloudtrail(
+        "DescribeTrails", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -215,6 +229,7 @@ function get_event_selectors(TrailName; aws_config::AbstractAWSConfig=global_aws
         "GetEventSelectors",
         Dict{String,Any}("TrailName" => TrailName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_event_selectors(
@@ -228,6 +243,7 @@ function get_event_selectors(
             mergewith(_merge, Dict{String,Any}("TrailName" => TrailName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -257,6 +273,7 @@ function get_insight_selectors(TrailName; aws_config::AbstractAWSConfig=global_a
         "GetInsightSelectors",
         Dict{String,Any}("TrailName" => TrailName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_insight_selectors(
@@ -270,6 +287,7 @@ function get_insight_selectors(
             mergewith(_merge, Dict{String,Any}("TrailName" => TrailName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -285,7 +303,12 @@ Returns settings information for a specified trail.
 
 """
 function get_trail(Name; aws_config::AbstractAWSConfig=global_aws_config())
-    return cloudtrail("GetTrail", Dict{String,Any}("Name" => Name); aws_config=aws_config)
+    return cloudtrail(
+        "GetTrail",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_trail(
     Name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -294,6 +317,7 @@ function get_trail(
         "GetTrail",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -315,7 +339,10 @@ trail status from all regions, you must call the operation on each region.
 """
 function get_trail_status(Name; aws_config::AbstractAWSConfig=global_aws_config())
     return cloudtrail(
-        "GetTrailStatus", Dict{String,Any}("Name" => Name); aws_config=aws_config
+        "GetTrailStatus",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_trail_status(
@@ -325,6 +352,7 @@ function get_trail_status(
         "GetTrailStatus",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -349,12 +377,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   the current public key is returned.
 """
 function list_public_keys(; aws_config::AbstractAWSConfig=global_aws_config())
-    return cloudtrail("ListPublicKeys"; aws_config=aws_config)
+    return cloudtrail(
+        "ListPublicKeys"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_public_keys(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return cloudtrail("ListPublicKeys", params; aws_config=aws_config)
+    return cloudtrail(
+        "ListPublicKeys", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -377,6 +409,7 @@ function list_tags(ResourceIdList; aws_config::AbstractAWSConfig=global_aws_conf
         "ListTags",
         Dict{String,Any}("ResourceIdList" => ResourceIdList);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags(
@@ -390,6 +423,7 @@ function list_tags(
             mergewith(_merge, Dict{String,Any}("ResourceIdList" => ResourceIdList), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -407,12 +441,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   with a value of 'root', the call with NextToken should include those same parameters.
 """
 function list_trails(; aws_config::AbstractAWSConfig=global_aws_config())
-    return cloudtrail("ListTrails"; aws_config=aws_config)
+    return cloudtrail("ListTrails"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_trails(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return cloudtrail("ListTrails", params; aws_config=aws_config)
+    return cloudtrail(
+        "ListTrails", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -449,12 +485,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   returned. If the specified start time is after the specified end time, an error is returned.
 """
 function lookup_events(; aws_config::AbstractAWSConfig=global_aws_config())
-    return cloudtrail("LookupEvents"; aws_config=aws_config)
+    return cloudtrail(
+        "LookupEvents"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function lookup_events(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return cloudtrail("LookupEvents", params; aws_config=aws_config)
+    return cloudtrail(
+        "LookupEvents", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -511,6 +551,7 @@ function put_event_selectors(TrailName; aws_config::AbstractAWSConfig=global_aws
         "PutEventSelectors",
         Dict{String,Any}("TrailName" => TrailName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_event_selectors(
@@ -524,6 +565,7 @@ function put_event_selectors(
             mergewith(_merge, Dict{String,Any}("TrailName" => TrailName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -550,6 +592,7 @@ function put_insight_selectors(
         "PutInsightSelectors",
         Dict{String,Any}("InsightSelectors" => InsightSelectors, "TrailName" => TrailName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_insight_selectors(
@@ -570,6 +613,7 @@ function put_insight_selectors(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -589,7 +633,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function remove_tags(ResourceId; aws_config::AbstractAWSConfig=global_aws_config())
     return cloudtrail(
-        "RemoveTags", Dict{String,Any}("ResourceId" => ResourceId); aws_config=aws_config
+        "RemoveTags",
+        Dict{String,Any}("ResourceId" => ResourceId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function remove_tags(
@@ -603,6 +650,7 @@ function remove_tags(
             mergewith(_merge, Dict{String,Any}("ResourceId" => ResourceId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -623,7 +671,10 @@ in which the trail was created. This operation cannot be called on the shadow tr
 """
 function start_logging(Name; aws_config::AbstractAWSConfig=global_aws_config())
     return cloudtrail(
-        "StartLogging", Dict{String,Any}("Name" => Name); aws_config=aws_config
+        "StartLogging",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_logging(
@@ -633,6 +684,7 @@ function start_logging(
         "StartLogging",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -656,7 +708,10 @@ all regions.
 """
 function stop_logging(Name; aws_config::AbstractAWSConfig=global_aws_config())
     return cloudtrail(
-        "StopLogging", Dict{String,Any}("Name" => Name); aws_config=aws_config
+        "StopLogging",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function stop_logging(
@@ -666,6 +721,7 @@ function stop_logging(
         "StopLogging",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -738,7 +794,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function update_trail(Name; aws_config::AbstractAWSConfig=global_aws_config())
     return cloudtrail(
-        "UpdateTrail", Dict{String,Any}("Name" => Name); aws_config=aws_config
+        "UpdateTrail",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_trail(
@@ -748,5 +807,6 @@ function update_trail(
         "UpdateTrail",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/cloudwatch.jl
+++ b/src/services/cloudwatch.jl
@@ -28,7 +28,10 @@ evaluation path.
 """
 function delete_alarms(AlarmNames; aws_config::AbstractAWSConfig=global_aws_config())
     return cloudwatch(
-        "DeleteAlarms", Dict{String,Any}("AlarmNames" => AlarmNames); aws_config=aws_config
+        "DeleteAlarms",
+        Dict{String,Any}("AlarmNames" => AlarmNames);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_alarms(
@@ -42,6 +45,7 @@ function delete_alarms(
             mergewith(_merge, Dict{String,Any}("AlarmNames" => AlarmNames), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -70,6 +74,7 @@ function delete_anomaly_detector(
             "MetricName" => MetricName, "Namespace" => Namespace, "Stat" => Stat
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_anomaly_detector(
@@ -91,6 +96,7 @@ function delete_anomaly_detector(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -112,6 +118,7 @@ function delete_dashboards(
         "DeleteDashboards",
         Dict{String,Any}("DashboardNames" => DashboardNames);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_dashboards(
@@ -125,6 +132,7 @@ function delete_dashboards(
             mergewith(_merge, Dict{String,Any}("DashboardNames" => DashboardNames), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -146,6 +154,7 @@ function delete_insight_rules(RuleNames; aws_config::AbstractAWSConfig=global_aw
         "DeleteInsightRules",
         Dict{String,Any}("RuleNames" => RuleNames);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_insight_rules(
@@ -159,6 +168,7 @@ function delete_insight_rules(
             mergewith(_merge, Dict{String,Any}("RuleNames" => RuleNames), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -174,7 +184,10 @@ Permanently deletes the metric stream that you specify.
 """
 function delete_metric_stream(Name; aws_config::AbstractAWSConfig=global_aws_config())
     return cloudwatch(
-        "DeleteMetricStream", Dict{String,Any}("Name" => Name); aws_config=aws_config
+        "DeleteMetricStream",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_metric_stream(
@@ -184,6 +197,7 @@ function delete_metric_stream(
         "DeleteMetricStream",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -213,12 +227,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"StartDate"`: The starting date to retrieve alarm history.
 """
 function describe_alarm_history(; aws_config::AbstractAWSConfig=global_aws_config())
-    return cloudwatch("DescribeAlarmHistory"; aws_config=aws_config)
+    return cloudwatch(
+        "DescribeAlarmHistory"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_alarm_history(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return cloudwatch("DescribeAlarmHistory", params; aws_config=aws_config)
+    return cloudwatch(
+        "DescribeAlarmHistory",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -268,12 +289,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   currently in the state that you specify.
 """
 function describe_alarms(; aws_config::AbstractAWSConfig=global_aws_config())
-    return cloudwatch("DescribeAlarms"; aws_config=aws_config)
+    return cloudwatch(
+        "DescribeAlarms"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_alarms(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return cloudwatch("DescribeAlarms", params; aws_config=aws_config)
+    return cloudwatch(
+        "DescribeAlarms", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -307,6 +332,7 @@ function describe_alarms_for_metric(
         "DescribeAlarmsForMetric",
         Dict{String,Any}("MetricName" => MetricName, "Namespace" => Namespace);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_alarms_for_metric(
@@ -325,6 +351,7 @@ function describe_alarms_for_metric(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -353,12 +380,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   of results.
 """
 function describe_anomaly_detectors(; aws_config::AbstractAWSConfig=global_aws_config())
-    return cloudwatch("DescribeAnomalyDetectors"; aws_config=aws_config)
+    return cloudwatch(
+        "DescribeAnomalyDetectors"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_anomaly_detectors(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return cloudwatch("DescribeAnomalyDetectors", params; aws_config=aws_config)
+    return cloudwatch(
+        "DescribeAnomalyDetectors",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -376,12 +410,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   the next set of rules.
 """
 function describe_insight_rules(; aws_config::AbstractAWSConfig=global_aws_config())
-    return cloudwatch("DescribeInsightRules"; aws_config=aws_config)
+    return cloudwatch(
+        "DescribeInsightRules"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_insight_rules(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return cloudwatch("DescribeInsightRules", params; aws_config=aws_config)
+    return cloudwatch(
+        "DescribeInsightRules",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -402,6 +443,7 @@ function disable_alarm_actions(
         "DisableAlarmActions",
         Dict{String,Any}("AlarmNames" => AlarmNames);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disable_alarm_actions(
@@ -415,6 +457,7 @@ function disable_alarm_actions(
             mergewith(_merge, Dict{String,Any}("AlarmNames" => AlarmNames), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -435,6 +478,7 @@ function disable_insight_rules(RuleNames; aws_config::AbstractAWSConfig=global_a
         "DisableInsightRules",
         Dict{String,Any}("RuleNames" => RuleNames);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disable_insight_rules(
@@ -448,6 +492,7 @@ function disable_insight_rules(
             mergewith(_merge, Dict{String,Any}("RuleNames" => RuleNames), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -466,6 +511,7 @@ function enable_alarm_actions(AlarmNames; aws_config::AbstractAWSConfig=global_a
         "EnableAlarmActions",
         Dict{String,Any}("AlarmNames" => AlarmNames);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function enable_alarm_actions(
@@ -479,6 +525,7 @@ function enable_alarm_actions(
             mergewith(_merge, Dict{String,Any}("AlarmNames" => AlarmNames), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -499,6 +546,7 @@ function enable_insight_rules(RuleNames; aws_config::AbstractAWSConfig=global_aw
         "EnableInsightRules",
         Dict{String,Any}("RuleNames" => RuleNames);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function enable_insight_rules(
@@ -512,6 +560,7 @@ function enable_insight_rules(
             mergewith(_merge, Dict{String,Any}("RuleNames" => RuleNames), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -532,6 +581,7 @@ function get_dashboard(DashboardName; aws_config::AbstractAWSConfig=global_aws_c
         "GetDashboard",
         Dict{String,Any}("DashboardName" => DashboardName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_dashboard(
@@ -545,6 +595,7 @@ function get_dashboard(
             mergewith(_merge, Dict{String,Any}("DashboardName" => DashboardName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -611,6 +662,7 @@ function get_insight_rule_report(
             "StartTime" => StartTime,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_insight_rule_report(
@@ -636,6 +688,7 @@ function get_insight_rule_report(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -722,6 +775,7 @@ function get_metric_data(
             "StartTime" => StartTime,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_metric_data(
@@ -745,6 +799,7 @@ function get_metric_data(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -856,6 +911,7 @@ function get_metric_statistics(
             "StartTime" => StartTime,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_metric_statistics(
@@ -883,6 +939,7 @@ function get_metric_statistics(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -898,7 +955,10 @@ Returns information about the metric stream that you specify.
 """
 function get_metric_stream(Name; aws_config::AbstractAWSConfig=global_aws_config())
     return cloudwatch(
-        "GetMetricStream", Dict{String,Any}("Name" => Name); aws_config=aws_config
+        "GetMetricStream",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_metric_stream(
@@ -908,6 +968,7 @@ function get_metric_stream(
         "GetMetricStream",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -955,6 +1016,7 @@ function get_metric_widget_image(
         "GetMetricWidgetImage",
         Dict{String,Any}("MetricWidget" => MetricWidget);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_metric_widget_image(
@@ -968,6 +1030,7 @@ function get_metric_widget_image(
             mergewith(_merge, Dict{String,Any}("MetricWidget" => MetricWidget), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -990,12 +1053,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   available.
 """
 function list_dashboards(; aws_config::AbstractAWSConfig=global_aws_config())
-    return cloudwatch("ListDashboards"; aws_config=aws_config)
+    return cloudwatch(
+        "ListDashboards"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_dashboards(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return cloudwatch("ListDashboards", params; aws_config=aws_config)
+    return cloudwatch(
+        "ListDashboards", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1011,12 +1078,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   next set of metric streams.
 """
 function list_metric_streams(; aws_config::AbstractAWSConfig=global_aws_config())
-    return cloudwatch("ListMetricStreams"; aws_config=aws_config)
+    return cloudwatch(
+        "ListMetricStreams"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_metric_streams(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return cloudwatch("ListMetricStreams", params; aws_config=aws_config)
+    return cloudwatch(
+        "ListMetricStreams", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1048,12 +1119,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   with last published data as much as 40 minutes more than the specified time interval.
 """
 function list_metrics(; aws_config::AbstractAWSConfig=global_aws_config())
-    return cloudwatch("ListMetrics"; aws_config=aws_config)
+    return cloudwatch("ListMetrics"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_metrics(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return cloudwatch("ListMetrics", params; aws_config=aws_config)
+    return cloudwatch(
+        "ListMetrics", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1079,6 +1152,7 @@ function list_tags_for_resource(
         "ListTagsForResource",
         Dict{String,Any}("ResourceARN" => ResourceARN);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags_for_resource(
@@ -1092,6 +1166,7 @@ function list_tags_for_resource(
             mergewith(_merge, Dict{String,Any}("ResourceARN" => ResourceARN), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1125,6 +1200,7 @@ function put_anomaly_detector(
             "MetricName" => MetricName, "Namespace" => Namespace, "Stat" => Stat
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_anomaly_detector(
@@ -1146,6 +1222,7 @@ function put_anomaly_detector(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1236,6 +1313,7 @@ function put_composite_alarm(
         "PutCompositeAlarm",
         Dict{String,Any}("AlarmName" => AlarmName, "AlarmRule" => AlarmRule);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_composite_alarm(
@@ -1254,6 +1332,7 @@ function put_composite_alarm(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1293,6 +1372,7 @@ function put_dashboard(
             "DashboardBody" => DashboardBody, "DashboardName" => DashboardName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_dashboard(
@@ -1313,6 +1393,7 @@ function put_dashboard(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1350,6 +1431,7 @@ function put_insight_rule(
         "PutInsightRule",
         Dict{String,Any}("RuleDefinition" => RuleDefinition, "RuleName" => RuleName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_insight_rule(
@@ -1370,6 +1452,7 @@ function put_insight_rule(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1546,6 +1629,7 @@ function put_metric_alarm(
             "EvaluationPeriods" => EvaluationPeriods,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_metric_alarm(
@@ -1569,6 +1653,7 @@ function put_metric_alarm(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1618,6 +1703,7 @@ function put_metric_data(
         "PutMetricData",
         Dict{String,Any}("MetricData" => MetricData, "Namespace" => Namespace);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_metric_data(
@@ -1636,6 +1722,7 @@ function put_metric_data(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1703,6 +1790,7 @@ function put_metric_stream(
             "RoleArn" => RoleArn,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_metric_stream(
@@ -1728,6 +1816,7 @@ function put_metric_stream(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1771,6 +1860,7 @@ function set_alarm_state(
             "StateValue" => StateValue,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function set_alarm_state(
@@ -1794,6 +1884,7 @@ function set_alarm_state(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1811,7 +1902,10 @@ Starts the streaming of metrics for one or more of your metric streams.
 """
 function start_metric_streams(Names; aws_config::AbstractAWSConfig=global_aws_config())
     return cloudwatch(
-        "StartMetricStreams", Dict{String,Any}("Names" => Names); aws_config=aws_config
+        "StartMetricStreams",
+        Dict{String,Any}("Names" => Names);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_metric_streams(
@@ -1821,6 +1915,7 @@ function start_metric_streams(
         "StartMetricStreams",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Names" => Names), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1838,7 +1933,10 @@ Stops the streaming of metrics for one or more of your metric streams.
 """
 function stop_metric_streams(Names; aws_config::AbstractAWSConfig=global_aws_config())
     return cloudwatch(
-        "StopMetricStreams", Dict{String,Any}("Names" => Names); aws_config=aws_config
+        "StopMetricStreams",
+        Dict{String,Any}("Names" => Names);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function stop_metric_streams(
@@ -1848,6 +1946,7 @@ function stop_metric_streams(
         "StopMetricStreams",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Names" => Names), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1881,6 +1980,7 @@ function tag_resource(ResourceARN, Tags; aws_config::AbstractAWSConfig=global_aw
         "TagResource",
         Dict{String,Any}("ResourceARN" => ResourceARN, "Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -1899,6 +1999,7 @@ function tag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1925,6 +2026,7 @@ function untag_resource(
         "UntagResource",
         Dict{String,Any}("ResourceARN" => ResourceARN, "TagKeys" => TagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -1943,5 +2045,6 @@ function untag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/cloudwatch_events.jl
+++ b/src/services/cloudwatch_events.jl
@@ -17,7 +17,10 @@ event bus will start receiving events from the event source.
 """
 function activate_event_source(Name; aws_config::AbstractAWSConfig=global_aws_config())
     return cloudwatch_events(
-        "ActivateEventSource", Dict{String,Any}("Name" => Name); aws_config=aws_config
+        "ActivateEventSource",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function activate_event_source(
@@ -27,6 +30,7 @@ function activate_event_source(
         "ActivateEventSource",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -42,7 +46,10 @@ Cancels the specified replay.
 """
 function cancel_replay(ReplayName; aws_config::AbstractAWSConfig=global_aws_config())
     return cloudwatch_events(
-        "CancelReplay", Dict{String,Any}("ReplayName" => ReplayName); aws_config=aws_config
+        "CancelReplay",
+        Dict{String,Any}("ReplayName" => ReplayName);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function cancel_replay(
@@ -56,6 +63,7 @@ function cancel_replay(
             mergewith(_merge, Dict{String,Any}("ReplayName" => ReplayName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -95,6 +103,7 @@ function create_api_destination(
             "Name" => Name,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_api_destination(
@@ -120,6 +129,7 @@ function create_api_destination(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -151,6 +161,7 @@ function create_archive(
         "CreateArchive",
         Dict{String,Any}("ArchiveName" => ArchiveName, "EventSourceArn" => EventSourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_archive(
@@ -171,6 +182,7 @@ function create_archive(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -205,6 +217,7 @@ function create_connection(
             "Name" => Name,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_connection(
@@ -228,6 +241,7 @@ function create_connection(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -253,7 +267,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function create_event_bus(Name; aws_config::AbstractAWSConfig=global_aws_config())
     return cloudwatch_events(
-        "CreateEventBus", Dict{String,Any}("Name" => Name); aws_config=aws_config
+        "CreateEventBus",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_event_bus(
@@ -263,6 +280,7 @@ function create_event_bus(
         "CreateEventBus",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -303,6 +321,7 @@ function create_partner_event_source(
         "CreatePartnerEventSource",
         Dict{String,Any}("Account" => Account, "Name" => Name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_partner_event_source(
@@ -319,6 +338,7 @@ function create_partner_event_source(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -338,7 +358,10 @@ ActivateEventSource.
 """
 function deactivate_event_source(Name; aws_config::AbstractAWSConfig=global_aws_config())
     return cloudwatch_events(
-        "DeactivateEventSource", Dict{String,Any}("Name" => Name); aws_config=aws_config
+        "DeactivateEventSource",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function deactivate_event_source(
@@ -348,6 +371,7 @@ function deactivate_event_source(
         "DeactivateEventSource",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -364,7 +388,10 @@ from the connection so you can reuse it without having to create a new connectio
 """
 function deauthorize_connection(Name; aws_config::AbstractAWSConfig=global_aws_config())
     return cloudwatch_events(
-        "DeauthorizeConnection", Dict{String,Any}("Name" => Name); aws_config=aws_config
+        "DeauthorizeConnection",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function deauthorize_connection(
@@ -374,6 +401,7 @@ function deauthorize_connection(
         "DeauthorizeConnection",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -389,7 +417,10 @@ Deletes the specified API destination.
 """
 function delete_api_destination(Name; aws_config::AbstractAWSConfig=global_aws_config())
     return cloudwatch_events(
-        "DeleteApiDestination", Dict{String,Any}("Name" => Name); aws_config=aws_config
+        "DeleteApiDestination",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_api_destination(
@@ -399,6 +430,7 @@ function delete_api_destination(
         "DeleteApiDestination",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -417,6 +449,7 @@ function delete_archive(ArchiveName; aws_config::AbstractAWSConfig=global_aws_co
         "DeleteArchive",
         Dict{String,Any}("ArchiveName" => ArchiveName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_archive(
@@ -430,6 +463,7 @@ function delete_archive(
             mergewith(_merge, Dict{String,Any}("ArchiveName" => ArchiveName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -445,7 +479,10 @@ Deletes a connection.
 """
 function delete_connection(Name; aws_config::AbstractAWSConfig=global_aws_config())
     return cloudwatch_events(
-        "DeleteConnection", Dict{String,Any}("Name" => Name); aws_config=aws_config
+        "DeleteConnection",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_connection(
@@ -455,6 +492,7 @@ function delete_connection(
         "DeleteConnection",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -471,7 +509,10 @@ event bus need to be deleted. You can't delete your account's default event bus.
 """
 function delete_event_bus(Name; aws_config::AbstractAWSConfig=global_aws_config())
     return cloudwatch_events(
-        "DeleteEventBus", Dict{String,Any}("Name" => Name); aws_config=aws_config
+        "DeleteEventBus",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_event_bus(
@@ -481,6 +522,7 @@ function delete_event_bus(
         "DeleteEventBus",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -506,6 +548,7 @@ function delete_partner_event_source(
         "DeletePartnerEventSource",
         Dict{String,Any}("Account" => Account, "Name" => Name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_partner_event_source(
@@ -522,6 +565,7 @@ function delete_partner_event_source(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -553,7 +597,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function delete_rule(Name; aws_config::AbstractAWSConfig=global_aws_config())
     return cloudwatch_events(
-        "DeleteRule", Dict{String,Any}("Name" => Name); aws_config=aws_config
+        "DeleteRule",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_rule(
@@ -563,6 +610,7 @@ function delete_rule(
         "DeleteRule",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -578,7 +626,10 @@ Retrieves details about an API destination.
 """
 function describe_api_destination(Name; aws_config::AbstractAWSConfig=global_aws_config())
     return cloudwatch_events(
-        "DescribeApiDestination", Dict{String,Any}("Name" => Name); aws_config=aws_config
+        "DescribeApiDestination",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_api_destination(
@@ -588,6 +639,7 @@ function describe_api_destination(
         "DescribeApiDestination",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -606,6 +658,7 @@ function describe_archive(ArchiveName; aws_config::AbstractAWSConfig=global_aws_
         "DescribeArchive",
         Dict{String,Any}("ArchiveName" => ArchiveName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_archive(
@@ -619,6 +672,7 @@ function describe_archive(
             mergewith(_merge, Dict{String,Any}("ArchiveName" => ArchiveName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -634,7 +688,10 @@ Retrieves details about a connection.
 """
 function describe_connection(Name; aws_config::AbstractAWSConfig=global_aws_config())
     return cloudwatch_events(
-        "DescribeConnection", Dict{String,Any}("Name" => Name); aws_config=aws_config
+        "DescribeConnection",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_connection(
@@ -644,6 +701,7 @@ function describe_connection(
         "DescribeConnection",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -664,12 +722,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   default event bus is displayed.
 """
 function describe_event_bus(; aws_config::AbstractAWSConfig=global_aws_config())
-    return cloudwatch_events("DescribeEventBus"; aws_config=aws_config)
+    return cloudwatch_events(
+        "DescribeEventBus"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_event_bus(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return cloudwatch_events("DescribeEventBus", params; aws_config=aws_config)
+    return cloudwatch_events(
+        "DescribeEventBus", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -684,7 +746,10 @@ This operation lists details about a partner event source that is shared with yo
 """
 function describe_event_source(Name; aws_config::AbstractAWSConfig=global_aws_config())
     return cloudwatch_events(
-        "DescribeEventSource", Dict{String,Any}("Name" => Name); aws_config=aws_config
+        "DescribeEventSource",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_event_source(
@@ -694,6 +759,7 @@ function describe_event_source(
         "DescribeEventSource",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -717,6 +783,7 @@ function describe_partner_event_source(
         "DescribePartnerEventSource",
         Dict{String,Any}("Name" => Name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_partner_event_source(
@@ -726,6 +793,7 @@ function describe_partner_event_source(
         "DescribePartnerEventSource",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -751,6 +819,7 @@ function describe_replay(ReplayName; aws_config::AbstractAWSConfig=global_aws_co
         "DescribeReplay",
         Dict{String,Any}("ReplayName" => ReplayName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_replay(
@@ -764,6 +833,7 @@ function describe_replay(
             mergewith(_merge, Dict{String,Any}("ReplayName" => ReplayName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -784,7 +854,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function describe_rule(Name; aws_config::AbstractAWSConfig=global_aws_config())
     return cloudwatch_events(
-        "DescribeRule", Dict{String,Any}("Name" => Name); aws_config=aws_config
+        "DescribeRule",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_rule(
@@ -794,6 +867,7 @@ function describe_rule(
         "DescribeRule",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -815,7 +889,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function disable_rule(Name; aws_config::AbstractAWSConfig=global_aws_config())
     return cloudwatch_events(
-        "DisableRule", Dict{String,Any}("Name" => Name); aws_config=aws_config
+        "DisableRule",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disable_rule(
@@ -825,6 +902,7 @@ function disable_rule(
         "DisableRule",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -846,7 +924,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function enable_rule(Name; aws_config::AbstractAWSConfig=global_aws_config())
     return cloudwatch_events(
-        "EnableRule", Dict{String,Any}("Name" => Name); aws_config=aws_config
+        "EnableRule",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function enable_rule(
@@ -856,6 +937,7 @@ function enable_rule(
         "EnableRule",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -874,12 +956,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`: The token returned by a previous call to retrieve the next set of results.
 """
 function list_api_destinations(; aws_config::AbstractAWSConfig=global_aws_config())
-    return cloudwatch_events("ListApiDestinations"; aws_config=aws_config)
+    return cloudwatch_events(
+        "ListApiDestinations"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_api_destinations(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return cloudwatch_events("ListApiDestinations", params; aws_config=aws_config)
+    return cloudwatch_events(
+        "ListApiDestinations",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -899,12 +988,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"State"`: The state of the archive.
 """
 function list_archives(; aws_config::AbstractAWSConfig=global_aws_config())
-    return cloudwatch_events("ListArchives"; aws_config=aws_config)
+    return cloudwatch_events(
+        "ListArchives"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_archives(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return cloudwatch_events("ListArchives", params; aws_config=aws_config)
+    return cloudwatch_events(
+        "ListArchives", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -922,12 +1015,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`: The token returned by a previous call to retrieve the next set of results.
 """
 function list_connections(; aws_config::AbstractAWSConfig=global_aws_config())
-    return cloudwatch_events("ListConnections"; aws_config=aws_config)
+    return cloudwatch_events(
+        "ListConnections"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_connections(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return cloudwatch_events("ListConnections", params; aws_config=aws_config)
+    return cloudwatch_events(
+        "ListConnections", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -947,12 +1044,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`: The token returned by a previous call to retrieve the next set of results.
 """
 function list_event_buses(; aws_config::AbstractAWSConfig=global_aws_config())
-    return cloudwatch_events("ListEventBuses"; aws_config=aws_config)
+    return cloudwatch_events(
+        "ListEventBuses"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_event_buses(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return cloudwatch_events("ListEventBuses", params; aws_config=aws_config)
+    return cloudwatch_events(
+        "ListEventBuses", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -973,12 +1074,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`: The token returned by a previous call to retrieve the next set of results.
 """
 function list_event_sources(; aws_config::AbstractAWSConfig=global_aws_config())
-    return cloudwatch_events("ListEventSources"; aws_config=aws_config)
+    return cloudwatch_events(
+        "ListEventSources"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_event_sources(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return cloudwatch_events("ListEventSources", params; aws_config=aws_config)
+    return cloudwatch_events(
+        "ListEventSources", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1008,6 +1113,7 @@ function list_partner_event_source_accounts(
         "ListPartnerEventSourceAccounts",
         Dict{String,Any}("EventSourceName" => EventSourceName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_partner_event_source_accounts(
@@ -1023,6 +1129,7 @@ function list_partner_event_source_accounts(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1052,6 +1159,7 @@ function list_partner_event_sources(
         "ListPartnerEventSources",
         Dict{String,Any}("NamePrefix" => NamePrefix);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_partner_event_sources(
@@ -1065,6 +1173,7 @@ function list_partner_event_sources(
             mergewith(_merge, Dict{String,Any}("NamePrefix" => NamePrefix), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1085,12 +1194,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"State"`: The state of the replay.
 """
 function list_replays(; aws_config::AbstractAWSConfig=global_aws_config())
-    return cloudwatch_events("ListReplays"; aws_config=aws_config)
+    return cloudwatch_events(
+        "ListReplays"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_replays(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return cloudwatch_events("ListReplays", params; aws_config=aws_config)
+    return cloudwatch_events(
+        "ListReplays", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1117,6 +1230,7 @@ function list_rule_names_by_target(
         "ListRuleNamesByTarget",
         Dict{String,Any}("TargetArn" => TargetArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_rule_names_by_target(
@@ -1130,6 +1244,7 @@ function list_rule_names_by_target(
             mergewith(_merge, Dict{String,Any}("TargetArn" => TargetArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1150,12 +1265,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`: The token returned by a previous call to retrieve the next set of results.
 """
 function list_rules(; aws_config::AbstractAWSConfig=global_aws_config())
-    return cloudwatch_events("ListRules"; aws_config=aws_config)
+    return cloudwatch_events(
+        "ListRules"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_rules(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return cloudwatch_events("ListRules", params; aws_config=aws_config)
+    return cloudwatch_events(
+        "ListRules", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1176,6 +1295,7 @@ function list_tags_for_resource(
         "ListTagsForResource",
         Dict{String,Any}("ResourceARN" => ResourceARN);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags_for_resource(
@@ -1189,6 +1309,7 @@ function list_tags_for_resource(
             mergewith(_merge, Dict{String,Any}("ResourceARN" => ResourceARN), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1210,7 +1331,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function list_targets_by_rule(Rule; aws_config::AbstractAWSConfig=global_aws_config())
     return cloudwatch_events(
-        "ListTargetsByRule", Dict{String,Any}("Rule" => Rule); aws_config=aws_config
+        "ListTargetsByRule",
+        Dict{String,Any}("Rule" => Rule);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_targets_by_rule(
@@ -1220,6 +1344,7 @@ function list_targets_by_rule(
         "ListTargetsByRule",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Rule" => Rule), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1237,7 +1362,10 @@ Sends custom events to Amazon EventBridge so that they can be matched to rules.
 """
 function put_events(Entries; aws_config::AbstractAWSConfig=global_aws_config())
     return cloudwatch_events(
-        "PutEvents", Dict{String,Any}("Entries" => Entries); aws_config=aws_config
+        "PutEvents",
+        Dict{String,Any}("Entries" => Entries);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_events(
@@ -1247,6 +1375,7 @@ function put_events(
         "PutEvents",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Entries" => Entries), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1263,7 +1392,10 @@ Services customers do not use this operation.
 """
 function put_partner_events(Entries; aws_config::AbstractAWSConfig=global_aws_config())
     return cloudwatch_events(
-        "PutPartnerEvents", Dict{String,Any}("Entries" => Entries); aws_config=aws_config
+        "PutPartnerEvents",
+        Dict{String,Any}("Entries" => Entries);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_partner_events(
@@ -1273,6 +1405,7 @@ function put_partner_events(
         "PutPartnerEvents",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Entries" => Entries), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1323,12 +1456,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   specify this StatementId when you run RemovePermission.
 """
 function put_permission(; aws_config::AbstractAWSConfig=global_aws_config())
-    return cloudwatch_events("PutPermission"; aws_config=aws_config)
+    return cloudwatch_events(
+        "PutPermission"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function put_permission(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return cloudwatch_events("PutPermission", params; aws_config=aws_config)
+    return cloudwatch_events(
+        "PutPermission", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1392,7 +1529,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function put_rule(Name; aws_config::AbstractAWSConfig=global_aws_config())
     return cloudwatch_events(
-        "PutRule", Dict{String,Any}("Name" => Name); aws_config=aws_config
+        "PutRule",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_rule(
@@ -1402,6 +1542,7 @@ function put_rule(
         "PutRule",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1479,6 +1620,7 @@ function put_targets(Rule, Targets; aws_config::AbstractAWSConfig=global_aws_con
         "PutTargets",
         Dict{String,Any}("Rule" => Rule, "Targets" => Targets);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_targets(
@@ -1495,6 +1637,7 @@ function put_targets(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1516,12 +1659,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   to put events to the default event bus.
 """
 function remove_permission(; aws_config::AbstractAWSConfig=global_aws_config())
-    return cloudwatch_events("RemovePermission"; aws_config=aws_config)
+    return cloudwatch_events(
+        "RemovePermission"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function remove_permission(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return cloudwatch_events("RemovePermission", params; aws_config=aws_config)
+    return cloudwatch_events(
+        "RemovePermission", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1553,6 +1700,7 @@ function remove_targets(Ids, Rule; aws_config::AbstractAWSConfig=global_aws_conf
         "RemoveTargets",
         Dict{String,Any}("Ids" => Ids, "Rule" => Rule);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function remove_targets(
@@ -1567,6 +1715,7 @@ function remove_targets(
             mergewith(_merge, Dict{String,Any}("Ids" => Ids, "Rule" => Rule), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1615,6 +1764,7 @@ function start_replay(
             "ReplayName" => ReplayName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_replay(
@@ -1642,6 +1792,7 @@ function start_replay(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1670,6 +1821,7 @@ function tag_resource(ResourceARN, Tags; aws_config::AbstractAWSConfig=global_aw
         "TagResource",
         Dict{String,Any}("ResourceARN" => ResourceARN, "Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -1688,6 +1840,7 @@ function tag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1716,6 +1869,7 @@ function test_event_pattern(
         "TestEventPattern",
         Dict{String,Any}("Event" => Event, "EventPattern" => EventPattern);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function test_event_pattern(
@@ -1734,6 +1888,7 @@ function test_event_pattern(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1756,6 +1911,7 @@ function untag_resource(
         "UntagResource",
         Dict{String,Any}("ResourceARN" => ResourceARN, "TagKeys" => TagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -1774,6 +1930,7 @@ function untag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1797,7 +1954,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function update_api_destination(Name; aws_config::AbstractAWSConfig=global_aws_config())
     return cloudwatch_events(
-        "UpdateApiDestination", Dict{String,Any}("Name" => Name); aws_config=aws_config
+        "UpdateApiDestination",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_api_destination(
@@ -1807,6 +1967,7 @@ function update_api_destination(
         "UpdateApiDestination",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1830,6 +1991,7 @@ function update_archive(ArchiveName; aws_config::AbstractAWSConfig=global_aws_co
         "UpdateArchive",
         Dict{String,Any}("ArchiveName" => ArchiveName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_archive(
@@ -1843,6 +2005,7 @@ function update_archive(
             mergewith(_merge, Dict{String,Any}("ArchiveName" => ArchiveName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1863,7 +2026,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function update_connection(Name; aws_config::AbstractAWSConfig=global_aws_config())
     return cloudwatch_events(
-        "UpdateConnection", Dict{String,Any}("Name" => Name); aws_config=aws_config
+        "UpdateConnection",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_connection(
@@ -1873,5 +2039,6 @@ function update_connection(
         "UpdateConnection",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/cloudwatch_logs.jl
+++ b/src/services/cloudwatch_logs.jl
@@ -34,6 +34,7 @@ function associate_kms_key(
         "AssociateKmsKey",
         Dict{String,Any}("kmsKeyId" => kmsKeyId, "logGroupName" => logGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_kms_key(
@@ -52,6 +53,7 @@ function associate_kms_key(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -67,7 +69,10 @@ Cancels the specified export task. The task must be in the PENDING or RUNNING st
 """
 function cancel_export_task(taskId; aws_config::AbstractAWSConfig=global_aws_config())
     return cloudwatch_logs(
-        "CancelExportTask", Dict{String,Any}("taskId" => taskId); aws_config=aws_config
+        "CancelExportTask",
+        Dict{String,Any}("taskId" => taskId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function cancel_export_task(
@@ -77,6 +82,7 @@ function cancel_export_task(
         "CancelExportTask",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("taskId" => taskId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -128,6 +134,7 @@ function create_export_task(
             "to" => to,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_export_task(
@@ -153,6 +160,7 @@ function create_export_task(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -193,6 +201,7 @@ function create_log_group(logGroupName; aws_config::AbstractAWSConfig=global_aws
         "CreateLogGroup",
         Dict{String,Any}("logGroupName" => logGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_log_group(
@@ -206,6 +215,7 @@ function create_log_group(
             mergewith(_merge, Dict{String,Any}("logGroupName" => logGroupName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -233,6 +243,7 @@ function create_log_stream(
         "CreateLogStream",
         Dict{String,Any}("logGroupName" => logGroupName, "logStreamName" => logStreamName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_log_stream(
@@ -253,6 +264,7 @@ function create_log_stream(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -275,6 +287,7 @@ function delete_destination(
         "DeleteDestination",
         Dict{String,Any}("destinationName" => destinationName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_destination(
@@ -290,6 +303,7 @@ function delete_destination(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -309,6 +323,7 @@ function delete_log_group(logGroupName; aws_config::AbstractAWSConfig=global_aws
         "DeleteLogGroup",
         Dict{String,Any}("logGroupName" => logGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_log_group(
@@ -322,6 +337,7 @@ function delete_log_group(
             mergewith(_merge, Dict{String,Any}("logGroupName" => logGroupName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -344,6 +360,7 @@ function delete_log_stream(
         "DeleteLogStream",
         Dict{String,Any}("logGroupName" => logGroupName, "logStreamName" => logStreamName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_log_stream(
@@ -364,6 +381,7 @@ function delete_log_stream(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -385,6 +403,7 @@ function delete_metric_filter(
         "DeleteMetricFilter",
         Dict{String,Any}("filterName" => filterName, "logGroupName" => logGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_metric_filter(
@@ -405,6 +424,7 @@ function delete_metric_filter(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -429,6 +449,7 @@ function delete_query_definition(
         "DeleteQueryDefinition",
         Dict{String,Any}("queryDefinitionId" => queryDefinitionId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_query_definition(
@@ -444,6 +465,7 @@ function delete_query_definition(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -459,12 +481,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"policyName"`: The name of the policy to be revoked. This parameter is required.
 """
 function delete_resource_policy(; aws_config::AbstractAWSConfig=global_aws_config())
-    return cloudwatch_logs("DeleteResourcePolicy"; aws_config=aws_config)
+    return cloudwatch_logs(
+        "DeleteResourcePolicy"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function delete_resource_policy(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return cloudwatch_logs("DeleteResourcePolicy", params; aws_config=aws_config)
+    return cloudwatch_logs(
+        "DeleteResourcePolicy",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -485,6 +514,7 @@ function delete_retention_policy(
         "DeleteRetentionPolicy",
         Dict{String,Any}("logGroupName" => logGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_retention_policy(
@@ -498,6 +528,7 @@ function delete_retention_policy(
             mergewith(_merge, Dict{String,Any}("logGroupName" => logGroupName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -519,6 +550,7 @@ function delete_subscription_filter(
         "DeleteSubscriptionFilter",
         Dict{String,Any}("filterName" => filterName, "logGroupName" => logGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_subscription_filter(
@@ -539,6 +571,7 @@ function delete_subscription_filter(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -558,12 +591,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   from a previous call.)
 """
 function describe_destinations(; aws_config::AbstractAWSConfig=global_aws_config())
-    return cloudwatch_logs("DescribeDestinations"; aws_config=aws_config)
+    return cloudwatch_logs(
+        "DescribeDestinations"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_destinations(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return cloudwatch_logs("DescribeDestinations", params; aws_config=aws_config)
+    return cloudwatch_logs(
+        "DescribeDestinations",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -585,12 +625,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   or one export tasks.
 """
 function describe_export_tasks(; aws_config::AbstractAWSConfig=global_aws_config())
-    return cloudwatch_logs("DescribeExportTasks"; aws_config=aws_config)
+    return cloudwatch_logs(
+        "DescribeExportTasks"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_export_tasks(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return cloudwatch_logs("DescribeExportTasks", params; aws_config=aws_config)
+    return cloudwatch_logs(
+        "DescribeExportTasks",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -614,12 +661,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   from a previous call.)
 """
 function describe_log_groups(; aws_config::AbstractAWSConfig=global_aws_config())
-    return cloudwatch_logs("DescribeLogGroups"; aws_config=aws_config)
+    return cloudwatch_logs(
+        "DescribeLogGroups"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_log_groups(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return cloudwatch_logs("DescribeLogGroups", params; aws_config=aws_config)
+    return cloudwatch_logs(
+        "DescribeLogGroups", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -660,6 +711,7 @@ function describe_log_streams(
         "DescribeLogStreams",
         Dict{String,Any}("logGroupName" => logGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_log_streams(
@@ -673,6 +725,7 @@ function describe_log_streams(
             mergewith(_merge, Dict{String,Any}("logGroupName" => logGroupName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -700,12 +753,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   from a previous call.)
 """
 function describe_metric_filters(; aws_config::AbstractAWSConfig=global_aws_config())
-    return cloudwatch_logs("DescribeMetricFilters"; aws_config=aws_config)
+    return cloudwatch_logs(
+        "DescribeMetricFilters"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_metric_filters(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return cloudwatch_logs("DescribeMetricFilters", params; aws_config=aws_config)
+    return cloudwatch_logs(
+        "DescribeMetricFilters",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -725,12 +785,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Valid values are Cancelled, Complete, Failed, Running, and Scheduled.
 """
 function describe_queries(; aws_config::AbstractAWSConfig=global_aws_config())
-    return cloudwatch_logs("DescribeQueries"; aws_config=aws_config)
+    return cloudwatch_logs(
+        "DescribeQueries"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_queries(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return cloudwatch_logs("DescribeQueries", params; aws_config=aws_config)
+    return cloudwatch_logs(
+        "DescribeQueries", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -749,12 +813,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   query definitions that have names that start with the prefix you specify.
 """
 function describe_query_definitions(; aws_config::AbstractAWSConfig=global_aws_config())
-    return cloudwatch_logs("DescribeQueryDefinitions"; aws_config=aws_config)
+    return cloudwatch_logs(
+        "DescribeQueryDefinitions"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_query_definitions(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return cloudwatch_logs("DescribeQueryDefinitions", params; aws_config=aws_config)
+    return cloudwatch_logs(
+        "DescribeQueryDefinitions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -770,12 +841,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`:
 """
 function describe_resource_policies(; aws_config::AbstractAWSConfig=global_aws_config())
-    return cloudwatch_logs("DescribeResourcePolicies"; aws_config=aws_config)
+    return cloudwatch_logs(
+        "DescribeResourcePolicies"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_resource_policies(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return cloudwatch_logs("DescribeResourcePolicies", params; aws_config=aws_config)
+    return cloudwatch_logs(
+        "DescribeResourcePolicies",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -805,6 +883,7 @@ function describe_subscription_filters(
         "DescribeSubscriptionFilters",
         Dict{String,Any}("logGroupName" => logGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_subscription_filters(
@@ -818,6 +897,7 @@ function describe_subscription_filters(
             mergewith(_merge, Dict{String,Any}("logGroupName" => logGroupName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -843,6 +923,7 @@ function disassociate_kms_key(
         "DisassociateKmsKey",
         Dict{String,Any}("logGroupName" => logGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disassociate_kms_key(
@@ -856,6 +937,7 @@ function disassociate_kms_key(
             mergewith(_merge, Dict{String,Any}("logGroupName" => logGroupName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -907,6 +989,7 @@ function filter_log_events(logGroupName; aws_config::AbstractAWSConfig=global_aw
         "FilterLogEvents",
         Dict{String,Any}("logGroupName" => logGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function filter_log_events(
@@ -920,6 +1003,7 @@ function filter_log_events(
             mergewith(_merge, Dict{String,Any}("logGroupName" => logGroupName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -962,6 +1046,7 @@ function get_log_events(
         "GetLogEvents",
         Dict{String,Any}("logGroupName" => logGroupName, "logStreamName" => logStreamName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_log_events(
@@ -982,6 +1067,7 @@ function get_log_events(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1014,6 +1100,7 @@ function get_log_group_fields(
         "GetLogGroupFields",
         Dict{String,Any}("logGroupName" => logGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_log_group_fields(
@@ -1027,6 +1114,7 @@ function get_log_group_fields(
             mergewith(_merge, Dict{String,Any}("logGroupName" => logGroupName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1051,6 +1139,7 @@ function get_log_record(logRecordPointer; aws_config::AbstractAWSConfig=global_a
         "GetLogRecord",
         Dict{String,Any}("logRecordPointer" => logRecordPointer);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_log_record(
@@ -1066,6 +1155,7 @@ function get_log_record(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1087,7 +1177,10 @@ see the final results.
 """
 function get_query_results(queryId; aws_config::AbstractAWSConfig=global_aws_config())
     return cloudwatch_logs(
-        "GetQueryResults", Dict{String,Any}("queryId" => queryId); aws_config=aws_config
+        "GetQueryResults",
+        Dict{String,Any}("queryId" => queryId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_query_results(
@@ -1097,6 +1190,7 @@ function get_query_results(
         "GetQueryResults",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("queryId" => queryId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1117,6 +1211,7 @@ function list_tags_log_group(
         "ListTagsLogGroup",
         Dict{String,Any}("logGroupName" => logGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags_log_group(
@@ -1130,6 +1225,7 @@ function list_tags_log_group(
             mergewith(_merge, Dict{String,Any}("logGroupName" => logGroupName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1165,6 +1261,7 @@ function put_destination(
             "targetArn" => targetArn,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_destination(
@@ -1188,6 +1285,7 @@ function put_destination(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1217,6 +1315,7 @@ function put_destination_policy(
             "accessPolicy" => accessPolicy, "destinationName" => destinationName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_destination_policy(
@@ -1237,6 +1336,7 @@ function put_destination_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1292,6 +1392,7 @@ function put_log_events(
             "logStreamName" => logStreamName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_log_events(
@@ -1315,6 +1416,7 @@ function put_log_events(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1360,6 +1462,7 @@ function put_metric_filter(
             "metricTransformations" => metricTransformations,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_metric_filter(
@@ -1385,6 +1488,7 @@ function put_metric_filter(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1427,6 +1531,7 @@ function put_query_definition(
         "PutQueryDefinition",
         Dict{String,Any}("name" => name, "queryString" => queryString);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_query_definition(
@@ -1445,6 +1550,7 @@ function put_query_definition(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1475,12 +1581,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"policyName"`: Name of the new policy. This parameter is required.
 """
 function put_resource_policy(; aws_config::AbstractAWSConfig=global_aws_config())
-    return cloudwatch_logs("PutResourcePolicy"; aws_config=aws_config)
+    return cloudwatch_logs(
+        "PutResourcePolicy"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function put_resource_policy(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return cloudwatch_logs("PutResourcePolicy", params; aws_config=aws_config)
+    return cloudwatch_logs(
+        "PutResourcePolicy", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1504,6 +1614,7 @@ function put_retention_policy(
             "logGroupName" => logGroupName, "retentionInDays" => retentionInDays
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_retention_policy(
@@ -1524,6 +1635,7 @@ function put_retention_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1588,6 +1700,7 @@ function put_subscription_filter(
             "logGroupName" => logGroupName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_subscription_filter(
@@ -1613,6 +1726,7 @@ function put_subscription_filter(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1656,6 +1770,7 @@ function start_query(
             "endTime" => endTime, "queryString" => queryString, "startTime" => startTime
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_query(
@@ -1679,6 +1794,7 @@ function start_query(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1696,7 +1812,10 @@ the operation returns an error indicating that the specified query is not runnin
 """
 function stop_query(queryId; aws_config::AbstractAWSConfig=global_aws_config())
     return cloudwatch_logs(
-        "StopQuery", Dict{String,Any}("queryId" => queryId); aws_config=aws_config
+        "StopQuery",
+        Dict{String,Any}("queryId" => queryId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function stop_query(
@@ -1706,6 +1825,7 @@ function stop_query(
         "StopQuery",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("queryId" => queryId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1733,6 +1853,7 @@ function tag_log_group(
         "TagLogGroup",
         Dict{String,Any}("logGroupName" => logGroupName, "tags" => tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_log_group(
@@ -1751,6 +1872,7 @@ function tag_log_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1775,6 +1897,7 @@ function test_metric_filter(
             "filterPattern" => filterPattern, "logEventMessages" => logEventMessages
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function test_metric_filter(
@@ -1795,6 +1918,7 @@ function test_metric_filter(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1819,6 +1943,7 @@ function untag_log_group(
         "UntagLogGroup",
         Dict{String,Any}("logGroupName" => logGroupName, "tags" => tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_log_group(
@@ -1837,5 +1962,6 @@ function untag_log_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/codeartifact.jl
+++ b/src/services/codeartifact.jl
@@ -42,6 +42,7 @@ function associate_external_connection(
             "repository" => repository,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_external_connection(
@@ -66,6 +67,7 @@ function associate_external_connection(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -129,6 +131,7 @@ function copy_package_versions(
             "source-repository" => source_repository,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function copy_package_versions(
@@ -157,6 +160,7 @@ function copy_package_versions(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -193,7 +197,11 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function create_domain(domain; aws_config::AbstractAWSConfig=global_aws_config())
     return codeartifact(
-        "POST", "/v1/domain", Dict{String,Any}("domain" => domain); aws_config=aws_config
+        "POST",
+        "/v1/domain",
+        Dict{String,Any}("domain" => domain);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_domain(
@@ -204,6 +212,7 @@ function create_domain(
         "/v1/domain",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("domain" => domain), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -236,6 +245,7 @@ function create_repository(
         "/v1/repository",
         Dict{String,Any}("domain" => domain, "repository" => repository);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_repository(
@@ -255,6 +265,7 @@ function create_repository(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -275,7 +286,11 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function delete_domain(domain; aws_config::AbstractAWSConfig=global_aws_config())
     return codeartifact(
-        "DELETE", "/v1/domain", Dict{String,Any}("domain" => domain); aws_config=aws_config
+        "DELETE",
+        "/v1/domain",
+        Dict{String,Any}("domain" => domain);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_domain(
@@ -286,6 +301,7 @@ function delete_domain(
         "/v1/domain",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("domain" => domain), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -314,6 +330,7 @@ function delete_domain_permissions_policy(
         "/v1/domain/permissions/policy",
         Dict{String,Any}("domain" => domain);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_domain_permissions_policy(
@@ -324,6 +341,7 @@ function delete_domain_permissions_policy(
         "/v1/domain/permissions/policy",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("domain" => domain), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -375,6 +393,7 @@ function delete_package_versions(
             "versions" => versions,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_package_versions(
@@ -403,6 +422,7 @@ function delete_package_versions(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -429,6 +449,7 @@ function delete_repository(
         "/v1/repository",
         Dict{String,Any}("domain" => domain, "repository" => repository);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_repository(
@@ -448,6 +469,7 @@ function delete_repository(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -484,6 +506,7 @@ function delete_repository_permissions_policy(
         "/v1/repository/permissions/policies",
         Dict{String,Any}("domain" => domain, "repository" => repository);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_repository_permissions_policy(
@@ -503,6 +526,7 @@ function delete_repository_permissions_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -522,7 +546,11 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function describe_domain(domain; aws_config::AbstractAWSConfig=global_aws_config())
     return codeartifact(
-        "GET", "/v1/domain", Dict{String,Any}("domain" => domain); aws_config=aws_config
+        "GET",
+        "/v1/domain",
+        Dict{String,Any}("domain" => domain);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_domain(
@@ -533,6 +561,7 @@ function describe_domain(
         "/v1/domain",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("domain" => domain), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -580,6 +609,7 @@ function describe_package_version(
             "version" => version,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_package_version(
@@ -608,6 +638,7 @@ function describe_package_version(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -635,6 +666,7 @@ function describe_repository(
         "/v1/repository",
         Dict{String,Any}("domain" => domain, "repository" => repository);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_repository(
@@ -654,6 +686,7 @@ function describe_repository(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -691,6 +724,7 @@ function disassociate_external_connection(
             "repository" => repository,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disassociate_external_connection(
@@ -715,6 +749,7 @@ function disassociate_external_connection(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -768,6 +803,7 @@ function dispose_package_versions(
             "versions" => versions,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function dispose_package_versions(
@@ -796,6 +832,7 @@ function dispose_package_versions(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -836,6 +873,7 @@ function get_authorization_token(domain; aws_config::AbstractAWSConfig=global_aw
         "/v1/authorization-token",
         Dict{String,Any}("domain" => domain);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_authorization_token(
@@ -846,6 +884,7 @@ function get_authorization_token(
         "/v1/authorization-token",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("domain" => domain), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -874,6 +913,7 @@ function get_domain_permissions_policy(
         "/v1/domain/permissions/policy",
         Dict{String,Any}("domain" => domain);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_domain_permissions_policy(
@@ -884,6 +924,7 @@ function get_domain_permissions_policy(
         "/v1/domain/permissions/policy",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("domain" => domain), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -937,6 +978,7 @@ function get_package_version_asset(
             "version" => version,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_package_version_asset(
@@ -967,6 +1009,7 @@ function get_package_version_asset(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1017,6 +1060,7 @@ function get_package_version_readme(
             "version" => version,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_package_version_readme(
@@ -1045,6 +1089,7 @@ function get_package_version_readme(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1076,6 +1121,7 @@ function get_repository_endpoint(
             "domain" => domain, "format" => format, "repository" => repository
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_repository_endpoint(
@@ -1098,6 +1144,7 @@ function get_repository_endpoint(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1126,6 +1173,7 @@ function get_repository_permissions_policy(
         "/v1/repository/permissions/policy",
         Dict{String,Any}("domain" => domain, "repository" => repository);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_repository_permissions_policy(
@@ -1145,6 +1193,7 @@ function get_repository_permissions_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1162,12 +1211,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   previous response in the next request to retrieve the next set of results.
 """
 function list_domains(; aws_config::AbstractAWSConfig=global_aws_config())
-    return codeartifact("POST", "/v1/domains"; aws_config=aws_config)
+    return codeartifact(
+        "POST", "/v1/domains"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_domains(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return codeartifact("POST", "/v1/domains", params; aws_config=aws_config)
+    return codeartifact(
+        "POST",
+        "/v1/domains",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1219,6 +1276,7 @@ function list_package_version_assets(
             "version" => version,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_package_version_assets(
@@ -1247,6 +1305,7 @@ function list_package_version_assets(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1301,6 +1360,7 @@ function list_package_version_dependencies(
             "version" => version,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_package_version_dependencies(
@@ -1329,6 +1389,7 @@ function list_package_version_dependencies(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1379,6 +1440,7 @@ function list_package_versions(
             "repository" => repository,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_package_versions(
@@ -1405,6 +1467,7 @@ function list_package_versions(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1446,6 +1509,7 @@ function list_packages(
         "/v1/packages",
         Dict{String,Any}("domain" => domain, "repository" => repository);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_packages(
@@ -1465,6 +1529,7 @@ function list_packages(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1484,12 +1549,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   with names that start with repositoryPrefix are returned.
 """
 function list_repositories(; aws_config::AbstractAWSConfig=global_aws_config())
-    return codeartifact("POST", "/v1/repositories"; aws_config=aws_config)
+    return codeartifact(
+        "POST", "/v1/repositories"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_repositories(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return codeartifact("POST", "/v1/repositories", params; aws_config=aws_config)
+    return codeartifact(
+        "POST",
+        "/v1/repositories",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1522,6 +1595,7 @@ function list_repositories_in_domain(
         "/v1/domain/repositories",
         Dict{String,Any}("domain" => domain);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_repositories_in_domain(
@@ -1532,6 +1606,7 @@ function list_repositories_in_domain(
         "/v1/domain/repositories",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("domain" => domain), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1554,6 +1629,7 @@ function list_tags_for_resource(
         "/v1/tags",
         Dict{String,Any}("resourceArn" => resourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags_for_resource(
@@ -1568,6 +1644,7 @@ function list_tags_for_resource(
             mergewith(_merge, Dict{String,Any}("resourceArn" => resourceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1601,6 +1678,7 @@ function put_domain_permissions_policy(
         "/v1/domain/permissions/policy",
         Dict{String,Any}("domain" => domain, "policyDocument" => policyDocument);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_domain_permissions_policy(
@@ -1620,6 +1698,7 @@ function put_domain_permissions_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1660,6 +1739,7 @@ function put_repository_permissions_policy(
             "repository" => repository,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_repository_permissions_policy(
@@ -1684,6 +1764,7 @@ function put_repository_permissions_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1705,6 +1786,7 @@ function tag_resource(resourceArn, tags; aws_config::AbstractAWSConfig=global_aw
         "/v1/tag",
         Dict{String,Any}("resourceArn" => resourceArn, "tags" => tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -1724,6 +1806,7 @@ function tag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1747,6 +1830,7 @@ function untag_resource(
         "/v1/untag",
         Dict{String,Any}("resourceArn" => resourceArn, "tagKeys" => tagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -1766,6 +1850,7 @@ function untag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1823,6 +1908,7 @@ function update_package_versions_status(
             "versions" => versions,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_package_versions_status(
@@ -1853,6 +1939,7 @@ function update_package_versions_status(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1884,6 +1971,7 @@ function update_repository(
         "/v1/repository",
         Dict{String,Any}("domain" => domain, "repository" => repository);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_repository(
@@ -1903,5 +1991,6 @@ function update_repository(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/codebuild.jl
+++ b/src/services/codebuild.jl
@@ -16,7 +16,10 @@ Deletes one or more builds.
 """
 function batch_delete_builds(ids; aws_config::AbstractAWSConfig=global_aws_config())
     return codebuild(
-        "BatchDeleteBuilds", Dict{String,Any}("ids" => ids); aws_config=aws_config
+        "BatchDeleteBuilds",
+        Dict{String,Any}("ids" => ids);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_delete_builds(
@@ -26,6 +29,7 @@ function batch_delete_builds(
         "BatchDeleteBuilds",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("ids" => ids), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -41,7 +45,10 @@ Retrieves information about one or more batch builds.
 """
 function batch_get_build_batches(ids; aws_config::AbstractAWSConfig=global_aws_config())
     return codebuild(
-        "BatchGetBuildBatches", Dict{String,Any}("ids" => ids); aws_config=aws_config
+        "BatchGetBuildBatches",
+        Dict{String,Any}("ids" => ids);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_get_build_batches(
@@ -51,6 +58,7 @@ function batch_get_build_batches(
         "BatchGetBuildBatches",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("ids" => ids), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -66,7 +74,10 @@ Gets information about one or more builds.
 """
 function batch_get_builds(ids; aws_config::AbstractAWSConfig=global_aws_config())
     return codebuild(
-        "BatchGetBuilds", Dict{String,Any}("ids" => ids); aws_config=aws_config
+        "BatchGetBuilds",
+        Dict{String,Any}("ids" => ids);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_get_builds(
@@ -76,6 +87,7 @@ function batch_get_builds(
         "BatchGetBuilds",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("ids" => ids), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -93,7 +105,10 @@ Gets information about one or more build projects.
 """
 function batch_get_projects(names; aws_config::AbstractAWSConfig=global_aws_config())
     return codebuild(
-        "BatchGetProjects", Dict{String,Any}("names" => names); aws_config=aws_config
+        "BatchGetProjects",
+        Dict{String,Any}("names" => names);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_get_projects(
@@ -103,6 +118,7 @@ function batch_get_projects(
         "BatchGetProjects",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("names" => names), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -124,6 +140,7 @@ function batch_get_report_groups(
         "BatchGetReportGroups",
         Dict{String,Any}("reportGroupArns" => reportGroupArns);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_get_report_groups(
@@ -139,6 +156,7 @@ function batch_get_report_groups(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -157,6 +175,7 @@ function batch_get_reports(reportArns; aws_config::AbstractAWSConfig=global_aws_
         "BatchGetReports",
         Dict{String,Any}("reportArns" => reportArns);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_get_reports(
@@ -170,6 +189,7 @@ function batch_get_reports(
             mergewith(_merge, Dict{String,Any}("reportArns" => reportArns), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -258,6 +278,7 @@ function create_project(
             "source" => source,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_project(
@@ -285,6 +306,7 @@ function create_project(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -313,6 +335,7 @@ function create_report_group(
         "CreateReportGroup",
         Dict{String,Any}("exportConfig" => exportConfig, "name" => name, "type" => type);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_report_group(
@@ -334,6 +357,7 @@ function create_report_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -371,6 +395,7 @@ function create_webhook(projectName; aws_config::AbstractAWSConfig=global_aws_co
         "CreateWebhook",
         Dict{String,Any}("projectName" => projectName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_webhook(
@@ -384,6 +409,7 @@ function create_webhook(
             mergewith(_merge, Dict{String,Any}("projectName" => projectName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -399,7 +425,10 @@ Deletes a batch build.
 """
 function delete_build_batch(id; aws_config::AbstractAWSConfig=global_aws_config())
     return codebuild(
-        "DeleteBuildBatch", Dict{String,Any}("id" => id); aws_config=aws_config
+        "DeleteBuildBatch",
+        Dict{String,Any}("id" => id);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_build_batch(
@@ -409,6 +438,7 @@ function delete_build_batch(
         "DeleteBuildBatch",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("id" => id), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -424,7 +454,10 @@ end
 """
 function delete_project(name; aws_config::AbstractAWSConfig=global_aws_config())
     return codebuild(
-        "DeleteProject", Dict{String,Any}("name" => name); aws_config=aws_config
+        "DeleteProject",
+        Dict{String,Any}("name" => name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_project(
@@ -434,6 +467,7 @@ function delete_project(
         "DeleteProject",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("name" => name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -448,7 +482,12 @@ end
 
 """
 function delete_report(arn; aws_config::AbstractAWSConfig=global_aws_config())
-    return codebuild("DeleteReport", Dict{String,Any}("arn" => arn); aws_config=aws_config)
+    return codebuild(
+        "DeleteReport",
+        Dict{String,Any}("arn" => arn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_report(
     arn, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -457,6 +496,7 @@ function delete_report(
         "DeleteReport",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("arn" => arn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -479,7 +519,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function delete_report_group(arn; aws_config::AbstractAWSConfig=global_aws_config())
     return codebuild(
-        "DeleteReportGroup", Dict{String,Any}("arn" => arn); aws_config=aws_config
+        "DeleteReportGroup",
+        Dict{String,Any}("arn" => arn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_report_group(
@@ -489,6 +532,7 @@ function delete_report_group(
         "DeleteReportGroup",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("arn" => arn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -509,6 +553,7 @@ function delete_resource_policy(
         "DeleteResourcePolicy",
         Dict{String,Any}("resourceArn" => resourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_resource_policy(
@@ -522,6 +567,7 @@ function delete_resource_policy(
             mergewith(_merge, Dict{String,Any}("resourceArn" => resourceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -537,7 +583,10 @@ end
 """
 function delete_source_credentials(arn; aws_config::AbstractAWSConfig=global_aws_config())
     return codebuild(
-        "DeleteSourceCredentials", Dict{String,Any}("arn" => arn); aws_config=aws_config
+        "DeleteSourceCredentials",
+        Dict{String,Any}("arn" => arn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_source_credentials(
@@ -547,6 +596,7 @@ function delete_source_credentials(
         "DeleteSourceCredentials",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("arn" => arn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -567,6 +617,7 @@ function delete_webhook(projectName; aws_config::AbstractAWSConfig=global_aws_co
         "DeleteWebhook",
         Dict{String,Any}("projectName" => projectName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_webhook(
@@ -580,6 +631,7 @@ function delete_webhook(
             mergewith(_merge, Dict{String,Any}("projectName" => projectName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -612,6 +664,7 @@ function describe_code_coverages(
         "DescribeCodeCoverages",
         Dict{String,Any}("reportArn" => reportArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_code_coverages(
@@ -625,6 +678,7 @@ function describe_code_coverages(
             mergewith(_merge, Dict{String,Any}("reportArn" => reportArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -655,6 +709,7 @@ function describe_test_cases(reportArn; aws_config::AbstractAWSConfig=global_aws
         "DescribeTestCases",
         Dict{String,Any}("reportArn" => reportArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_test_cases(
@@ -668,6 +723,7 @@ function describe_test_cases(
             mergewith(_merge, Dict{String,Any}("reportArn" => reportArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -703,6 +759,7 @@ function get_report_group_trend(
         "GetReportGroupTrend",
         Dict{String,Any}("reportGroupArn" => reportGroupArn, "trendField" => trendField);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_report_group_trend(
@@ -723,6 +780,7 @@ function get_report_group_trend(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -741,6 +799,7 @@ function get_resource_policy(resourceArn; aws_config::AbstractAWSConfig=global_a
         "GetResourcePolicy",
         Dict{String,Any}("resourceArn" => resourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_resource_policy(
@@ -754,6 +813,7 @@ function get_resource_policy(
             mergewith(_merge, Dict{String,Any}("resourceArn" => resourceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -789,6 +849,7 @@ function import_source_credentials(
             "authType" => authType, "serverType" => serverType, "token" => token
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function import_source_credentials(
@@ -810,6 +871,7 @@ function import_source_credentials(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -830,6 +892,7 @@ function invalidate_project_cache(
         "InvalidateProjectCache",
         Dict{String,Any}("projectName" => projectName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function invalidate_project_cache(
@@ -843,6 +906,7 @@ function invalidate_project_cache(
             mergewith(_merge, Dict{String,Any}("projectName" => projectName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -864,12 +928,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   DESCENDING: List the batch build identifiers in descending order by identifier.
 """
 function list_build_batches(; aws_config::AbstractAWSConfig=global_aws_config())
-    return codebuild("ListBuildBatches"; aws_config=aws_config)
+    return codebuild(
+        "ListBuildBatches"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_build_batches(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return codebuild("ListBuildBatches", params; aws_config=aws_config)
+    return codebuild(
+        "ListBuildBatches", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -891,12 +959,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   DESCENDING: List the batch build identifiers in descending order by identifier.
 """
 function list_build_batches_for_project(; aws_config::AbstractAWSConfig=global_aws_config())
-    return codebuild("ListBuildBatchesForProject"; aws_config=aws_config)
+    return codebuild(
+        "ListBuildBatchesForProject"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_build_batches_for_project(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return codebuild("ListBuildBatchesForProject", params; aws_config=aws_config)
+    return codebuild(
+        "ListBuildBatchesForProject",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -917,12 +992,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   order by build ID.
 """
 function list_builds(; aws_config::AbstractAWSConfig=global_aws_config())
-    return codebuild("ListBuilds"; aws_config=aws_config)
+    return codebuild("ListBuilds"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_builds(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return codebuild("ListBuilds", params; aws_config=aws_config)
+    return codebuild(
+        "ListBuilds", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -954,6 +1031,7 @@ function list_builds_for_project(
         "ListBuildsForProject",
         Dict{String,Any}("projectName" => projectName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_builds_for_project(
@@ -967,6 +1045,7 @@ function list_builds_for_project(
             mergewith(_merge, Dict{String,Any}("projectName" => projectName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -980,12 +1059,21 @@ Gets information about Docker images that are managed by CodeBuild.
 function list_curated_environment_images(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return codebuild("ListCuratedEnvironmentImages"; aws_config=aws_config)
+    return codebuild(
+        "ListCuratedEnvironmentImages";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_curated_environment_images(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return codebuild("ListCuratedEnvironmentImages", params; aws_config=aws_config)
+    return codebuild(
+        "ListCuratedEnvironmentImages",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1012,12 +1100,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   to specify the criterion to be used to list build project names.
 """
 function list_projects(; aws_config::AbstractAWSConfig=global_aws_config())
-    return codebuild("ListProjects"; aws_config=aws_config)
+    return codebuild("ListProjects"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_projects(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return codebuild("ListProjects", params; aws_config=aws_config)
+    return codebuild(
+        "ListProjects", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1045,12 +1135,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Valid values are ASCENDING and DESCENDING.
 """
 function list_report_groups(; aws_config::AbstractAWSConfig=global_aws_config())
-    return codebuild("ListReportGroups"; aws_config=aws_config)
+    return codebuild(
+        "ListReportGroups"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_report_groups(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return codebuild("ListReportGroups", params; aws_config=aws_config)
+    return codebuild(
+        "ListReportGroups", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1077,12 +1171,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   
 """
 function list_reports(; aws_config::AbstractAWSConfig=global_aws_config())
-    return codebuild("ListReports"; aws_config=aws_config)
+    return codebuild("ListReports"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_reports(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return codebuild("ListReports", params; aws_config=aws_config)
+    return codebuild(
+        "ListReports", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1117,6 +1213,7 @@ function list_reports_for_report_group(
         "ListReportsForReportGroup",
         Dict{String,Any}("reportGroupArn" => reportGroupArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_reports_for_report_group(
@@ -1130,6 +1227,7 @@ function list_reports_for_report_group(
             mergewith(_merge, Dict{String,Any}("reportGroupArn" => reportGroupArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1158,12 +1256,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   ASCENDING: List in ascending order.    DESCENDING: List in descending order.
 """
 function list_shared_projects(; aws_config::AbstractAWSConfig=global_aws_config())
-    return codebuild("ListSharedProjects"; aws_config=aws_config)
+    return codebuild(
+        "ListSharedProjects"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_shared_projects(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return codebuild("ListSharedProjects", params; aws_config=aws_config)
+    return codebuild(
+        "ListSharedProjects", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1192,12 +1294,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   ASCENDING: List in ascending order.    DESCENDING: List in descending order.
 """
 function list_shared_report_groups(; aws_config::AbstractAWSConfig=global_aws_config())
-    return codebuild("ListSharedReportGroups"; aws_config=aws_config)
+    return codebuild(
+        "ListSharedReportGroups"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_shared_report_groups(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return codebuild("ListSharedReportGroups", params; aws_config=aws_config)
+    return codebuild(
+        "ListSharedReportGroups",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1208,12 +1317,19 @@ end
 
 """
 function list_source_credentials(; aws_config::AbstractAWSConfig=global_aws_config())
-    return codebuild("ListSourceCredentials"; aws_config=aws_config)
+    return codebuild(
+        "ListSourceCredentials"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_source_credentials(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return codebuild("ListSourceCredentials", params; aws_config=aws_config)
+    return codebuild(
+        "ListSourceCredentials",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1236,6 +1352,7 @@ function put_resource_policy(
         "PutResourcePolicy",
         Dict{String,Any}("policy" => policy, "resourceArn" => resourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_resource_policy(
@@ -1254,6 +1371,7 @@ function put_resource_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1272,12 +1390,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   change a parameter, CodeBuild returns a parameter mismatch error.
 """
 function retry_build(; aws_config::AbstractAWSConfig=global_aws_config())
-    return codebuild("RetryBuild"; aws_config=aws_config)
+    return codebuild("RetryBuild"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function retry_build(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return codebuild("RetryBuild", params; aws_config=aws_config)
+    return codebuild(
+        "RetryBuild", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1296,12 +1416,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"retryType"`: Specifies the type of retry to perform.
 """
 function retry_build_batch(; aws_config::AbstractAWSConfig=global_aws_config())
-    return codebuild("RetryBuildBatch"; aws_config=aws_config)
+    return codebuild(
+        "RetryBuildBatch"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function retry_build_batch(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return codebuild("RetryBuildBatch", params; aws_config=aws_config)
+    return codebuild(
+        "RetryBuildBatch", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1418,7 +1542,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function start_build(projectName; aws_config::AbstractAWSConfig=global_aws_config())
     return codebuild(
-        "StartBuild", Dict{String,Any}("projectName" => projectName); aws_config=aws_config
+        "StartBuild",
+        Dict{String,Any}("projectName" => projectName);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_build(
@@ -1432,6 +1559,7 @@ function start_build(
             mergewith(_merge, Dict{String,Any}("projectName" => projectName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1549,6 +1677,7 @@ function start_build_batch(projectName; aws_config::AbstractAWSConfig=global_aws
         "StartBuildBatch",
         Dict{String,Any}("projectName" => projectName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_build_batch(
@@ -1562,6 +1691,7 @@ function start_build_batch(
             mergewith(_merge, Dict{String,Any}("projectName" => projectName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1576,7 +1706,12 @@ Attempts to stop running a build.
 
 """
 function stop_build(id; aws_config::AbstractAWSConfig=global_aws_config())
-    return codebuild("StopBuild", Dict{String,Any}("id" => id); aws_config=aws_config)
+    return codebuild(
+        "StopBuild",
+        Dict{String,Any}("id" => id);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function stop_build(
     id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -1585,6 +1720,7 @@ function stop_build(
         "StopBuild",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("id" => id), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1599,7 +1735,12 @@ Stops a running batch build.
 
 """
 function stop_build_batch(id; aws_config::AbstractAWSConfig=global_aws_config())
-    return codebuild("StopBuildBatch", Dict{String,Any}("id" => id); aws_config=aws_config)
+    return codebuild(
+        "StopBuildBatch",
+        Dict{String,Any}("id" => id);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function stop_build_batch(
     id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -1608,6 +1749,7 @@ function stop_build_batch(
         "StopBuildBatch",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("id" => id), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1681,7 +1823,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function update_project(name; aws_config::AbstractAWSConfig=global_aws_config())
     return codebuild(
-        "UpdateProject", Dict{String,Any}("name" => name); aws_config=aws_config
+        "UpdateProject",
+        Dict{String,Any}("name" => name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_project(
@@ -1691,6 +1836,7 @@ function update_project(
         "UpdateProject",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("name" => name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1735,6 +1881,7 @@ function update_project_visibility(
             "projectArn" => projectArn, "projectVisibility" => projectVisibility
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_project_visibility(
@@ -1755,6 +1902,7 @@ function update_project_visibility(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1778,7 +1926,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function update_report_group(arn; aws_config::AbstractAWSConfig=global_aws_config())
     return codebuild(
-        "UpdateReportGroup", Dict{String,Any}("arn" => arn); aws_config=aws_config
+        "UpdateReportGroup",
+        Dict{String,Any}("arn" => arn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_report_group(
@@ -1788,6 +1939,7 @@ function update_report_group(
         "UpdateReportGroup",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("arn" => arn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1820,6 +1972,7 @@ function update_webhook(projectName; aws_config::AbstractAWSConfig=global_aws_co
         "UpdateWebhook",
         Dict{String,Any}("projectName" => projectName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_webhook(
@@ -1833,5 +1986,6 @@ function update_webhook(
             mergewith(_merge, Dict{String,Any}("projectName" => projectName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/codecommit.jl
+++ b/src/services/codecommit.jl
@@ -33,6 +33,7 @@ function associate_approval_rule_template_with_repository(
             "repositoryName" => repositoryName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_approval_rule_template_with_repository(
@@ -54,6 +55,7 @@ function associate_approval_rule_template_with_repository(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -84,6 +86,7 @@ function batch_associate_approval_rule_template_with_repositories(
             "repositoryNames" => repositoryNames,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_associate_approval_rule_template_with_repositories(
@@ -105,6 +108,7 @@ function batch_associate_approval_rule_template_with_repositories(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -157,6 +161,7 @@ function batch_describe_merge_conflicts(
             "sourceCommitSpecifier" => sourceCommitSpecifier,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_describe_merge_conflicts(
@@ -182,6 +187,7 @@ function batch_describe_merge_conflicts(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -212,6 +218,7 @@ function batch_disassociate_approval_rule_template_from_repositories(
             "repositoryNames" => repositoryNames,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_disassociate_approval_rule_template_from_repositories(
@@ -233,6 +240,7 @@ function batch_disassociate_approval_rule_template_from_repositories(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -255,6 +263,7 @@ function batch_get_commits(
         "BatchGetCommits",
         Dict{String,Any}("commitIds" => commitIds, "repositoryName" => repositoryName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_get_commits(
@@ -275,6 +284,7 @@ function batch_get_commits(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -300,6 +310,7 @@ function batch_get_repositories(
         "BatchGetRepositories",
         Dict{String,Any}("repositoryNames" => repositoryNames);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_get_repositories(
@@ -315,6 +326,7 @@ function batch_get_repositories(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -369,6 +381,7 @@ function create_approval_rule_template(
             "approvalRuleTemplateName" => approvalRuleTemplateName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_approval_rule_template(
@@ -390,6 +403,7 @@ function create_approval_rule_template(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -418,6 +432,7 @@ function create_branch(
             "repositoryName" => repositoryName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_branch(
@@ -441,6 +456,7 @@ function create_branch(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -478,6 +494,7 @@ function create_commit(
         "CreateCommit",
         Dict{String,Any}("branchName" => branchName, "repositoryName" => repositoryName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_commit(
@@ -498,6 +515,7 @@ function create_commit(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -533,6 +551,7 @@ function create_pull_request(
             "targets" => targets, "title" => title, "clientRequestToken" => string(uuid4())
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_pull_request(
@@ -555,6 +574,7 @@ function create_pull_request(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -601,6 +621,7 @@ function create_pull_request_approval_rule(
             "pullRequestId" => pullRequestId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_pull_request_approval_rule(
@@ -624,6 +645,7 @@ function create_pull_request_approval_rule(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -657,6 +679,7 @@ function create_repository(
         "CreateRepository",
         Dict{String,Any}("repositoryName" => repositoryName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_repository(
@@ -670,6 +693,7 @@ function create_repository(
             mergewith(_merge, Dict{String,Any}("repositoryName" => repositoryName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -729,6 +753,7 @@ function create_unreferenced_merge_commit(
             "sourceCommitSpecifier" => sourceCommitSpecifier,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_unreferenced_merge_commit(
@@ -754,6 +779,7 @@ function create_unreferenced_merge_commit(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -775,6 +801,7 @@ function delete_approval_rule_template(
         "DeleteApprovalRuleTemplate",
         Dict{String,Any}("approvalRuleTemplateName" => approvalRuleTemplateName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_approval_rule_template(
@@ -792,6 +819,7 @@ function delete_approval_rule_template(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -814,6 +842,7 @@ function delete_branch(
         "DeleteBranch",
         Dict{String,Any}("branchName" => branchName, "repositoryName" => repositoryName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_branch(
@@ -834,6 +863,7 @@ function delete_branch(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -855,6 +885,7 @@ function delete_comment_content(
         "DeleteCommentContent",
         Dict{String,Any}("commentId" => commentId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_comment_content(
@@ -868,6 +899,7 @@ function delete_comment_content(
             mergewith(_merge, Dict{String,Any}("commentId" => commentId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -920,6 +952,7 @@ function delete_file(
             "repositoryName" => repositoryName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_file(
@@ -945,6 +978,7 @@ function delete_file(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -973,6 +1007,7 @@ function delete_pull_request_approval_rule(
             "approvalRuleName" => approvalRuleName, "pullRequestId" => pullRequestId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_pull_request_approval_rule(
@@ -993,6 +1028,7 @@ function delete_pull_request_approval_rule(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1015,6 +1051,7 @@ function delete_repository(
         "DeleteRepository",
         Dict{String,Any}("repositoryName" => repositoryName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_repository(
@@ -1028,6 +1065,7 @@ function delete_repository(
             mergewith(_merge, Dict{String,Any}("repositoryName" => repositoryName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1081,6 +1119,7 @@ function describe_merge_conflicts(
             "sourceCommitSpecifier" => sourceCommitSpecifier,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_merge_conflicts(
@@ -1108,6 +1147,7 @@ function describe_merge_conflicts(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1141,6 +1181,7 @@ function describe_pull_request_events(
         "DescribePullRequestEvents",
         Dict{String,Any}("pullRequestId" => pullRequestId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_pull_request_events(
@@ -1154,6 +1195,7 @@ function describe_pull_request_events(
             mergewith(_merge, Dict{String,Any}("pullRequestId" => pullRequestId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1184,6 +1226,7 @@ function disassociate_approval_rule_template_from_repository(
             "repositoryName" => repositoryName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disassociate_approval_rule_template_from_repository(
@@ -1205,6 +1248,7 @@ function disassociate_approval_rule_template_from_repository(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1228,6 +1272,7 @@ function evaluate_pull_request_approval_rules(
         "EvaluatePullRequestApprovalRules",
         Dict{String,Any}("pullRequestId" => pullRequestId, "revisionId" => revisionId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function evaluate_pull_request_approval_rules(
@@ -1248,6 +1293,7 @@ function evaluate_pull_request_approval_rules(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1269,6 +1315,7 @@ function get_approval_rule_template(
         "GetApprovalRuleTemplate",
         Dict{String,Any}("approvalRuleTemplateName" => approvalRuleTemplateName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_approval_rule_template(
@@ -1286,6 +1333,7 @@ function get_approval_rule_template(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1305,6 +1353,7 @@ function get_blob(blobId, repositoryName; aws_config::AbstractAWSConfig=global_a
         "GetBlob",
         Dict{String,Any}("blobId" => blobId, "repositoryName" => repositoryName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_blob(
@@ -1323,6 +1372,7 @@ function get_blob(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1339,12 +1389,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   want to retrieve information.
 """
 function get_branch(; aws_config::AbstractAWSConfig=global_aws_config())
-    return codecommit("GetBranch"; aws_config=aws_config)
+    return codecommit("GetBranch"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function get_branch(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return codecommit("GetBranch", params; aws_config=aws_config)
+    return codecommit(
+        "GetBranch", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1363,7 +1415,10 @@ GetCommentReactions.
 """
 function get_comment(commentId; aws_config::AbstractAWSConfig=global_aws_config())
     return codecommit(
-        "GetComment", Dict{String,Any}("commentId" => commentId); aws_config=aws_config
+        "GetComment",
+        Dict{String,Any}("commentId" => commentId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_comment(
@@ -1377,6 +1432,7 @@ function get_comment(
             mergewith(_merge, Dict{String,Any}("commentId" => commentId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1404,6 +1460,7 @@ function get_comment_reactions(commentId; aws_config::AbstractAWSConfig=global_a
         "GetCommentReactions",
         Dict{String,Any}("commentId" => commentId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_comment_reactions(
@@ -1417,6 +1474,7 @@ function get_comment_reactions(
             mergewith(_merge, Dict{String,Any}("commentId" => commentId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1451,6 +1509,7 @@ function get_comments_for_compared_commit(
             "afterCommitId" => afterCommitId, "repositoryName" => repositoryName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_comments_for_compared_commit(
@@ -1471,6 +1530,7 @@ function get_comments_for_compared_commit(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1506,6 +1566,7 @@ function get_comments_for_pull_request(
         "GetCommentsForPullRequest",
         Dict{String,Any}("pullRequestId" => pullRequestId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_comments_for_pull_request(
@@ -1519,6 +1580,7 @@ function get_comments_for_pull_request(
             mergewith(_merge, Dict{String,Any}("pullRequestId" => pullRequestId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1540,6 +1602,7 @@ function get_commit(
         "GetCommit",
         Dict{String,Any}("commitId" => commitId, "repositoryName" => repositoryName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_commit(
@@ -1560,6 +1623,7 @@ function get_commit(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1603,6 +1667,7 @@ function get_differences(
             "repositoryName" => repositoryName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_differences(
@@ -1624,6 +1689,7 @@ function get_differences(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1652,6 +1718,7 @@ function get_file(
         "GetFile",
         Dict{String,Any}("filePath" => filePath, "repositoryName" => repositoryName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_file(
@@ -1672,6 +1739,7 @@ function get_file(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1701,6 +1769,7 @@ function get_folder(
         "GetFolder",
         Dict{String,Any}("folderPath" => folderPath, "repositoryName" => repositoryName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_folder(
@@ -1721,6 +1790,7 @@ function get_folder(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1763,6 +1833,7 @@ function get_merge_commit(
             "sourceCommitSpecifier" => sourceCommitSpecifier,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_merge_commit(
@@ -1786,6 +1857,7 @@ function get_merge_commit(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1834,6 +1906,7 @@ function get_merge_conflicts(
             "sourceCommitSpecifier" => sourceCommitSpecifier,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_merge_conflicts(
@@ -1859,6 +1932,7 @@ function get_merge_conflicts(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1903,6 +1977,7 @@ function get_merge_options(
             "sourceCommitSpecifier" => sourceCommitSpecifier,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_merge_options(
@@ -1926,6 +2001,7 @@ function get_merge_options(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1945,6 +2021,7 @@ function get_pull_request(pullRequestId; aws_config::AbstractAWSConfig=global_aw
         "GetPullRequest",
         Dict{String,Any}("pullRequestId" => pullRequestId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_pull_request(
@@ -1958,6 +2035,7 @@ function get_pull_request(
             mergewith(_merge, Dict{String,Any}("pullRequestId" => pullRequestId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1980,6 +2058,7 @@ function get_pull_request_approval_states(
         "GetPullRequestApprovalStates",
         Dict{String,Any}("pullRequestId" => pullRequestId, "revisionId" => revisionId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_pull_request_approval_states(
@@ -2000,6 +2079,7 @@ function get_pull_request_approval_states(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2025,6 +2105,7 @@ function get_pull_request_override_state(
         "GetPullRequestOverrideState",
         Dict{String,Any}("pullRequestId" => pullRequestId, "revisionId" => revisionId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_pull_request_override_state(
@@ -2045,6 +2126,7 @@ function get_pull_request_override_state(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2067,6 +2149,7 @@ function get_repository(repositoryName; aws_config::AbstractAWSConfig=global_aws
         "GetRepository",
         Dict{String,Any}("repositoryName" => repositoryName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_repository(
@@ -2080,6 +2163,7 @@ function get_repository(
             mergewith(_merge, Dict{String,Any}("repositoryName" => repositoryName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2100,6 +2184,7 @@ function get_repository_triggers(
         "GetRepositoryTriggers",
         Dict{String,Any}("repositoryName" => repositoryName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_repository_triggers(
@@ -2113,6 +2198,7 @@ function get_repository_triggers(
             mergewith(_merge, Dict{String,Any}("repositoryName" => repositoryName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2131,12 +2217,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   batch of the results.
 """
 function list_approval_rule_templates(; aws_config::AbstractAWSConfig=global_aws_config())
-    return codecommit("ListApprovalRuleTemplates"; aws_config=aws_config)
+    return codecommit(
+        "ListApprovalRuleTemplates"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_approval_rule_templates(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return codecommit("ListApprovalRuleTemplates", params; aws_config=aws_config)
+    return codecommit(
+        "ListApprovalRuleTemplates",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2163,6 +2256,7 @@ function list_associated_approval_rule_templates_for_repository(
         "ListAssociatedApprovalRuleTemplatesForRepository",
         Dict{String,Any}("repositoryName" => repositoryName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_associated_approval_rule_templates_for_repository(
@@ -2176,6 +2270,7 @@ function list_associated_approval_rule_templates_for_repository(
             mergewith(_merge, Dict{String,Any}("repositoryName" => repositoryName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2197,6 +2292,7 @@ function list_branches(repositoryName; aws_config::AbstractAWSConfig=global_aws_
         "ListBranches",
         Dict{String,Any}("repositoryName" => repositoryName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_branches(
@@ -2210,6 +2306,7 @@ function list_branches(
             mergewith(_merge, Dict{String,Any}("repositoryName" => repositoryName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2241,6 +2338,7 @@ function list_pull_requests(
         "ListPullRequests",
         Dict{String,Any}("repositoryName" => repositoryName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_pull_requests(
@@ -2254,6 +2352,7 @@ function list_pull_requests(
             mergewith(_merge, Dict{String,Any}("repositoryName" => repositoryName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2272,12 +2371,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"sortBy"`: The criteria used to sort the results of a list repositories operation.
 """
 function list_repositories(; aws_config::AbstractAWSConfig=global_aws_config())
-    return codecommit("ListRepositories"; aws_config=aws_config)
+    return codecommit(
+        "ListRepositories"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_repositories(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return codecommit("ListRepositories", params; aws_config=aws_config)
+    return codecommit(
+        "ListRepositories", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -2304,6 +2407,7 @@ function list_repositories_for_approval_rule_template(
         "ListRepositoriesForApprovalRuleTemplate",
         Dict{String,Any}("approvalRuleTemplateName" => approvalRuleTemplateName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_repositories_for_approval_rule_template(
@@ -2321,6 +2425,7 @@ function list_repositories_for_approval_rule_template(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2348,6 +2453,7 @@ function list_tags_for_resource(
         "ListTagsForResource",
         Dict{String,Any}("resourceArn" => resourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags_for_resource(
@@ -2361,6 +2467,7 @@ function list_tags_for_resource(
             mergewith(_merge, Dict{String,Any}("resourceArn" => resourceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2395,6 +2502,7 @@ function merge_branches_by_fast_forward(
             "sourceCommitSpecifier" => sourceCommitSpecifier,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function merge_branches_by_fast_forward(
@@ -2418,6 +2526,7 @@ function merge_branches_by_fast_forward(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2470,6 +2579,7 @@ function merge_branches_by_squash(
             "sourceCommitSpecifier" => sourceCommitSpecifier,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function merge_branches_by_squash(
@@ -2493,6 +2603,7 @@ function merge_branches_by_squash(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2545,6 +2656,7 @@ function merge_branches_by_three_way(
             "sourceCommitSpecifier" => sourceCommitSpecifier,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function merge_branches_by_three_way(
@@ -2568,6 +2680,7 @@ function merge_branches_by_three_way(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2599,6 +2712,7 @@ function merge_pull_request_by_fast_forward(
             "pullRequestId" => pullRequestId, "repositoryName" => repositoryName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function merge_pull_request_by_fast_forward(
@@ -2619,6 +2733,7 @@ function merge_pull_request_by_fast_forward(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2668,6 +2783,7 @@ function merge_pull_request_by_squash(
             "pullRequestId" => pullRequestId, "repositoryName" => repositoryName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function merge_pull_request_by_squash(
@@ -2688,6 +2804,7 @@ function merge_pull_request_by_squash(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2737,6 +2854,7 @@ function merge_pull_request_by_three_way(
             "pullRequestId" => pullRequestId, "repositoryName" => repositoryName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function merge_pull_request_by_three_way(
@@ -2757,6 +2875,7 @@ function merge_pull_request_by_three_way(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2791,6 +2910,7 @@ function override_pull_request_approval_rules(
             "revisionId" => revisionId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function override_pull_request_approval_rules(
@@ -2814,6 +2934,7 @@ function override_pull_request_approval_rules(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2856,6 +2977,7 @@ function post_comment_for_compared_commit(
             "clientRequestToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function post_comment_for_compared_commit(
@@ -2880,6 +3002,7 @@ function post_comment_for_compared_commit(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2929,6 +3052,7 @@ function post_comment_for_pull_request(
             "clientRequestToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function post_comment_for_pull_request(
@@ -2957,6 +3081,7 @@ function post_comment_for_pull_request(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2990,6 +3115,7 @@ function post_comment_reply(
             "clientRequestToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function post_comment_reply(
@@ -3012,6 +3138,7 @@ function post_comment_reply(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3037,6 +3164,7 @@ function put_comment_reaction(
         "PutCommentReaction",
         Dict{String,Any}("commentId" => commentId, "reactionValue" => reactionValue);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_comment_reaction(
@@ -3057,6 +3185,7 @@ function put_comment_reaction(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3107,6 +3236,7 @@ function put_file(
             "repositoryName" => repositoryName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_file(
@@ -3132,6 +3262,7 @@ function put_file(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3154,6 +3285,7 @@ function put_repository_triggers(
         "PutRepositoryTriggers",
         Dict{String,Any}("repositoryName" => repositoryName, "triggers" => triggers);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_repository_triggers(
@@ -3174,6 +3306,7 @@ function put_repository_triggers(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3195,6 +3328,7 @@ function tag_resource(resourceArn, tags; aws_config::AbstractAWSConfig=global_aw
         "TagResource",
         Dict{String,Any}("resourceArn" => resourceArn, "tags" => tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -3213,6 +3347,7 @@ function tag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3236,6 +3371,7 @@ function test_repository_triggers(
         "TestRepositoryTriggers",
         Dict{String,Any}("repositoryName" => repositoryName, "triggers" => triggers);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function test_repository_triggers(
@@ -3256,6 +3392,7 @@ function test_repository_triggers(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3279,6 +3416,7 @@ function untag_resource(
         "UntagResource",
         Dict{String,Any}("resourceArn" => resourceArn, "tagKeys" => tagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -3297,6 +3435,7 @@ function untag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3330,6 +3469,7 @@ function update_approval_rule_template_content(
             "newRuleContent" => newRuleContent,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_approval_rule_template_content(
@@ -3351,6 +3491,7 @@ function update_approval_rule_template_content(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3379,6 +3520,7 @@ function update_approval_rule_template_description(
             "approvalRuleTemplateName" => approvalRuleTemplateName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_approval_rule_template_description(
@@ -3400,6 +3542,7 @@ function update_approval_rule_template_description(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3427,6 +3570,7 @@ function update_approval_rule_template_name(
             "oldApprovalRuleTemplateName" => oldApprovalRuleTemplateName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_approval_rule_template_name(
@@ -3448,6 +3592,7 @@ function update_approval_rule_template_name(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3470,6 +3615,7 @@ function update_comment(
         "UpdateComment",
         Dict{String,Any}("commentId" => commentId, "content" => content);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_comment(
@@ -3488,6 +3634,7 @@ function update_comment(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3513,6 +3660,7 @@ function update_default_branch(
             "defaultBranchName" => defaultBranchName, "repositoryName" => repositoryName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_default_branch(
@@ -3534,6 +3682,7 @@ function update_default_branch(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3583,6 +3732,7 @@ function update_pull_request_approval_rule_content(
             "pullRequestId" => pullRequestId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_pull_request_approval_rule_content(
@@ -3606,6 +3756,7 @@ function update_pull_request_approval_rule_content(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3636,6 +3787,7 @@ function update_pull_request_approval_state(
             "revisionId" => revisionId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_pull_request_approval_state(
@@ -3659,6 +3811,7 @@ function update_pull_request_approval_state(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3682,6 +3835,7 @@ function update_pull_request_description(
         "UpdatePullRequestDescription",
         Dict{String,Any}("description" => description, "pullRequestId" => pullRequestId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_pull_request_description(
@@ -3702,6 +3856,7 @@ function update_pull_request_description(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3727,6 +3882,7 @@ function update_pull_request_status(
             "pullRequestId" => pullRequestId, "pullRequestStatus" => pullRequestStatus
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_pull_request_status(
@@ -3748,6 +3904,7 @@ function update_pull_request_status(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3770,6 +3927,7 @@ function update_pull_request_title(
         "UpdatePullRequestTitle",
         Dict{String,Any}("pullRequestId" => pullRequestId, "title" => title);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_pull_request_title(
@@ -3788,6 +3946,7 @@ function update_pull_request_title(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3817,6 +3976,7 @@ function update_repository_description(
         "UpdateRepositoryDescription",
         Dict{String,Any}("repositoryName" => repositoryName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_repository_description(
@@ -3830,6 +3990,7 @@ function update_repository_description(
             mergewith(_merge, Dict{String,Any}("repositoryName" => repositoryName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3854,6 +4015,7 @@ function update_repository_name(
         "UpdateRepositoryName",
         Dict{String,Any}("newName" => newName, "oldName" => oldName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_repository_name(
@@ -3870,5 +4032,6 @@ function update_repository_name(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/codedeploy.jl
+++ b/src/services/codedeploy.jl
@@ -23,6 +23,7 @@ function add_tags_to_on_premises_instances(
         "AddTagsToOnPremisesInstances",
         Dict{String,Any}("instanceNames" => instanceNames, "tags" => tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function add_tags_to_on_premises_instances(
@@ -41,6 +42,7 @@ function add_tags_to_on_premises_instances(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -66,6 +68,7 @@ function batch_get_application_revisions(
         "BatchGetApplicationRevisions",
         Dict{String,Any}("applicationName" => applicationName, "revisions" => revisions);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_get_application_revisions(
@@ -86,6 +89,7 @@ function batch_get_application_revisions(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -108,6 +112,7 @@ function batch_get_applications(
         "BatchGetApplications",
         Dict{String,Any}("applicationNames" => applicationNames);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_get_applications(
@@ -123,6 +128,7 @@ function batch_get_applications(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -148,6 +154,7 @@ function batch_get_deployment_groups(
             "deploymentGroupNames" => deploymentGroupNames,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_get_deployment_groups(
@@ -169,6 +176,7 @@ function batch_get_deployment_groups(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -194,6 +202,7 @@ function batch_get_deployment_instances(
         "BatchGetDeploymentInstances",
         Dict{String,Any}("deploymentId" => deploymentId, "instanceIds" => instanceIds);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_get_deployment_instances(
@@ -214,6 +223,7 @@ function batch_get_deployment_instances(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -246,12 +256,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   stack IDs. Their target type is cloudFormationTarget.
 """
 function batch_get_deployment_targets(; aws_config::AbstractAWSConfig=global_aws_config())
-    return codedeploy("BatchGetDeploymentTargets"; aws_config=aws_config)
+    return codedeploy(
+        "BatchGetDeploymentTargets"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function batch_get_deployment_targets(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return codedeploy("BatchGetDeploymentTargets", params; aws_config=aws_config)
+    return codedeploy(
+        "BatchGetDeploymentTargets",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -273,6 +290,7 @@ function batch_get_deployments(
         "BatchGetDeployments",
         Dict{String,Any}("deploymentIds" => deploymentIds);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_get_deployments(
@@ -286,6 +304,7 @@ function batch_get_deployments(
             mergewith(_merge, Dict{String,Any}("deploymentIds" => deploymentIds), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -308,6 +327,7 @@ function batch_get_on_premises_instances(
         "BatchGetOnPremisesInstances",
         Dict{String,Any}("instanceNames" => instanceNames);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_get_on_premises_instances(
@@ -321,6 +341,7 @@ function batch_get_on_premises_instances(
             mergewith(_merge, Dict{String,Any}("instanceNames" => instanceNames), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -343,12 +364,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   indicates that the traffic is shifted, but the original target is not terminated.
 """
 function continue_deployment(; aws_config::AbstractAWSConfig=global_aws_config())
-    return codedeploy("ContinueDeployment"; aws_config=aws_config)
+    return codedeploy(
+        "ContinueDeployment"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function continue_deployment(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return codedeploy("ContinueDeployment", params; aws_config=aws_config)
+    return codedeploy(
+        "ContinueDeployment", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -376,6 +401,7 @@ function create_application(
         "CreateApplication",
         Dict{String,Any}("applicationName" => applicationName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_application(
@@ -391,6 +417,7 @@ function create_application(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -451,6 +478,7 @@ function create_deployment(
         "CreateDeployment",
         Dict{String,Any}("applicationName" => applicationName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_deployment(
@@ -466,6 +494,7 @@ function create_deployment(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -502,6 +531,7 @@ function create_deployment_config(
         "CreateDeploymentConfig",
         Dict{String,Any}("deploymentConfigName" => deploymentConfigName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_deployment_config(
@@ -519,6 +549,7 @@ function create_deployment_config(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -596,6 +627,7 @@ function create_deployment_group(
             "serviceRoleArn" => serviceRoleArn,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_deployment_group(
@@ -619,6 +651,7 @@ function create_deployment_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -640,6 +673,7 @@ function delete_application(
         "DeleteApplication",
         Dict{String,Any}("applicationName" => applicationName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_application(
@@ -655,6 +689,7 @@ function delete_application(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -677,6 +712,7 @@ function delete_deployment_config(
         "DeleteDeploymentConfig",
         Dict{String,Any}("deploymentConfigName" => deploymentConfigName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_deployment_config(
@@ -694,6 +730,7 @@ function delete_deployment_config(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -719,6 +756,7 @@ function delete_deployment_group(
             "deploymentGroupName" => deploymentGroupName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_deployment_group(
@@ -740,6 +778,7 @@ function delete_deployment_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -754,12 +793,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"tokenName"`: The name of the GitHub account connection to delete.
 """
 function delete_git_hub_account_token(; aws_config::AbstractAWSConfig=global_aws_config())
-    return codedeploy("DeleteGitHubAccountToken"; aws_config=aws_config)
+    return codedeploy(
+        "DeleteGitHubAccountToken"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function delete_git_hub_account_token(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return codedeploy("DeleteGitHubAccountToken", params; aws_config=aws_config)
+    return codedeploy(
+        "DeleteGitHubAccountToken",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -776,12 +822,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function delete_resources_by_external_id(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return codedeploy("DeleteResourcesByExternalId"; aws_config=aws_config)
+    return codedeploy(
+        "DeleteResourcesByExternalId";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_resources_by_external_id(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return codedeploy("DeleteResourcesByExternalId", params; aws_config=aws_config)
+    return codedeploy(
+        "DeleteResourcesByExternalId",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -801,6 +856,7 @@ function deregister_on_premises_instance(
         "DeregisterOnPremisesInstance",
         Dict{String,Any}("instanceName" => instanceName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function deregister_on_premises_instance(
@@ -814,6 +870,7 @@ function deregister_on_premises_instance(
             mergewith(_merge, Dict{String,Any}("instanceName" => instanceName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -833,6 +890,7 @@ function get_application(applicationName; aws_config::AbstractAWSConfig=global_a
         "GetApplication",
         Dict{String,Any}("applicationName" => applicationName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_application(
@@ -848,6 +906,7 @@ function get_application(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -870,6 +929,7 @@ function get_application_revision(
         "GetApplicationRevision",
         Dict{String,Any}("applicationName" => applicationName, "revision" => revision);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_application_revision(
@@ -890,6 +950,7 @@ function get_application_revision(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -911,6 +972,7 @@ function get_deployment(deploymentId; aws_config::AbstractAWSConfig=global_aws_c
         "GetDeployment",
         Dict{String,Any}("deploymentId" => deploymentId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_deployment(
@@ -924,6 +986,7 @@ function get_deployment(
             mergewith(_merge, Dict{String,Any}("deploymentId" => deploymentId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -945,6 +1008,7 @@ function get_deployment_config(
         "GetDeploymentConfig",
         Dict{String,Any}("deploymentConfigName" => deploymentConfigName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_deployment_config(
@@ -962,6 +1026,7 @@ function get_deployment_config(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -987,6 +1052,7 @@ function get_deployment_group(
             "deploymentGroupName" => deploymentGroupName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_deployment_group(
@@ -1008,6 +1074,7 @@ function get_deployment_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1029,6 +1096,7 @@ function get_deployment_instance(
         "GetDeploymentInstance",
         Dict{String,Any}("deploymentId" => deploymentId, "instanceId" => instanceId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_deployment_instance(
@@ -1049,6 +1117,7 @@ function get_deployment_instance(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1064,12 +1133,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"targetId"`:  The unique ID of a deployment target.
 """
 function get_deployment_target(; aws_config::AbstractAWSConfig=global_aws_config())
-    return codedeploy("GetDeploymentTarget"; aws_config=aws_config)
+    return codedeploy(
+        "GetDeploymentTarget"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_deployment_target(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return codedeploy("GetDeploymentTarget", params; aws_config=aws_config)
+    return codedeploy(
+        "GetDeploymentTarget",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1089,6 +1165,7 @@ function get_on_premises_instance(
         "GetOnPremisesInstance",
         Dict{String,Any}("instanceName" => instanceName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_on_premises_instance(
@@ -1102,6 +1179,7 @@ function get_on_premises_instance(
             mergewith(_merge, Dict{String,Any}("instanceName" => instanceName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1143,6 +1221,7 @@ function list_application_revisions(
         "ListApplicationRevisions",
         Dict{String,Any}("applicationName" => applicationName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_application_revisions(
@@ -1158,6 +1237,7 @@ function list_application_revisions(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1173,12 +1253,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   used to return the next set of applications in the list.
 """
 function list_applications(; aws_config::AbstractAWSConfig=global_aws_config())
-    return codedeploy("ListApplications"; aws_config=aws_config)
+    return codedeploy(
+        "ListApplications"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_applications(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return codedeploy("ListApplications", params; aws_config=aws_config)
+    return codedeploy(
+        "ListApplications", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1193,12 +1277,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   can be used to return the next set of deployment configurations in the list.
 """
 function list_deployment_configs(; aws_config::AbstractAWSConfig=global_aws_config())
-    return codedeploy("ListDeploymentConfigs"; aws_config=aws_config)
+    return codedeploy(
+        "ListDeploymentConfigs"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_deployment_configs(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return codedeploy("ListDeploymentConfigs", params; aws_config=aws_config)
+    return codedeploy(
+        "ListDeploymentConfigs",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1223,6 +1314,7 @@ function list_deployment_groups(
         "ListDeploymentGroups",
         Dict{String,Any}("applicationName" => applicationName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_deployment_groups(
@@ -1238,6 +1330,7 @@ function list_deployment_groups(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1274,6 +1367,7 @@ function list_deployment_instances(
         "ListDeploymentInstances",
         Dict{String,Any}("deploymentId" => deploymentId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_deployment_instances(
@@ -1287,6 +1381,7 @@ function list_deployment_instances(
             mergewith(_merge, Dict{String,Any}("deploymentId" => deploymentId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1307,12 +1402,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   string can be Blue or Green.
 """
 function list_deployment_targets(; aws_config::AbstractAWSConfig=global_aws_config())
-    return codedeploy("ListDeploymentTargets"; aws_config=aws_config)
+    return codedeploy(
+        "ListDeploymentTargets"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_deployment_targets(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return codedeploy("ListDeploymentTargets", params; aws_config=aws_config)
+    return codedeploy(
+        "ListDeploymentTargets",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1344,12 +1446,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   used to return the next set of deployments in the list.
 """
 function list_deployments(; aws_config::AbstractAWSConfig=global_aws_config())
-    return codedeploy("ListDeployments"; aws_config=aws_config)
+    return codedeploy(
+        "ListDeployments"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_deployments(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return codedeploy("ListDeployments", params; aws_config=aws_config)
+    return codedeploy(
+        "ListDeployments", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1366,12 +1472,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function list_git_hub_account_token_names(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return codedeploy("ListGitHubAccountTokenNames"; aws_config=aws_config)
+    return codedeploy(
+        "ListGitHubAccountTokenNames";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_git_hub_account_token_names(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return codedeploy("ListGitHubAccountTokenNames", params; aws_config=aws_config)
+    return codedeploy(
+        "ListGitHubAccountTokenNames",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1394,12 +1509,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   instance names returned.
 """
 function list_on_premises_instances(; aws_config::AbstractAWSConfig=global_aws_config())
-    return codedeploy("ListOnPremisesInstances"; aws_config=aws_config)
+    return codedeploy(
+        "ListOnPremisesInstances"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_on_premises_instances(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return codedeploy("ListOnPremisesInstances", params; aws_config=aws_config)
+    return codedeploy(
+        "ListOnPremisesInstances",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1425,6 +1547,7 @@ function list_tags_for_resource(
         "ListTagsForResource",
         Dict{String,Any}("ResourceArn" => ResourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags_for_resource(
@@ -1438,6 +1561,7 @@ function list_tags_for_resource(
             mergewith(_merge, Dict{String,Any}("ResourceArn" => ResourceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1465,12 +1589,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function put_lifecycle_event_hook_execution_status(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return codedeploy("PutLifecycleEventHookExecutionStatus"; aws_config=aws_config)
+    return codedeploy(
+        "PutLifecycleEventHookExecutionStatus";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function put_lifecycle_event_hook_execution_status(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return codedeploy("PutLifecycleEventHookExecutionStatus", params; aws_config=aws_config)
+    return codedeploy(
+        "PutLifecycleEventHookExecutionStatus",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1496,6 +1629,7 @@ function register_application_revision(
         "RegisterApplicationRevision",
         Dict{String,Any}("applicationName" => applicationName, "revision" => revision);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function register_application_revision(
@@ -1516,6 +1650,7 @@ function register_application_revision(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1541,6 +1676,7 @@ function register_on_premises_instance(
         "RegisterOnPremisesInstance",
         Dict{String,Any}("instanceName" => instanceName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function register_on_premises_instance(
@@ -1554,6 +1690,7 @@ function register_on_premises_instance(
             mergewith(_merge, Dict{String,Any}("instanceName" => instanceName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1575,6 +1712,7 @@ function remove_tags_from_on_premises_instances(
         "RemoveTagsFromOnPremisesInstances",
         Dict{String,Any}("instanceNames" => instanceNames, "tags" => tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function remove_tags_from_on_premises_instances(
@@ -1593,6 +1731,7 @@ function remove_tags_from_on_premises_instances(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1611,12 +1750,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function skip_wait_time_for_instance_termination(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return codedeploy("SkipWaitTimeForInstanceTermination"; aws_config=aws_config)
+    return codedeploy(
+        "SkipWaitTimeForInstanceTermination";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function skip_wait_time_for_instance_termination(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return codedeploy("SkipWaitTimeForInstanceTermination", params; aws_config=aws_config)
+    return codedeploy(
+        "SkipWaitTimeForInstanceTermination",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1639,6 +1787,7 @@ function stop_deployment(deploymentId; aws_config::AbstractAWSConfig=global_aws_
         "StopDeployment",
         Dict{String,Any}("deploymentId" => deploymentId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function stop_deployment(
@@ -1652,6 +1801,7 @@ function stop_deployment(
             mergewith(_merge, Dict{String,Any}("deploymentId" => deploymentId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1674,6 +1824,7 @@ function tag_resource(ResourceArn, Tags; aws_config::AbstractAWSConfig=global_aw
         "TagResource",
         Dict{String,Any}("ResourceArn" => ResourceArn, "Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -1692,6 +1843,7 @@ function tag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1717,6 +1869,7 @@ function untag_resource(
         "UntagResource",
         Dict{String,Any}("ResourceArn" => ResourceArn, "TagKeys" => TagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -1735,6 +1888,7 @@ function untag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1750,12 +1904,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"newApplicationName"`: The new name to give the application.
 """
 function update_application(; aws_config::AbstractAWSConfig=global_aws_config())
-    return codedeploy("UpdateApplication"; aws_config=aws_config)
+    return codedeploy(
+        "UpdateApplication"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function update_application(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return codedeploy("UpdateApplication", params; aws_config=aws_config)
+    return codedeploy(
+        "UpdateApplication", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1824,6 +1982,7 @@ function update_deployment_group(
             "currentDeploymentGroupName" => currentDeploymentGroupName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_deployment_group(
@@ -1845,5 +2004,6 @@ function update_deployment_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/codeguru_reviewer.jl
+++ b/src/services/codeguru_reviewer.jl
@@ -48,6 +48,7 @@ function associate_repository(Repository; aws_config::AbstractAWSConfig=global_a
             "Repository" => Repository, "ClientRequestToken" => string(uuid4())
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_repository(
@@ -68,6 +69,7 @@ function associate_repository(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -107,6 +109,7 @@ function create_code_review(
             "ClientRequestToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_code_review(
@@ -132,6 +135,7 @@ function create_code_review(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -148,7 +152,12 @@ end
 function describe_code_review(
     CodeReviewArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return codeguru_reviewer("GET", "/codereviews/$(CodeReviewArn)"; aws_config=aws_config)
+    return codeguru_reviewer(
+        "GET",
+        "/codereviews/$(CodeReviewArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_code_review(
     CodeReviewArn,
@@ -156,7 +165,11 @@ function describe_code_review(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return codeguru_reviewer(
-        "GET", "/codereviews/$(CodeReviewArn)", params; aws_config=aws_config
+        "GET",
+        "/codereviews/$(CodeReviewArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -187,6 +200,7 @@ function describe_recommendation_feedback(
         "/feedback/$(CodeReviewArn)",
         Dict{String,Any}("RecommendationId" => RecommendationId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_recommendation_feedback(
@@ -204,6 +218,7 @@ function describe_recommendation_feedback(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -223,7 +238,10 @@ function describe_repository_association(
     AssociationArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return codeguru_reviewer(
-        "GET", "/associations/$(AssociationArn)"; aws_config=aws_config
+        "GET",
+        "/associations/$(AssociationArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_repository_association(
@@ -232,7 +250,11 @@ function describe_repository_association(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return codeguru_reviewer(
-        "GET", "/associations/$(AssociationArn)", params; aws_config=aws_config
+        "GET",
+        "/associations/$(AssociationArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -251,7 +273,10 @@ function disassociate_repository(
     AssociationArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return codeguru_reviewer(
-        "DELETE", "/associations/$(AssociationArn)"; aws_config=aws_config
+        "DELETE",
+        "/associations/$(AssociationArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disassociate_repository(
@@ -260,7 +285,11 @@ function disassociate_repository(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return codeguru_reviewer(
-        "DELETE", "/associations/$(AssociationArn)", params; aws_config=aws_config
+        "DELETE",
+        "/associations/$(AssociationArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -292,7 +321,11 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function list_code_reviews(Type; aws_config::AbstractAWSConfig=global_aws_config())
     return codeguru_reviewer(
-        "GET", "/codereviews", Dict{String,Any}("Type" => Type); aws_config=aws_config
+        "GET",
+        "/codereviews",
+        Dict{String,Any}("Type" => Type);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_code_reviews(
@@ -303,6 +336,7 @@ function list_code_reviews(
         "/codereviews",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Type" => Type), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -335,7 +369,10 @@ function list_recommendation_feedback(
     CodeReviewArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return codeguru_reviewer(
-        "GET", "/feedback/$(CodeReviewArn)/RecommendationFeedback"; aws_config=aws_config
+        "GET",
+        "/feedback/$(CodeReviewArn)/RecommendationFeedback";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_recommendation_feedback(
@@ -348,6 +385,7 @@ function list_recommendation_feedback(
         "/feedback/$(CodeReviewArn)/RecommendationFeedback",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -370,7 +408,10 @@ function list_recommendations(
     CodeReviewArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return codeguru_reviewer(
-        "GET", "/codereviews/$(CodeReviewArn)/Recommendations"; aws_config=aws_config
+        "GET",
+        "/codereviews/$(CodeReviewArn)/Recommendations";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_recommendations(
@@ -383,6 +424,7 @@ function list_recommendations(
         "/codereviews/$(CodeReviewArn)/Recommendations",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -431,12 +473,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   to control access to associated repositories in the Amazon CodeGuru Reviewer User Guide.
 """
 function list_repository_associations(; aws_config::AbstractAWSConfig=global_aws_config())
-    return codeguru_reviewer("GET", "/associations"; aws_config=aws_config)
+    return codeguru_reviewer(
+        "GET", "/associations"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_repository_associations(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return codeguru_reviewer("GET", "/associations", params; aws_config=aws_config)
+    return codeguru_reviewer(
+        "GET",
+        "/associations",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -453,14 +503,25 @@ Returns the list of tags associated with an associated repository resource.
 function list_tags_for_resource(
     resourceArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return codeguru_reviewer("GET", "/tags/$(resourceArn)"; aws_config=aws_config)
+    return codeguru_reviewer(
+        "GET",
+        "/tags/$(resourceArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_tags_for_resource(
     resourceArn,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return codeguru_reviewer("GET", "/tags/$(resourceArn)", params; aws_config=aws_config)
+    return codeguru_reviewer(
+        "GET",
+        "/tags/$(resourceArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -493,6 +554,7 @@ function put_recommendation_feedback(
             "RecommendationId" => RecommendationId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_recommendation_feedback(
@@ -517,6 +579,7 @@ function put_recommendation_feedback(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -542,6 +605,7 @@ function tag_resource(Tags, resourceArn; aws_config::AbstractAWSConfig=global_aw
         "/tags/$(resourceArn)",
         Dict{String,Any}("Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -555,6 +619,7 @@ function tag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Tags" => Tags), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -579,6 +644,7 @@ function untag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}("tagKeys" => tagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -592,5 +658,6 @@ function untag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tagKeys" => tagKeys), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/codeguruprofiler.jl
+++ b/src/services/codeguruprofiler.jl
@@ -24,6 +24,7 @@ function add_notification_channels(
         "/profilingGroups/$(profilingGroupName)/notificationConfiguration",
         Dict{String,Any}("channels" => channels);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function add_notification_channels(
@@ -39,6 +40,7 @@ function add_notification_channels(
             mergewith(_merge, Dict{String,Any}("channels" => channels), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -79,6 +81,7 @@ function batch_get_frame_metric_data(
         "POST",
         "/profilingGroups/$(profilingGroupName)/frames/-/metrics";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_get_frame_metric_data(
@@ -91,6 +94,7 @@ function batch_get_frame_metric_data(
         "/profilingGroups/$(profilingGroupName)/frames/-/metrics",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -131,6 +135,7 @@ function configure_agent(
         "POST",
         "/profilingGroups/$(profilingGroupName)/configureAgent";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function configure_agent(
@@ -143,6 +148,7 @@ function configure_agent(
         "/profilingGroups/$(profilingGroupName)/configureAgent",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -178,6 +184,7 @@ function create_profiling_group(
             "clientToken" => clientToken, "profilingGroupName" => profilingGroupName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_profiling_group(
@@ -199,6 +206,7 @@ function create_profiling_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -216,7 +224,10 @@ function delete_profiling_group(
     profilingGroupName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return codeguruprofiler(
-        "DELETE", "/profilingGroups/$(profilingGroupName)"; aws_config=aws_config
+        "DELETE",
+        "/profilingGroups/$(profilingGroupName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_profiling_group(
@@ -225,7 +236,11 @@ function delete_profiling_group(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return codeguruprofiler(
-        "DELETE", "/profilingGroups/$(profilingGroupName)", params; aws_config=aws_config
+        "DELETE",
+        "/profilingGroups/$(profilingGroupName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -244,7 +259,10 @@ function describe_profiling_group(
     profilingGroupName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return codeguruprofiler(
-        "GET", "/profilingGroups/$(profilingGroupName)"; aws_config=aws_config
+        "GET",
+        "/profilingGroups/$(profilingGroupName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_profiling_group(
@@ -253,7 +271,11 @@ function describe_profiling_group(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return codeguruprofiler(
-        "GET", "/profilingGroups/$(profilingGroupName)", params; aws_config=aws_config
+        "GET",
+        "/profilingGroups/$(profilingGroupName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -283,13 +305,22 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function get_findings_report_account_summary(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return codeguruprofiler("GET", "/internal/findingsReports"; aws_config=aws_config)
+    return codeguruprofiler(
+        "GET",
+        "/internal/findingsReports";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_findings_report_account_summary(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return codeguruprofiler(
-        "GET", "/internal/findingsReports", params; aws_config=aws_config
+        "GET",
+        "/internal/findingsReports",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -311,6 +342,7 @@ function get_notification_configuration(
         "GET",
         "/profilingGroups/$(profilingGroupName)/notificationConfiguration";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_notification_configuration(
@@ -323,6 +355,7 @@ function get_notification_configuration(
         "/profilingGroups/$(profilingGroupName)/notificationConfiguration",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -338,7 +371,10 @@ end
 """
 function get_policy(profilingGroupName; aws_config::AbstractAWSConfig=global_aws_config())
     return codeguruprofiler(
-        "GET", "/profilingGroups/$(profilingGroupName)/policy"; aws_config=aws_config
+        "GET",
+        "/profilingGroups/$(profilingGroupName)/policy";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_policy(
@@ -351,6 +387,7 @@ function get_policy(
         "/profilingGroups/$(profilingGroupName)/policy",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -426,7 +463,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function get_profile(profilingGroupName; aws_config::AbstractAWSConfig=global_aws_config())
     return codeguruprofiler(
-        "GET", "/profilingGroups/$(profilingGroupName)/profile"; aws_config=aws_config
+        "GET",
+        "/profilingGroups/$(profilingGroupName)/profile";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_profile(
@@ -439,6 +479,7 @@ function get_profile(
         "/profilingGroups/$(profilingGroupName)/profile",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -479,6 +520,7 @@ function get_recommendations(
         "/internal/profilingGroups/$(profilingGroupName)/recommendations",
         Dict{String,Any}("endTime" => endTime, "startTime" => startTime);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_recommendations(
@@ -499,6 +541,7 @@ function get_recommendations(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -545,6 +588,7 @@ function list_findings_reports(
         "/internal/profilingGroups/$(profilingGroupName)/findingsReports",
         Dict{String,Any}("endTime" => endTime, "startTime" => startTime);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_findings_reports(
@@ -565,6 +609,7 @@ function list_findings_reports(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -612,6 +657,7 @@ function list_profile_times(
             "endTime" => endTime, "period" => period, "startTime" => startTime
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_profile_times(
@@ -635,6 +681,7 @@ function list_profile_times(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -663,12 +710,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   the next items in a list and not for other programmatic purposes.
 """
 function list_profiling_groups(; aws_config::AbstractAWSConfig=global_aws_config())
-    return codeguruprofiler("GET", "/profilingGroups"; aws_config=aws_config)
+    return codeguruprofiler(
+        "GET", "/profilingGroups"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_profiling_groups(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return codeguruprofiler("GET", "/profilingGroups", params; aws_config=aws_config)
+    return codeguruprofiler(
+        "GET",
+        "/profilingGroups",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -685,14 +740,25 @@ end
 function list_tags_for_resource(
     resourceArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return codeguruprofiler("GET", "/tags/$(resourceArn)"; aws_config=aws_config)
+    return codeguruprofiler(
+        "GET",
+        "/tags/$(resourceArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_tags_for_resource(
     resourceArn,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return codeguruprofiler("GET", "/tags/$(resourceArn)", params; aws_config=aws_config)
+    return codeguruprofiler(
+        "GET",
+        "/tags/$(resourceArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -736,6 +802,7 @@ function post_agent_profile(
             "headers" => Dict{String,Any}("Content-Type" => Content_Type),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function post_agent_profile(
@@ -760,6 +827,7 @@ function post_agent_profile(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -814,6 +882,7 @@ function put_permission(
         "/profilingGroups/$(profilingGroupName)/policy/$(actionGroup)",
         Dict{String,Any}("principals" => principals);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_permission(
@@ -830,6 +899,7 @@ function put_permission(
             mergewith(_merge, Dict{String,Any}("principals" => principals), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -852,6 +922,7 @@ function remove_notification_channel(
         "DELETE",
         "/profilingGroups/$(profilingGroupName)/notificationConfiguration/$(channelId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function remove_notification_channel(
@@ -865,6 +936,7 @@ function remove_notification_channel(
         "/profilingGroups/$(profilingGroupName)/notificationConfiguration/$(channelId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -898,6 +970,7 @@ function remove_permission(
         "/profilingGroups/$(profilingGroupName)/policy/$(actionGroup)",
         Dict{String,Any}("revisionId" => revisionId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function remove_permission(
@@ -914,6 +987,7 @@ function remove_permission(
             mergewith(_merge, Dict{String,Any}("revisionId" => revisionId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -946,6 +1020,7 @@ function submit_feedback(
         "/internal/profilingGroups/$(profilingGroupName)/anomalies/$(anomalyInstanceId)/feedback",
         Dict{String,Any}("type" => type);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function submit_feedback(
@@ -960,6 +1035,7 @@ function submit_feedback(
         "/internal/profilingGroups/$(profilingGroupName)/anomalies/$(anomalyInstanceId)/feedback",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("type" => type), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -981,6 +1057,7 @@ function tag_resource(resourceArn, tags; aws_config::AbstractAWSConfig=global_aw
         "/tags/$(resourceArn)",
         Dict{String,Any}("tags" => tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -994,6 +1071,7 @@ function tag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tags" => tags), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1018,6 +1096,7 @@ function untag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}("tagKeys" => tagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -1031,6 +1110,7 @@ function untag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tagKeys" => tagKeys), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1056,6 +1136,7 @@ function update_profiling_group(
         "/profilingGroups/$(profilingGroupName)",
         Dict{String,Any}("agentOrchestrationConfig" => agentOrchestrationConfig);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_profiling_group(
@@ -1075,5 +1156,6 @@ function update_profiling_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/codepipeline.jl
+++ b/src/services/codepipeline.jl
@@ -23,6 +23,7 @@ function acknowledge_job(jobId, nonce; aws_config::AbstractAWSConfig=global_aws_
         "AcknowledgeJob",
         Dict{String,Any}("jobId" => jobId, "nonce" => nonce);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function acknowledge_job(
@@ -37,6 +38,7 @@ function acknowledge_job(
             mergewith(_merge, Dict{String,Any}("jobId" => jobId, "nonce" => nonce), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -62,6 +64,7 @@ function acknowledge_third_party_job(
         "AcknowledgeThirdPartyJob",
         Dict{String,Any}("clientToken" => clientToken, "jobId" => jobId, "nonce" => nonce);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function acknowledge_third_party_job(
@@ -83,6 +86,7 @@ function acknowledge_third_party_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -130,6 +134,7 @@ function create_custom_action_type(
             "version" => version,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_custom_action_type(
@@ -157,6 +162,7 @@ function create_custom_action_type(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -178,7 +184,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function create_pipeline(pipeline; aws_config::AbstractAWSConfig=global_aws_config())
     return codepipeline(
-        "CreatePipeline", Dict{String,Any}("pipeline" => pipeline); aws_config=aws_config
+        "CreatePipeline",
+        Dict{String,Any}("pipeline" => pipeline);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_pipeline(
@@ -192,6 +201,7 @@ function create_pipeline(
             mergewith(_merge, Dict{String,Any}("pipeline" => pipeline), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -222,6 +232,7 @@ function delete_custom_action_type(
             "category" => category, "provider" => provider, "version" => version
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_custom_action_type(
@@ -243,6 +254,7 @@ function delete_custom_action_type(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -258,7 +270,10 @@ Deletes the specified pipeline.
 """
 function delete_pipeline(name; aws_config::AbstractAWSConfig=global_aws_config())
     return codepipeline(
-        "DeletePipeline", Dict{String,Any}("name" => name); aws_config=aws_config
+        "DeletePipeline",
+        Dict{String,Any}("name" => name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_pipeline(
@@ -268,6 +283,7 @@ function delete_pipeline(
         "DeletePipeline",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("name" => name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -286,7 +302,10 @@ by calling PutWebhook with the same name, it will have a different URL.
 """
 function delete_webhook(name; aws_config::AbstractAWSConfig=global_aws_config())
     return codepipeline(
-        "DeleteWebhook", Dict{String,Any}("name" => name); aws_config=aws_config
+        "DeleteWebhook",
+        Dict{String,Any}("name" => name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_webhook(
@@ -296,6 +315,7 @@ function delete_webhook(
         "DeleteWebhook",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("name" => name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -314,12 +334,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function deregister_webhook_with_third_party(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return codepipeline("DeregisterWebhookWithThirdParty"; aws_config=aws_config)
+    return codepipeline(
+        "DeregisterWebhookWithThirdParty";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function deregister_webhook_with_third_party(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return codepipeline("DeregisterWebhookWithThirdParty", params; aws_config=aws_config)
+    return codepipeline(
+        "DeregisterWebhookWithThirdParty",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -357,6 +386,7 @@ function disable_stage_transition(
             "transitionType" => transitionType,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disable_stage_transition(
@@ -382,6 +412,7 @@ function disable_stage_transition(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -415,6 +446,7 @@ function enable_stage_transition(
             "transitionType" => transitionType,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function enable_stage_transition(
@@ -438,6 +470,7 @@ function enable_stage_transition(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -471,6 +504,7 @@ function get_action_type(
             "version" => version,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_action_type(
@@ -496,6 +530,7 @@ function get_action_type(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -514,7 +549,10 @@ artifacts. This API also returns any secret values defined for the action.
 """
 function get_job_details(jobId; aws_config::AbstractAWSConfig=global_aws_config())
     return codepipeline(
-        "GetJobDetails", Dict{String,Any}("jobId" => jobId); aws_config=aws_config
+        "GetJobDetails",
+        Dict{String,Any}("jobId" => jobId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_job_details(
@@ -524,6 +562,7 @@ function get_job_details(
         "GetJobDetails",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("jobId" => jobId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -546,7 +585,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function get_pipeline(name; aws_config::AbstractAWSConfig=global_aws_config())
     return codepipeline(
-        "GetPipeline", Dict{String,Any}("name" => name); aws_config=aws_config
+        "GetPipeline",
+        Dict{String,Any}("name" => name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_pipeline(
@@ -556,6 +598,7 @@ function get_pipeline(
         "GetPipeline",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("name" => name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -581,6 +624,7 @@ function get_pipeline_execution(
             "pipelineExecutionId" => pipelineExecutionId, "pipelineName" => pipelineName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_pipeline_execution(
@@ -602,6 +646,7 @@ function get_pipeline_execution(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -619,7 +664,10 @@ information, such as the commit ID, for the current state.
 """
 function get_pipeline_state(name; aws_config::AbstractAWSConfig=global_aws_config())
     return codepipeline(
-        "GetPipelineState", Dict{String,Any}("name" => name); aws_config=aws_config
+        "GetPipelineState",
+        Dict{String,Any}("name" => name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_pipeline_state(
@@ -629,6 +677,7 @@ function get_pipeline_state(
         "GetPipelineState",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("name" => name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -655,6 +704,7 @@ function get_third_party_job_details(
         "GetThirdPartyJobDetails",
         Dict{String,Any}("clientToken" => clientToken, "jobId" => jobId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_third_party_job_details(
@@ -673,6 +723,7 @@ function get_third_party_job_details(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -704,6 +755,7 @@ function list_action_executions(
         "ListActionExecutions",
         Dict{String,Any}("pipelineName" => pipelineName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_action_executions(
@@ -717,6 +769,7 @@ function list_action_executions(
             mergewith(_merge, Dict{String,Any}("pipelineName" => pipelineName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -735,12 +788,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"regionFilter"`: The Region to filter on for the list of action types.
 """
 function list_action_types(; aws_config::AbstractAWSConfig=global_aws_config())
-    return codepipeline("ListActionTypes"; aws_config=aws_config)
+    return codepipeline(
+        "ListActionTypes"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_action_types(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return codepipeline("ListActionTypes", params; aws_config=aws_config)
+    return codepipeline(
+        "ListActionTypes", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -769,6 +826,7 @@ function list_pipeline_executions(
         "ListPipelineExecutions",
         Dict{String,Any}("pipelineName" => pipelineName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_pipeline_executions(
@@ -782,6 +840,7 @@ function list_pipeline_executions(
             mergewith(_merge, Dict{String,Any}("pipelineName" => pipelineName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -800,12 +859,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   can be used to return the next set of pipelines in the list.
 """
 function list_pipelines(; aws_config::AbstractAWSConfig=global_aws_config())
-    return codepipeline("ListPipelines"; aws_config=aws_config)
+    return codepipeline(
+        "ListPipelines"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_pipelines(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return codepipeline("ListPipelines", params; aws_config=aws_config)
+    return codepipeline(
+        "ListPipelines", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -831,6 +894,7 @@ function list_tags_for_resource(
         "ListTagsForResource",
         Dict{String,Any}("resourceArn" => resourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags_for_resource(
@@ -844,6 +908,7 @@ function list_tags_for_resource(
             mergewith(_merge, Dict{String,Any}("resourceArn" => resourceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -862,12 +927,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   be used to return the next set of webhooks in the list.
 """
 function list_webhooks(; aws_config::AbstractAWSConfig=global_aws_config())
-    return codepipeline("ListWebhooks"; aws_config=aws_config)
+    return codepipeline(
+        "ListWebhooks"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_webhooks(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return codepipeline("ListWebhooks", params; aws_config=aws_config)
+    return codepipeline(
+        "ListWebhooks", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -898,6 +967,7 @@ function poll_for_jobs(actionTypeId; aws_config::AbstractAWSConfig=global_aws_co
         "PollForJobs",
         Dict{String,Any}("actionTypeId" => actionTypeId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function poll_for_jobs(
@@ -911,6 +981,7 @@ function poll_for_jobs(
             mergewith(_merge, Dict{String,Any}("actionTypeId" => actionTypeId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -937,6 +1008,7 @@ function poll_for_third_party_jobs(
         "PollForThirdPartyJobs",
         Dict{String,Any}("actionTypeId" => actionTypeId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function poll_for_third_party_jobs(
@@ -950,6 +1022,7 @@ function poll_for_third_party_jobs(
             mergewith(_merge, Dict{String,Any}("actionTypeId" => actionTypeId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -983,6 +1056,7 @@ function put_action_revision(
             "stageName" => stageName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_action_revision(
@@ -1008,6 +1082,7 @@ function put_action_revision(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1046,6 +1121,7 @@ function put_approval_result(
             "token" => token,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_approval_result(
@@ -1073,6 +1149,7 @@ function put_approval_result(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1096,6 +1173,7 @@ function put_job_failure_result(
         "PutJobFailureResult",
         Dict{String,Any}("failureDetails" => failureDetails, "jobId" => jobId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_job_failure_result(
@@ -1114,6 +1192,7 @@ function put_job_failure_result(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1145,7 +1224,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function put_job_success_result(jobId; aws_config::AbstractAWSConfig=global_aws_config())
     return codepipeline(
-        "PutJobSuccessResult", Dict{String,Any}("jobId" => jobId); aws_config=aws_config
+        "PutJobSuccessResult",
+        Dict{String,Any}("jobId" => jobId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_job_success_result(
@@ -1155,6 +1237,7 @@ function put_job_success_result(
         "PutJobSuccessResult",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("jobId" => jobId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1184,6 +1267,7 @@ function put_third_party_job_failure_result(
             "jobId" => jobId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_third_party_job_failure_result(
@@ -1207,6 +1291,7 @@ function put_third_party_job_failure_result(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1241,6 +1326,7 @@ function put_third_party_job_success_result(
         "PutThirdPartyJobSuccessResult",
         Dict{String,Any}("clientToken" => clientToken, "jobId" => jobId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_third_party_job_success_result(
@@ -1259,6 +1345,7 @@ function put_third_party_job_success_result(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1286,7 +1373,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function put_webhook(webhook; aws_config::AbstractAWSConfig=global_aws_config())
     return codepipeline(
-        "PutWebhook", Dict{String,Any}("webhook" => webhook); aws_config=aws_config
+        "PutWebhook",
+        Dict{String,Any}("webhook" => webhook);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_webhook(
@@ -1296,6 +1386,7 @@ function put_webhook(
         "PutWebhook",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("webhook" => webhook), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1314,12 +1405,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function register_webhook_with_third_party(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return codepipeline("RegisterWebhookWithThirdParty"; aws_config=aws_config)
+    return codepipeline(
+        "RegisterWebhookWithThirdParty";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function register_webhook_with_third_party(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return codepipeline("RegisterWebhookWithThirdParty", params; aws_config=aws_config)
+    return codepipeline(
+        "RegisterWebhookWithThirdParty",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1356,6 +1456,7 @@ function retry_stage_execution(
             "stageName" => stageName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function retry_stage_execution(
@@ -1381,6 +1482,7 @@ function retry_stage_execution(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1404,6 +1506,7 @@ function start_pipeline_execution(name; aws_config::AbstractAWSConfig=global_aws
         "StartPipelineExecution",
         Dict{String,Any}("name" => name, "clientRequestToken" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_pipeline_execution(
@@ -1419,6 +1522,7 @@ function start_pipeline_execution(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1453,6 +1557,7 @@ function stop_pipeline_execution(
             "pipelineExecutionId" => pipelineExecutionId, "pipelineName" => pipelineName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function stop_pipeline_execution(
@@ -1474,6 +1579,7 @@ function stop_pipeline_execution(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1494,6 +1600,7 @@ function tag_resource(resourceArn, tags; aws_config::AbstractAWSConfig=global_aw
         "TagResource",
         Dict{String,Any}("resourceArn" => resourceArn, "tags" => tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -1512,6 +1619,7 @@ function tag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1533,6 +1641,7 @@ function untag_resource(
         "UntagResource",
         Dict{String,Any}("resourceArn" => resourceArn, "tagKeys" => tagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -1551,6 +1660,7 @@ function untag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1571,6 +1681,7 @@ function update_action_type(actionType; aws_config::AbstractAWSConfig=global_aws
         "UpdateActionType",
         Dict{String,Any}("actionType" => actionType);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_action_type(
@@ -1584,6 +1695,7 @@ function update_action_type(
             mergewith(_merge, Dict{String,Any}("actionType" => actionType), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1601,7 +1713,10 @@ Updating the pipeline increases the version number of the pipeline by 1.
 """
 function update_pipeline(pipeline; aws_config::AbstractAWSConfig=global_aws_config())
     return codepipeline(
-        "UpdatePipeline", Dict{String,Any}("pipeline" => pipeline); aws_config=aws_config
+        "UpdatePipeline",
+        Dict{String,Any}("pipeline" => pipeline);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_pipeline(
@@ -1615,5 +1730,6 @@ function update_pipeline(
             mergewith(_merge, Dict{String,Any}("pipeline" => pipeline), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/codestar.jl
+++ b/src/services/codestar.jl
@@ -34,6 +34,7 @@ function associate_team_member(
             "projectId" => projectId, "projectRole" => projectRole, "userArn" => userArn
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_team_member(
@@ -57,6 +58,7 @@ function associate_team_member(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -86,7 +88,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function create_project(id, name; aws_config::AbstractAWSConfig=global_aws_config())
     return codestar(
-        "CreateProject", Dict{String,Any}("id" => id, "name" => name); aws_config=aws_config
+        "CreateProject",
+        Dict{String,Any}("id" => id, "name" => name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_project(
@@ -101,6 +106,7 @@ function create_project(
             mergewith(_merge, Dict{String,Any}("id" => id, "name" => name), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -137,6 +143,7 @@ function create_user_profile(
             "userArn" => userArn,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_user_profile(
@@ -160,6 +167,7 @@ function create_user_profile(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -183,7 +191,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   deleting the project itself. Recommended for most use cases.
 """
 function delete_project(id; aws_config::AbstractAWSConfig=global_aws_config())
-    return codestar("DeleteProject", Dict{String,Any}("id" => id); aws_config=aws_config)
+    return codestar(
+        "DeleteProject",
+        Dict{String,Any}("id" => id);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_project(
     id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -192,6 +205,7 @@ function delete_project(
         "DeleteProject",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("id" => id), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -209,7 +223,10 @@ of that user, for example the history of commits made by that user.
 """
 function delete_user_profile(userArn; aws_config::AbstractAWSConfig=global_aws_config())
     return codestar(
-        "DeleteUserProfile", Dict{String,Any}("userArn" => userArn); aws_config=aws_config
+        "DeleteUserProfile",
+        Dict{String,Any}("userArn" => userArn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_user_profile(
@@ -219,6 +236,7 @@ function delete_user_profile(
         "DeleteUserProfile",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("userArn" => userArn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -233,7 +251,12 @@ Describes a project and its resources.
 
 """
 function describe_project(id; aws_config::AbstractAWSConfig=global_aws_config())
-    return codestar("DescribeProject", Dict{String,Any}("id" => id); aws_config=aws_config)
+    return codestar(
+        "DescribeProject",
+        Dict{String,Any}("id" => id);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_project(
     id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -242,6 +265,7 @@ function describe_project(
         "DescribeProject",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("id" => id), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -257,7 +281,10 @@ Describes a user in AWS CodeStar and the user attributes across all projects.
 """
 function describe_user_profile(userArn; aws_config::AbstractAWSConfig=global_aws_config())
     return codestar(
-        "DescribeUserProfile", Dict{String,Any}("userArn" => userArn); aws_config=aws_config
+        "DescribeUserProfile",
+        Dict{String,Any}("userArn" => userArn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_user_profile(
@@ -267,6 +294,7 @@ function describe_user_profile(
         "DescribeUserProfile",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("userArn" => userArn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -293,6 +321,7 @@ function disassociate_team_member(
         "DisassociateTeamMember",
         Dict{String,Any}("projectId" => projectId, "userArn" => userArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disassociate_team_member(
@@ -311,6 +340,7 @@ function disassociate_team_member(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -328,12 +358,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   the results cannot be returned in one response.
 """
 function list_projects(; aws_config::AbstractAWSConfig=global_aws_config())
-    return codestar("ListProjects"; aws_config=aws_config)
+    return codestar("ListProjects"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_projects(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return codestar("ListProjects", params; aws_config=aws_config)
+    return codestar(
+        "ListProjects", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -354,7 +386,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function list_resources(projectId; aws_config::AbstractAWSConfig=global_aws_config())
     return codestar(
-        "ListResources", Dict{String,Any}("projectId" => projectId); aws_config=aws_config
+        "ListResources",
+        Dict{String,Any}("projectId" => projectId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_resources(
@@ -368,6 +403,7 @@ function list_resources(
             mergewith(_merge, Dict{String,Any}("projectId" => projectId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -387,7 +423,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function list_tags_for_project(id; aws_config::AbstractAWSConfig=global_aws_config())
     return codestar(
-        "ListTagsForProject", Dict{String,Any}("id" => id); aws_config=aws_config
+        "ListTagsForProject",
+        Dict{String,Any}("id" => id);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags_for_project(
@@ -397,6 +436,7 @@ function list_tags_for_project(
         "ListTagsForProject",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("id" => id), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -417,7 +457,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function list_team_members(projectId; aws_config::AbstractAWSConfig=global_aws_config())
     return codestar(
-        "ListTeamMembers", Dict{String,Any}("projectId" => projectId); aws_config=aws_config
+        "ListTeamMembers",
+        Dict{String,Any}("projectId" => projectId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_team_members(
@@ -431,6 +474,7 @@ function list_team_members(
             mergewith(_merge, Dict{String,Any}("projectId" => projectId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -447,12 +491,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   be returned in one response.
 """
 function list_user_profiles(; aws_config::AbstractAWSConfig=global_aws_config())
-    return codestar("ListUserProfiles"; aws_config=aws_config)
+    return codestar(
+        "ListUserProfiles"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_user_profiles(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return codestar("ListUserProfiles", params; aws_config=aws_config)
+    return codestar(
+        "ListUserProfiles", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -468,7 +516,10 @@ Adds tags to a project.
 """
 function tag_project(id, tags; aws_config::AbstractAWSConfig=global_aws_config())
     return codestar(
-        "TagProject", Dict{String,Any}("id" => id, "tags" => tags); aws_config=aws_config
+        "TagProject",
+        Dict{String,Any}("id" => id, "tags" => tags);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_project(
@@ -483,6 +534,7 @@ function tag_project(
             mergewith(_merge, Dict{String,Any}("id" => id, "tags" => tags), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -499,7 +551,10 @@ Removes tags from a project.
 """
 function untag_project(id, tags; aws_config::AbstractAWSConfig=global_aws_config())
     return codestar(
-        "UntagProject", Dict{String,Any}("id" => id, "tags" => tags); aws_config=aws_config
+        "UntagProject",
+        Dict{String,Any}("id" => id, "tags" => tags);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_project(
@@ -514,6 +569,7 @@ function untag_project(
             mergewith(_merge, Dict{String,Any}("id" => id, "tags" => tags), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -532,7 +588,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"name"`: The name of the project you want to update.
 """
 function update_project(id; aws_config::AbstractAWSConfig=global_aws_config())
-    return codestar("UpdateProject", Dict{String,Any}("id" => id); aws_config=aws_config)
+    return codestar(
+        "UpdateProject",
+        Dict{String,Any}("id" => id);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function update_project(
     id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -541,6 +602,7 @@ function update_project(
         "UpdateProject",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("id" => id), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -574,6 +636,7 @@ function update_team_member(
         "UpdateTeamMember",
         Dict{String,Any}("projectId" => projectId, "userArn" => userArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_team_member(
@@ -592,6 +655,7 @@ function update_team_member(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -619,7 +683,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function update_user_profile(userArn; aws_config::AbstractAWSConfig=global_aws_config())
     return codestar(
-        "UpdateUserProfile", Dict{String,Any}("userArn" => userArn); aws_config=aws_config
+        "UpdateUserProfile",
+        Dict{String,Any}("userArn" => userArn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_user_profile(
@@ -629,5 +696,6 @@ function update_user_profile(
         "UpdateUserProfile",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("userArn" => userArn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/codestar_connections.jl
+++ b/src/services/codestar_connections.jl
@@ -31,6 +31,7 @@ function create_connection(
         "CreateConnection",
         Dict{String,Any}("ConnectionName" => ConnectionName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_connection(
@@ -44,6 +45,7 @@ function create_connection(
             mergewith(_merge, Dict{String,Any}("ConnectionName" => ConnectionName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -84,6 +86,7 @@ function create_host(
             "ProviderType" => ProviderType,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_host(
@@ -107,6 +110,7 @@ function create_host(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -126,6 +130,7 @@ function delete_connection(ConnectionArn; aws_config::AbstractAWSConfig=global_a
         "DeleteConnection",
         Dict{String,Any}("ConnectionArn" => ConnectionArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_connection(
@@ -139,6 +144,7 @@ function delete_connection(
             mergewith(_merge, Dict{String,Any}("ConnectionArn" => ConnectionArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -156,7 +162,10 @@ VPC_CONFIG_DELETING state.
 """
 function delete_host(HostArn; aws_config::AbstractAWSConfig=global_aws_config())
     return codestar_connections(
-        "DeleteHost", Dict{String,Any}("HostArn" => HostArn); aws_config=aws_config
+        "DeleteHost",
+        Dict{String,Any}("HostArn" => HostArn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_host(
@@ -166,6 +175,7 @@ function delete_host(
         "DeleteHost",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("HostArn" => HostArn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -184,6 +194,7 @@ function get_connection(ConnectionArn; aws_config::AbstractAWSConfig=global_aws_
         "GetConnection",
         Dict{String,Any}("ConnectionArn" => ConnectionArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_connection(
@@ -197,6 +208,7 @@ function get_connection(
             mergewith(_merge, Dict{String,Any}("ConnectionArn" => ConnectionArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -213,7 +225,10 @@ applicable, the VPC configuration.
 """
 function get_host(HostArn; aws_config::AbstractAWSConfig=global_aws_config())
     return codestar_connections(
-        "GetHost", Dict{String,Any}("HostArn" => HostArn); aws_config=aws_config
+        "GetHost",
+        Dict{String,Any}("HostArn" => HostArn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_host(
@@ -223,6 +238,7 @@ function get_host(
         "GetHost",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("HostArn" => HostArn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -244,12 +260,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   specified provider, such as Bitbucket.
 """
 function list_connections(; aws_config::AbstractAWSConfig=global_aws_config())
-    return codestar_connections("ListConnections"; aws_config=aws_config)
+    return codestar_connections(
+        "ListConnections"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_connections(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return codestar_connections("ListConnections", params; aws_config=aws_config)
+    return codestar_connections(
+        "ListConnections", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -266,12 +286,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   used to return the next set of hosts in the list.
 """
 function list_hosts(; aws_config::AbstractAWSConfig=global_aws_config())
-    return codestar_connections("ListHosts"; aws_config=aws_config)
+    return codestar_connections(
+        "ListHosts"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_hosts(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return codestar_connections("ListHosts", params; aws_config=aws_config)
+    return codestar_connections(
+        "ListHosts", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -292,6 +316,7 @@ function list_tags_for_resource(
         "ListTagsForResource",
         Dict{String,Any}("ResourceArn" => ResourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags_for_resource(
@@ -305,6 +330,7 @@ function list_tags_for_resource(
             mergewith(_merge, Dict{String,Any}("ResourceArn" => ResourceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -326,6 +352,7 @@ function tag_resource(ResourceArn, Tags; aws_config::AbstractAWSConfig=global_aw
         "TagResource",
         Dict{String,Any}("ResourceArn" => ResourceArn, "Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -344,6 +371,7 @@ function tag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -365,6 +393,7 @@ function untag_resource(
         "UntagResource",
         Dict{String,Any}("ResourceArn" => ResourceArn, "TagKeys" => TagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -383,6 +412,7 @@ function untag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -404,7 +434,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function update_host(HostArn; aws_config::AbstractAWSConfig=global_aws_config())
     return codestar_connections(
-        "UpdateHost", Dict{String,Any}("HostArn" => HostArn); aws_config=aws_config
+        "UpdateHost",
+        Dict{String,Any}("HostArn" => HostArn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_host(
@@ -414,5 +447,6 @@ function update_host(
         "UpdateHost",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("HostArn" => HostArn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/codestar_notifications.jl
+++ b/src/services/codestar_notifications.jl
@@ -59,6 +59,7 @@ function create_notification_rule(
             "ClientRequestToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_notification_rule(
@@ -88,6 +89,7 @@ function create_notification_rule(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -107,6 +109,7 @@ function delete_notification_rule(Arn; aws_config::AbstractAWSConfig=global_aws_
         "/deleteNotificationRule",
         Dict{String,Any}("Arn" => Arn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_notification_rule(
@@ -117,6 +120,7 @@ function delete_notification_rule(
         "/deleteNotificationRule",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Arn" => Arn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -141,6 +145,7 @@ function delete_target(TargetAddress; aws_config::AbstractAWSConfig=global_aws_c
         "/deleteTarget",
         Dict{String,Any}("TargetAddress" => TargetAddress);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_target(
@@ -155,6 +160,7 @@ function delete_target(
             mergewith(_merge, Dict{String,Any}("TargetAddress" => TargetAddress), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -174,6 +180,7 @@ function describe_notification_rule(Arn; aws_config::AbstractAWSConfig=global_aw
         "/describeNotificationRule",
         Dict{String,Any}("Arn" => Arn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_notification_rule(
@@ -184,6 +191,7 @@ function describe_notification_rule(
         "/describeNotificationRule",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Arn" => Arn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -202,12 +210,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   batch of the results.
 """
 function list_event_types(; aws_config::AbstractAWSConfig=global_aws_config())
-    return codestar_notifications("POST", "/listEventTypes"; aws_config=aws_config)
+    return codestar_notifications(
+        "POST", "/listEventTypes"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_event_types(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return codestar_notifications("POST", "/listEventTypes", params; aws_config=aws_config)
+    return codestar_notifications(
+        "POST",
+        "/listEventTypes",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -228,13 +244,22 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   batch of the results.
 """
 function list_notification_rules(; aws_config::AbstractAWSConfig=global_aws_config())
-    return codestar_notifications("POST", "/listNotificationRules"; aws_config=aws_config)
+    return codestar_notifications(
+        "POST",
+        "/listNotificationRules";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_notification_rules(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return codestar_notifications(
-        "POST", "/listNotificationRules", params; aws_config=aws_config
+        "POST",
+        "/listNotificationRules",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -254,6 +279,7 @@ function list_tags_for_resource(Arn; aws_config::AbstractAWSConfig=global_aws_co
         "/listTagsForResource",
         Dict{String,Any}("Arn" => Arn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags_for_resource(
@@ -264,6 +290,7 @@ function list_tags_for_resource(
         "/listTagsForResource",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Arn" => Arn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -285,12 +312,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   batch of the results.
 """
 function list_targets(; aws_config::AbstractAWSConfig=global_aws_config())
-    return codestar_notifications("POST", "/listTargets"; aws_config=aws_config)
+    return codestar_notifications(
+        "POST", "/listTargets"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_targets(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return codestar_notifications("POST", "/listTargets", params; aws_config=aws_config)
+    return codestar_notifications(
+        "POST",
+        "/listTargets",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -316,6 +351,7 @@ function subscribe(Arn, Target; aws_config::AbstractAWSConfig=global_aws_config(
         "/subscribe",
         Dict{String,Any}("Arn" => Arn, "Target" => Target);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function subscribe(
@@ -331,6 +367,7 @@ function subscribe(
             mergewith(_merge, Dict{String,Any}("Arn" => Arn, "Target" => Target), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -352,6 +389,7 @@ function tag_resource(Arn, Tags; aws_config::AbstractAWSConfig=global_aws_config
         "/tagResource",
         Dict{String,Any}("Arn" => Arn, "Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -367,6 +405,7 @@ function tag_resource(
             mergewith(_merge, Dict{String,Any}("Arn" => Arn, "Tags" => Tags), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -389,6 +428,7 @@ function unsubscribe(Arn, TargetAddress; aws_config::AbstractAWSConfig=global_aw
         "/unsubscribe",
         Dict{String,Any}("Arn" => Arn, "TargetAddress" => TargetAddress);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function unsubscribe(
@@ -408,6 +448,7 @@ function unsubscribe(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -429,6 +470,7 @@ function untag_resource(Arn, TagKeys; aws_config::AbstractAWSConfig=global_aws_c
         "/untagResource",
         Dict{String,Any}("Arn" => Arn, "TagKeys" => TagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -444,6 +486,7 @@ function untag_resource(
             mergewith(_merge, Dict{String,Any}("Arn" => Arn, "TagKeys" => TagKeys), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -477,6 +520,7 @@ function update_notification_rule(Arn; aws_config::AbstractAWSConfig=global_aws_
         "/updateNotificationRule",
         Dict{String,Any}("Arn" => Arn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_notification_rule(
@@ -487,5 +531,6 @@ function update_notification_rule(
         "/updateNotificationRule",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Arn" => Arn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/cognito_identity.jl
+++ b/src/services/cognito_identity.jl
@@ -52,6 +52,7 @@ function create_identity_pool(
             "IdentityPoolName" => IdentityPoolName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_identity_pool(
@@ -73,6 +74,7 @@ function create_identity_pool(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -94,6 +96,7 @@ function delete_identities(
         "DeleteIdentities",
         Dict{String,Any}("IdentityIdsToDelete" => IdentityIdsToDelete);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_identities(
@@ -111,6 +114,7 @@ function delete_identities(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -132,6 +136,7 @@ function delete_identity_pool(
         "DeleteIdentityPool",
         Dict{String,Any}("IdentityPoolId" => IdentityPoolId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_identity_pool(
@@ -145,6 +150,7 @@ function delete_identity_pool(
             mergewith(_merge, Dict{String,Any}("IdentityPoolId" => IdentityPoolId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -164,6 +170,7 @@ function describe_identity(IdentityId; aws_config::AbstractAWSConfig=global_aws_
         "DescribeIdentity",
         Dict{String,Any}("IdentityId" => IdentityId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_identity(
@@ -177,6 +184,7 @@ function describe_identity(
             mergewith(_merge, Dict{String,Any}("IdentityId" => IdentityId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -199,6 +207,7 @@ function describe_identity_pool(
         "DescribeIdentityPool",
         Dict{String,Any}("IdentityPoolId" => IdentityPoolId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_identity_pool(
@@ -212,6 +221,7 @@ function describe_identity_pool(
             mergewith(_merge, Dict{String,Any}("IdentityPoolId" => IdentityPoolId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -248,6 +258,7 @@ function get_credentials_for_identity(
         "GetCredentialsForIdentity",
         Dict{String,Any}("IdentityId" => IdentityId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_credentials_for_identity(
@@ -261,6 +272,7 @@ function get_credentials_for_identity(
             mergewith(_merge, Dict{String,Any}("IdentityId" => IdentityId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -286,7 +298,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function get_id(IdentityPoolId; aws_config::AbstractAWSConfig=global_aws_config())
     return cognito_identity(
-        "GetId", Dict{String,Any}("IdentityPoolId" => IdentityPoolId); aws_config=aws_config
+        "GetId",
+        Dict{String,Any}("IdentityPoolId" => IdentityPoolId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_id(
@@ -300,6 +315,7 @@ function get_id(
             mergewith(_merge, Dict{String,Any}("IdentityPoolId" => IdentityPoolId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -321,6 +337,7 @@ function get_identity_pool_roles(
         "GetIdentityPoolRoles",
         Dict{String,Any}("IdentityPoolId" => IdentityPoolId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_identity_pool_roles(
@@ -334,6 +351,7 @@ function get_identity_pool_roles(
             mergewith(_merge, Dict{String,Any}("IdentityPoolId" => IdentityPoolId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -361,6 +379,7 @@ function get_open_id_token(IdentityId; aws_config::AbstractAWSConfig=global_aws_
         "GetOpenIdToken",
         Dict{String,Any}("IdentityId" => IdentityId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_open_id_token(
@@ -374,6 +393,7 @@ function get_open_id_token(
             mergewith(_merge, Dict{String,Any}("IdentityId" => IdentityId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -425,6 +445,7 @@ function get_open_id_token_for_developer_identity(
         "GetOpenIdTokenForDeveloperIdentity",
         Dict{String,Any}("IdentityPoolId" => IdentityPoolId, "Logins" => Logins);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_open_id_token_for_developer_identity(
@@ -443,6 +464,7 @@ function get_open_id_token_for_developer_identity(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -469,6 +491,7 @@ function get_principal_tag_attribute_map(
             "IdentityProviderName" => IdentityProviderName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_principal_tag_attribute_map(
@@ -490,6 +513,7 @@ function get_principal_tag_attribute_map(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -518,6 +542,7 @@ function list_identities(
         "ListIdentities",
         Dict{String,Any}("IdentityPoolId" => IdentityPoolId, "MaxResults" => MaxResults);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_identities(
@@ -538,6 +563,7 @@ function list_identities(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -560,6 +586,7 @@ function list_identity_pools(MaxResults; aws_config::AbstractAWSConfig=global_aw
         "ListIdentityPools",
         Dict{String,Any}("MaxResults" => MaxResults);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_identity_pools(
@@ -573,6 +600,7 @@ function list_identity_pools(
             mergewith(_merge, Dict{String,Any}("MaxResults" => MaxResults), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -597,6 +625,7 @@ function list_tags_for_resource(
         "ListTagsForResource",
         Dict{String,Any}("ResourceArn" => ResourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags_for_resource(
@@ -610,6 +639,7 @@ function list_tags_for_resource(
             mergewith(_merge, Dict{String,Any}("ResourceArn" => ResourceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -653,6 +683,7 @@ function lookup_developer_identity(
         "LookupDeveloperIdentity",
         Dict{String,Any}("IdentityPoolId" => IdentityPoolId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function lookup_developer_identity(
@@ -666,6 +697,7 @@ function lookup_developer_identity(
             mergewith(_merge, Dict{String,Any}("IdentityPoolId" => IdentityPoolId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -713,6 +745,7 @@ function merge_developer_identities(
             "SourceUserIdentifier" => SourceUserIdentifier,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function merge_developer_identities(
@@ -738,6 +771,7 @@ function merge_developer_identities(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -768,6 +802,7 @@ function set_identity_pool_roles(
         "SetIdentityPoolRoles",
         Dict{String,Any}("IdentityPoolId" => IdentityPoolId, "Roles" => Roles);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function set_identity_pool_roles(
@@ -786,6 +821,7 @@ function set_identity_pool_roles(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -816,6 +852,7 @@ function set_principal_tag_attribute_map(
             "IdentityProviderName" => IdentityProviderName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function set_principal_tag_attribute_map(
@@ -837,6 +874,7 @@ function set_principal_tag_attribute_map(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -867,6 +905,7 @@ function tag_resource(ResourceArn, Tags; aws_config::AbstractAWSConfig=global_aw
         "TagResource",
         Dict{String,Any}("ResourceArn" => ResourceArn, "Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -885,6 +924,7 @@ function tag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -921,6 +961,7 @@ function unlink_developer_identity(
             "IdentityPoolId" => IdentityPoolId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function unlink_developer_identity(
@@ -946,6 +987,7 @@ function unlink_developer_identity(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -975,6 +1017,7 @@ function unlink_identity(
             "LoginsToRemove" => LoginsToRemove,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function unlink_identity(
@@ -998,6 +1041,7 @@ function unlink_identity(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1020,6 +1064,7 @@ function untag_resource(
         "UntagResource",
         Dict{String,Any}("ResourceArn" => ResourceArn, "TagKeys" => TagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -1038,6 +1083,7 @@ function untag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1084,6 +1130,7 @@ function update_identity_pool(
             "IdentityPoolName" => IdentityPoolName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_identity_pool(
@@ -1107,5 +1154,6 @@ function update_identity_pool(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/cognito_identity_provider.jl
+++ b/src/services/cognito_identity_provider.jl
@@ -25,6 +25,7 @@ function add_custom_attributes(
             "CustomAttributes" => CustomAttributes, "UserPoolId" => UserPoolId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function add_custom_attributes(
@@ -45,6 +46,7 @@ function add_custom_attributes(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -70,6 +72,7 @@ function admin_add_user_to_group(
             "GroupName" => GroupName, "UserPoolId" => UserPoolId, "Username" => Username
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function admin_add_user_to_group(
@@ -93,6 +96,7 @@ function admin_add_user_to_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -133,6 +137,7 @@ function admin_confirm_sign_up(
         "AdminConfirmSignUp",
         Dict{String,Any}("UserPoolId" => UserPoolId, "Username" => Username);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function admin_confirm_sign_up(
@@ -151,6 +156,7 @@ function admin_confirm_sign_up(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -256,6 +262,7 @@ function admin_create_user(
         "AdminCreateUser",
         Dict{String,Any}("UserPoolId" => UserPoolId, "Username" => Username);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function admin_create_user(
@@ -274,6 +281,7 @@ function admin_create_user(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -296,6 +304,7 @@ function admin_delete_user(
         "AdminDeleteUser",
         Dict{String,Any}("UserPoolId" => UserPoolId, "Username" => Username);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function admin_delete_user(
@@ -314,6 +323,7 @@ function admin_delete_user(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -347,6 +357,7 @@ function admin_delete_user_attributes(
             "Username" => Username,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function admin_delete_user_attributes(
@@ -370,6 +381,7 @@ function admin_delete_user_attributes(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -409,6 +421,7 @@ function admin_disable_provider_for_user(
         "AdminDisableProviderForUser",
         Dict{String,Any}("User" => User, "UserPoolId" => UserPoolId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function admin_disable_provider_for_user(
@@ -425,6 +438,7 @@ function admin_disable_provider_for_user(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -446,6 +460,7 @@ function admin_disable_user(
         "AdminDisableUser",
         Dict{String,Any}("UserPoolId" => UserPoolId, "Username" => Username);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function admin_disable_user(
@@ -464,6 +479,7 @@ function admin_disable_user(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -486,6 +502,7 @@ function admin_enable_user(
         "AdminEnableUser",
         Dict{String,Any}("UserPoolId" => UserPoolId, "Username" => Username);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function admin_enable_user(
@@ -504,6 +521,7 @@ function admin_enable_user(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -528,6 +546,7 @@ function admin_forget_device(
             "DeviceKey" => DeviceKey, "UserPoolId" => UserPoolId, "Username" => Username
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function admin_forget_device(
@@ -551,6 +570,7 @@ function admin_forget_device(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -575,6 +595,7 @@ function admin_get_device(
             "DeviceKey" => DeviceKey, "UserPoolId" => UserPoolId, "Username" => Username
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function admin_get_device(
@@ -598,6 +619,7 @@ function admin_get_device(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -621,6 +643,7 @@ function admin_get_user(
         "AdminGetUser",
         Dict{String,Any}("UserPoolId" => UserPoolId, "Username" => Username);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function admin_get_user(
@@ -639,6 +662,7 @@ function admin_get_user(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -728,6 +752,7 @@ function admin_initiate_auth(
             "AuthFlow" => AuthFlow, "ClientId" => ClientId, "UserPoolId" => UserPoolId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function admin_initiate_auth(
@@ -751,6 +776,7 @@ function admin_initiate_auth(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -813,6 +839,7 @@ function admin_link_provider_for_user(
             "UserPoolId" => UserPoolId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function admin_link_provider_for_user(
@@ -836,6 +863,7 @@ function admin_link_provider_for_user(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -861,6 +889,7 @@ function admin_list_devices(
         "AdminListDevices",
         Dict{String,Any}("UserPoolId" => UserPoolId, "Username" => Username);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function admin_list_devices(
@@ -879,6 +908,7 @@ function admin_list_devices(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -906,6 +936,7 @@ function admin_list_groups_for_user(
         "AdminListGroupsForUser",
         Dict{String,Any}("UserPoolId" => UserPoolId, "Username" => Username);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function admin_list_groups_for_user(
@@ -924,6 +955,7 @@ function admin_list_groups_for_user(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -950,6 +982,7 @@ function admin_list_user_auth_events(
         "AdminListUserAuthEvents",
         Dict{String,Any}("UserPoolId" => UserPoolId, "Username" => Username);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function admin_list_user_auth_events(
@@ -968,6 +1001,7 @@ function admin_list_user_auth_events(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -993,6 +1027,7 @@ function admin_remove_user_from_group(
             "GroupName" => GroupName, "UserPoolId" => UserPoolId, "Username" => Username
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function admin_remove_user_from_group(
@@ -1016,6 +1051,7 @@ function admin_remove_user_from_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1075,6 +1111,7 @@ function admin_reset_user_password(
         "AdminResetUserPassword",
         Dict{String,Any}("UserPoolId" => UserPoolId, "Username" => Username);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function admin_reset_user_password(
@@ -1093,6 +1130,7 @@ function admin_reset_user_password(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1174,6 +1212,7 @@ function admin_respond_to_auth_challenge(
             "UserPoolId" => UserPoolId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function admin_respond_to_auth_challenge(
@@ -1197,6 +1236,7 @@ function admin_respond_to_auth_challenge(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1227,6 +1267,7 @@ function admin_set_user_mfapreference(
         "AdminSetUserMFAPreference",
         Dict{String,Any}("UserPoolId" => UserPoolId, "Username" => Username);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function admin_set_user_mfapreference(
@@ -1245,6 +1286,7 @@ function admin_set_user_mfapreference(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1279,6 +1321,7 @@ function admin_set_user_password(
             "Password" => Password, "UserPoolId" => UserPoolId, "Username" => Username
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function admin_set_user_password(
@@ -1302,6 +1345,7 @@ function admin_set_user_password(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1330,6 +1374,7 @@ function admin_set_user_settings(
             "MFAOptions" => MFAOptions, "UserPoolId" => UserPoolId, "Username" => Username
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function admin_set_user_settings(
@@ -1353,6 +1398,7 @@ function admin_set_user_settings(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1387,6 +1433,7 @@ function admin_update_auth_event_feedback(
             "Username" => Username,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function admin_update_auth_event_feedback(
@@ -1412,6 +1459,7 @@ function admin_update_auth_event_feedback(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1441,6 +1489,7 @@ function admin_update_device_status(
             "DeviceKey" => DeviceKey, "UserPoolId" => UserPoolId, "Username" => Username
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function admin_update_device_status(
@@ -1464,6 +1513,7 @@ function admin_update_device_status(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1525,6 +1575,7 @@ function admin_update_user_attributes(
             "Username" => Username,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function admin_update_user_attributes(
@@ -1548,6 +1599,7 @@ function admin_update_user_attributes(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1572,6 +1624,7 @@ function admin_user_global_sign_out(
         "AdminUserGlobalSignOut",
         Dict{String,Any}("UserPoolId" => UserPoolId, "Username" => Username);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function admin_user_global_sign_out(
@@ -1590,6 +1643,7 @@ function admin_user_global_sign_out(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1612,13 +1666,18 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   the service. This allows authentication of the user as part of the MFA setup process.
 """
 function associate_software_token(; aws_config::AbstractAWSConfig=global_aws_config())
-    return cognito_identity_provider("AssociateSoftwareToken"; aws_config=aws_config)
+    return cognito_identity_provider(
+        "AssociateSoftwareToken"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function associate_software_token(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return cognito_identity_provider(
-        "AssociateSoftwareToken", params; aws_config=aws_config
+        "AssociateSoftwareToken",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1648,6 +1707,7 @@ function change_password(
             "ProposedPassword" => ProposedPassword,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function change_password(
@@ -1671,6 +1731,7 @@ function change_password(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1696,6 +1757,7 @@ function confirm_device(
         "ConfirmDevice",
         Dict{String,Any}("AccessToken" => AccessToken, "DeviceKey" => DeviceKey);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function confirm_device(
@@ -1714,6 +1776,7 @@ function confirm_device(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1773,6 +1836,7 @@ function confirm_forgot_password(
             "Username" => Username,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function confirm_forgot_password(
@@ -1798,6 +1862,7 @@ function confirm_forgot_password(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1855,6 +1920,7 @@ function confirm_sign_up(
             "Username" => Username,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function confirm_sign_up(
@@ -1878,6 +1944,7 @@ function confirm_sign_up(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1915,6 +1982,7 @@ function create_group(
         "CreateGroup",
         Dict{String,Any}("GroupName" => GroupName, "UserPoolId" => UserPoolId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_group(
@@ -1933,6 +2001,7 @@ function create_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1980,6 +2049,7 @@ function create_identity_provider(
             "UserPoolId" => UserPoolId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_identity_provider(
@@ -2005,6 +2075,7 @@ function create_identity_provider(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2034,6 +2105,7 @@ function create_resource_server(
             "Identifier" => Identifier, "Name" => Name, "UserPoolId" => UserPoolId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_resource_server(
@@ -2055,6 +2127,7 @@ function create_resource_server(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2085,6 +2158,7 @@ function create_user_import_job(
             "UserPoolId" => UserPoolId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_user_import_job(
@@ -2108,6 +2182,7 @@ function create_user_import_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2179,7 +2254,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function create_user_pool(PoolName; aws_config::AbstractAWSConfig=global_aws_config())
     return cognito_identity_provider(
-        "CreateUserPool", Dict{String,Any}("PoolName" => PoolName); aws_config=aws_config
+        "CreateUserPool",
+        Dict{String,Any}("PoolName" => PoolName);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_user_pool(
@@ -2193,6 +2271,7 @@ function create_user_pool(
             mergewith(_merge, Dict{String,Any}("PoolName" => PoolName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2295,6 +2374,7 @@ function create_user_pool_client(
         "CreateUserPoolClient",
         Dict{String,Any}("ClientName" => ClientName, "UserPoolId" => UserPoolId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_user_pool_client(
@@ -2313,6 +2393,7 @@ function create_user_pool_client(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2341,6 +2422,7 @@ function create_user_pool_domain(
         "CreateUserPoolDomain",
         Dict{String,Any}("Domain" => Domain, "UserPoolId" => UserPoolId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_user_pool_domain(
@@ -2359,6 +2441,7 @@ function create_user_pool_domain(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2380,6 +2463,7 @@ function delete_group(
         "DeleteGroup",
         Dict{String,Any}("GroupName" => GroupName, "UserPoolId" => UserPoolId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_group(
@@ -2398,6 +2482,7 @@ function delete_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2419,6 +2504,7 @@ function delete_identity_provider(
         "DeleteIdentityProvider",
         Dict{String,Any}("ProviderName" => ProviderName, "UserPoolId" => UserPoolId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_identity_provider(
@@ -2439,6 +2525,7 @@ function delete_identity_provider(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2460,6 +2547,7 @@ function delete_resource_server(
         "DeleteResourceServer",
         Dict{String,Any}("Identifier" => Identifier, "UserPoolId" => UserPoolId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_resource_server(
@@ -2478,6 +2566,7 @@ function delete_resource_server(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2493,7 +2582,10 @@ Allows a user to delete himself or herself.
 """
 function delete_user(AccessToken; aws_config::AbstractAWSConfig=global_aws_config())
     return cognito_identity_provider(
-        "DeleteUser", Dict{String,Any}("AccessToken" => AccessToken); aws_config=aws_config
+        "DeleteUser",
+        Dict{String,Any}("AccessToken" => AccessToken);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_user(
@@ -2507,6 +2599,7 @@ function delete_user(
             mergewith(_merge, Dict{String,Any}("AccessToken" => AccessToken), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2532,6 +2625,7 @@ function delete_user_attributes(
             "AccessToken" => AccessToken, "UserAttributeNames" => UserAttributeNames
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_user_attributes(
@@ -2552,6 +2646,7 @@ function delete_user_attributes(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2570,6 +2665,7 @@ function delete_user_pool(UserPoolId; aws_config::AbstractAWSConfig=global_aws_c
         "DeleteUserPool",
         Dict{String,Any}("UserPoolId" => UserPoolId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_user_pool(
@@ -2583,6 +2679,7 @@ function delete_user_pool(
             mergewith(_merge, Dict{String,Any}("UserPoolId" => UserPoolId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2604,6 +2701,7 @@ function delete_user_pool_client(
         "DeleteUserPoolClient",
         Dict{String,Any}("ClientId" => ClientId, "UserPoolId" => UserPoolId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_user_pool_client(
@@ -2622,6 +2720,7 @@ function delete_user_pool_client(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2643,6 +2742,7 @@ function delete_user_pool_domain(
         "DeleteUserPoolDomain",
         Dict{String,Any}("Domain" => Domain, "UserPoolId" => UserPoolId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_user_pool_domain(
@@ -2661,6 +2761,7 @@ function delete_user_pool_domain(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2682,6 +2783,7 @@ function describe_identity_provider(
         "DescribeIdentityProvider",
         Dict{String,Any}("ProviderName" => ProviderName, "UserPoolId" => UserPoolId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_identity_provider(
@@ -2702,6 +2804,7 @@ function describe_identity_provider(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2723,6 +2826,7 @@ function describe_resource_server(
         "DescribeResourceServer",
         Dict{String,Any}("Identifier" => Identifier, "UserPoolId" => UserPoolId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_resource_server(
@@ -2741,6 +2845,7 @@ function describe_resource_server(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2764,6 +2869,7 @@ function describe_risk_configuration(
         "DescribeRiskConfiguration",
         Dict{String,Any}("UserPoolId" => UserPoolId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_risk_configuration(
@@ -2777,6 +2883,7 @@ function describe_risk_configuration(
             mergewith(_merge, Dict{String,Any}("UserPoolId" => UserPoolId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2798,6 +2905,7 @@ function describe_user_import_job(
         "DescribeUserImportJob",
         Dict{String,Any}("JobId" => JobId, "UserPoolId" => UserPoolId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_user_import_job(
@@ -2816,6 +2924,7 @@ function describe_user_import_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2834,6 +2943,7 @@ function describe_user_pool(UserPoolId; aws_config::AbstractAWSConfig=global_aws
         "DescribeUserPool",
         Dict{String,Any}("UserPoolId" => UserPoolId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_user_pool(
@@ -2847,6 +2957,7 @@ function describe_user_pool(
             mergewith(_merge, Dict{String,Any}("UserPoolId" => UserPoolId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2869,6 +2980,7 @@ function describe_user_pool_client(
         "DescribeUserPoolClient",
         Dict{String,Any}("ClientId" => ClientId, "UserPoolId" => UserPoolId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_user_pool_client(
@@ -2887,6 +2999,7 @@ function describe_user_pool_client(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2907,6 +3020,7 @@ function describe_user_pool_domain(
         "DescribeUserPoolDomain",
         Dict{String,Any}("Domain" => Domain);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_user_pool_domain(
@@ -2916,6 +3030,7 @@ function describe_user_pool_domain(
         "DescribeUserPoolDomain",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Domain" => Domain), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2934,7 +3049,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function forget_device(DeviceKey; aws_config::AbstractAWSConfig=global_aws_config())
     return cognito_identity_provider(
-        "ForgetDevice", Dict{String,Any}("DeviceKey" => DeviceKey); aws_config=aws_config
+        "ForgetDevice",
+        Dict{String,Any}("DeviceKey" => DeviceKey);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function forget_device(
@@ -2948,6 +3066,7 @@ function forget_device(
             mergewith(_merge, Dict{String,Any}("DeviceKey" => DeviceKey), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3012,6 +3131,7 @@ function forgot_password(
         "ForgotPassword",
         Dict{String,Any}("ClientId" => ClientId, "Username" => Username);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function forgot_password(
@@ -3030,6 +3150,7 @@ function forgot_password(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3045,7 +3166,10 @@ Gets the header information for the .csv file to be used as input for the user i
 """
 function get_csvheader(UserPoolId; aws_config::AbstractAWSConfig=global_aws_config())
     return cognito_identity_provider(
-        "GetCSVHeader", Dict{String,Any}("UserPoolId" => UserPoolId); aws_config=aws_config
+        "GetCSVHeader",
+        Dict{String,Any}("UserPoolId" => UserPoolId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_csvheader(
@@ -3059,6 +3183,7 @@ function get_csvheader(
             mergewith(_merge, Dict{String,Any}("UserPoolId" => UserPoolId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3077,7 +3202,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function get_device(DeviceKey; aws_config::AbstractAWSConfig=global_aws_config())
     return cognito_identity_provider(
-        "GetDevice", Dict{String,Any}("DeviceKey" => DeviceKey); aws_config=aws_config
+        "GetDevice",
+        Dict{String,Any}("DeviceKey" => DeviceKey);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_device(
@@ -3091,6 +3219,7 @@ function get_device(
             mergewith(_merge, Dict{String,Any}("DeviceKey" => DeviceKey), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3110,6 +3239,7 @@ function get_group(GroupName, UserPoolId; aws_config::AbstractAWSConfig=global_a
         "GetGroup",
         Dict{String,Any}("GroupName" => GroupName, "UserPoolId" => UserPoolId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_group(
@@ -3128,6 +3258,7 @@ function get_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3149,6 +3280,7 @@ function get_identity_provider_by_identifier(
         "GetIdentityProviderByIdentifier",
         Dict{String,Any}("IdpIdentifier" => IdpIdentifier, "UserPoolId" => UserPoolId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_identity_provider_by_identifier(
@@ -3169,6 +3301,7 @@ function get_identity_provider_by_identifier(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3189,6 +3322,7 @@ function get_signing_certificate(
         "GetSigningCertificate",
         Dict{String,Any}("UserPoolId" => UserPoolId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_signing_certificate(
@@ -3202,6 +3336,7 @@ function get_signing_certificate(
             mergewith(_merge, Dict{String,Any}("UserPoolId" => UserPoolId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3226,6 +3361,7 @@ function get_uicustomization(UserPoolId; aws_config::AbstractAWSConfig=global_aw
         "GetUICustomization",
         Dict{String,Any}("UserPoolId" => UserPoolId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_uicustomization(
@@ -3239,6 +3375,7 @@ function get_uicustomization(
             mergewith(_merge, Dict{String,Any}("UserPoolId" => UserPoolId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3255,7 +3392,10 @@ Gets the user attributes and metadata for a user.
 """
 function get_user(AccessToken; aws_config::AbstractAWSConfig=global_aws_config())
     return cognito_identity_provider(
-        "GetUser", Dict{String,Any}("AccessToken" => AccessToken); aws_config=aws_config
+        "GetUser",
+        Dict{String,Any}("AccessToken" => AccessToken);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_user(
@@ -3269,6 +3409,7 @@ function get_user(
             mergewith(_merge, Dict{String,Any}("AccessToken" => AccessToken), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3322,6 +3463,7 @@ function get_user_attribute_verification_code(
         "GetUserAttributeVerificationCode",
         Dict{String,Any}("AccessToken" => AccessToken, "AttributeName" => AttributeName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_user_attribute_verification_code(
@@ -3342,6 +3484,7 @@ function get_user_attribute_verification_code(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3362,6 +3505,7 @@ function get_user_pool_mfa_config(
         "GetUserPoolMfaConfig",
         Dict{String,Any}("UserPoolId" => UserPoolId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_user_pool_mfa_config(
@@ -3375,6 +3519,7 @@ function get_user_pool_mfa_config(
             mergewith(_merge, Dict{String,Any}("UserPoolId" => UserPoolId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3395,6 +3540,7 @@ function global_sign_out(AccessToken; aws_config::AbstractAWSConfig=global_aws_c
         "GlobalSignOut",
         Dict{String,Any}("AccessToken" => AccessToken);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function global_sign_out(
@@ -3408,6 +3554,7 @@ function global_sign_out(
             mergewith(_merge, Dict{String,Any}("AccessToken" => AccessToken), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3490,6 +3637,7 @@ function initiate_auth(
         "InitiateAuth",
         Dict{String,Any}("AuthFlow" => AuthFlow, "ClientId" => ClientId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function initiate_auth(
@@ -3508,6 +3656,7 @@ function initiate_auth(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3527,7 +3676,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function list_devices(AccessToken; aws_config::AbstractAWSConfig=global_aws_config())
     return cognito_identity_provider(
-        "ListDevices", Dict{String,Any}("AccessToken" => AccessToken); aws_config=aws_config
+        "ListDevices",
+        Dict{String,Any}("AccessToken" => AccessToken);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_devices(
@@ -3541,6 +3693,7 @@ function list_devices(
             mergewith(_merge, Dict{String,Any}("AccessToken" => AccessToken), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3562,7 +3715,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function list_groups(UserPoolId; aws_config::AbstractAWSConfig=global_aws_config())
     return cognito_identity_provider(
-        "ListGroups", Dict{String,Any}("UserPoolId" => UserPoolId); aws_config=aws_config
+        "ListGroups",
+        Dict{String,Any}("UserPoolId" => UserPoolId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_groups(
@@ -3576,6 +3732,7 @@ function list_groups(
             mergewith(_merge, Dict{String,Any}("UserPoolId" => UserPoolId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3600,6 +3757,7 @@ function list_identity_providers(
         "ListIdentityProviders",
         Dict{String,Any}("UserPoolId" => UserPoolId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_identity_providers(
@@ -3613,6 +3771,7 @@ function list_identity_providers(
             mergewith(_merge, Dict{String,Any}("UserPoolId" => UserPoolId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3637,6 +3796,7 @@ function list_resource_servers(
         "ListResourceServers",
         Dict{String,Any}("UserPoolId" => UserPoolId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_resource_servers(
@@ -3650,6 +3810,7 @@ function list_resource_servers(
             mergewith(_merge, Dict{String,Any}("UserPoolId" => UserPoolId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3674,6 +3835,7 @@ function list_tags_for_resource(
         "ListTagsForResource",
         Dict{String,Any}("ResourceArn" => ResourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags_for_resource(
@@ -3687,6 +3849,7 @@ function list_tags_for_resource(
             mergewith(_merge, Dict{String,Any}("ResourceArn" => ResourceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3712,6 +3875,7 @@ function list_user_import_jobs(
         "ListUserImportJobs",
         Dict{String,Any}("MaxResults" => MaxResults, "UserPoolId" => UserPoolId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_user_import_jobs(
@@ -3730,6 +3894,7 @@ function list_user_import_jobs(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3757,6 +3922,7 @@ function list_user_pool_clients(
         "ListUserPoolClients",
         Dict{String,Any}("UserPoolId" => UserPoolId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_user_pool_clients(
@@ -3770,6 +3936,7 @@ function list_user_pool_clients(
             mergewith(_merge, Dict{String,Any}("UserPoolId" => UserPoolId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3790,7 +3957,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function list_user_pools(MaxResults; aws_config::AbstractAWSConfig=global_aws_config())
     return cognito_identity_provider(
-        "ListUserPools", Dict{String,Any}("MaxResults" => MaxResults); aws_config=aws_config
+        "ListUserPools",
+        Dict{String,Any}("MaxResults" => MaxResults);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_user_pools(
@@ -3804,6 +3974,7 @@ function list_user_pools(
             mergewith(_merge, Dict{String,Any}("MaxResults" => MaxResults), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3842,7 +4013,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function list_users(UserPoolId; aws_config::AbstractAWSConfig=global_aws_config())
     return cognito_identity_provider(
-        "ListUsers", Dict{String,Any}("UserPoolId" => UserPoolId); aws_config=aws_config
+        "ListUsers",
+        Dict{String,Any}("UserPoolId" => UserPoolId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_users(
@@ -3856,6 +4030,7 @@ function list_users(
             mergewith(_merge, Dict{String,Any}("UserPoolId" => UserPoolId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3882,6 +4057,7 @@ function list_users_in_group(
         "ListUsersInGroup",
         Dict{String,Any}("GroupName" => GroupName, "UserPoolId" => UserPoolId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_users_in_group(
@@ -3900,6 +4076,7 @@ function list_users_in_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3957,6 +4134,7 @@ function resend_confirmation_code(
         "ResendConfirmationCode",
         Dict{String,Any}("ClientId" => ClientId, "Username" => Username);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function resend_confirmation_code(
@@ -3975,6 +4153,7 @@ function resend_confirmation_code(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4047,6 +4226,7 @@ function respond_to_auth_challenge(
         "RespondToAuthChallenge",
         Dict{String,Any}("ChallengeName" => ChallengeName, "ClientId" => ClientId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function respond_to_auth_challenge(
@@ -4065,6 +4245,7 @@ function respond_to_auth_challenge(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4089,6 +4270,7 @@ function revoke_token(ClientId, Token; aws_config::AbstractAWSConfig=global_aws_
         "RevokeToken",
         Dict{String,Any}("ClientId" => ClientId, "Token" => Token);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function revoke_token(
@@ -4105,6 +4287,7 @@ function revoke_token(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4139,6 +4322,7 @@ function set_risk_configuration(
         "SetRiskConfiguration",
         Dict{String,Any}("UserPoolId" => UserPoolId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function set_risk_configuration(
@@ -4152,6 +4336,7 @@ function set_risk_configuration(
             mergewith(_merge, Dict{String,Any}("UserPoolId" => UserPoolId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4181,6 +4366,7 @@ function set_uicustomization(UserPoolId; aws_config::AbstractAWSConfig=global_aw
         "SetUICustomization",
         Dict{String,Any}("UserPoolId" => UserPoolId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function set_uicustomization(
@@ -4194,6 +4380,7 @@ function set_uicustomization(
             mergewith(_merge, Dict{String,Any}("UserPoolId" => UserPoolId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4227,6 +4414,7 @@ function set_user_mfapreference(
         "SetUserMFAPreference",
         Dict{String,Any}("AccessToken" => AccessToken);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function set_user_mfapreference(
@@ -4240,6 +4428,7 @@ function set_user_mfapreference(
             mergewith(_merge, Dict{String,Any}("AccessToken" => AccessToken), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4280,6 +4469,7 @@ function set_user_pool_mfa_config(
         "SetUserPoolMfaConfig",
         Dict{String,Any}("UserPoolId" => UserPoolId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function set_user_pool_mfa_config(
@@ -4293,6 +4483,7 @@ function set_user_pool_mfa_config(
             mergewith(_merge, Dict{String,Any}("UserPoolId" => UserPoolId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4317,6 +4508,7 @@ function set_user_settings(
         "SetUserSettings",
         Dict{String,Any}("AccessToken" => AccessToken, "MFAOptions" => MFAOptions);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function set_user_settings(
@@ -4335,6 +4527,7 @@ function set_user_settings(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4399,6 +4592,7 @@ function sign_up(
             "ClientId" => ClientId, "Password" => Password, "Username" => Username
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function sign_up(
@@ -4420,6 +4614,7 @@ function sign_up(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4441,6 +4636,7 @@ function start_user_import_job(
         "StartUserImportJob",
         Dict{String,Any}("JobId" => JobId, "UserPoolId" => UserPoolId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_user_import_job(
@@ -4459,6 +4655,7 @@ function start_user_import_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4480,6 +4677,7 @@ function stop_user_import_job(
         "StopUserImportJob",
         Dict{String,Any}("JobId" => JobId, "UserPoolId" => UserPoolId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function stop_user_import_job(
@@ -4498,6 +4696,7 @@ function stop_user_import_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4527,6 +4726,7 @@ function tag_resource(ResourceArn, Tags; aws_config::AbstractAWSConfig=global_aw
         "TagResource",
         Dict{String,Any}("ResourceArn" => ResourceArn, "Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -4545,6 +4745,7 @@ function tag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4568,6 +4769,7 @@ function untag_resource(
         "UntagResource",
         Dict{String,Any}("ResourceArn" => ResourceArn, "TagKeys" => TagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -4586,6 +4788,7 @@ function untag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4623,6 +4826,7 @@ function update_auth_event_feedback(
             "Username" => Username,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_auth_event_feedback(
@@ -4650,6 +4854,7 @@ function update_auth_event_feedback(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4674,6 +4879,7 @@ function update_device_status(
         "UpdateDeviceStatus",
         Dict{String,Any}("AccessToken" => AccessToken, "DeviceKey" => DeviceKey);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_device_status(
@@ -4692,6 +4898,7 @@ function update_device_status(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4721,6 +4928,7 @@ function update_group(
         "UpdateGroup",
         Dict{String,Any}("GroupName" => GroupName, "UserPoolId" => UserPoolId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_group(
@@ -4739,6 +4947,7 @@ function update_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4766,6 +4975,7 @@ function update_identity_provider(
         "UpdateIdentityProvider",
         Dict{String,Any}("ProviderName" => ProviderName, "UserPoolId" => UserPoolId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_identity_provider(
@@ -4786,6 +4996,7 @@ function update_identity_provider(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4814,6 +5025,7 @@ function update_resource_server(
             "Identifier" => Identifier, "Name" => Name, "UserPoolId" => UserPoolId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_resource_server(
@@ -4835,6 +5047,7 @@ function update_resource_server(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4886,6 +5099,7 @@ function update_user_attributes(
         "UpdateUserAttributes",
         Dict{String,Any}("AccessToken" => AccessToken, "UserAttributes" => UserAttributes);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_user_attributes(
@@ -4906,6 +5120,7 @@ function update_user_attributes(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4970,6 +5185,7 @@ function update_user_pool(UserPoolId; aws_config::AbstractAWSConfig=global_aws_c
         "UpdateUserPool",
         Dict{String,Any}("UserPoolId" => UserPoolId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_user_pool(
@@ -4983,6 +5199,7 @@ function update_user_pool(
             mergewith(_merge, Dict{String,Any}("UserPoolId" => UserPoolId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5077,6 +5294,7 @@ function update_user_pool_client(
         "UpdateUserPoolClient",
         Dict{String,Any}("ClientId" => ClientId, "UserPoolId" => UserPoolId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_user_pool_client(
@@ -5095,6 +5313,7 @@ function update_user_pool_client(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5145,6 +5364,7 @@ function update_user_pool_domain(
             "UserPoolId" => UserPoolId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_user_pool_domain(
@@ -5168,6 +5388,7 @@ function update_user_pool_domain(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5195,6 +5416,7 @@ function verify_software_token(UserCode; aws_config::AbstractAWSConfig=global_aw
         "VerifySoftwareToken",
         Dict{String,Any}("UserCode" => UserCode);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function verify_software_token(
@@ -5208,6 +5430,7 @@ function verify_software_token(
             mergewith(_merge, Dict{String,Any}("UserCode" => UserCode), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5232,6 +5455,7 @@ function verify_user_attribute(
             "AccessToken" => AccessToken, "AttributeName" => AttributeName, "Code" => Code
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function verify_user_attribute(
@@ -5255,5 +5479,6 @@ function verify_user_attribute(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/cognito_sync.jl
+++ b/src/services/cognito_sync.jl
@@ -22,7 +22,10 @@ cannot call this API with the temporary user credentials provided by Cognito Ide
 """
 function bulk_publish(IdentityPoolId; aws_config::AbstractAWSConfig=global_aws_config())
     return cognito_sync(
-        "POST", "/identitypools/$(IdentityPoolId)/bulkpublish"; aws_config=aws_config
+        "POST",
+        "/identitypools/$(IdentityPoolId)/bulkpublish";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function bulk_publish(
@@ -35,6 +38,7 @@ function bulk_publish(
         "/identitypools/$(IdentityPoolId)/bulkpublish",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -69,6 +73,7 @@ function delete_dataset(
         "DELETE",
         "/identitypools/$(IdentityPoolId)/identities/$(IdentityId)/datasets/$(DatasetName)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_dataset(
@@ -83,6 +88,7 @@ function delete_dataset(
         "/identitypools/$(IdentityPoolId)/identities/$(IdentityId)/datasets/$(DatasetName)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -117,6 +123,7 @@ function describe_dataset(
         "GET",
         "/identitypools/$(IdentityPoolId)/identities/$(IdentityId)/datasets/$(DatasetName)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_dataset(
@@ -131,6 +138,7 @@ function describe_dataset(
         "/identitypools/$(IdentityPoolId)/identities/$(IdentityId)/datasets/$(DatasetName)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -151,7 +159,12 @@ user credentials provided by Cognito Identity.
 function describe_identity_pool_usage(
     IdentityPoolId; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return cognito_sync("GET", "/identitypools/$(IdentityPoolId)"; aws_config=aws_config)
+    return cognito_sync(
+        "GET",
+        "/identitypools/$(IdentityPoolId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_identity_pool_usage(
     IdentityPoolId,
@@ -159,7 +172,11 @@ function describe_identity_pool_usage(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return cognito_sync(
-        "GET", "/identitypools/$(IdentityPoolId)", params; aws_config=aws_config
+        "GET",
+        "/identitypools/$(IdentityPoolId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -187,6 +204,7 @@ function describe_identity_usage(
         "GET",
         "/identitypools/$(IdentityPoolId)/identities/$(IdentityId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_identity_usage(
@@ -200,6 +218,7 @@ function describe_identity_usage(
         "/identitypools/$(IdentityPoolId)/identities/$(IdentityId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -224,6 +243,7 @@ function get_bulk_publish_details(
         "POST",
         "/identitypools/$(IdentityPoolId)/getBulkPublishDetails";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_bulk_publish_details(
@@ -236,6 +256,7 @@ function get_bulk_publish_details(
         "/identitypools/$(IdentityPoolId)/getBulkPublishDetails",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -255,7 +276,10 @@ function get_cognito_events(
     IdentityPoolId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return cognito_sync(
-        "GET", "/identitypools/$(IdentityPoolId)/events"; aws_config=aws_config
+        "GET",
+        "/identitypools/$(IdentityPoolId)/events";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_cognito_events(
@@ -264,7 +288,11 @@ function get_cognito_events(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return cognito_sync(
-        "GET", "/identitypools/$(IdentityPoolId)/events", params; aws_config=aws_config
+        "GET",
+        "/identitypools/$(IdentityPoolId)/events",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -286,7 +314,10 @@ function get_identity_pool_configuration(
     IdentityPoolId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return cognito_sync(
-        "GET", "/identitypools/$(IdentityPoolId)/configuration"; aws_config=aws_config
+        "GET",
+        "/identitypools/$(IdentityPoolId)/configuration";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_identity_pool_configuration(
@@ -299,6 +330,7 @@ function get_identity_pool_configuration(
         "/identitypools/$(IdentityPoolId)/configuration",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -332,6 +364,7 @@ function list_datasets(
         "GET",
         "/identitypools/$(IdentityPoolId)/identities/$(IdentityId)/datasets";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_datasets(
@@ -345,6 +378,7 @@ function list_datasets(
         "/identitypools/$(IdentityPoolId)/identities/$(IdentityId)/datasets",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -362,12 +396,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: A pagination token for obtaining the next page of results.
 """
 function list_identity_pool_usage(; aws_config::AbstractAWSConfig=global_aws_config())
-    return cognito_sync("GET", "/identitypools"; aws_config=aws_config)
+    return cognito_sync(
+        "GET", "/identitypools"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_identity_pool_usage(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return cognito_sync("GET", "/identitypools", params; aws_config=aws_config)
+    return cognito_sync(
+        "GET",
+        "/identitypools",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -408,6 +450,7 @@ function list_records(
         "GET",
         "/identitypools/$(IdentityPoolId)/identities/$(IdentityId)/datasets/$(DatasetName)/records";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_records(
@@ -422,6 +465,7 @@ function list_records(
         "/identitypools/$(IdentityPoolId)/identities/$(IdentityId)/datasets/$(DatasetName)/records",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -454,6 +498,7 @@ function register_device(
         "/identitypools/$(IdentityPoolId)/identity/$(IdentityId)/device",
         Dict{String,Any}("Platform" => Platform, "Token" => Token);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function register_device(
@@ -473,6 +518,7 @@ function register_device(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -499,6 +545,7 @@ function set_cognito_events(
         "/identitypools/$(IdentityPoolId)/events",
         Dict{String,Any}("Events" => Events);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function set_cognito_events(
@@ -512,6 +559,7 @@ function set_cognito_events(
         "/identitypools/$(IdentityPoolId)/events",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Events" => Events), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -537,7 +585,10 @@ function set_identity_pool_configuration(
     IdentityPoolId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return cognito_sync(
-        "POST", "/identitypools/$(IdentityPoolId)/configuration"; aws_config=aws_config
+        "POST",
+        "/identitypools/$(IdentityPoolId)/configuration";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function set_identity_pool_configuration(
@@ -550,6 +601,7 @@ function set_identity_pool_configuration(
         "/identitypools/$(IdentityPoolId)/configuration",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -581,6 +633,7 @@ function subscribe_to_dataset(
         "POST",
         "/identitypools/$(IdentityPoolId)/identities/$(IdentityId)/datasets/$(DatasetName)/subscriptions/$(DeviceId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function subscribe_to_dataset(
@@ -596,6 +649,7 @@ function subscribe_to_dataset(
         "/identitypools/$(IdentityPoolId)/identities/$(IdentityId)/datasets/$(DatasetName)/subscriptions/$(DeviceId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -627,6 +681,7 @@ function unsubscribe_from_dataset(
         "DELETE",
         "/identitypools/$(IdentityPoolId)/identities/$(IdentityId)/datasets/$(DatasetName)/subscriptions/$(DeviceId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function unsubscribe_from_dataset(
@@ -642,6 +697,7 @@ function unsubscribe_from_dataset(
         "/identitypools/$(IdentityPoolId)/identities/$(IdentityId)/datasets/$(DatasetName)/subscriptions/$(DeviceId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -693,6 +749,7 @@ function update_records(
         "/identitypools/$(IdentityPoolId)/identities/$(IdentityId)/datasets/$(DatasetName)",
         Dict{String,Any}("SyncSessionToken" => SyncSessionToken);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_records(
@@ -712,5 +769,6 @@ function update_records(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/comprehend.jl
+++ b/src/services/comprehend.jl
@@ -24,6 +24,7 @@ function batch_detect_dominant_language(
         "BatchDetectDominantLanguage",
         Dict{String,Any}("TextList" => TextList);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_detect_dominant_language(
@@ -37,6 +38,7 @@ function batch_detect_dominant_language(
             mergewith(_merge, Dict{String,Any}("TextList" => TextList), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -62,6 +64,7 @@ function batch_detect_entities(
         "BatchDetectEntities",
         Dict{String,Any}("LanguageCode" => LanguageCode, "TextList" => TextList);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_detect_entities(
@@ -80,6 +83,7 @@ function batch_detect_entities(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -104,6 +108,7 @@ function batch_detect_key_phrases(
         "BatchDetectKeyPhrases",
         Dict{String,Any}("LanguageCode" => LanguageCode, "TextList" => TextList);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_detect_key_phrases(
@@ -122,6 +127,7 @@ function batch_detect_key_phrases(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -147,6 +153,7 @@ function batch_detect_sentiment(
         "BatchDetectSentiment",
         Dict{String,Any}("LanguageCode" => LanguageCode, "TextList" => TextList);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_detect_sentiment(
@@ -165,6 +172,7 @@ function batch_detect_sentiment(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -192,6 +200,7 @@ function batch_detect_syntax(
         "BatchDetectSyntax",
         Dict{String,Any}("LanguageCode" => LanguageCode, "TextList" => TextList);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_detect_syntax(
@@ -210,6 +219,7 @@ function batch_detect_syntax(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -232,6 +242,7 @@ function classify_document(
         "ClassifyDocument",
         Dict{String,Any}("EndpointArn" => EndpointArn, "Text" => Text);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function classify_document(
@@ -250,6 +261,7 @@ function classify_document(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -274,6 +286,7 @@ function contains_pii_entities(
         "ContainsPiiEntities",
         Dict{String,Any}("LanguageCode" => LanguageCode, "Text" => Text);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function contains_pii_entities(
@@ -292,6 +305,7 @@ function contains_pii_entities(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -366,6 +380,7 @@ function create_document_classifier(
             "ClientRequestToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_document_classifier(
@@ -392,6 +407,7 @@ function create_document_classifier(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -438,6 +454,7 @@ function create_endpoint(
             "ClientRequestToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_endpoint(
@@ -462,6 +479,7 @@ function create_endpoint(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -529,6 +547,7 @@ function create_entity_recognizer(
             "ClientRequestToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_entity_recognizer(
@@ -555,6 +574,7 @@ function create_entity_recognizer(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -580,6 +600,7 @@ function delete_document_classifier(
         "DeleteDocumentClassifier",
         Dict{String,Any}("DocumentClassifierArn" => DocumentClassifierArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_document_classifier(
@@ -597,6 +618,7 @@ function delete_document_classifier(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -616,6 +638,7 @@ function delete_endpoint(EndpointArn; aws_config::AbstractAWSConfig=global_aws_c
         "DeleteEndpoint",
         Dict{String,Any}("EndpointArn" => EndpointArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_endpoint(
@@ -629,6 +652,7 @@ function delete_endpoint(
             mergewith(_merge, Dict{String,Any}("EndpointArn" => EndpointArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -654,6 +678,7 @@ function delete_entity_recognizer(
         "DeleteEntityRecognizer",
         Dict{String,Any}("EntityRecognizerArn" => EntityRecognizerArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_entity_recognizer(
@@ -671,6 +696,7 @@ function delete_entity_recognizer(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -693,6 +719,7 @@ function describe_document_classification_job(
         "DescribeDocumentClassificationJob",
         Dict{String,Any}("JobId" => JobId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_document_classification_job(
@@ -702,6 +729,7 @@ function describe_document_classification_job(
         "DescribeDocumentClassificationJob",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("JobId" => JobId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -723,6 +751,7 @@ function describe_document_classifier(
         "DescribeDocumentClassifier",
         Dict{String,Any}("DocumentClassifierArn" => DocumentClassifierArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_document_classifier(
@@ -740,6 +769,7 @@ function describe_document_classifier(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -762,6 +792,7 @@ function describe_dominant_language_detection_job(
         "DescribeDominantLanguageDetectionJob",
         Dict{String,Any}("JobId" => JobId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_dominant_language_detection_job(
@@ -771,6 +802,7 @@ function describe_dominant_language_detection_job(
         "DescribeDominantLanguageDetectionJob",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("JobId" => JobId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -790,6 +822,7 @@ function describe_endpoint(EndpointArn; aws_config::AbstractAWSConfig=global_aws
         "DescribeEndpoint",
         Dict{String,Any}("EndpointArn" => EndpointArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_endpoint(
@@ -803,6 +836,7 @@ function describe_endpoint(
             mergewith(_merge, Dict{String,Any}("EndpointArn" => EndpointArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -825,6 +859,7 @@ function describe_entities_detection_job(
         "DescribeEntitiesDetectionJob",
         Dict{String,Any}("JobId" => JobId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_entities_detection_job(
@@ -834,6 +869,7 @@ function describe_entities_detection_job(
         "DescribeEntitiesDetectionJob",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("JobId" => JobId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -856,6 +892,7 @@ function describe_entity_recognizer(
         "DescribeEntityRecognizer",
         Dict{String,Any}("EntityRecognizerArn" => EntityRecognizerArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_entity_recognizer(
@@ -873,6 +910,7 @@ function describe_entity_recognizer(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -893,6 +931,7 @@ function describe_events_detection_job(
         "DescribeEventsDetectionJob",
         Dict{String,Any}("JobId" => JobId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_events_detection_job(
@@ -902,6 +941,7 @@ function describe_events_detection_job(
         "DescribeEventsDetectionJob",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("JobId" => JobId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -924,6 +964,7 @@ function describe_key_phrases_detection_job(
         "DescribeKeyPhrasesDetectionJob",
         Dict{String,Any}("JobId" => JobId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_key_phrases_detection_job(
@@ -933,6 +974,7 @@ function describe_key_phrases_detection_job(
         "DescribeKeyPhrasesDetectionJob",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("JobId" => JobId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -955,6 +997,7 @@ function describe_pii_entities_detection_job(
         "DescribePiiEntitiesDetectionJob",
         Dict{String,Any}("JobId" => JobId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_pii_entities_detection_job(
@@ -964,6 +1007,7 @@ function describe_pii_entities_detection_job(
         "DescribePiiEntitiesDetectionJob",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("JobId" => JobId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -986,6 +1030,7 @@ function describe_sentiment_detection_job(
         "DescribeSentimentDetectionJob",
         Dict{String,Any}("JobId" => JobId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_sentiment_detection_job(
@@ -995,6 +1040,7 @@ function describe_sentiment_detection_job(
         "DescribeSentimentDetectionJob",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("JobId" => JobId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1016,6 +1062,7 @@ function describe_topics_detection_job(
         "DescribeTopicsDetectionJob",
         Dict{String,Any}("JobId" => JobId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_topics_detection_job(
@@ -1025,6 +1072,7 @@ function describe_topics_detection_job(
         "DescribeTopicsDetectionJob",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("JobId" => JobId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1042,7 +1090,10 @@ Comprehend can detect, see Amazon Comprehend Supported Languages.
 """
 function detect_dominant_language(Text; aws_config::AbstractAWSConfig=global_aws_config())
     return comprehend(
-        "DetectDominantLanguage", Dict{String,Any}("Text" => Text); aws_config=aws_config
+        "DetectDominantLanguage",
+        Dict{String,Any}("Text" => Text);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function detect_dominant_language(
@@ -1052,6 +1103,7 @@ function detect_dominant_language(
         "DetectDominantLanguage",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Text" => Text), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1081,7 +1133,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function detect_entities(Text; aws_config::AbstractAWSConfig=global_aws_config())
     return comprehend(
-        "DetectEntities", Dict{String,Any}("Text" => Text); aws_config=aws_config
+        "DetectEntities",
+        Dict{String,Any}("Text" => Text);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function detect_entities(
@@ -1091,6 +1146,7 @@ function detect_entities(
         "DetectEntities",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Text" => Text), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1114,6 +1170,7 @@ function detect_key_phrases(
         "DetectKeyPhrases",
         Dict{String,Any}("LanguageCode" => LanguageCode, "Text" => Text);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function detect_key_phrases(
@@ -1132,6 +1189,7 @@ function detect_key_phrases(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1155,6 +1213,7 @@ function detect_pii_entities(
         "DetectPiiEntities",
         Dict{String,Any}("LanguageCode" => LanguageCode, "Text" => Text);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function detect_pii_entities(
@@ -1173,6 +1232,7 @@ function detect_pii_entities(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1197,6 +1257,7 @@ function detect_sentiment(
         "DetectSentiment",
         Dict{String,Any}("LanguageCode" => LanguageCode, "Text" => Text);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function detect_sentiment(
@@ -1215,6 +1276,7 @@ function detect_sentiment(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1240,6 +1302,7 @@ function detect_syntax(
         "DetectSyntax",
         Dict{String,Any}("LanguageCode" => LanguageCode, "Text" => Text);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function detect_syntax(
@@ -1258,6 +1321,7 @@ function detect_syntax(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1278,12 +1342,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function list_document_classification_jobs(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return comprehend("ListDocumentClassificationJobs"; aws_config=aws_config)
+    return comprehend(
+        "ListDocumentClassificationJobs";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_document_classification_jobs(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return comprehend("ListDocumentClassificationJobs", params; aws_config=aws_config)
+    return comprehend(
+        "ListDocumentClassificationJobs",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1300,12 +1373,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function list_document_classifier_summaries(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return comprehend("ListDocumentClassifierSummaries"; aws_config=aws_config)
+    return comprehend(
+        "ListDocumentClassifierSummaries";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_document_classifier_summaries(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return comprehend("ListDocumentClassifierSummaries", params; aws_config=aws_config)
+    return comprehend(
+        "ListDocumentClassifierSummaries",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1323,12 +1405,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`: Identifies the next page of results to return.
 """
 function list_document_classifiers(; aws_config::AbstractAWSConfig=global_aws_config())
-    return comprehend("ListDocumentClassifiers"; aws_config=aws_config)
+    return comprehend(
+        "ListDocumentClassifiers"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_document_classifiers(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return comprehend("ListDocumentClassifiers", params; aws_config=aws_config)
+    return comprehend(
+        "ListDocumentClassifiers",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1348,12 +1437,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function list_dominant_language_detection_jobs(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return comprehend("ListDominantLanguageDetectionJobs"; aws_config=aws_config)
+    return comprehend(
+        "ListDominantLanguageDetectionJobs";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_dominant_language_detection_jobs(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return comprehend("ListDominantLanguageDetectionJobs", params; aws_config=aws_config)
+    return comprehend(
+        "ListDominantLanguageDetectionJobs",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1371,12 +1469,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`: Identifies the next page of results to return.
 """
 function list_endpoints(; aws_config::AbstractAWSConfig=global_aws_config())
-    return comprehend("ListEndpoints"; aws_config=aws_config)
+    return comprehend(
+        "ListEndpoints"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_endpoints(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return comprehend("ListEndpoints", params; aws_config=aws_config)
+    return comprehend(
+        "ListEndpoints", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1394,12 +1496,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`: Identifies the next page of results to return.
 """
 function list_entities_detection_jobs(; aws_config::AbstractAWSConfig=global_aws_config())
-    return comprehend("ListEntitiesDetectionJobs"; aws_config=aws_config)
+    return comprehend(
+        "ListEntitiesDetectionJobs"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_entities_detection_jobs(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return comprehend("ListEntitiesDetectionJobs", params; aws_config=aws_config)
+    return comprehend(
+        "ListEntitiesDetectionJobs",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1416,12 +1525,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function list_entity_recognizer_summaries(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return comprehend("ListEntityRecognizerSummaries"; aws_config=aws_config)
+    return comprehend(
+        "ListEntityRecognizerSummaries";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_entity_recognizer_summaries(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return comprehend("ListEntityRecognizerSummaries", params; aws_config=aws_config)
+    return comprehend(
+        "ListEntityRecognizerSummaries",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1442,12 +1560,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`: Identifies the next page of results to return.
 """
 function list_entity_recognizers(; aws_config::AbstractAWSConfig=global_aws_config())
-    return comprehend("ListEntityRecognizers"; aws_config=aws_config)
+    return comprehend(
+        "ListEntityRecognizers"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_entity_recognizers(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return comprehend("ListEntityRecognizers", params; aws_config=aws_config)
+    return comprehend(
+        "ListEntityRecognizers",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1465,12 +1590,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`: Identifies the next page of results to return.
 """
 function list_events_detection_jobs(; aws_config::AbstractAWSConfig=global_aws_config())
-    return comprehend("ListEventsDetectionJobs"; aws_config=aws_config)
+    return comprehend(
+        "ListEventsDetectionJobs"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_events_detection_jobs(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return comprehend("ListEventsDetectionJobs", params; aws_config=aws_config)
+    return comprehend(
+        "ListEventsDetectionJobs",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1490,12 +1622,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function list_key_phrases_detection_jobs(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return comprehend("ListKeyPhrasesDetectionJobs"; aws_config=aws_config)
+    return comprehend(
+        "ListKeyPhrasesDetectionJobs";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_key_phrases_detection_jobs(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return comprehend("ListKeyPhrasesDetectionJobs", params; aws_config=aws_config)
+    return comprehend(
+        "ListKeyPhrasesDetectionJobs",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1515,12 +1656,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function list_pii_entities_detection_jobs(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return comprehend("ListPiiEntitiesDetectionJobs"; aws_config=aws_config)
+    return comprehend(
+        "ListPiiEntitiesDetectionJobs";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_pii_entities_detection_jobs(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return comprehend("ListPiiEntitiesDetectionJobs", params; aws_config=aws_config)
+    return comprehend(
+        "ListPiiEntitiesDetectionJobs",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1538,12 +1688,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`: Identifies the next page of results to return.
 """
 function list_sentiment_detection_jobs(; aws_config::AbstractAWSConfig=global_aws_config())
-    return comprehend("ListSentimentDetectionJobs"; aws_config=aws_config)
+    return comprehend(
+        "ListSentimentDetectionJobs"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_sentiment_detection_jobs(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return comprehend("ListSentimentDetectionJobs", params; aws_config=aws_config)
+    return comprehend(
+        "ListSentimentDetectionJobs",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1564,6 +1721,7 @@ function list_tags_for_resource(
         "ListTagsForResource",
         Dict{String,Any}("ResourceArn" => ResourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags_for_resource(
@@ -1577,6 +1735,7 @@ function list_tags_for_resource(
             mergewith(_merge, Dict{String,Any}("ResourceArn" => ResourceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1595,12 +1754,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`: Identifies the next page of results to return.
 """
 function list_topics_detection_jobs(; aws_config::AbstractAWSConfig=global_aws_config())
-    return comprehend("ListTopicsDetectionJobs"; aws_config=aws_config)
+    return comprehend(
+        "ListTopicsDetectionJobs"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_topics_detection_jobs(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return comprehend("ListTopicsDetectionJobs", params; aws_config=aws_config)
+    return comprehend(
+        "ListTopicsDetectionJobs",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1654,6 +1820,7 @@ function start_document_classification_job(
             "ClientRequestToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_document_classification_job(
@@ -1680,6 +1847,7 @@ function start_document_classification_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1733,6 +1901,7 @@ function start_dominant_language_detection_job(
             "ClientRequestToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_dominant_language_detection_job(
@@ -1757,6 +1926,7 @@ function start_dominant_language_detection_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1822,6 +1992,7 @@ function start_entities_detection_job(
             "ClientRequestToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_entities_detection_job(
@@ -1848,6 +2019,7 @@ function start_entities_detection_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1894,6 +2066,7 @@ function start_events_detection_job(
             "ClientRequestToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_events_detection_job(
@@ -1922,6 +2095,7 @@ function start_events_detection_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1979,6 +2153,7 @@ function start_key_phrases_detection_job(
             "ClientRequestToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_key_phrases_detection_job(
@@ -2005,6 +2180,7 @@ function start_key_phrases_detection_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2056,6 +2232,7 @@ function start_pii_entities_detection_job(
             "ClientRequestToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_pii_entities_detection_job(
@@ -2084,6 +2261,7 @@ function start_pii_entities_detection_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2141,6 +2319,7 @@ function start_sentiment_detection_job(
             "ClientRequestToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_sentiment_detection_job(
@@ -2167,6 +2346,7 @@ function start_sentiment_detection_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2223,6 +2403,7 @@ function start_topics_detection_job(
             "ClientRequestToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_topics_detection_job(
@@ -2247,6 +2428,7 @@ function start_topics_detection_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2273,6 +2455,7 @@ function stop_dominant_language_detection_job(
         "StopDominantLanguageDetectionJob",
         Dict{String,Any}("JobId" => JobId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function stop_dominant_language_detection_job(
@@ -2282,6 +2465,7 @@ function stop_dominant_language_detection_job(
         "StopDominantLanguageDetectionJob",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("JobId" => JobId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2308,6 +2492,7 @@ function stop_entities_detection_job(
         "StopEntitiesDetectionJob",
         Dict{String,Any}("JobId" => JobId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function stop_entities_detection_job(
@@ -2317,6 +2502,7 @@ function stop_entities_detection_job(
         "StopEntitiesDetectionJob",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("JobId" => JobId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2332,7 +2518,10 @@ Stops an events detection job in progress.
 """
 function stop_events_detection_job(JobId; aws_config::AbstractAWSConfig=global_aws_config())
     return comprehend(
-        "StopEventsDetectionJob", Dict{String,Any}("JobId" => JobId); aws_config=aws_config
+        "StopEventsDetectionJob",
+        Dict{String,Any}("JobId" => JobId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function stop_events_detection_job(
@@ -2342,6 +2531,7 @@ function stop_events_detection_job(
         "StopEventsDetectionJob",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("JobId" => JobId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2368,6 +2558,7 @@ function stop_key_phrases_detection_job(
         "StopKeyPhrasesDetectionJob",
         Dict{String,Any}("JobId" => JobId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function stop_key_phrases_detection_job(
@@ -2377,6 +2568,7 @@ function stop_key_phrases_detection_job(
         "StopKeyPhrasesDetectionJob",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("JobId" => JobId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2397,6 +2589,7 @@ function stop_pii_entities_detection_job(
         "StopPiiEntitiesDetectionJob",
         Dict{String,Any}("JobId" => JobId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function stop_pii_entities_detection_job(
@@ -2406,6 +2599,7 @@ function stop_pii_entities_detection_job(
         "StopPiiEntitiesDetectionJob",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("JobId" => JobId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2432,6 +2626,7 @@ function stop_sentiment_detection_job(
         "StopSentimentDetectionJob",
         Dict{String,Any}("JobId" => JobId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function stop_sentiment_detection_job(
@@ -2441,6 +2636,7 @@ function stop_sentiment_detection_job(
         "StopSentimentDetectionJob",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("JobId" => JobId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2466,6 +2662,7 @@ function stop_training_document_classifier(
         "StopTrainingDocumentClassifier",
         Dict{String,Any}("DocumentClassifierArn" => DocumentClassifierArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function stop_training_document_classifier(
@@ -2483,6 +2680,7 @@ function stop_training_document_classifier(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2508,6 +2706,7 @@ function stop_training_entity_recognizer(
         "StopTrainingEntityRecognizer",
         Dict{String,Any}("EntityRecognizerArn" => EntityRecognizerArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function stop_training_entity_recognizer(
@@ -2525,6 +2724,7 @@ function stop_training_entity_recognizer(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2549,6 +2749,7 @@ function tag_resource(ResourceArn, Tags; aws_config::AbstractAWSConfig=global_aw
         "TagResource",
         Dict{String,Any}("ResourceArn" => ResourceArn, "Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -2567,6 +2768,7 @@ function tag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2592,6 +2794,7 @@ function untag_resource(
         "UntagResource",
         Dict{String,Any}("ResourceArn" => ResourceArn, "TagKeys" => TagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -2610,6 +2813,7 @@ function untag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2636,6 +2840,7 @@ function update_endpoint(EndpointArn; aws_config::AbstractAWSConfig=global_aws_c
         "UpdateEndpoint",
         Dict{String,Any}("EndpointArn" => EndpointArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_endpoint(
@@ -2649,5 +2854,6 @@ function update_endpoint(
             mergewith(_merge, Dict{String,Any}("EndpointArn" => EndpointArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/comprehendmedical.jl
+++ b/src/services/comprehendmedical.jl
@@ -23,6 +23,7 @@ function describe_entities_detection_v2_job(
         "DescribeEntitiesDetectionV2Job",
         Dict{String,Any}("JobId" => JobId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_entities_detection_v2_job(
@@ -32,6 +33,7 @@ function describe_entities_detection_v2_job(
         "DescribeEntitiesDetectionV2Job",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("JobId" => JobId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -54,6 +56,7 @@ function describe_icd10_cminference_job(
         "DescribeICD10CMInferenceJob",
         Dict{String,Any}("JobId" => JobId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_icd10_cminference_job(
@@ -63,6 +66,7 @@ function describe_icd10_cminference_job(
         "DescribeICD10CMInferenceJob",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("JobId" => JobId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -80,7 +84,10 @@ this operation to get the status of a detection job.
 """
 function describe_phidetection_job(JobId; aws_config::AbstractAWSConfig=global_aws_config())
     return comprehendmedical(
-        "DescribePHIDetectionJob", Dict{String,Any}("JobId" => JobId); aws_config=aws_config
+        "DescribePHIDetectionJob",
+        Dict{String,Any}("JobId" => JobId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_phidetection_job(
@@ -90,6 +97,7 @@ function describe_phidetection_job(
         "DescribePHIDetectionJob",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("JobId" => JobId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -112,6 +120,7 @@ function describe_rx_norm_inference_job(
         "DescribeRxNormInferenceJob",
         Dict{String,Any}("JobId" => JobId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_rx_norm_inference_job(
@@ -121,6 +130,7 @@ function describe_rx_norm_inference_job(
         "DescribeRxNormInferenceJob",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("JobId" => JobId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -140,7 +150,10 @@ information .
 """
 function detect_entities(Text; aws_config::AbstractAWSConfig=global_aws_config())
     return comprehendmedical(
-        "DetectEntities", Dict{String,Any}("Text" => Text); aws_config=aws_config
+        "DetectEntities",
+        Dict{String,Any}("Text" => Text);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function detect_entities(
@@ -150,6 +163,7 @@ function detect_entities(
         "DetectEntities",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Text" => Text), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -173,7 +187,10 @@ Direction entities as attributes instead of types.
 """
 function detect_entities_v2(Text; aws_config::AbstractAWSConfig=global_aws_config())
     return comprehendmedical(
-        "DetectEntitiesV2", Dict{String,Any}("Text" => Text); aws_config=aws_config
+        "DetectEntitiesV2",
+        Dict{String,Any}("Text" => Text);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function detect_entities_v2(
@@ -183,6 +200,7 @@ function detect_entities_v2(
         "DetectEntitiesV2",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Text" => Text), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -201,7 +219,10 @@ only detects entities in English language texts.
 """
 function detect_phi(Text; aws_config::AbstractAWSConfig=global_aws_config())
     return comprehendmedical(
-        "DetectPHI", Dict{String,Any}("Text" => Text); aws_config=aws_config
+        "DetectPHI",
+        Dict{String,Any}("Text" => Text);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function detect_phi(
@@ -211,6 +232,7 @@ function detect_phi(
         "DetectPHI",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Text" => Text), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -230,7 +252,10 @@ English language texts.
 """
 function infer_icd10_cm(Text; aws_config::AbstractAWSConfig=global_aws_config())
     return comprehendmedical(
-        "InferICD10CM", Dict{String,Any}("Text" => Text); aws_config=aws_config
+        "InferICD10CM",
+        Dict{String,Any}("Text" => Text);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function infer_icd10_cm(
@@ -240,6 +265,7 @@ function infer_icd10_cm(
         "InferICD10CM",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Text" => Text), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -259,7 +285,10 @@ texts.
 """
 function infer_rx_norm(Text; aws_config::AbstractAWSConfig=global_aws_config())
     return comprehendmedical(
-        "InferRxNorm", Dict{String,Any}("Text" => Text); aws_config=aws_config
+        "InferRxNorm",
+        Dict{String,Any}("Text" => Text);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function infer_rx_norm(
@@ -269,6 +298,7 @@ function infer_rx_norm(
         "InferRxNorm",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Text" => Text), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -289,12 +319,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function list_entities_detection_v2_jobs(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return comprehendmedical("ListEntitiesDetectionV2Jobs"; aws_config=aws_config)
+    return comprehendmedical(
+        "ListEntitiesDetectionV2Jobs";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_entities_detection_v2_jobs(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return comprehendmedical("ListEntitiesDetectionV2Jobs", params; aws_config=aws_config)
+    return comprehendmedical(
+        "ListEntitiesDetectionV2Jobs",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -312,12 +351,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`: Identifies the next page of results to return.
 """
 function list_icd10_cminference_jobs(; aws_config::AbstractAWSConfig=global_aws_config())
-    return comprehendmedical("ListICD10CMInferenceJobs"; aws_config=aws_config)
+    return comprehendmedical(
+        "ListICD10CMInferenceJobs"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_icd10_cminference_jobs(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return comprehendmedical("ListICD10CMInferenceJobs", params; aws_config=aws_config)
+    return comprehendmedical(
+        "ListICD10CMInferenceJobs",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -335,12 +381,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`: Identifies the next page of results to return.
 """
 function list_phidetection_jobs(; aws_config::AbstractAWSConfig=global_aws_config())
-    return comprehendmedical("ListPHIDetectionJobs"; aws_config=aws_config)
+    return comprehendmedical(
+        "ListPHIDetectionJobs"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_phidetection_jobs(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return comprehendmedical("ListPHIDetectionJobs", params; aws_config=aws_config)
+    return comprehendmedical(
+        "ListPHIDetectionJobs",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -358,12 +411,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`: Identifies the next page of results to return.
 """
 function list_rx_norm_inference_jobs(; aws_config::AbstractAWSConfig=global_aws_config())
-    return comprehendmedical("ListRxNormInferenceJobs"; aws_config=aws_config)
+    return comprehendmedical(
+        "ListRxNormInferenceJobs"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_rx_norm_inference_jobs(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return comprehendmedical("ListRxNormInferenceJobs", params; aws_config=aws_config)
+    return comprehendmedical(
+        "ListRxNormInferenceJobs",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -407,6 +467,7 @@ function start_entities_detection_v2_job(
             "ClientRequestToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_entities_detection_v2_job(
@@ -433,6 +494,7 @@ function start_entities_detection_v2_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -477,6 +539,7 @@ function start_icd10_cminference_job(
             "ClientRequestToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_icd10_cminference_job(
@@ -503,6 +566,7 @@ function start_icd10_cminference_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -547,6 +611,7 @@ function start_phidetection_job(
             "ClientRequestToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_phidetection_job(
@@ -573,6 +638,7 @@ function start_phidetection_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -617,6 +683,7 @@ function start_rx_norm_inference_job(
             "ClientRequestToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_rx_norm_inference_job(
@@ -643,6 +710,7 @@ function start_rx_norm_inference_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -663,6 +731,7 @@ function stop_entities_detection_v2_job(
         "StopEntitiesDetectionV2Job",
         Dict{String,Any}("JobId" => JobId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function stop_entities_detection_v2_job(
@@ -672,6 +741,7 @@ function stop_entities_detection_v2_job(
         "StopEntitiesDetectionV2Job",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("JobId" => JobId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -689,7 +759,10 @@ function stop_icd10_cminference_job(
     JobId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return comprehendmedical(
-        "StopICD10CMInferenceJob", Dict{String,Any}("JobId" => JobId); aws_config=aws_config
+        "StopICD10CMInferenceJob",
+        Dict{String,Any}("JobId" => JobId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function stop_icd10_cminference_job(
@@ -699,6 +772,7 @@ function stop_icd10_cminference_job(
         "StopICD10CMInferenceJob",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("JobId" => JobId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -714,7 +788,10 @@ Stops a protected health information (PHI) detection job in progress.
 """
 function stop_phidetection_job(JobId; aws_config::AbstractAWSConfig=global_aws_config())
     return comprehendmedical(
-        "StopPHIDetectionJob", Dict{String,Any}("JobId" => JobId); aws_config=aws_config
+        "StopPHIDetectionJob",
+        Dict{String,Any}("JobId" => JobId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function stop_phidetection_job(
@@ -724,6 +801,7 @@ function stop_phidetection_job(
         "StopPHIDetectionJob",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("JobId" => JobId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -741,7 +819,10 @@ function stop_rx_norm_inference_job(
     JobId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return comprehendmedical(
-        "StopRxNormInferenceJob", Dict{String,Any}("JobId" => JobId); aws_config=aws_config
+        "StopRxNormInferenceJob",
+        Dict{String,Any}("JobId" => JobId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function stop_rx_norm_inference_job(
@@ -751,5 +832,6 @@ function stop_rx_norm_inference_job(
         "StopRxNormInferenceJob",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("JobId" => JobId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/compute_optimizer.jl
+++ b/src/services/compute_optimizer.jl
@@ -28,13 +28,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_recommendation_export_jobs(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return compute_optimizer("DescribeRecommendationExportJobs"; aws_config=aws_config)
+    return compute_optimizer(
+        "DescribeRecommendationExportJobs";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_recommendation_export_jobs(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return compute_optimizer(
-        "DescribeRecommendationExportJobs", params; aws_config=aws_config
+        "DescribeRecommendationExportJobs",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -96,6 +103,7 @@ function export_auto_scaling_group_recommendations(
         "ExportAutoScalingGroupRecommendations",
         Dict{String,Any}("s3DestinationConfig" => s3DestinationConfig);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function export_auto_scaling_group_recommendations(
@@ -113,6 +121,7 @@ function export_auto_scaling_group_recommendations(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -164,6 +173,7 @@ function export_ebsvolume_recommendations(
         "ExportEBSVolumeRecommendations",
         Dict{String,Any}("s3DestinationConfig" => s3DestinationConfig);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function export_ebsvolume_recommendations(
@@ -181,6 +191,7 @@ function export_ebsvolume_recommendations(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -241,6 +252,7 @@ function export_ec2_instance_recommendations(
         "ExportEC2InstanceRecommendations",
         Dict{String,Any}("s3DestinationConfig" => s3DestinationConfig);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function export_ec2_instance_recommendations(
@@ -258,6 +270,7 @@ function export_ec2_instance_recommendations(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -309,6 +322,7 @@ function export_lambda_function_recommendations(
         "ExportLambdaFunctionRecommendations",
         Dict{String,Any}("s3DestinationConfig" => s3DestinationConfig);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function export_lambda_function_recommendations(
@@ -326,6 +340,7 @@ function export_lambda_function_recommendations(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -359,13 +374,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function get_auto_scaling_group_recommendations(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return compute_optimizer("GetAutoScalingGroupRecommendations"; aws_config=aws_config)
+    return compute_optimizer(
+        "GetAutoScalingGroupRecommendations";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_auto_scaling_group_recommendations(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return compute_optimizer(
-        "GetAutoScalingGroupRecommendations", params; aws_config=aws_config
+        "GetAutoScalingGroupRecommendations",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -394,12 +416,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   recommendations.
 """
 function get_ebsvolume_recommendations(; aws_config::AbstractAWSConfig=global_aws_config())
-    return compute_optimizer("GetEBSVolumeRecommendations"; aws_config=aws_config)
+    return compute_optimizer(
+        "GetEBSVolumeRecommendations";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_ebsvolume_recommendations(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return compute_optimizer("GetEBSVolumeRecommendations", params; aws_config=aws_config)
+    return compute_optimizer(
+        "GetEBSVolumeRecommendations",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -431,12 +462,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function get_ec2_instance_recommendations(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return compute_optimizer("GetEC2InstanceRecommendations"; aws_config=aws_config)
+    return compute_optimizer(
+        "GetEC2InstanceRecommendations";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_ec2_instance_recommendations(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return compute_optimizer("GetEC2InstanceRecommendations", params; aws_config=aws_config)
+    return compute_optimizer(
+        "GetEC2InstanceRecommendations",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -480,6 +520,7 @@ function get_ec2_recommendation_projected_metrics(
             "stat" => stat,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_ec2_recommendation_projected_metrics(
@@ -507,6 +548,7 @@ function get_ec2_recommendation_projected_metrics(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -522,12 +564,19 @@ enrollment status of member accounts of an organization.
 
 """
 function get_enrollment_status(; aws_config::AbstractAWSConfig=global_aws_config())
-    return compute_optimizer("GetEnrollmentStatus"; aws_config=aws_config)
+    return compute_optimizer(
+        "GetEnrollmentStatus"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_enrollment_status(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return compute_optimizer("GetEnrollmentStatus", params; aws_config=aws_config)
+    return compute_optimizer(
+        "GetEnrollmentStatus",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -550,13 +599,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function get_enrollment_statuses_for_organization(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return compute_optimizer("GetEnrollmentStatusesForOrganization"; aws_config=aws_config)
+    return compute_optimizer(
+        "GetEnrollmentStatusesForOrganization";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_enrollment_statuses_for_organization(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return compute_optimizer(
-        "GetEnrollmentStatusesForOrganization", params; aws_config=aws_config
+        "GetEnrollmentStatusesForOrganization",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -591,13 +647,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function get_lambda_function_recommendations(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return compute_optimizer("GetLambdaFunctionRecommendations"; aws_config=aws_config)
+    return compute_optimizer(
+        "GetLambdaFunctionRecommendations";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_lambda_function_recommendations(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return compute_optimizer(
-        "GetLambdaFunctionRecommendations", params; aws_config=aws_config
+        "GetLambdaFunctionRecommendations",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -623,12 +686,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: The token to advance to the next page of recommendation summaries.
 """
 function get_recommendation_summaries(; aws_config::AbstractAWSConfig=global_aws_config())
-    return compute_optimizer("GetRecommendationSummaries"; aws_config=aws_config)
+    return compute_optimizer(
+        "GetRecommendationSummaries"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_recommendation_summaries(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return compute_optimizer("GetRecommendationSummaries", params; aws_config=aws_config)
+    return compute_optimizer(
+        "GetRecommendationSummaries",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -666,6 +736,7 @@ function update_enrollment_status(status; aws_config::AbstractAWSConfig=global_a
         "UpdateEnrollmentStatus",
         Dict{String,Any}("status" => status);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_enrollment_status(
@@ -675,5 +746,6 @@ function update_enrollment_status(
         "UpdateEnrollmentStatus",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("status" => status), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/config_service.jl
+++ b/src/services/config_service.jl
@@ -31,6 +31,7 @@ function batch_get_aggregate_resource_config(
             "ResourceIdentifiers" => ResourceIdentifiers,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_get_aggregate_resource_config(
@@ -52,6 +53,7 @@ function batch_get_aggregate_resource_config(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -78,6 +80,7 @@ function batch_get_resource_config(
         "BatchGetResourceConfig",
         Dict{String,Any}("resourceKeys" => resourceKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_get_resource_config(
@@ -91,6 +94,7 @@ function batch_get_resource_config(
             mergewith(_merge, Dict{String,Any}("resourceKeys" => resourceKeys), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -119,6 +123,7 @@ function delete_aggregation_authorization(
             "AuthorizedAwsRegion" => AuthorizedAwsRegion,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_aggregation_authorization(
@@ -140,6 +145,7 @@ function delete_aggregation_authorization(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -164,6 +170,7 @@ function delete_config_rule(
         "DeleteConfigRule",
         Dict{String,Any}("ConfigRuleName" => ConfigRuleName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_config_rule(
@@ -177,6 +184,7 @@ function delete_config_rule(
             mergewith(_merge, Dict{String,Any}("ConfigRuleName" => ConfigRuleName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -198,6 +206,7 @@ function delete_configuration_aggregator(
         "DeleteConfigurationAggregator",
         Dict{String,Any}("ConfigurationAggregatorName" => ConfigurationAggregatorName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_configuration_aggregator(
@@ -217,6 +226,7 @@ function delete_configuration_aggregator(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -244,6 +254,7 @@ function delete_configuration_recorder(
         "DeleteConfigurationRecorder",
         Dict{String,Any}("ConfigurationRecorderName" => ConfigurationRecorderName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_configuration_recorder(
@@ -261,6 +272,7 @@ function delete_configuration_recorder(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -284,6 +296,7 @@ function delete_conformance_pack(
         "DeleteConformancePack",
         Dict{String,Any}("ConformancePackName" => ConformancePackName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_conformance_pack(
@@ -301,6 +314,7 @@ function delete_conformance_pack(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -322,6 +336,7 @@ function delete_delivery_channel(
         "DeleteDeliveryChannel",
         Dict{String,Any}("DeliveryChannelName" => DeliveryChannelName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_delivery_channel(
@@ -339,6 +354,7 @@ function delete_delivery_channel(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -363,6 +379,7 @@ function delete_evaluation_results(
         "DeleteEvaluationResults",
         Dict{String,Any}("ConfigRuleName" => ConfigRuleName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_evaluation_results(
@@ -376,6 +393,7 @@ function delete_evaluation_results(
             mergewith(_merge, Dict{String,Any}("ConfigRuleName" => ConfigRuleName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -402,6 +420,7 @@ function delete_organization_config_rule(
         "DeleteOrganizationConfigRule",
         Dict{String,Any}("OrganizationConfigRuleName" => OrganizationConfigRuleName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_organization_config_rule(
@@ -421,6 +440,7 @@ function delete_organization_config_rule(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -450,6 +470,7 @@ function delete_organization_conformance_pack(
             "OrganizationConformancePackName" => OrganizationConformancePackName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_organization_conformance_pack(
@@ -469,6 +490,7 @@ function delete_organization_conformance_pack(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -497,6 +519,7 @@ function delete_pending_aggregation_request(
             "RequesterAwsRegion" => RequesterAwsRegion,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_pending_aggregation_request(
@@ -518,6 +541,7 @@ function delete_pending_aggregation_request(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -542,6 +566,7 @@ function delete_remediation_configuration(
         "DeleteRemediationConfiguration",
         Dict{String,Any}("ConfigRuleName" => ConfigRuleName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_remediation_configuration(
@@ -555,6 +580,7 @@ function delete_remediation_configuration(
             mergewith(_merge, Dict{String,Any}("ConfigRuleName" => ConfigRuleName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -584,6 +610,7 @@ function delete_remediation_exceptions(
             "ConfigRuleName" => ConfigRuleName, "ResourceKeys" => ResourceKeys
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_remediation_exceptions(
@@ -604,6 +631,7 @@ function delete_remediation_exceptions(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -627,6 +655,7 @@ function delete_resource_config(
         "DeleteResourceConfig",
         Dict{String,Any}("ResourceId" => ResourceId, "ResourceType" => ResourceType);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_resource_config(
@@ -647,6 +676,7 @@ function delete_resource_config(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -667,6 +697,7 @@ function delete_retention_configuration(
         "DeleteRetentionConfiguration",
         Dict{String,Any}("RetentionConfigurationName" => RetentionConfigurationName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_retention_configuration(
@@ -686,6 +717,7 @@ function delete_retention_configuration(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -705,6 +737,7 @@ function delete_stored_query(QueryName; aws_config::AbstractAWSConfig=global_aws
         "DeleteStoredQuery",
         Dict{String,Any}("QueryName" => QueryName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_stored_query(
@@ -718,6 +751,7 @@ function delete_stored_query(
             mergewith(_merge, Dict{String,Any}("QueryName" => QueryName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -743,6 +777,7 @@ function deliver_config_snapshot(
         "DeliverConfigSnapshot",
         Dict{String,Any}("deliveryChannelName" => deliveryChannelName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function deliver_config_snapshot(
@@ -760,6 +795,7 @@ function deliver_config_snapshot(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -790,6 +826,7 @@ function describe_aggregate_compliance_by_config_rules(
         "DescribeAggregateComplianceByConfigRules",
         Dict{String,Any}("ConfigurationAggregatorName" => ConfigurationAggregatorName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_aggregate_compliance_by_config_rules(
@@ -809,6 +846,7 @@ function describe_aggregate_compliance_by_config_rules(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -840,6 +878,7 @@ function describe_aggregate_compliance_by_conformance_packs(
         "DescribeAggregateComplianceByConformancePacks",
         Dict{String,Any}("ConfigurationAggregatorName" => ConfigurationAggregatorName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_aggregate_compliance_by_conformance_packs(
@@ -859,6 +898,7 @@ function describe_aggregate_compliance_by_conformance_packs(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -878,13 +918,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_aggregation_authorizations(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return config_service("DescribeAggregationAuthorizations"; aws_config=aws_config)
+    return config_service(
+        "DescribeAggregationAuthorizations";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_aggregation_authorizations(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return config_service(
-        "DescribeAggregationAuthorizations", params; aws_config=aws_config
+        "DescribeAggregationAuthorizations",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -917,12 +964,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_compliance_by_config_rule(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return config_service("DescribeComplianceByConfigRule"; aws_config=aws_config)
+    return config_service(
+        "DescribeComplianceByConfigRule";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_compliance_by_config_rule(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return config_service("DescribeComplianceByConfigRule", params; aws_config=aws_config)
+    return config_service(
+        "DescribeComplianceByConfigRule",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -962,12 +1018,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_compliance_by_resource(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return config_service("DescribeComplianceByResource"; aws_config=aws_config)
+    return config_service(
+        "DescribeComplianceByResource";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_compliance_by_resource(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return config_service("DescribeComplianceByResource", params; aws_config=aws_config)
+    return config_service(
+        "DescribeComplianceByResource",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -993,13 +1058,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_config_rule_evaluation_status(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return config_service("DescribeConfigRuleEvaluationStatus"; aws_config=aws_config)
+    return config_service(
+        "DescribeConfigRuleEvaluationStatus";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_config_rule_evaluation_status(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return config_service(
-        "DescribeConfigRuleEvaluationStatus", params; aws_config=aws_config
+        "DescribeConfigRuleEvaluationStatus",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1017,12 +1089,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   next page of results in a paginated response.
 """
 function describe_config_rules(; aws_config::AbstractAWSConfig=global_aws_config())
-    return config_service("DescribeConfigRules"; aws_config=aws_config)
+    return config_service(
+        "DescribeConfigRules"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_config_rules(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return config_service("DescribeConfigRules", params; aws_config=aws_config)
+    return config_service(
+        "DescribeConfigRules",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1054,6 +1133,7 @@ function describe_configuration_aggregator_sources_status(
         "DescribeConfigurationAggregatorSourcesStatus",
         Dict{String,Any}("ConfigurationAggregatorName" => ConfigurationAggregatorName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_configuration_aggregator_sources_status(
@@ -1073,6 +1153,7 @@ function describe_configuration_aggregator_sources_status(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1095,12 +1176,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_configuration_aggregators(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return config_service("DescribeConfigurationAggregators"; aws_config=aws_config)
+    return config_service(
+        "DescribeConfigurationAggregators";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_configuration_aggregators(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return config_service("DescribeConfigurationAggregators", params; aws_config=aws_config)
+    return config_service(
+        "DescribeConfigurationAggregators",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1121,13 +1211,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_configuration_recorder_status(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return config_service("DescribeConfigurationRecorderStatus"; aws_config=aws_config)
+    return config_service(
+        "DescribeConfigurationRecorderStatus";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_configuration_recorder_status(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return config_service(
-        "DescribeConfigurationRecorderStatus", params; aws_config=aws_config
+        "DescribeConfigurationRecorderStatus",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1147,12 +1244,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_configuration_recorders(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return config_service("DescribeConfigurationRecorders"; aws_config=aws_config)
+    return config_service(
+        "DescribeConfigurationRecorders";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_configuration_recorders(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return config_service("DescribeConfigurationRecorders", params; aws_config=aws_config)
+    return config_service(
+        "DescribeConfigurationRecorders",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1180,6 +1286,7 @@ function describe_conformance_pack_compliance(
         "DescribeConformancePackCompliance",
         Dict{String,Any}("ConformancePackName" => ConformancePackName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_conformance_pack_compliance(
@@ -1197,6 +1304,7 @@ function describe_conformance_pack_compliance(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1217,12 +1325,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_conformance_pack_status(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return config_service("DescribeConformancePackStatus"; aws_config=aws_config)
+    return config_service(
+        "DescribeConformancePackStatus";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_conformance_pack_status(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return config_service("DescribeConformancePackStatus", params; aws_config=aws_config)
+    return config_service(
+        "DescribeConformancePackStatus",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1241,12 +1358,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   request the next page of results in a paginated response.
 """
 function describe_conformance_packs(; aws_config::AbstractAWSConfig=global_aws_config())
-    return config_service("DescribeConformancePacks"; aws_config=aws_config)
+    return config_service(
+        "DescribeConformancePacks"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_conformance_packs(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return config_service("DescribeConformancePacks", params; aws_config=aws_config)
+    return config_service(
+        "DescribeConformancePacks",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1265,12 +1389,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_delivery_channel_status(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return config_service("DescribeDeliveryChannelStatus"; aws_config=aws_config)
+    return config_service(
+        "DescribeDeliveryChannelStatus";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_delivery_channel_status(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return config_service("DescribeDeliveryChannelStatus", params; aws_config=aws_config)
+    return config_service(
+        "DescribeDeliveryChannelStatus",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1286,12 +1419,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"DeliveryChannelNames"`: A list of delivery channel names.
 """
 function describe_delivery_channels(; aws_config::AbstractAWSConfig=global_aws_config())
-    return config_service("DescribeDeliveryChannels"; aws_config=aws_config)
+    return config_service(
+        "DescribeDeliveryChannels"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_delivery_channels(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return config_service("DescribeDeliveryChannels", params; aws_config=aws_config)
+    return config_service(
+        "DescribeDeliveryChannels",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1318,13 +1458,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_organization_config_rule_statuses(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return config_service("DescribeOrganizationConfigRuleStatuses"; aws_config=aws_config)
+    return config_service(
+        "DescribeOrganizationConfigRuleStatuses";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_organization_config_rule_statuses(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return config_service(
-        "DescribeOrganizationConfigRuleStatuses", params; aws_config=aws_config
+        "DescribeOrganizationConfigRuleStatuses",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1350,12 +1497,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_organization_config_rules(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return config_service("DescribeOrganizationConfigRules"; aws_config=aws_config)
+    return config_service(
+        "DescribeOrganizationConfigRules";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_organization_config_rules(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return config_service("DescribeOrganizationConfigRules", params; aws_config=aws_config)
+    return config_service(
+        "DescribeOrganizationConfigRules",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1383,14 +1539,19 @@ function describe_organization_conformance_pack_statuses(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
     return config_service(
-        "DescribeOrganizationConformancePackStatuses"; aws_config=aws_config
+        "DescribeOrganizationConformancePackStatuses";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_organization_conformance_pack_statuses(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return config_service(
-        "DescribeOrganizationConformancePackStatuses", params; aws_config=aws_config
+        "DescribeOrganizationConformancePackStatuses",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1415,13 +1576,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_organization_conformance_packs(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return config_service("DescribeOrganizationConformancePacks"; aws_config=aws_config)
+    return config_service(
+        "DescribeOrganizationConformancePacks";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_organization_conformance_packs(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return config_service(
-        "DescribeOrganizationConformancePacks", params; aws_config=aws_config
+        "DescribeOrganizationConformancePacks",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1441,13 +1609,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_pending_aggregation_requests(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return config_service("DescribePendingAggregationRequests"; aws_config=aws_config)
+    return config_service(
+        "DescribePendingAggregationRequests";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_pending_aggregation_requests(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return config_service(
-        "DescribePendingAggregationRequests", params; aws_config=aws_config
+        "DescribePendingAggregationRequests",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1469,6 +1644,7 @@ function describe_remediation_configurations(
         "DescribeRemediationConfigurations",
         Dict{String,Any}("ConfigRuleNames" => ConfigRuleNames);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_remediation_configurations(
@@ -1484,6 +1660,7 @@ function describe_remediation_configurations(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1520,6 +1697,7 @@ function describe_remediation_exceptions(
         "DescribeRemediationExceptions",
         Dict{String,Any}("ConfigRuleName" => ConfigRuleName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_remediation_exceptions(
@@ -1533,6 +1711,7 @@ function describe_remediation_exceptions(
             mergewith(_merge, Dict{String,Any}("ConfigRuleName" => ConfigRuleName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1564,6 +1743,7 @@ function describe_remediation_execution_status(
         "DescribeRemediationExecutionStatus",
         Dict{String,Any}("ConfigRuleName" => ConfigRuleName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_remediation_execution_status(
@@ -1577,6 +1757,7 @@ function describe_remediation_execution_status(
             mergewith(_merge, Dict{String,Any}("ConfigRuleName" => ConfigRuleName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1601,12 +1782,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_retention_configurations(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return config_service("DescribeRetentionConfigurations"; aws_config=aws_config)
+    return config_service(
+        "DescribeRetentionConfigurations";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_retention_configurations(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return config_service("DescribeRetentionConfigurations", params; aws_config=aws_config)
+    return config_service(
+        "DescribeRetentionConfigurations",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1652,6 +1842,7 @@ function get_aggregate_compliance_details_by_config_rule(
             "ConfigurationAggregatorName" => ConfigurationAggregatorName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_aggregate_compliance_details_by_config_rule(
@@ -1677,6 +1868,7 @@ function get_aggregate_compliance_details_by_config_rule(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1708,6 +1900,7 @@ function get_aggregate_config_rule_compliance_summary(
         "GetAggregateConfigRuleComplianceSummary",
         Dict{String,Any}("ConfigurationAggregatorName" => ConfigurationAggregatorName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_aggregate_config_rule_compliance_summary(
@@ -1727,6 +1920,7 @@ function get_aggregate_config_rule_compliance_summary(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1760,6 +1954,7 @@ function get_aggregate_conformance_pack_compliance_summary(
         "GetAggregateConformancePackComplianceSummary",
         Dict{String,Any}("ConfigurationAggregatorName" => ConfigurationAggregatorName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_aggregate_conformance_pack_compliance_summary(
@@ -1779,6 +1974,7 @@ function get_aggregate_conformance_pack_compliance_summary(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1813,6 +2009,7 @@ function get_aggregate_discovered_resource_counts(
         "GetAggregateDiscoveredResourceCounts",
         Dict{String,Any}("ConfigurationAggregatorName" => ConfigurationAggregatorName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_aggregate_discovered_resource_counts(
@@ -1832,6 +2029,7 @@ function get_aggregate_discovered_resource_counts(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1859,6 +2057,7 @@ function get_aggregate_resource_config(
             "ResourceIdentifier" => ResourceIdentifier,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_aggregate_resource_config(
@@ -1880,6 +2079,7 @@ function get_aggregate_resource_config(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1910,6 +2110,7 @@ function get_compliance_details_by_config_rule(
         "GetComplianceDetailsByConfigRule",
         Dict{String,Any}("ConfigRuleName" => ConfigRuleName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_compliance_details_by_config_rule(
@@ -1923,6 +2124,7 @@ function get_compliance_details_by_config_rule(
             mergewith(_merge, Dict{String,Any}("ConfigRuleName" => ConfigRuleName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1954,6 +2156,7 @@ function get_compliance_details_by_resource(
         "GetComplianceDetailsByResource",
         Dict{String,Any}("ResourceId" => ResourceId, "ResourceType" => ResourceType);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_compliance_details_by_resource(
@@ -1974,6 +2177,7 @@ function get_compliance_details_by_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1988,12 +2192,21 @@ Returns the number of Config rules that are compliant and noncompliant, up to a 
 function get_compliance_summary_by_config_rule(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return config_service("GetComplianceSummaryByConfigRule"; aws_config=aws_config)
+    return config_service(
+        "GetComplianceSummaryByConfigRule";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_compliance_summary_by_config_rule(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return config_service("GetComplianceSummaryByConfigRule", params; aws_config=aws_config)
+    return config_service(
+        "GetComplianceSummaryByConfigRule",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2015,13 +2228,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function get_compliance_summary_by_resource_type(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return config_service("GetComplianceSummaryByResourceType"; aws_config=aws_config)
+    return config_service(
+        "GetComplianceSummaryByResourceType";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_compliance_summary_by_resource_type(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return config_service(
-        "GetComplianceSummaryByResourceType", params; aws_config=aws_config
+        "GetComplianceSummaryByResourceType",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2050,6 +2270,7 @@ function get_conformance_pack_compliance_details(
         "GetConformancePackComplianceDetails",
         Dict{String,Any}("ConformancePackName" => ConformancePackName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_conformance_pack_compliance_details(
@@ -2067,6 +2288,7 @@ function get_conformance_pack_compliance_details(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2093,6 +2315,7 @@ function get_conformance_pack_compliance_summary(
         "GetConformancePackComplianceSummary",
         Dict{String,Any}("ConformancePackNames" => ConformancePackNames);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_conformance_pack_compliance_summary(
@@ -2110,6 +2333,7 @@ function get_conformance_pack_compliance_summary(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2149,12 +2373,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   returned in the list of ResourceCount objects.
 """
 function get_discovered_resource_counts(; aws_config::AbstractAWSConfig=global_aws_config())
-    return config_service("GetDiscoveredResourceCounts"; aws_config=aws_config)
+    return config_service(
+        "GetDiscoveredResourceCounts";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_discovered_resource_counts(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return config_service("GetDiscoveredResourceCounts", params; aws_config=aws_config)
+    return config_service(
+        "GetDiscoveredResourceCounts",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2183,6 +2416,7 @@ function get_organization_config_rule_detailed_status(
         "GetOrganizationConfigRuleDetailedStatus",
         Dict{String,Any}("OrganizationConfigRuleName" => OrganizationConfigRuleName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_organization_config_rule_detailed_status(
@@ -2202,6 +2436,7 @@ function get_organization_config_rule_detailed_status(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2233,6 +2468,7 @@ function get_organization_conformance_pack_detailed_status(
             "OrganizationConformancePackName" => OrganizationConformancePackName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_organization_conformance_pack_detailed_status(
@@ -2252,6 +2488,7 @@ function get_organization_conformance_pack_detailed_status(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2297,6 +2534,7 @@ function get_resource_config_history(
         "GetResourceConfigHistory",
         Dict{String,Any}("resourceId" => resourceId, "resourceType" => resourceType);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_resource_config_history(
@@ -2317,6 +2555,7 @@ function get_resource_config_history(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2332,7 +2571,10 @@ Returns the details of a specific stored query.
 """
 function get_stored_query(QueryName; aws_config::AbstractAWSConfig=global_aws_config())
     return config_service(
-        "GetStoredQuery", Dict{String,Any}("QueryName" => QueryName); aws_config=aws_config
+        "GetStoredQuery",
+        Dict{String,Any}("QueryName" => QueryName);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_stored_query(
@@ -2346,6 +2588,7 @@ function get_stored_query(
             mergewith(_merge, Dict{String,Any}("QueryName" => QueryName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2386,6 +2629,7 @@ function list_aggregate_discovered_resources(
             "ResourceType" => ResourceType,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_aggregate_discovered_resources(
@@ -2407,6 +2651,7 @@ function list_aggregate_discovered_resources(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2451,6 +2696,7 @@ function list_discovered_resources(
         "ListDiscoveredResources",
         Dict{String,Any}("resourceType" => resourceType);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_discovered_resources(
@@ -2464,6 +2710,7 @@ function list_discovered_resources(
             mergewith(_merge, Dict{String,Any}("resourceType" => resourceType), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2481,12 +2728,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   request the next page of results in a paginated response.
 """
 function list_stored_queries(; aws_config::AbstractAWSConfig=global_aws_config())
-    return config_service("ListStoredQueries"; aws_config=aws_config)
+    return config_service(
+        "ListStoredQueries"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_stored_queries(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return config_service("ListStoredQueries", params; aws_config=aws_config)
+    return config_service(
+        "ListStoredQueries", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -2514,6 +2765,7 @@ function list_tags_for_resource(
         "ListTagsForResource",
         Dict{String,Any}("ResourceArn" => ResourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags_for_resource(
@@ -2527,6 +2779,7 @@ function list_tags_for_resource(
             mergewith(_merge, Dict{String,Any}("ResourceArn" => ResourceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2558,6 +2811,7 @@ function put_aggregation_authorization(
             "AuthorizedAwsRegion" => AuthorizedAwsRegion,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_aggregation_authorization(
@@ -2579,6 +2833,7 @@ function put_aggregation_authorization(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2615,7 +2870,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function put_config_rule(ConfigRule; aws_config::AbstractAWSConfig=global_aws_config())
     return config_service(
-        "PutConfigRule", Dict{String,Any}("ConfigRule" => ConfigRule); aws_config=aws_config
+        "PutConfigRule",
+        Dict{String,Any}("ConfigRule" => ConfigRule);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_config_rule(
@@ -2629,6 +2887,7 @@ function put_config_rule(
             mergewith(_merge, Dict{String,Any}("ConfigRule" => ConfigRule), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2666,6 +2925,7 @@ function put_configuration_aggregator(
         "PutConfigurationAggregator",
         Dict{String,Any}("ConfigurationAggregatorName" => ConfigurationAggregatorName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_configuration_aggregator(
@@ -2685,6 +2945,7 @@ function put_configuration_aggregator(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2711,6 +2972,7 @@ function put_configuration_recorder(
         "PutConfigurationRecorder",
         Dict{String,Any}("ConfigurationRecorder" => ConfigurationRecorder);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_configuration_recorder(
@@ -2728,6 +2990,7 @@ function put_configuration_recorder(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2768,6 +3031,7 @@ function put_conformance_pack(
         "PutConformancePack",
         Dict{String,Any}("ConformancePackName" => ConformancePackName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_conformance_pack(
@@ -2785,6 +3049,7 @@ function put_conformance_pack(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2813,6 +3078,7 @@ function put_delivery_channel(
         "PutDeliveryChannel",
         Dict{String,Any}("DeliveryChannel" => DeliveryChannel);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_delivery_channel(
@@ -2828,6 +3094,7 @@ function put_delivery_channel(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2858,6 +3125,7 @@ function put_evaluations(ResultToken; aws_config::AbstractAWSConfig=global_aws_c
         "PutEvaluations",
         Dict{String,Any}("ResultToken" => ResultToken);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_evaluations(
@@ -2871,6 +3139,7 @@ function put_evaluations(
             mergewith(_merge, Dict{String,Any}("ResultToken" => ResultToken), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2896,6 +3165,7 @@ function put_external_evaluation(
             "ConfigRuleName" => ConfigRuleName, "ExternalEvaluation" => ExternalEvaluation
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_external_evaluation(
@@ -2917,6 +3187,7 @@ function put_external_evaluation(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2965,6 +3236,7 @@ function put_organization_config_rule(
         "PutOrganizationConfigRule",
         Dict{String,Any}("OrganizationConfigRuleName" => OrganizationConfigRuleName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_organization_config_rule(
@@ -2984,6 +3256,7 @@ function put_organization_config_rule(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3038,6 +3311,7 @@ function put_organization_conformance_pack(
             "OrganizationConformancePackName" => OrganizationConformancePackName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_organization_conformance_pack(
@@ -3057,6 +3331,7 @@ function put_organization_conformance_pack(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3084,6 +3359,7 @@ function put_remediation_configurations(
         "PutRemediationConfigurations",
         Dict{String,Any}("RemediationConfigurations" => RemediationConfigurations);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_remediation_configurations(
@@ -3101,6 +3377,7 @@ function put_remediation_configurations(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3135,6 +3412,7 @@ function put_remediation_exceptions(
             "ConfigRuleName" => ConfigRuleName, "ResourceKeys" => ResourceKeys
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_remediation_exceptions(
@@ -3155,6 +3433,7 @@ function put_remediation_exceptions(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3205,6 +3484,7 @@ function put_resource_config(
             "SchemaVersionId" => SchemaVersionId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_resource_config(
@@ -3230,6 +3510,7 @@ function put_resource_config(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3255,6 +3536,7 @@ function put_retention_configuration(
         "PutRetentionConfiguration",
         Dict{String,Any}("RetentionPeriodInDays" => RetentionPeriodInDays);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_retention_configuration(
@@ -3272,6 +3554,7 @@ function put_retention_configuration(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3299,6 +3582,7 @@ function put_stored_query(StoredQuery; aws_config::AbstractAWSConfig=global_aws_
         "PutStoredQuery",
         Dict{String,Any}("StoredQuery" => StoredQuery);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_stored_query(
@@ -3312,6 +3596,7 @@ function put_stored_query(
             mergewith(_merge, Dict{String,Any}("StoredQuery" => StoredQuery), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3355,6 +3640,7 @@ function select_aggregate_resource_config(
             "Expression" => Expression,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function select_aggregate_resource_config(
@@ -3376,6 +3662,7 @@ function select_aggregate_resource_config(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3403,6 +3690,7 @@ function select_resource_config(
         "SelectResourceConfig",
         Dict{String,Any}("Expression" => Expression);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function select_resource_config(
@@ -3416,6 +3704,7 @@ function select_resource_config(
             mergewith(_merge, Dict{String,Any}("Expression" => Expression), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3446,12 +3735,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   for.
 """
 function start_config_rules_evaluation(; aws_config::AbstractAWSConfig=global_aws_config())
-    return config_service("StartConfigRulesEvaluation"; aws_config=aws_config)
+    return config_service(
+        "StartConfigRulesEvaluation"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function start_config_rules_evaluation(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return config_service("StartConfigRulesEvaluation", params; aws_config=aws_config)
+    return config_service(
+        "StartConfigRulesEvaluation",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -3474,6 +3770,7 @@ function start_configuration_recorder(
         "StartConfigurationRecorder",
         Dict{String,Any}("ConfigurationRecorderName" => ConfigurationRecorderName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_configuration_recorder(
@@ -3491,6 +3788,7 @@ function start_configuration_recorder(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3520,6 +3818,7 @@ function start_remediation_execution(
             "ConfigRuleName" => ConfigRuleName, "ResourceKeys" => ResourceKeys
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_remediation_execution(
@@ -3540,6 +3839,7 @@ function start_remediation_execution(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3562,6 +3862,7 @@ function stop_configuration_recorder(
         "StopConfigurationRecorder",
         Dict{String,Any}("ConfigurationRecorderName" => ConfigurationRecorderName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function stop_configuration_recorder(
@@ -3579,6 +3880,7 @@ function stop_configuration_recorder(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3602,6 +3904,7 @@ function tag_resource(ResourceArn, Tags; aws_config::AbstractAWSConfig=global_aw
         "TagResource",
         Dict{String,Any}("ResourceArn" => ResourceArn, "Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -3620,6 +3923,7 @@ function tag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3643,6 +3947,7 @@ function untag_resource(
         "UntagResource",
         Dict{String,Any}("ResourceArn" => ResourceArn, "TagKeys" => TagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -3661,5 +3966,6 @@ function untag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/connect.jl
+++ b/src/services/connect.jl
@@ -25,6 +25,7 @@ function associate_approved_origin(
         "/instance/$(InstanceId)/approved-origin",
         Dict{String,Any}("Origin" => Origin);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_approved_origin(
@@ -38,6 +39,7 @@ function associate_approved_origin(
         "/instance/$(InstanceId)/approved-origin",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Origin" => Origin), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -58,14 +60,25 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"LexV2Bot"`: The Amazon Lex V2 bot to associate with the instance.
 """
 function associate_bot(InstanceId; aws_config::AbstractAWSConfig=global_aws_config())
-    return connect("PUT", "/instance/$(InstanceId)/bot"; aws_config=aws_config)
+    return connect(
+        "PUT",
+        "/instance/$(InstanceId)/bot";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function associate_bot(
     InstanceId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return connect("PUT", "/instance/$(InstanceId)/bot", params; aws_config=aws_config)
+    return connect(
+        "PUT",
+        "/instance/$(InstanceId)/bot",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -98,6 +111,7 @@ function associate_instance_storage_config(
         "/instance/$(InstanceId)/storage-config",
         Dict{String,Any}("ResourceType" => ResourceType, "StorageConfig" => StorageConfig);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_instance_storage_config(
@@ -120,6 +134,7 @@ function associate_instance_storage_config(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -145,6 +160,7 @@ function associate_lambda_function(
         "/instance/$(InstanceId)/lambda-function",
         Dict{String,Any}("FunctionArn" => FunctionArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_lambda_function(
@@ -160,6 +176,7 @@ function associate_lambda_function(
             mergewith(_merge, Dict{String,Any}("FunctionArn" => FunctionArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -184,6 +201,7 @@ function associate_lex_bot(
         "/instance/$(InstanceId)/lex-bot",
         Dict{String,Any}("LexBot" => LexBot);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_lex_bot(
@@ -197,6 +215,7 @@ function associate_lex_bot(
         "/instance/$(InstanceId)/lex-bot",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("LexBot" => LexBot), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -222,6 +241,7 @@ function associate_queue_quick_connects(
         "/queues/$(InstanceId)/$(QueueId)/associate-quick-connects",
         Dict{String,Any}("QuickConnectIds" => QuickConnectIds);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_queue_quick_connects(
@@ -240,6 +260,7 @@ function associate_queue_quick_connects(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -267,6 +288,7 @@ function associate_routing_profile_queues(
         "/routing-profiles/$(InstanceId)/$(RoutingProfileId)/associate-queues",
         Dict{String,Any}("QueueConfigs" => QueueConfigs);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_routing_profile_queues(
@@ -283,6 +305,7 @@ function associate_routing_profile_queues(
             mergewith(_merge, Dict{String,Any}("QueueConfigs" => QueueConfigs), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -307,6 +330,7 @@ function associate_security_key(
         "/instance/$(InstanceId)/security-key",
         Dict{String,Any}("Key" => Key);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_security_key(
@@ -320,6 +344,7 @@ function associate_security_key(
         "/instance/$(InstanceId)/security-key",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Key" => Key), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -350,6 +375,7 @@ function create_agent_status(
         "/agent-status/$(InstanceId)",
         Dict{String,Any}("Name" => Name, "State" => State);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_agent_status(
@@ -366,6 +392,7 @@ function create_agent_status(
             mergewith(_merge, Dict{String,Any}("Name" => Name, "State" => State), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -396,6 +423,7 @@ function create_contact_flow(
         "/contact-flows/$(InstanceId)",
         Dict{String,Any}("Content" => Content, "Name" => Name, "Type" => Type);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_contact_flow(
@@ -417,6 +445,7 @@ function create_contact_flow(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -448,6 +477,7 @@ function create_hours_of_operation(
         "/hours-of-operations/$(InstanceId)",
         Dict{String,Any}("Config" => Config, "Name" => Name, "TimeZone" => TimeZone);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_hours_of_operation(
@@ -471,6 +501,7 @@ function create_hours_of_operation(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -513,6 +544,7 @@ function create_instance(
             "OutboundCallsEnabled" => OutboundCallsEnabled,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_instance(
@@ -537,57 +569,52 @@ function create_instance(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
 """
-    create_integration_association(instance_id, integration_arn, integration_type, source_application_name, source_application_url, source_type)
-    create_integration_association(instance_id, integration_arn, integration_type, source_application_name, source_application_url, source_type, params::Dict{String,<:Any})
+    create_integration_association(instance_id, integration_arn, integration_type)
+    create_integration_association(instance_id, integration_arn, integration_type, params::Dict{String,<:Any})
 
-Create an AppIntegration association with an Amazon Connect instance.
+Creates an AWS resource association with an Amazon Connect instance.
 
 # Arguments
 - `instance_id`: The identifier of the Amazon Connect instance. You can find the instanceId
   in the ARN of the instance.
 - `integration_arn`: The Amazon Resource Name (ARN) of the integration.
 - `integration_type`: The type of information to be ingested.
-- `source_application_name`: The name of the external application.
-- `source_application_url`: The URL for the external application.
-- `source_type`: The type of the data source.
 
 # Optional Parameters
 Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys are:
+- `"SourceApplicationName"`: The name of the external application. This field is only
+  required for the EVENT integration type.
+- `"SourceApplicationUrl"`: The URL for the external application. This field is only
+  required for the EVENT integration type.
+- `"SourceType"`: The type of the data source. This field is only required for the EVENT
+  integration type.
 - `"Tags"`: One or more tags.
 """
 function create_integration_association(
     InstanceId,
     IntegrationArn,
-    IntegrationType,
-    SourceApplicationName,
-    SourceApplicationUrl,
-    SourceType;
+    IntegrationType;
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return connect(
         "PUT",
         "/instance/$(InstanceId)/integration-associations",
         Dict{String,Any}(
-            "IntegrationArn" => IntegrationArn,
-            "IntegrationType" => IntegrationType,
-            "SourceApplicationName" => SourceApplicationName,
-            "SourceApplicationUrl" => SourceApplicationUrl,
-            "SourceType" => SourceType,
+            "IntegrationArn" => IntegrationArn, "IntegrationType" => IntegrationType
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_integration_association(
     InstanceId,
     IntegrationArn,
     IntegrationType,
-    SourceApplicationName,
-    SourceApplicationUrl,
-    SourceType,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
@@ -598,16 +625,13 @@ function create_integration_association(
             mergewith(
                 _merge,
                 Dict{String,Any}(
-                    "IntegrationArn" => IntegrationArn,
-                    "IntegrationType" => IntegrationType,
-                    "SourceApplicationName" => SourceApplicationName,
-                    "SourceApplicationUrl" => SourceApplicationUrl,
-                    "SourceType" => SourceType,
+                    "IntegrationArn" => IntegrationArn, "IntegrationType" => IntegrationType
                 ),
                 params,
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -641,6 +665,7 @@ function create_queue(
         "/queues/$(InstanceId)",
         Dict{String,Any}("HoursOfOperationId" => HoursOfOperationId, "Name" => Name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_queue(
@@ -663,6 +688,7 @@ function create_queue(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -691,6 +717,7 @@ function create_quick_connect(
         "/quick-connects/$(InstanceId)",
         Dict{String,Any}("Name" => Name, "QuickConnectConfig" => QuickConnectConfig);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_quick_connect(
@@ -713,6 +740,7 @@ function create_quick_connect(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -755,6 +783,7 @@ function create_routing_profile(
             "Name" => Name,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_routing_profile(
@@ -782,6 +811,7 @@ function create_routing_profile(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -789,14 +819,14 @@ end
     create_use_case(instance_id, integration_association_id, use_case_type)
     create_use_case(instance_id, integration_association_id, use_case_type, params::Dict{String,<:Any})
 
-Creates a use case for an AppIntegration association.
+Creates a use case for an integration association.
 
 # Arguments
 - `instance_id`: The identifier of the Amazon Connect instance. You can find the instanceId
   in the ARN of the instance.
-- `integration_association_id`: The identifier for the AppIntegration association.
-- `use_case_type`: The type of use case to associate to the AppIntegration association.
-  Each AppIntegration association can have only one of each use case type.
+- `integration_association_id`: The identifier for the integration association.
+- `use_case_type`: The type of use case to associate to the integration association. Each
+  integration association can have only one of each use case type.
 
 # Optional Parameters
 Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys are:
@@ -813,6 +843,7 @@ function create_use_case(
         "/instance/$(InstanceId)/integration-associations/$(IntegrationAssociationId)/use-cases",
         Dict{String,Any}("UseCaseType" => UseCaseType);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_use_case(
@@ -829,6 +860,7 @@ function create_use_case(
             mergewith(_merge, Dict{String,Any}("UseCaseType" => UseCaseType), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -884,6 +916,7 @@ function create_user(
             "Username" => Username,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_user(
@@ -911,6 +944,7 @@ function create_user(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -938,6 +972,7 @@ function create_user_hierarchy_group(
         "/user-hierarchy-groups/$(InstanceId)",
         Dict{String,Any}("Name" => Name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_user_hierarchy_group(
@@ -951,6 +986,7 @@ function create_user_hierarchy_group(
         "/user-hierarchy-groups/$(InstanceId)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -974,6 +1010,7 @@ function delete_hours_of_operation(
         "DELETE",
         "/hours-of-operations/$(InstanceId)/$(HoursOfOperationId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_hours_of_operation(
@@ -987,6 +1024,7 @@ function delete_hours_of_operation(
         "/hours-of-operations/$(InstanceId)/$(HoursOfOperationId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1007,27 +1045,38 @@ your account.
 
 """
 function delete_instance(InstanceId; aws_config::AbstractAWSConfig=global_aws_config())
-    return connect("DELETE", "/instance/$(InstanceId)"; aws_config=aws_config)
+    return connect(
+        "DELETE",
+        "/instance/$(InstanceId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_instance(
     InstanceId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return connect("DELETE", "/instance/$(InstanceId)", params; aws_config=aws_config)
+    return connect(
+        "DELETE",
+        "/instance/$(InstanceId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
     delete_integration_association(instance_id, integration_association_id)
     delete_integration_association(instance_id, integration_association_id, params::Dict{String,<:Any})
 
-Deletes an AppIntegration association from an Amazon Connect instance. The association must
+Deletes an AWS resource association from an Amazon Connect instance. The association must
 not have any use cases associated with it.
 
 # Arguments
 - `instance_id`: The identifier of the Amazon Connect instance. You can find the instanceId
   in the ARN of the instance.
-- `integration_association_id`: The identifier for the AppIntegration association.
+- `integration_association_id`: The identifier for the integration association.
 
 """
 function delete_integration_association(
@@ -1037,6 +1086,7 @@ function delete_integration_association(
         "DELETE",
         "/instance/$(InstanceId)/integration-associations/$(IntegrationAssociationId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_integration_association(
@@ -1050,6 +1100,7 @@ function delete_integration_association(
         "/instance/$(InstanceId)/integration-associations/$(IntegrationAssociationId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1069,7 +1120,10 @@ function delete_quick_connect(
     InstanceId, QuickConnectId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return connect(
-        "DELETE", "/quick-connects/$(InstanceId)/$(QuickConnectId)"; aws_config=aws_config
+        "DELETE",
+        "/quick-connects/$(InstanceId)/$(QuickConnectId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_quick_connect(
@@ -1083,6 +1137,7 @@ function delete_quick_connect(
         "/quick-connects/$(InstanceId)/$(QuickConnectId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1090,12 +1145,12 @@ end
     delete_use_case(instance_id, integration_association_id, use_case_id)
     delete_use_case(instance_id, integration_association_id, use_case_id, params::Dict{String,<:Any})
 
-Deletes a use case from an AppIntegration association.
+Deletes a use case from an integration association.
 
 # Arguments
 - `instance_id`: The identifier of the Amazon Connect instance. You can find the instanceId
   in the ARN of the instance.
-- `integration_association_id`: The identifier for the AppIntegration association.
+- `integration_association_id`: The identifier for the integration association.
 - `use_case_id`: The identifier for the use case.
 
 """
@@ -1109,6 +1164,7 @@ function delete_use_case(
         "DELETE",
         "/instance/$(InstanceId)/integration-associations/$(IntegrationAssociationId)/use-cases/$(UseCaseId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_use_case(
@@ -1123,6 +1179,7 @@ function delete_use_case(
         "/instance/$(InstanceId)/integration-associations/$(IntegrationAssociationId)/use-cases/$(UseCaseId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1141,7 +1198,12 @@ Amazon Connect Instance in the Amazon Connect Administrator Guide.
 
 """
 function delete_user(InstanceId, UserId; aws_config::AbstractAWSConfig=global_aws_config())
-    return connect("DELETE", "/users/$(InstanceId)/$(UserId)"; aws_config=aws_config)
+    return connect(
+        "DELETE",
+        "/users/$(InstanceId)/$(UserId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_user(
     InstanceId,
@@ -1150,7 +1212,11 @@ function delete_user(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return connect(
-        "DELETE", "/users/$(InstanceId)/$(UserId)", params; aws_config=aws_config
+        "DELETE",
+        "/users/$(InstanceId)/$(UserId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1174,6 +1240,7 @@ function delete_user_hierarchy_group(
         "DELETE",
         "/user-hierarchy-groups/$(InstanceId)/$(HierarchyGroupId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_user_hierarchy_group(
@@ -1187,6 +1254,7 @@ function delete_user_hierarchy_group(
         "/user-hierarchy-groups/$(InstanceId)/$(HierarchyGroupId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1207,7 +1275,10 @@ function describe_agent_status(
     AgentStatusId, InstanceId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return connect(
-        "GET", "/agent-status/$(InstanceId)/$(AgentStatusId)"; aws_config=aws_config
+        "GET",
+        "/agent-status/$(InstanceId)/$(AgentStatusId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_agent_status(
@@ -1217,7 +1288,11 @@ function describe_agent_status(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return connect(
-        "GET", "/agent-status/$(InstanceId)/$(AgentStatusId)", params; aws_config=aws_config
+        "GET",
+        "/agent-status/$(InstanceId)/$(AgentStatusId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1237,7 +1312,10 @@ function describe_contact_flow(
     ContactFlowId, InstanceId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return connect(
-        "GET", "/contact-flows/$(InstanceId)/$(ContactFlowId)"; aws_config=aws_config
+        "GET",
+        "/contact-flows/$(InstanceId)/$(ContactFlowId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_contact_flow(
@@ -1251,6 +1329,7 @@ function describe_contact_flow(
         "/contact-flows/$(InstanceId)/$(ContactFlowId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1274,6 +1353,7 @@ function describe_hours_of_operation(
         "GET",
         "/hours-of-operations/$(InstanceId)/$(HoursOfOperationId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_hours_of_operation(
@@ -1287,6 +1367,7 @@ function describe_hours_of_operation(
         "/hours-of-operations/$(InstanceId)/$(HoursOfOperationId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1307,14 +1388,25 @@ invoked.
 
 """
 function describe_instance(InstanceId; aws_config::AbstractAWSConfig=global_aws_config())
-    return connect("GET", "/instance/$(InstanceId)"; aws_config=aws_config)
+    return connect(
+        "GET",
+        "/instance/$(InstanceId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_instance(
     InstanceId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return connect("GET", "/instance/$(InstanceId)", params; aws_config=aws_config)
+    return connect(
+        "GET",
+        "/instance/$(InstanceId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1334,7 +1426,10 @@ function describe_instance_attribute(
     AttributeType, InstanceId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return connect(
-        "GET", "/instance/$(InstanceId)/attribute/$(AttributeType)"; aws_config=aws_config
+        "GET",
+        "/instance/$(InstanceId)/attribute/$(AttributeType)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_instance_attribute(
@@ -1348,6 +1443,7 @@ function describe_instance_attribute(
         "/instance/$(InstanceId)/attribute/$(AttributeType)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1378,6 +1474,7 @@ function describe_instance_storage_config(
         "/instance/$(InstanceId)/storage-config/$(AssociationId)",
         Dict{String,Any}("resourceType" => resourceType);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_instance_storage_config(
@@ -1394,6 +1491,7 @@ function describe_instance_storage_config(
             mergewith(_merge, Dict{String,Any}("resourceType" => resourceType), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1413,7 +1511,12 @@ specified queue.
 function describe_queue(
     InstanceId, QueueId; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return connect("GET", "/queues/$(InstanceId)/$(QueueId)"; aws_config=aws_config)
+    return connect(
+        "GET",
+        "/queues/$(InstanceId)/$(QueueId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_queue(
     InstanceId,
@@ -1421,7 +1524,13 @@ function describe_queue(
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return connect("GET", "/queues/$(InstanceId)/$(QueueId)", params; aws_config=aws_config)
+    return connect(
+        "GET",
+        "/queues/$(InstanceId)/$(QueueId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1440,7 +1549,10 @@ function describe_quick_connect(
     InstanceId, QuickConnectId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return connect(
-        "GET", "/quick-connects/$(InstanceId)/$(QuickConnectId)"; aws_config=aws_config
+        "GET",
+        "/quick-connects/$(InstanceId)/$(QuickConnectId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_quick_connect(
@@ -1454,6 +1566,7 @@ function describe_quick_connect(
         "/quick-connects/$(InstanceId)/$(QuickConnectId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1473,7 +1586,10 @@ function describe_routing_profile(
     InstanceId, RoutingProfileId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return connect(
-        "GET", "/routing-profiles/$(InstanceId)/$(RoutingProfileId)"; aws_config=aws_config
+        "GET",
+        "/routing-profiles/$(InstanceId)/$(RoutingProfileId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_routing_profile(
@@ -1487,6 +1603,7 @@ function describe_routing_profile(
         "/routing-profiles/$(InstanceId)/$(RoutingProfileId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1507,7 +1624,12 @@ users and note the IDs provided in the output.
 function describe_user(
     InstanceId, UserId; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return connect("GET", "/users/$(InstanceId)/$(UserId)"; aws_config=aws_config)
+    return connect(
+        "GET",
+        "/users/$(InstanceId)/$(UserId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_user(
     InstanceId,
@@ -1515,7 +1637,13 @@ function describe_user(
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return connect("GET", "/users/$(InstanceId)/$(UserId)", params; aws_config=aws_config)
+    return connect(
+        "GET",
+        "/users/$(InstanceId)/$(UserId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1537,6 +1665,7 @@ function describe_user_hierarchy_group(
         "GET",
         "/user-hierarchy-groups/$(InstanceId)/$(HierarchyGroupId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_user_hierarchy_group(
@@ -1550,6 +1679,7 @@ function describe_user_hierarchy_group(
         "/user-hierarchy-groups/$(InstanceId)/$(HierarchyGroupId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1567,7 +1697,12 @@ Describes the hierarchy structure of the specified Amazon Connect instance.
 function describe_user_hierarchy_structure(
     InstanceId; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return connect("GET", "/user-hierarchy-structure/$(InstanceId)"; aws_config=aws_config)
+    return connect(
+        "GET",
+        "/user-hierarchy-structure/$(InstanceId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_user_hierarchy_structure(
     InstanceId,
@@ -1575,7 +1710,11 @@ function describe_user_hierarchy_structure(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return connect(
-        "GET", "/user-hierarchy-structure/$(InstanceId)", params; aws_config=aws_config
+        "GET",
+        "/user-hierarchy-structure/$(InstanceId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1600,6 +1739,7 @@ function disassociate_approved_origin(
         "/instance/$(InstanceId)/approved-origin",
         Dict{String,Any}("origin" => origin);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disassociate_approved_origin(
@@ -1613,6 +1753,7 @@ function disassociate_approved_origin(
         "/instance/$(InstanceId)/approved-origin",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("origin" => origin), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1634,14 +1775,25 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"LexV2Bot"`: The Amazon Lex V2 bot to disassociate from the instance.
 """
 function disassociate_bot(InstanceId; aws_config::AbstractAWSConfig=global_aws_config())
-    return connect("POST", "/instance/$(InstanceId)/bot"; aws_config=aws_config)
+    return connect(
+        "POST",
+        "/instance/$(InstanceId)/bot";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function disassociate_bot(
     InstanceId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return connect("POST", "/instance/$(InstanceId)/bot", params; aws_config=aws_config)
+    return connect(
+        "POST",
+        "/instance/$(InstanceId)/bot",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1670,6 +1822,7 @@ function disassociate_instance_storage_config(
         "/instance/$(InstanceId)/storage-config/$(AssociationId)",
         Dict{String,Any}("resourceType" => resourceType);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disassociate_instance_storage_config(
@@ -1686,6 +1839,7 @@ function disassociate_instance_storage_config(
             mergewith(_merge, Dict{String,Any}("resourceType" => resourceType), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1710,6 +1864,7 @@ function disassociate_lambda_function(
         "/instance/$(InstanceId)/lambda-function",
         Dict{String,Any}("functionArn" => functionArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disassociate_lambda_function(
@@ -1725,6 +1880,7 @@ function disassociate_lambda_function(
             mergewith(_merge, Dict{String,Any}("functionArn" => functionArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1750,6 +1906,7 @@ function disassociate_lex_bot(
         "/instance/$(InstanceId)/lex-bot",
         Dict{String,Any}("botName" => botName, "lexRegion" => lexRegion);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disassociate_lex_bot(
@@ -1770,6 +1927,7 @@ function disassociate_lex_bot(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1795,6 +1953,7 @@ function disassociate_queue_quick_connects(
         "/queues/$(InstanceId)/$(QueueId)/disassociate-quick-connects",
         Dict{String,Any}("QuickConnectIds" => QuickConnectIds);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disassociate_queue_quick_connects(
@@ -1813,6 +1972,7 @@ function disassociate_queue_quick_connects(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1840,6 +2000,7 @@ function disassociate_routing_profile_queues(
         "/routing-profiles/$(InstanceId)/$(RoutingProfileId)/disassociate-queues",
         Dict{String,Any}("QueueReferences" => QueueReferences);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disassociate_routing_profile_queues(
@@ -1858,6 +2019,7 @@ function disassociate_routing_profile_queues(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1882,6 +2044,7 @@ function disassociate_security_key(
         "DELETE",
         "/instance/$(InstanceId)/security-key/$(AssociationId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disassociate_security_key(
@@ -1895,6 +2058,7 @@ function disassociate_security_key(
         "/instance/$(InstanceId)/security-key/$(AssociationId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1916,6 +2080,7 @@ function get_contact_attributes(
         "GET",
         "/contact/attributes/$(InstanceId)/$(InitialContactId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_contact_attributes(
@@ -1929,6 +2094,7 @@ function get_contact_attributes(
         "/contact/attributes/$(InstanceId)/$(InitialContactId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1953,6 +2119,7 @@ Administrator Guide.
   COUNT Name in real-time metrics report: Staffed   CONTACTS_IN_QUEUE  Unit: COUNT Name in
   real-time metrics report: In queue   CONTACTS_SCHEDULED  Unit: COUNT Name in real-time
   metrics report: Scheduled   OLDEST_CONTACT_AGE  Unit: SECONDS When you use groupings, Unit
+  says SECONDS and the Value is returned in SECONDS.  When you do not use groupings, Unit
   says SECONDS but the Value is returned in MILLISECONDS. For example, if you get a response
   like this:  { \"Metric\": { \"Name\": \"OLDEST_CONTACT_AGE\", \"Unit\": \"SECONDS\" },
   \"Value\": 24113.0 } The actual OLDEST_CONTACT_AGE is 24 seconds. Name in real-time metrics
@@ -1985,6 +2152,7 @@ function get_current_metric_data(
         "/metrics/current/$(InstanceId)",
         Dict{String,Any}("CurrentMetrics" => CurrentMetrics, "Filters" => Filters);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_current_metric_data(
@@ -2005,6 +2173,7 @@ function get_current_metric_data(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2023,14 +2192,25 @@ with Amazon Connect
 
 """
 function get_federation_token(InstanceId; aws_config::AbstractAWSConfig=global_aws_config())
-    return connect("GET", "/user/federate/$(InstanceId)"; aws_config=aws_config)
+    return connect(
+        "GET",
+        "/user/federate/$(InstanceId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_federation_token(
     InstanceId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return connect("GET", "/user/federate/$(InstanceId)", params; aws_config=aws_config)
+    return connect(
+        "GET",
+        "/user/federate/$(InstanceId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2108,6 +2288,7 @@ function get_metric_data(
             "StartTime" => StartTime,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_metric_data(
@@ -2135,6 +2316,7 @@ function get_metric_data(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2157,14 +2339,25 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   previous response in the next request to retrieve the next set of results.
 """
 function list_agent_statuses(InstanceId; aws_config::AbstractAWSConfig=global_aws_config())
-    return connect("GET", "/agent-status/$(InstanceId)"; aws_config=aws_config)
+    return connect(
+        "GET",
+        "/agent-status/$(InstanceId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_agent_statuses(
     InstanceId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return connect("GET", "/agent-status/$(InstanceId)", params; aws_config=aws_config)
+    return connect(
+        "GET",
+        "/agent-status/$(InstanceId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2187,7 +2380,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function list_approved_origins(
     InstanceId; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return connect("GET", "/instance/$(InstanceId)/approved-origins"; aws_config=aws_config)
+    return connect(
+        "GET",
+        "/instance/$(InstanceId)/approved-origins";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_approved_origins(
     InstanceId,
@@ -2195,7 +2393,11 @@ function list_approved_origins(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return connect(
-        "GET", "/instance/$(InstanceId)/approved-origins", params; aws_config=aws_config
+        "GET",
+        "/instance/$(InstanceId)/approved-origins",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2226,6 +2428,7 @@ function list_bots(
         "/instance/$(InstanceId)/bots",
         Dict{String,Any}("lexVersion" => lexVersion);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_bots(
@@ -2241,6 +2444,7 @@ function list_bots(
             mergewith(_merge, Dict{String,Any}("lexVersion" => lexVersion), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2265,7 +2469,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   previous response in the next request to retrieve the next set of results.
 """
 function list_contact_flows(InstanceId; aws_config::AbstractAWSConfig=global_aws_config())
-    return connect("GET", "/contact-flows-summary/$(InstanceId)"; aws_config=aws_config)
+    return connect(
+        "GET",
+        "/contact-flows-summary/$(InstanceId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_contact_flows(
     InstanceId,
@@ -2273,7 +2482,11 @@ function list_contact_flows(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return connect(
-        "GET", "/contact-flows-summary/$(InstanceId)", params; aws_config=aws_config
+        "GET",
+        "/contact-flows-summary/$(InstanceId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2299,7 +2512,10 @@ function list_hours_of_operations(
     InstanceId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return connect(
-        "GET", "/hours-of-operations-summary/$(InstanceId)"; aws_config=aws_config
+        "GET",
+        "/hours-of-operations-summary/$(InstanceId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_hours_of_operations(
@@ -2308,7 +2524,11 @@ function list_hours_of_operations(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return connect(
-        "GET", "/hours-of-operations-summary/$(InstanceId)", params; aws_config=aws_config
+        "GET",
+        "/hours-of-operations-summary/$(InstanceId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2332,7 +2552,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function list_instance_attributes(
     InstanceId; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return connect("GET", "/instance/$(InstanceId)/attributes"; aws_config=aws_config)
+    return connect(
+        "GET",
+        "/instance/$(InstanceId)/attributes";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_instance_attributes(
     InstanceId,
@@ -2340,7 +2565,11 @@ function list_instance_attributes(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return connect(
-        "GET", "/instance/$(InstanceId)/attributes", params; aws_config=aws_config
+        "GET",
+        "/instance/$(InstanceId)/attributes",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2370,6 +2599,7 @@ function list_instance_storage_configs(
         "/instance/$(InstanceId)/storage-configs",
         Dict{String,Any}("resourceType" => resourceType);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_instance_storage_configs(
@@ -2385,6 +2615,7 @@ function list_instance_storage_configs(
             mergewith(_merge, Dict{String,Any}("resourceType" => resourceType), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2404,19 +2635,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   previous response in the next request to retrieve the next set of results.
 """
 function list_instances(; aws_config::AbstractAWSConfig=global_aws_config())
-    return connect("GET", "/instance"; aws_config=aws_config)
+    return connect(
+        "GET", "/instance"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_instances(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return connect("GET", "/instance", params; aws_config=aws_config)
+    return connect(
+        "GET", "/instance", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
     list_integration_associations(instance_id)
     list_integration_associations(instance_id, params::Dict{String,<:Any})
 
-Provides summary information about the AppIntegration associations for the specified Amazon
+Provides summary information about the AWS resource associations for the specified Amazon
 Connect instance.
 
 # Arguments
@@ -2425,6 +2660,7 @@ Connect instance.
 
 # Optional Parameters
 Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys are:
+- `"integrationType"`:
 - `"maxResults"`: The maximum number of results to return per page.
 - `"nextToken"`: The token for the next set of results. Use the value returned in the
   previous response in the next request to retrieve the next set of results.
@@ -2433,7 +2669,10 @@ function list_integration_associations(
     InstanceId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return connect(
-        "GET", "/instance/$(InstanceId)/integration-associations"; aws_config=aws_config
+        "GET",
+        "/instance/$(InstanceId)/integration-associations";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_integration_associations(
@@ -2446,6 +2685,7 @@ function list_integration_associations(
         "/instance/$(InstanceId)/integration-associations",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2470,7 +2710,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function list_lambda_functions(
     InstanceId; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return connect("GET", "/instance/$(InstanceId)/lambda-functions"; aws_config=aws_config)
+    return connect(
+        "GET",
+        "/instance/$(InstanceId)/lambda-functions";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_lambda_functions(
     InstanceId,
@@ -2478,7 +2723,11 @@ function list_lambda_functions(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return connect(
-        "GET", "/instance/$(InstanceId)/lambda-functions", params; aws_config=aws_config
+        "GET",
+        "/instance/$(InstanceId)/lambda-functions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2500,14 +2749,25 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   previous response in the next request to retrieve the next set of results.
 """
 function list_lex_bots(InstanceId; aws_config::AbstractAWSConfig=global_aws_config())
-    return connect("GET", "/instance/$(InstanceId)/lex-bots"; aws_config=aws_config)
+    return connect(
+        "GET",
+        "/instance/$(InstanceId)/lex-bots";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_lex_bots(
     InstanceId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return connect("GET", "/instance/$(InstanceId)/lex-bots", params; aws_config=aws_config)
+    return connect(
+        "GET",
+        "/instance/$(InstanceId)/lex-bots",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2531,7 +2791,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"phoneNumberTypes"`: The type of phone number.
 """
 function list_phone_numbers(InstanceId; aws_config::AbstractAWSConfig=global_aws_config())
-    return connect("GET", "/phone-numbers-summary/$(InstanceId)"; aws_config=aws_config)
+    return connect(
+        "GET",
+        "/phone-numbers-summary/$(InstanceId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_phone_numbers(
     InstanceId,
@@ -2539,7 +2804,11 @@ function list_phone_numbers(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return connect(
-        "GET", "/phone-numbers-summary/$(InstanceId)", params; aws_config=aws_config
+        "GET",
+        "/phone-numbers-summary/$(InstanceId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2559,14 +2828,25 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   previous response in the next request to retrieve the next set of results.
 """
 function list_prompts(InstanceId; aws_config::AbstractAWSConfig=global_aws_config())
-    return connect("GET", "/prompts-summary/$(InstanceId)"; aws_config=aws_config)
+    return connect(
+        "GET",
+        "/prompts-summary/$(InstanceId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_prompts(
     InstanceId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return connect("GET", "/prompts-summary/$(InstanceId)", params; aws_config=aws_config)
+    return connect(
+        "GET",
+        "/prompts-summary/$(InstanceId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2591,7 +2871,10 @@ function list_queue_quick_connects(
     InstanceId, QueueId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return connect(
-        "GET", "/queues/$(InstanceId)/$(QueueId)/quick-connects"; aws_config=aws_config
+        "GET",
+        "/queues/$(InstanceId)/$(QueueId)/quick-connects";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_queue_quick_connects(
@@ -2605,6 +2888,7 @@ function list_queue_quick_connects(
         "/queues/$(InstanceId)/$(QueueId)/quick-connects",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2630,14 +2914,25 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"queueTypes"`: The type of queue.
 """
 function list_queues(InstanceId; aws_config::AbstractAWSConfig=global_aws_config())
-    return connect("GET", "/queues-summary/$(InstanceId)"; aws_config=aws_config)
+    return connect(
+        "GET",
+        "/queues-summary/$(InstanceId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_queues(
     InstanceId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return connect("GET", "/queues-summary/$(InstanceId)", params; aws_config=aws_config)
+    return connect(
+        "GET",
+        "/queues-summary/$(InstanceId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2660,14 +2955,25 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   previous response in the next request to retrieve the next set of results.
 """
 function list_quick_connects(InstanceId; aws_config::AbstractAWSConfig=global_aws_config())
-    return connect("GET", "/quick-connects/$(InstanceId)"; aws_config=aws_config)
+    return connect(
+        "GET",
+        "/quick-connects/$(InstanceId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_quick_connects(
     InstanceId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return connect("GET", "/quick-connects/$(InstanceId)", params; aws_config=aws_config)
+    return connect(
+        "GET",
+        "/quick-connects/$(InstanceId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2694,6 +3000,7 @@ function list_routing_profile_queues(
         "GET",
         "/routing-profiles/$(InstanceId)/$(RoutingProfileId)/queues";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_routing_profile_queues(
@@ -2707,6 +3014,7 @@ function list_routing_profile_queues(
         "/routing-profiles/$(InstanceId)/$(RoutingProfileId)/queues",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2731,7 +3039,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function list_routing_profiles(
     InstanceId; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return connect("GET", "/routing-profiles-summary/$(InstanceId)"; aws_config=aws_config)
+    return connect(
+        "GET",
+        "/routing-profiles-summary/$(InstanceId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_routing_profiles(
     InstanceId,
@@ -2739,7 +3052,11 @@ function list_routing_profiles(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return connect(
-        "GET", "/routing-profiles-summary/$(InstanceId)", params; aws_config=aws_config
+        "GET",
+        "/routing-profiles-summary/$(InstanceId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2761,7 +3078,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   previous response in the next request to retrieve the next set of results.
 """
 function list_security_keys(InstanceId; aws_config::AbstractAWSConfig=global_aws_config())
-    return connect("GET", "/instance/$(InstanceId)/security-keys"; aws_config=aws_config)
+    return connect(
+        "GET",
+        "/instance/$(InstanceId)/security-keys";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_security_keys(
     InstanceId,
@@ -2769,7 +3091,11 @@ function list_security_keys(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return connect(
-        "GET", "/instance/$(InstanceId)/security-keys", params; aws_config=aws_config
+        "GET",
+        "/instance/$(InstanceId)/security-keys",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2794,7 +3120,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function list_security_profiles(
     InstanceId; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return connect("GET", "/security-profiles-summary/$(InstanceId)"; aws_config=aws_config)
+    return connect(
+        "GET",
+        "/security-profiles-summary/$(InstanceId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_security_profiles(
     InstanceId,
@@ -2802,7 +3133,11 @@ function list_security_profiles(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return connect(
-        "GET", "/security-profiles-summary/$(InstanceId)", params; aws_config=aws_config
+        "GET",
+        "/security-profiles-summary/$(InstanceId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2820,21 +3155,32 @@ Connect Identity-Based Policy Examples in the Amazon Connect Administrator Guide
 function list_tags_for_resource(
     resourceArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return connect("GET", "/tags/$(resourceArn)"; aws_config=aws_config)
+    return connect(
+        "GET",
+        "/tags/$(resourceArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_tags_for_resource(
     resourceArn,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return connect("GET", "/tags/$(resourceArn)", params; aws_config=aws_config)
+    return connect(
+        "GET",
+        "/tags/$(resourceArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
     list_use_cases(instance_id, integration_association_id)
     list_use_cases(instance_id, integration_association_id, params::Dict{String,<:Any})
 
-Lists the use cases.
+Lists the use cases for the integration association.
 
 # Arguments
 - `instance_id`: The identifier of the Amazon Connect instance. You can find the instanceId
@@ -2854,6 +3200,7 @@ function list_use_cases(
         "GET",
         "/instance/$(InstanceId)/integration-associations/$(IntegrationAssociationId)/use-cases";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_use_cases(
@@ -2867,6 +3214,7 @@ function list_use_cases(
         "/instance/$(InstanceId)/integration-associations/$(IntegrationAssociationId)/use-cases",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2892,7 +3240,10 @@ function list_user_hierarchy_groups(
     InstanceId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return connect(
-        "GET", "/user-hierarchy-groups-summary/$(InstanceId)"; aws_config=aws_config
+        "GET",
+        "/user-hierarchy-groups-summary/$(InstanceId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_user_hierarchy_groups(
@@ -2901,7 +3252,11 @@ function list_user_hierarchy_groups(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return connect(
-        "GET", "/user-hierarchy-groups-summary/$(InstanceId)", params; aws_config=aws_config
+        "GET",
+        "/user-hierarchy-groups-summary/$(InstanceId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2922,14 +3277,25 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   previous response in the next request to retrieve the next set of results.
 """
 function list_users(InstanceId; aws_config::AbstractAWSConfig=global_aws_config())
-    return connect("GET", "/users-summary/$(InstanceId)"; aws_config=aws_config)
+    return connect(
+        "GET",
+        "/users-summary/$(InstanceId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_users(
     InstanceId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return connect("GET", "/users-summary/$(InstanceId)", params; aws_config=aws_config)
+    return connect(
+        "GET",
+        "/users-summary/$(InstanceId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2963,6 +3329,7 @@ function resume_contact_recording(
             "InstanceId" => InstanceId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function resume_contact_recording(
@@ -2987,6 +3354,7 @@ function resume_contact_recording(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3043,6 +3411,7 @@ function start_chat_contact(
             "ClientToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_chat_contact(
@@ -3068,6 +3437,7 @@ function start_chat_contact(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3109,6 +3479,7 @@ function start_contact_recording(
             "VoiceRecordingConfiguration" => VoiceRecordingConfiguration,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_contact_recording(
@@ -3135,6 +3506,7 @@ function start_contact_recording(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3150,7 +3522,10 @@ the agent, like any other inbound case. There is a 60-second dialing timeout for
 operation. If the call is not connected after 60 seconds, it fails.  UK numbers with a 447
 prefix are not allowed by default. Before you can dial these UK mobile numbers, you must
 submit a service quota increase request. For more information, see Amazon Connect Service
-Quotas in the Amazon Connect Administrator Guide.
+Quotas in the Amazon Connect Administrator Guide.    Campaign calls are not allowed by
+default. Before you can make a call with TrafficType = CAMPAIGN, you must submit a service
+quota increase request. For more information, see Amazon Connect Service Quotas in the
+Amazon Connect Administrator Guide.
 
 # Arguments
 - `contact_flow_id`: The identifier of the contact flow for the outbound call. To see the
@@ -3166,10 +3541,13 @@ Quotas in the Amazon Connect Administrator Guide.
 
 # Optional Parameters
 Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys are:
+- `"AnswerMachineDetectionConfig"`: Configuration of the answering machine detection for
+  this outbound call.
 - `"Attributes"`: A custom key-value pair using an attribute map. The attributes are
   standard Amazon Connect attributes, and can be accessed in contact flows just like any
   other contact attributes. There can be up to 32,768 UTF-8 bytes across all key-value pairs
   per contact. Attribute keys can include only alphanumeric, dash, and underscore characters.
+- `"CampaignId"`: The campaign identifier of the outbound communication.
 - `"ClientToken"`: A unique, case-sensitive identifier that you provide to ensure the
   idempotency of the request. The token is valid for 7 days after creation. If a contact is
   already started, the contact ID is returned.
@@ -3179,6 +3557,9 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   a source phone number.
 - `"SourcePhoneNumber"`: The phone number associated with the Amazon Connect instance, in
   E.164 format. If you do not specify a source phone number, you must specify a queue.
+- `"TrafficType"`: Denotes the class of traffic. Calls with different traffic types are
+  handled differently by Amazon Connect. The default value is GENERAL. Use CAMPAIGN if
+  EnableAnswerMachineDetection is set to true. For all other cases, use GENERAL.
 """
 function start_outbound_voice_contact(
     ContactFlowId,
@@ -3196,6 +3577,7 @@ function start_outbound_voice_contact(
             "ClientToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_outbound_voice_contact(
@@ -3221,6 +3603,7 @@ function start_outbound_voice_contact(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3269,6 +3652,7 @@ function start_task_contact(
             "ClientToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_task_contact(
@@ -3294,6 +3678,7 @@ function start_task_contact(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3317,6 +3702,7 @@ function stop_contact(
         "/contact/stop",
         Dict{String,Any}("ContactId" => ContactId, "InstanceId" => InstanceId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function stop_contact(
@@ -3336,6 +3722,7 @@ function stop_contact(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3373,6 +3760,7 @@ function stop_contact_recording(
             "InstanceId" => InstanceId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function stop_contact_recording(
@@ -3397,6 +3785,7 @@ function stop_contact_recording(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3433,6 +3822,7 @@ function suspend_contact_recording(
             "InstanceId" => InstanceId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function suspend_contact_recording(
@@ -3457,6 +3847,7 @@ function suspend_contact_recording(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3481,6 +3872,7 @@ function tag_resource(resourceArn, tags; aws_config::AbstractAWSConfig=global_aw
         "/tags/$(resourceArn)",
         Dict{String,Any}("tags" => tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -3494,6 +3886,7 @@ function tag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tags" => tags), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3516,6 +3909,7 @@ function untag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}("tagKeys" => tagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -3529,6 +3923,7 @@ function untag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tagKeys" => tagKeys), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3556,7 +3951,10 @@ function update_agent_status(
     AgentStatusId, InstanceId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return connect(
-        "POST", "/agent-status/$(InstanceId)/$(AgentStatusId)"; aws_config=aws_config
+        "POST",
+        "/agent-status/$(InstanceId)/$(AgentStatusId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_agent_status(
@@ -3570,6 +3968,7 @@ function update_agent_status(
         "/agent-status/$(InstanceId)/$(AgentStatusId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3620,6 +4019,7 @@ function update_contact_attributes(
             "InstanceId" => InstanceId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_contact_attributes(
@@ -3644,6 +4044,7 @@ function update_contact_attributes(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3670,6 +4071,7 @@ function update_contact_flow_content(
         "/contact-flows/$(InstanceId)/$(ContactFlowId)/content",
         Dict{String,Any}("Content" => Content);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_contact_flow_content(
@@ -3684,6 +4086,7 @@ function update_contact_flow_content(
         "/contact-flows/$(InstanceId)/$(ContactFlowId)/content",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Content" => Content), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3707,7 +4110,10 @@ function update_contact_flow_name(
     ContactFlowId, InstanceId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return connect(
-        "POST", "/contact-flows/$(InstanceId)/$(ContactFlowId)/name"; aws_config=aws_config
+        "POST",
+        "/contact-flows/$(InstanceId)/$(ContactFlowId)/name";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_contact_flow_name(
@@ -3721,6 +4127,7 @@ function update_contact_flow_name(
         "/contact-flows/$(InstanceId)/$(ContactFlowId)/name",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3750,6 +4157,7 @@ function update_hours_of_operation(
         "POST",
         "/hours-of-operations/$(InstanceId)/$(HoursOfOperationId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_hours_of_operation(
@@ -3763,6 +4171,7 @@ function update_hours_of_operation(
         "/hours-of-operations/$(InstanceId)/$(HoursOfOperationId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3774,7 +4183,8 @@ This API is in preview release for Amazon Connect and is subject to change. Upda
 value for the specified attribute type.
 
 # Arguments
-- `attribute_type`: The type of attribute.
+- `attribute_type`: The type of attribute.  Only allowlisted customers can consume
+  USE_CUSTOM_TTS_VOICES. To access this feature, contact AWS Support for allowlisting.
 - `instance_id`: The identifier of the Amazon Connect instance. You can find the instanceId
   in the ARN of the instance.
 - `value`: The value for the attribute. Maximum character limit is 100.
@@ -3788,6 +4198,7 @@ function update_instance_attribute(
         "/instance/$(InstanceId)/attribute/$(AttributeType)",
         Dict{String,Any}("Value" => Value);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_instance_attribute(
@@ -3802,6 +4213,7 @@ function update_instance_attribute(
         "/instance/$(InstanceId)/attribute/$(AttributeType)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Value" => Value), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3833,6 +4245,7 @@ function update_instance_storage_config(
         "/instance/$(InstanceId)/storage-config/$(AssociationId)",
         Dict{String,Any}("StorageConfig" => StorageConfig, "resourceType" => resourceType);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_instance_storage_config(
@@ -3856,6 +4269,7 @@ function update_instance_storage_config(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3884,6 +4298,7 @@ function update_queue_hours_of_operation(
         "/queues/$(InstanceId)/$(QueueId)/hours-of-operation",
         Dict{String,Any}("HoursOfOperationId" => HoursOfOperationId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_queue_hours_of_operation(
@@ -3902,6 +4317,7 @@ function update_queue_hours_of_operation(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3926,7 +4342,10 @@ function update_queue_max_contacts(
     InstanceId, QueueId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return connect(
-        "POST", "/queues/$(InstanceId)/$(QueueId)/max-contacts"; aws_config=aws_config
+        "POST",
+        "/queues/$(InstanceId)/$(QueueId)/max-contacts";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_queue_max_contacts(
@@ -3940,6 +4359,7 @@ function update_queue_max_contacts(
         "/queues/$(InstanceId)/$(QueueId)/max-contacts",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3963,7 +4383,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function update_queue_name(
     InstanceId, QueueId; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return connect("POST", "/queues/$(InstanceId)/$(QueueId)/name"; aws_config=aws_config)
+    return connect(
+        "POST",
+        "/queues/$(InstanceId)/$(QueueId)/name";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function update_queue_name(
     InstanceId,
@@ -3972,7 +4397,11 @@ function update_queue_name(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return connect(
-        "POST", "/queues/$(InstanceId)/$(QueueId)/name", params; aws_config=aws_config
+        "POST",
+        "/queues/$(InstanceId)/$(QueueId)/name",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4001,6 +4430,7 @@ function update_queue_outbound_caller_config(
         "/queues/$(InstanceId)/$(QueueId)/outbound-caller-config",
         Dict{String,Any}("OutboundCallerConfig" => OutboundCallerConfig);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_queue_outbound_caller_config(
@@ -4021,6 +4451,7 @@ function update_queue_outbound_caller_config(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4046,6 +4477,7 @@ function update_queue_status(
         "/queues/$(InstanceId)/$(QueueId)/status",
         Dict{String,Any}("Status" => Status);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_queue_status(
@@ -4060,6 +4492,7 @@ function update_queue_status(
         "/queues/$(InstanceId)/$(QueueId)/status",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Status" => Status), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4088,6 +4521,7 @@ function update_quick_connect_config(
         "/quick-connects/$(InstanceId)/$(QuickConnectId)/config",
         Dict{String,Any}("QuickConnectConfig" => QuickConnectConfig);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_quick_connect_config(
@@ -4106,6 +4540,7 @@ function update_quick_connect_config(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4133,6 +4568,7 @@ function update_quick_connect_name(
         "POST",
         "/quick-connects/$(InstanceId)/$(QuickConnectId)/name";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_quick_connect_name(
@@ -4146,6 +4582,7 @@ function update_quick_connect_name(
         "/quick-connects/$(InstanceId)/$(QuickConnectId)/name",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4175,6 +4612,7 @@ function update_routing_profile_concurrency(
         "/routing-profiles/$(InstanceId)/$(RoutingProfileId)/concurrency",
         Dict{String,Any}("MediaConcurrencies" => MediaConcurrencies);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_routing_profile_concurrency(
@@ -4193,6 +4631,7 @@ function update_routing_profile_concurrency(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4220,6 +4659,7 @@ function update_routing_profile_default_outbound_queue(
         "/routing-profiles/$(InstanceId)/$(RoutingProfileId)/default-outbound-queue",
         Dict{String,Any}("DefaultOutboundQueueId" => DefaultOutboundQueueId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_routing_profile_default_outbound_queue(
@@ -4240,6 +4680,7 @@ function update_routing_profile_default_outbound_queue(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4268,6 +4709,7 @@ function update_routing_profile_name(
         "POST",
         "/routing-profiles/$(InstanceId)/$(RoutingProfileId)/name";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_routing_profile_name(
@@ -4281,6 +4723,7 @@ function update_routing_profile_name(
         "/routing-profiles/$(InstanceId)/$(RoutingProfileId)/name",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4309,6 +4752,7 @@ function update_routing_profile_queues(
         "/routing-profiles/$(InstanceId)/$(RoutingProfileId)/queues",
         Dict{String,Any}("QueueConfigs" => QueueConfigs);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_routing_profile_queues(
@@ -4325,6 +4769,7 @@ function update_routing_profile_queues(
             mergewith(_merge, Dict{String,Any}("QueueConfigs" => QueueConfigs), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4347,7 +4792,10 @@ function update_user_hierarchy(
     InstanceId, UserId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return connect(
-        "POST", "/users/$(InstanceId)/$(UserId)/hierarchy"; aws_config=aws_config
+        "POST",
+        "/users/$(InstanceId)/$(UserId)/hierarchy";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_user_hierarchy(
@@ -4357,7 +4805,11 @@ function update_user_hierarchy(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return connect(
-        "POST", "/users/$(InstanceId)/$(UserId)/hierarchy", params; aws_config=aws_config
+        "POST",
+        "/users/$(InstanceId)/$(UserId)/hierarchy",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4382,6 +4834,7 @@ function update_user_hierarchy_group_name(
         "/user-hierarchy-groups/$(InstanceId)/$(HierarchyGroupId)/name",
         Dict{String,Any}("Name" => Name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_user_hierarchy_group_name(
@@ -4396,6 +4849,7 @@ function update_user_hierarchy_group_name(
         "/user-hierarchy-groups/$(InstanceId)/$(HierarchyGroupId)/name",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4419,6 +4873,7 @@ function update_user_hierarchy_structure(
         "/user-hierarchy-structure/$(InstanceId)",
         Dict{String,Any}("HierarchyStructure" => HierarchyStructure);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_user_hierarchy_structure(
@@ -4436,6 +4891,7 @@ function update_user_hierarchy_structure(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4465,6 +4921,7 @@ function update_user_identity_info(
         "/users/$(InstanceId)/$(UserId)/identity-info",
         Dict{String,Any}("IdentityInfo" => IdentityInfo);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_user_identity_info(
@@ -4481,6 +4938,7 @@ function update_user_identity_info(
             mergewith(_merge, Dict{String,Any}("IdentityInfo" => IdentityInfo), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4505,6 +4963,7 @@ function update_user_phone_config(
         "/users/$(InstanceId)/$(UserId)/phone-config",
         Dict{String,Any}("PhoneConfig" => PhoneConfig);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_user_phone_config(
@@ -4521,6 +4980,7 @@ function update_user_phone_config(
             mergewith(_merge, Dict{String,Any}("PhoneConfig" => PhoneConfig), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4545,6 +5005,7 @@ function update_user_routing_profile(
         "/users/$(InstanceId)/$(UserId)/routing-profile",
         Dict{String,Any}("RoutingProfileId" => RoutingProfileId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_user_routing_profile(
@@ -4563,6 +5024,7 @@ function update_user_routing_profile(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4590,6 +5052,7 @@ function update_user_security_profiles(
         "/users/$(InstanceId)/$(UserId)/security-profiles",
         Dict{String,Any}("SecurityProfileIds" => SecurityProfileIds);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_user_security_profiles(
@@ -4608,5 +5071,6 @@ function update_user_security_profiles(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/connect_contact_lens.jl
+++ b/src/services/connect_contact_lens.jl
@@ -28,6 +28,7 @@ function list_realtime_contact_analysis_segments(
         "/realtime-contact-analysis/analysis-segments",
         Dict{String,Any}("ContactId" => ContactId, "InstanceId" => InstanceId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_realtime_contact_analysis_segments(
@@ -47,5 +48,6 @@ function list_realtime_contact_analysis_segments(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/connectparticipant.jl
+++ b/src/services/connectparticipant.jl
@@ -33,6 +33,7 @@ function complete_attachment_upload(
             "headers" => Dict{String,Any}("X-Amz-Bearer" => X_Amz_Bearer),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function complete_attachment_upload(
@@ -57,6 +58,7 @@ function complete_attachment_upload(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -91,6 +93,7 @@ function create_participant_connection(
             "Type" => Type, "headers" => Dict{String,Any}("X-Amz-Bearer" => X_Amz_Bearer)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_participant_connection(
@@ -113,6 +116,7 @@ function create_participant_connection(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -143,6 +147,7 @@ function disconnect_participant(
             "headers" => Dict{String,Any}("X-Amz-Bearer" => X_Amz_Bearer),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disconnect_participant(
@@ -164,6 +169,7 @@ function disconnect_participant(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -190,6 +196,7 @@ function get_attachment(
             "headers" => Dict{String,Any}("X-Amz-Bearer" => X_Amz_Bearer),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_attachment(
@@ -212,6 +219,7 @@ function get_attachment(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -244,6 +252,7 @@ function get_transcript(X_Amz_Bearer; aws_config::AbstractAWSConfig=global_aws_c
         "/participant/transcript",
         Dict{String,Any}("headers" => Dict{String,Any}("X-Amz-Bearer" => X_Amz_Bearer));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_transcript(
@@ -264,6 +273,7 @@ function get_transcript(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -300,6 +310,7 @@ function send_event(
             "headers" => Dict{String,Any}("X-Amz-Bearer" => X_Amz_Bearer),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function send_event(
@@ -323,6 +334,7 @@ function send_event(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -357,6 +369,7 @@ function send_message(
             "headers" => Dict{String,Any}("X-Amz-Bearer" => X_Amz_Bearer),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function send_message(
@@ -382,6 +395,7 @@ function send_message(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -419,6 +433,7 @@ function start_attachment_upload(
             "headers" => Dict{String,Any}("X-Amz-Bearer" => X_Amz_Bearer),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_attachment_upload(
@@ -447,5 +462,6 @@ function start_attachment_upload(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/cost_and_usage_report_service.jl
+++ b/src/services/cost_and_usage_report_service.jl
@@ -16,13 +16,18 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   is case sensitive, and can't include spaces.
 """
 function delete_report_definition(; aws_config::AbstractAWSConfig=global_aws_config())
-    return cost_and_usage_report_service("DeleteReportDefinition"; aws_config=aws_config)
+    return cost_and_usage_report_service(
+        "DeleteReportDefinition"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function delete_report_definition(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return cost_and_usage_report_service(
-        "DeleteReportDefinition", params; aws_config=aws_config
+        "DeleteReportDefinition",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -38,13 +43,18 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`:
 """
 function describe_report_definitions(; aws_config::AbstractAWSConfig=global_aws_config())
-    return cost_and_usage_report_service("DescribeReportDefinitions"; aws_config=aws_config)
+    return cost_and_usage_report_service(
+        "DescribeReportDefinitions"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_report_definitions(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return cost_and_usage_report_service(
-        "DescribeReportDefinitions", params; aws_config=aws_config
+        "DescribeReportDefinitions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -68,6 +78,7 @@ function modify_report_definition(
             "ReportDefinition" => ReportDefinition, "ReportName" => ReportName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_report_definition(
@@ -88,6 +99,7 @@ function modify_report_definition(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -109,6 +121,7 @@ function put_report_definition(
         "PutReportDefinition",
         Dict{String,Any}("ReportDefinition" => ReportDefinition);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_report_definition(
@@ -124,5 +137,6 @@ function put_report_definition(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/cost_explorer.jl
+++ b/src/services/cost_explorer.jl
@@ -22,6 +22,7 @@ function create_anomaly_monitor(
         "CreateAnomalyMonitor",
         Dict{String,Any}("AnomalyMonitor" => AnomalyMonitor);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_anomaly_monitor(
@@ -35,6 +36,7 @@ function create_anomaly_monitor(
             mergewith(_merge, Dict{String,Any}("AnomalyMonitor" => AnomalyMonitor), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -57,6 +59,7 @@ function create_anomaly_subscription(
         "CreateAnomalySubscription",
         Dict{String,Any}("AnomalySubscription" => AnomalySubscription);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_anomaly_subscription(
@@ -74,6 +77,7 @@ function create_anomaly_subscription(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -102,6 +106,7 @@ function create_cost_category_definition(
         "CreateCostCategoryDefinition",
         Dict{String,Any}("Name" => Name, "RuleVersion" => RuleVersion, "Rules" => Rules);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_cost_category_definition(
@@ -123,6 +128,7 @@ function create_cost_category_definition(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -143,6 +149,7 @@ function delete_anomaly_monitor(
         "DeleteAnomalyMonitor",
         Dict{String,Any}("MonitorArn" => MonitorArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_anomaly_monitor(
@@ -156,6 +163,7 @@ function delete_anomaly_monitor(
             mergewith(_merge, Dict{String,Any}("MonitorArn" => MonitorArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -177,6 +185,7 @@ function delete_anomaly_subscription(
         "DeleteAnomalySubscription",
         Dict{String,Any}("SubscriptionArn" => SubscriptionArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_anomaly_subscription(
@@ -192,6 +201,7 @@ function delete_anomaly_subscription(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -213,6 +223,7 @@ function delete_cost_category_definition(
         "DeleteCostCategoryDefinition",
         Dict{String,Any}("CostCategoryArn" => CostCategoryArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_cost_category_definition(
@@ -228,6 +239,7 @@ function delete_cost_category_definition(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -255,6 +267,7 @@ function describe_cost_category_definition(
         "DescribeCostCategoryDefinition",
         Dict{String,Any}("CostCategoryArn" => CostCategoryArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_cost_category_definition(
@@ -270,6 +283,7 @@ function describe_cost_category_definition(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -302,6 +316,7 @@ function get_anomalies(DateInterval; aws_config::AbstractAWSConfig=global_aws_co
         "GetAnomalies",
         Dict{String,Any}("DateInterval" => DateInterval);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_anomalies(
@@ -315,6 +330,7 @@ function get_anomalies(
             mergewith(_merge, Dict{String,Any}("DateInterval" => DateInterval), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -334,12 +350,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   page size.
 """
 function get_anomaly_monitors(; aws_config::AbstractAWSConfig=global_aws_config())
-    return cost_explorer("GetAnomalyMonitors"; aws_config=aws_config)
+    return cost_explorer(
+        "GetAnomalyMonitors"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_anomaly_monitors(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return cost_explorer("GetAnomalyMonitors", params; aws_config=aws_config)
+    return cost_explorer(
+        "GetAnomalyMonitors", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -359,12 +379,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"SubscriptionArnList"`: A list of cost anomaly subscription ARNs.
 """
 function get_anomaly_subscriptions(; aws_config::AbstractAWSConfig=global_aws_config())
-    return cost_explorer("GetAnomalySubscriptions"; aws_config=aws_config)
+    return cost_explorer(
+        "GetAnomalySubscriptions"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_anomaly_subscriptions(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return cost_explorer("GetAnomalySubscriptions", params; aws_config=aws_config)
+    return cost_explorer(
+        "GetAnomalySubscriptions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -421,6 +448,7 @@ function get_cost_and_usage(
             "Granularity" => Granularity, "Metrics" => Metrics, "TimePeriod" => TimePeriod
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_cost_and_usage(
@@ -444,6 +472,7 @@ function get_cost_and_usage(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -506,6 +535,7 @@ function get_cost_and_usage_with_resources(
             "Filter" => Filter, "Granularity" => Granularity, "TimePeriod" => TimePeriod
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_cost_and_usage_with_resources(
@@ -529,6 +559,7 @@ function get_cost_and_usage_with_resources(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -569,6 +600,7 @@ function get_cost_categories(TimePeriod; aws_config::AbstractAWSConfig=global_aw
         "GetCostCategories",
         Dict{String,Any}("TimePeriod" => TimePeriod);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_cost_categories(
@@ -582,6 +614,7 @@ function get_cost_categories(
             mergewith(_merge, Dict{String,Any}("TimePeriod" => TimePeriod), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -627,6 +660,7 @@ function get_cost_forecast(
             "Granularity" => Granularity, "Metric" => Metric, "TimePeriod" => TimePeriod
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_cost_forecast(
@@ -650,6 +684,7 @@ function get_cost_forecast(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -736,6 +771,7 @@ function get_dimension_values(
         "GetDimensionValues",
         Dict{String,Any}("Dimension" => Dimension, "TimePeriod" => TimePeriod);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_dimension_values(
@@ -754,6 +790,7 @@ function get_dimension_values(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -816,6 +853,7 @@ function get_reservation_coverage(
         "GetReservationCoverage",
         Dict{String,Any}("TimePeriod" => TimePeriod);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_reservation_coverage(
@@ -829,6 +867,7 @@ function get_reservation_coverage(
             mergewith(_merge, Dict{String,Any}("TimePeriod" => TimePeriod), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -881,6 +920,7 @@ function get_reservation_purchase_recommendation(
         "GetReservationPurchaseRecommendation",
         Dict{String,Any}("Service" => Service);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_reservation_purchase_recommendation(
@@ -890,6 +930,7 @@ function get_reservation_purchase_recommendation(
         "GetReservationPurchaseRecommendation",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Service" => Service), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -942,6 +983,7 @@ function get_reservation_utilization(
         "GetReservationUtilization",
         Dict{String,Any}("TimePeriod" => TimePeriod);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_reservation_utilization(
@@ -955,6 +997,7 @@ function get_reservation_utilization(
             mergewith(_merge, Dict{String,Any}("TimePeriod" => TimePeriod), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -992,6 +1035,7 @@ function get_rightsizing_recommendation(
         "GetRightsizingRecommendation",
         Dict{String,Any}("Service" => Service);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_rightsizing_recommendation(
@@ -1001,6 +1045,7 @@ function get_rightsizing_recommendation(
         "GetRightsizingRecommendation",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Service" => Service), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1051,6 +1096,7 @@ function get_savings_plans_coverage(
         "GetSavingsPlansCoverage",
         Dict{String,Any}("TimePeriod" => TimePeriod);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_savings_plans_coverage(
@@ -1064,6 +1110,7 @@ function get_savings_plans_coverage(
             mergewith(_merge, Dict{String,Any}("TimePeriod" => TimePeriod), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1116,6 +1163,7 @@ function get_savings_plans_purchase_recommendation(
             "TermInYears" => TermInYears,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_savings_plans_purchase_recommendation(
@@ -1141,6 +1189,7 @@ function get_savings_plans_purchase_recommendation(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1180,6 +1229,7 @@ function get_savings_plans_utilization(
         "GetSavingsPlansUtilization",
         Dict{String,Any}("TimePeriod" => TimePeriod);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_savings_plans_utilization(
@@ -1193,6 +1243,7 @@ function get_savings_plans_utilization(
             mergewith(_merge, Dict{String,Any}("TimePeriod" => TimePeriod), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1238,6 +1289,7 @@ function get_savings_plans_utilization_details(
         "GetSavingsPlansUtilizationDetails",
         Dict{String,Any}("TimePeriod" => TimePeriod);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_savings_plans_utilization_details(
@@ -1251,6 +1303,7 @@ function get_savings_plans_utilization_details(
             mergewith(_merge, Dict{String,Any}("TimePeriod" => TimePeriod), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1287,7 +1340,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function get_tags(TimePeriod; aws_config::AbstractAWSConfig=global_aws_config())
     return cost_explorer(
-        "GetTags", Dict{String,Any}("TimePeriod" => TimePeriod); aws_config=aws_config
+        "GetTags",
+        Dict{String,Any}("TimePeriod" => TimePeriod);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_tags(
@@ -1301,6 +1357,7 @@ function get_tags(
             mergewith(_merge, Dict{String,Any}("TimePeriod" => TimePeriod), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1347,6 +1404,7 @@ function get_usage_forecast(
             "Granularity" => Granularity, "Metric" => Metric, "TimePeriod" => TimePeriod
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_usage_forecast(
@@ -1370,6 +1428,7 @@ function get_usage_forecast(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1393,12 +1452,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   page size.
 """
 function list_cost_category_definitions(; aws_config::AbstractAWSConfig=global_aws_config())
-    return cost_explorer("ListCostCategoryDefinitions"; aws_config=aws_config)
+    return cost_explorer(
+        "ListCostCategoryDefinitions";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_cost_category_definitions(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return cost_explorer("ListCostCategoryDefinitions", params; aws_config=aws_config)
+    return cost_explorer(
+        "ListCostCategoryDefinitions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1420,6 +1488,7 @@ function provide_anomaly_feedback(
         "ProvideAnomalyFeedback",
         Dict{String,Any}("AnomalyId" => AnomalyId, "Feedback" => Feedback);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function provide_anomaly_feedback(
@@ -1438,6 +1507,7 @@ function provide_anomaly_feedback(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1462,6 +1532,7 @@ function update_anomaly_monitor(
         "UpdateAnomalyMonitor",
         Dict{String,Any}("MonitorArn" => MonitorArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_anomaly_monitor(
@@ -1475,6 +1546,7 @@ function update_anomaly_monitor(
             mergewith(_merge, Dict{String,Any}("MonitorArn" => MonitorArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1502,6 +1574,7 @@ function update_anomaly_subscription(
         "UpdateAnomalySubscription",
         Dict{String,Any}("SubscriptionArn" => SubscriptionArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_anomaly_subscription(
@@ -1517,6 +1590,7 @@ function update_anomaly_subscription(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1551,6 +1625,7 @@ function update_cost_category_definition(
             "Rules" => Rules,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_cost_category_definition(
@@ -1574,5 +1649,6 @@ function update_cost_category_definition(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/customer_profiles.jl
+++ b/src/services/customer_profiles.jl
@@ -33,6 +33,7 @@ function add_profile_key(
             "KeyName" => KeyName, "ProfileId" => ProfileId, "Values" => Values
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function add_profile_key(
@@ -56,6 +57,7 @@ function add_profile_key(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -98,6 +100,7 @@ function create_domain(
         "/domains/$(DomainName)",
         Dict{String,Any}("DefaultExpirationDays" => DefaultExpirationDays);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_domain(
@@ -117,6 +120,7 @@ function create_domain(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -160,7 +164,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function create_profile(DomainName; aws_config::AbstractAWSConfig=global_aws_config())
     return customer_profiles(
-        "POST", "/domains/$(DomainName)/profiles"; aws_config=aws_config
+        "POST",
+        "/domains/$(DomainName)/profiles";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_profile(
@@ -169,7 +176,11 @@ function create_profile(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return customer_profiles(
-        "POST", "/domains/$(DomainName)/profiles", params; aws_config=aws_config
+        "POST",
+        "/domains/$(DomainName)/profiles",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -185,7 +196,12 @@ and their related objects.
 
 """
 function delete_domain(DomainName; aws_config::AbstractAWSConfig=global_aws_config())
-    return customer_profiles("DELETE", "/domains/$(DomainName)"; aws_config=aws_config)
+    return customer_profiles(
+        "DELETE",
+        "/domains/$(DomainName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_domain(
     DomainName,
@@ -193,7 +209,11 @@ function delete_domain(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return customer_profiles(
-        "DELETE", "/domains/$(DomainName)", params; aws_config=aws_config
+        "DELETE",
+        "/domains/$(DomainName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -216,6 +236,7 @@ function delete_integration(
         "/domains/$(DomainName)/integrations/delete",
         Dict{String,Any}("Uri" => Uri);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_integration(
@@ -229,6 +250,7 @@ function delete_integration(
         "/domains/$(DomainName)/integrations/delete",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Uri" => Uri), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -251,6 +273,7 @@ function delete_profile(
         "/domains/$(DomainName)/profiles/delete",
         Dict{String,Any}("ProfileId" => ProfileId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_profile(
@@ -266,6 +289,7 @@ function delete_profile(
             mergewith(_merge, Dict{String,Any}("ProfileId" => ProfileId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -296,6 +320,7 @@ function delete_profile_key(
             "KeyName" => KeyName, "ProfileId" => ProfileId, "Values" => Values
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_profile_key(
@@ -319,6 +344,7 @@ function delete_profile_key(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -352,6 +378,7 @@ function delete_profile_object(
             "ProfileObjectUniqueKey" => ProfileObjectUniqueKey,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_profile_object(
@@ -377,6 +404,7 @@ function delete_profile_object(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -401,6 +429,7 @@ function delete_profile_object_type(
         "DELETE",
         "/domains/$(DomainName)/object-types/$(ObjectTypeName)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_profile_object_type(
@@ -414,6 +443,7 @@ function delete_profile_object_type(
         "/domains/$(DomainName)/object-types/$(ObjectTypeName)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -428,14 +458,25 @@ Returns information about a specific domain.
 
 """
 function get_domain(DomainName; aws_config::AbstractAWSConfig=global_aws_config())
-    return customer_profiles("GET", "/domains/$(DomainName)"; aws_config=aws_config)
+    return customer_profiles(
+        "GET",
+        "/domains/$(DomainName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_domain(
     DomainName,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return customer_profiles("GET", "/domains/$(DomainName)", params; aws_config=aws_config)
+    return customer_profiles(
+        "GET",
+        "/domains/$(DomainName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -455,6 +496,7 @@ function get_integration(DomainName, Uri; aws_config::AbstractAWSConfig=global_a
         "/domains/$(DomainName)/integrations",
         Dict{String,Any}("Uri" => Uri);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_integration(
@@ -468,6 +510,7 @@ function get_integration(
         "/domains/$(DomainName)/integrations",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Uri" => Uri), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -499,7 +542,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   previous response in the next request to retrieve the next set of results.
 """
 function get_matches(DomainName; aws_config::AbstractAWSConfig=global_aws_config())
-    return customer_profiles("GET", "/domains/$(DomainName)/matches"; aws_config=aws_config)
+    return customer_profiles(
+        "GET",
+        "/domains/$(DomainName)/matches";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_matches(
     DomainName,
@@ -507,7 +555,11 @@ function get_matches(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return customer_profiles(
-        "GET", "/domains/$(DomainName)/matches", params; aws_config=aws_config
+        "GET",
+        "/domains/$(DomainName)/matches",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -529,6 +581,7 @@ function get_profile_object_type(
         "GET",
         "/domains/$(DomainName)/object-types/$(ObjectTypeName)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_profile_object_type(
@@ -542,6 +595,7 @@ function get_profile_object_type(
         "/domains/$(DomainName)/object-types/$(ObjectTypeName)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -561,7 +615,12 @@ matches one of the TemplateIds, it uses the mappings from the template.
 function get_profile_object_type_template(
     TemplateId; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return customer_profiles("GET", "/templates/$(TemplateId)"; aws_config=aws_config)
+    return customer_profiles(
+        "GET",
+        "/templates/$(TemplateId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_profile_object_type_template(
     TemplateId,
@@ -569,7 +628,11 @@ function get_profile_object_type_template(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return customer_profiles(
-        "GET", "/templates/$(TemplateId)", params; aws_config=aws_config
+        "GET",
+        "/templates/$(TemplateId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -589,7 +652,11 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function list_account_integrations(Uri; aws_config::AbstractAWSConfig=global_aws_config())
     return customer_profiles(
-        "POST", "/integrations", Dict{String,Any}("Uri" => Uri); aws_config=aws_config
+        "POST",
+        "/integrations",
+        Dict{String,Any}("Uri" => Uri);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_account_integrations(
@@ -600,6 +667,7 @@ function list_account_integrations(
         "/integrations",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Uri" => Uri), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -615,12 +683,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"next-token"`: The pagination token from the previous ListDomain API call.
 """
 function list_domains(; aws_config::AbstractAWSConfig=global_aws_config())
-    return customer_profiles("GET", "/domains"; aws_config=aws_config)
+    return customer_profiles(
+        "GET", "/domains"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_domains(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return customer_profiles("GET", "/domains", params; aws_config=aws_config)
+    return customer_profiles(
+        "GET", "/domains", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -639,7 +711,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function list_integrations(DomainName; aws_config::AbstractAWSConfig=global_aws_config())
     return customer_profiles(
-        "GET", "/domains/$(DomainName)/integrations"; aws_config=aws_config
+        "GET",
+        "/domains/$(DomainName)/integrations";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_integrations(
@@ -648,7 +723,11 @@ function list_integrations(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return customer_profiles(
-        "GET", "/domains/$(DomainName)/integrations", params; aws_config=aws_config
+        "GET",
+        "/domains/$(DomainName)/integrations",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -666,12 +745,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function list_profile_object_type_templates(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return customer_profiles("GET", "/templates"; aws_config=aws_config)
+    return customer_profiles(
+        "GET", "/templates"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_profile_object_type_templates(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return customer_profiles("GET", "/templates", params; aws_config=aws_config)
+    return customer_profiles(
+        "GET", "/templates", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -692,7 +775,10 @@ function list_profile_object_types(
     DomainName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return customer_profiles(
-        "GET", "/domains/$(DomainName)/object-types"; aws_config=aws_config
+        "GET",
+        "/domains/$(DomainName)/object-types";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_profile_object_types(
@@ -701,7 +787,11 @@ function list_profile_object_types(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return customer_profiles(
-        "GET", "/domains/$(DomainName)/object-types", params; aws_config=aws_config
+        "GET",
+        "/domains/$(DomainName)/object-types",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -731,6 +821,7 @@ function list_profile_objects(
         "/domains/$(DomainName)/profiles/objects",
         Dict{String,Any}("ObjectTypeName" => ObjectTypeName, "ProfileId" => ProfileId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_profile_objects(
@@ -753,6 +844,7 @@ function list_profile_objects(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -770,14 +862,25 @@ Customer Profiles, domains, profile object types, and integrations can be tagged
 function list_tags_for_resource(
     resourceArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return customer_profiles("GET", "/tags/$(resourceArn)"; aws_config=aws_config)
+    return customer_profiles(
+        "GET",
+        "/tags/$(resourceArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_tags_for_resource(
     resourceArn,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return customer_profiles("GET", "/tags/$(resourceArn)", params; aws_config=aws_config)
+    return customer_profiles(
+        "GET",
+        "/tags/$(resourceArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -822,6 +925,7 @@ function merge_profiles(
             "MainProfileId" => MainProfileId, "ProfileIdsToBeMerged" => ProfileIdsToBeMerged
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function merge_profiles(
@@ -845,6 +949,7 @@ function merge_profiles(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -874,6 +979,7 @@ function put_integration(
         "/domains/$(DomainName)/integrations",
         Dict{String,Any}("ObjectTypeName" => ObjectTypeName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_integration(
@@ -889,6 +995,7 @@ function put_integration(
             mergewith(_merge, Dict{String,Any}("ObjectTypeName" => ObjectTypeName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -919,6 +1026,7 @@ function put_profile_object(
         "/domains/$(DomainName)/profiles/objects",
         Dict{String,Any}("Object" => Object, "ObjectTypeName" => ObjectTypeName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_profile_object(
@@ -939,6 +1047,7 @@ function put_profile_object(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -979,6 +1088,7 @@ function put_profile_object_type(
         "/domains/$(DomainName)/object-types/$(ObjectTypeName)",
         Dict{String,Any}("Description" => Description);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_profile_object_type(
@@ -995,6 +1105,7 @@ function put_profile_object_type(
             mergewith(_merge, Dict{String,Any}("Description" => Description), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1026,6 +1137,7 @@ function search_profiles(
         "/domains/$(DomainName)/profiles/search",
         Dict{String,Any}("KeyName" => KeyName, "Values" => Values);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function search_profiles(
@@ -1044,6 +1156,7 @@ function search_profiles(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1073,6 +1186,7 @@ function tag_resource(resourceArn, tags; aws_config::AbstractAWSConfig=global_aw
         "/tags/$(resourceArn)",
         Dict{String,Any}("tags" => tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -1086,6 +1200,7 @@ function tag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tags" => tags), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1109,6 +1224,7 @@ function untag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}("tagKeys" => tagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -1122,6 +1238,7 @@ function untag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tagKeys" => tagKeys), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1156,14 +1273,25 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"Tags"`: The tags used to organize, track, or control access for this resource.
 """
 function update_domain(DomainName; aws_config::AbstractAWSConfig=global_aws_config())
-    return customer_profiles("PUT", "/domains/$(DomainName)"; aws_config=aws_config)
+    return customer_profiles(
+        "PUT",
+        "/domains/$(DomainName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function update_domain(
     DomainName,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return customer_profiles("PUT", "/domains/$(DomainName)", params; aws_config=aws_config)
+    return customer_profiles(
+        "PUT",
+        "/domains/$(DomainName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1215,6 +1343,7 @@ function update_profile(
         "/domains/$(DomainName)/profiles",
         Dict{String,Any}("ProfileId" => ProfileId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_profile(
@@ -1230,5 +1359,6 @@ function update_profile(
             mergewith(_merge, Dict{String,Any}("ProfileId" => ProfileId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/data_pipeline.jl
+++ b/src/services/data_pipeline.jl
@@ -27,6 +27,7 @@ function activate_pipeline(pipelineId; aws_config::AbstractAWSConfig=global_aws_
         "ActivatePipeline",
         Dict{String,Any}("pipelineId" => pipelineId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function activate_pipeline(
@@ -40,6 +41,7 @@ function activate_pipeline(
             mergewith(_merge, Dict{String,Any}("pipelineId" => pipelineId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -59,6 +61,7 @@ function add_tags(pipelineId, tags; aws_config::AbstractAWSConfig=global_aws_con
         "AddTags",
         Dict{String,Any}("pipelineId" => pipelineId, "tags" => tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function add_tags(
@@ -75,6 +78,7 @@ function add_tags(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -110,6 +114,7 @@ function create_pipeline(name, uniqueId; aws_config::AbstractAWSConfig=global_aw
         "CreatePipeline",
         Dict{String,Any}("name" => name, "uniqueId" => uniqueId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_pipeline(
@@ -126,6 +131,7 @@ function create_pipeline(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -152,6 +158,7 @@ function deactivate_pipeline(pipelineId; aws_config::AbstractAWSConfig=global_aw
         "DeactivatePipeline",
         Dict{String,Any}("pipelineId" => pipelineId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function deactivate_pipeline(
@@ -165,6 +172,7 @@ function deactivate_pipeline(
             mergewith(_merge, Dict{String,Any}("pipelineId" => pipelineId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -188,6 +196,7 @@ function delete_pipeline(pipelineId; aws_config::AbstractAWSConfig=global_aws_co
         "DeletePipeline",
         Dict{String,Any}("pipelineId" => pipelineId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_pipeline(
@@ -201,6 +210,7 @@ function delete_pipeline(
             mergewith(_merge, Dict{String,Any}("pipelineId" => pipelineId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -231,6 +241,7 @@ function describe_objects(
         "DescribeObjects",
         Dict{String,Any}("objectIds" => objectIds, "pipelineId" => pipelineId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_objects(
@@ -249,6 +260,7 @@ function describe_objects(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -273,6 +285,7 @@ function describe_pipelines(pipelineIds; aws_config::AbstractAWSConfig=global_aw
         "DescribePipelines",
         Dict{String,Any}("pipelineIds" => pipelineIds);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_pipelines(
@@ -286,6 +299,7 @@ function describe_pipelines(
             mergewith(_merge, Dict{String,Any}("pipelineIds" => pipelineIds), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -311,6 +325,7 @@ function evaluate_expression(
             "expression" => expression, "objectId" => objectId, "pipelineId" => pipelineId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function evaluate_expression(
@@ -334,6 +349,7 @@ function evaluate_expression(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -360,6 +376,7 @@ function get_pipeline_definition(
         "GetPipelineDefinition",
         Dict{String,Any}("pipelineId" => pipelineId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_pipeline_definition(
@@ -373,6 +390,7 @@ function get_pipeline_definition(
             mergewith(_merge, Dict{String,Any}("pipelineId" => pipelineId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -389,12 +407,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   with the marker value from the previous call to retrieve the next set of results.
 """
 function list_pipelines(; aws_config::AbstractAWSConfig=global_aws_config())
-    return data_pipeline("ListPipelines"; aws_config=aws_config)
+    return data_pipeline(
+        "ListPipelines"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_pipelines(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return data_pipeline("ListPipelines", params; aws_config=aws_config)
+    return data_pipeline(
+        "ListPipelines", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -431,7 +453,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function poll_for_task(workerGroup; aws_config::AbstractAWSConfig=global_aws_config())
     return data_pipeline(
-        "PollForTask", Dict{String,Any}("workerGroup" => workerGroup); aws_config=aws_config
+        "PollForTask",
+        Dict{String,Any}("workerGroup" => workerGroup);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function poll_for_task(
@@ -445,6 +470,7 @@ function poll_for_task(
             mergewith(_merge, Dict{String,Any}("workerGroup" => workerGroup), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -478,6 +504,7 @@ function put_pipeline_definition(
         "PutPipelineDefinition",
         Dict{String,Any}("pipelineId" => pipelineId, "pipelineObjects" => pipelineObjects);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_pipeline_definition(
@@ -498,6 +525,7 @@ function put_pipeline_definition(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -532,6 +560,7 @@ function query_objects(
         "QueryObjects",
         Dict{String,Any}("pipelineId" => pipelineId, "sphere" => sphere);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function query_objects(
@@ -550,6 +579,7 @@ function query_objects(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -569,6 +599,7 @@ function remove_tags(pipelineId, tagKeys; aws_config::AbstractAWSConfig=global_a
         "RemoveTags",
         Dict{String,Any}("pipelineId" => pipelineId, "tagKeys" => tagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function remove_tags(
@@ -587,6 +618,7 @@ function remove_tags(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -615,7 +647,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function report_task_progress(taskId; aws_config::AbstractAWSConfig=global_aws_config())
     return data_pipeline(
-        "ReportTaskProgress", Dict{String,Any}("taskId" => taskId); aws_config=aws_config
+        "ReportTaskProgress",
+        Dict{String,Any}("taskId" => taskId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function report_task_progress(
@@ -625,6 +660,7 @@ function report_task_progress(
         "ReportTaskProgress",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("taskId" => taskId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -659,6 +695,7 @@ function report_task_runner_heartbeat(
         "ReportTaskRunnerHeartbeat",
         Dict{String,Any}("taskrunnerId" => taskrunnerId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function report_task_runner_heartbeat(
@@ -672,6 +709,7 @@ function report_task_runner_heartbeat(
             mergewith(_merge, Dict{String,Any}("taskrunnerId" => taskrunnerId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -702,6 +740,7 @@ function set_status(
             "objectIds" => objectIds, "pipelineId" => pipelineId, "status" => status
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function set_status(
@@ -723,6 +762,7 @@ function set_status(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -760,6 +800,7 @@ function set_task_status(
         "SetTaskStatus",
         Dict{String,Any}("taskId" => taskId, "taskStatus" => taskStatus);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function set_task_status(
@@ -778,6 +819,7 @@ function set_task_status(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -805,6 +847,7 @@ function validate_pipeline_definition(
         "ValidatePipelineDefinition",
         Dict{String,Any}("pipelineId" => pipelineId, "pipelineObjects" => pipelineObjects);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function validate_pipeline_definition(
@@ -825,5 +868,6 @@ function validate_pipeline_definition(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/database_migration_service.jl
+++ b/src/services/database_migration_service.jl
@@ -27,6 +27,7 @@ function add_tags_to_resource(
         "AddTagsToResource",
         Dict{String,Any}("ResourceArn" => ResourceArn, "Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function add_tags_to_resource(
@@ -45,6 +46,7 @@ function add_tags_to_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -80,6 +82,7 @@ function apply_pending_maintenance_action(
             "ReplicationInstanceArn" => ReplicationInstanceArn,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function apply_pending_maintenance_action(
@@ -103,6 +106,7 @@ function apply_pending_maintenance_action(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -128,6 +132,7 @@ function cancel_replication_task_assessment_run(
             "ReplicationTaskAssessmentRunArn" => ReplicationTaskAssessmentRunArn
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function cancel_replication_task_assessment_run(
@@ -147,6 +152,7 @@ function cancel_replication_task_assessment_run(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -276,6 +282,7 @@ function create_endpoint(
             "EngineName" => EngineName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_endpoint(
@@ -299,6 +306,7 @@ function create_endpoint(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -351,6 +359,7 @@ function create_event_subscription(
             "SnsTopicArn" => SnsTopicArn, "SubscriptionName" => SubscriptionName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_event_subscription(
@@ -371,6 +380,7 @@ function create_event_subscription(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -455,6 +465,7 @@ function create_replication_instance(
             "ReplicationInstanceIdentifier" => ReplicationInstanceIdentifier,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_replication_instance(
@@ -476,6 +487,7 @@ function create_replication_instance(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -514,6 +526,7 @@ function create_replication_subnet_group(
             "SubnetIds" => SubnetIds,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_replication_subnet_group(
@@ -538,6 +551,7 @@ function create_replication_subnet_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -619,6 +633,7 @@ function create_replication_task(
             "TargetEndpointArn" => TargetEndpointArn,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_replication_task(
@@ -648,6 +663,7 @@ function create_replication_task(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -668,6 +684,7 @@ function delete_certificate(
         "DeleteCertificate",
         Dict{String,Any}("CertificateArn" => CertificateArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_certificate(
@@ -681,6 +698,7 @@ function delete_certificate(
             mergewith(_merge, Dict{String,Any}("CertificateArn" => CertificateArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -705,6 +723,7 @@ function delete_connection(
             "EndpointArn" => EndpointArn, "ReplicationInstanceArn" => ReplicationInstanceArn
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_connection(
@@ -726,6 +745,7 @@ function delete_connection(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -746,6 +766,7 @@ function delete_endpoint(EndpointArn; aws_config::AbstractAWSConfig=global_aws_c
         "DeleteEndpoint",
         Dict{String,Any}("EndpointArn" => EndpointArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_endpoint(
@@ -759,6 +780,7 @@ function delete_endpoint(
             mergewith(_merge, Dict{String,Any}("EndpointArn" => EndpointArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -779,6 +801,7 @@ function delete_event_subscription(
         "DeleteEventSubscription",
         Dict{String,Any}("SubscriptionName" => SubscriptionName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_event_subscription(
@@ -794,6 +817,7 @@ function delete_event_subscription(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -816,6 +840,7 @@ function delete_replication_instance(
         "DeleteReplicationInstance",
         Dict{String,Any}("ReplicationInstanceArn" => ReplicationInstanceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_replication_instance(
@@ -833,6 +858,7 @@ function delete_replication_instance(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -855,6 +881,7 @@ function delete_replication_subnet_group(
             "ReplicationSubnetGroupIdentifier" => ReplicationSubnetGroupIdentifier
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_replication_subnet_group(
@@ -874,6 +901,7 @@ function delete_replication_subnet_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -895,6 +923,7 @@ function delete_replication_task(
         "DeleteReplicationTask",
         Dict{String,Any}("ReplicationTaskArn" => ReplicationTaskArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_replication_task(
@@ -910,6 +939,7 @@ function delete_replication_task(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -935,6 +965,7 @@ function delete_replication_task_assessment_run(
             "ReplicationTaskAssessmentRunArn" => ReplicationTaskAssessmentRunArn
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_replication_task_assessment_run(
@@ -954,6 +985,7 @@ function delete_replication_task_assessment_run(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -971,13 +1003,18 @@ not take any parameters.
 
 """
 function describe_account_attributes(; aws_config::AbstractAWSConfig=global_aws_config())
-    return database_migration_service("DescribeAccountAttributes"; aws_config=aws_config)
+    return database_migration_service(
+        "DescribeAccountAttributes"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_account_attributes(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return database_migration_service(
-        "DescribeAccountAttributes", params; aws_config=aws_config
+        "DescribeAccountAttributes",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1024,14 +1061,19 @@ function describe_applicable_individual_assessments(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
     return database_migration_service(
-        "DescribeApplicableIndividualAssessments"; aws_config=aws_config
+        "DescribeApplicableIndividualAssessments";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_applicable_individual_assessments(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return database_migration_service(
-        "DescribeApplicableIndividualAssessments", params; aws_config=aws_config
+        "DescribeApplicableIndividualAssessments",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1052,12 +1094,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   included in the response so that the remaining results can be retrieved.  Default: 10
 """
 function describe_certificates(; aws_config::AbstractAWSConfig=global_aws_config())
-    return database_migration_service("DescribeCertificates"; aws_config=aws_config)
+    return database_migration_service(
+        "DescribeCertificates"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_certificates(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return database_migration_service("DescribeCertificates", params; aws_config=aws_config)
+    return database_migration_service(
+        "DescribeCertificates",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1080,12 +1129,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Constraints: Minimum 20, maximum 100.
 """
 function describe_connections(; aws_config::AbstractAWSConfig=global_aws_config())
-    return database_migration_service("DescribeConnections"; aws_config=aws_config)
+    return database_migration_service(
+        "DescribeConnections"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_connections(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return database_migration_service("DescribeConnections", params; aws_config=aws_config)
+    return database_migration_service(
+        "DescribeConnections",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1114,6 +1170,7 @@ function describe_endpoint_settings(
         "DescribeEndpointSettings",
         Dict{String,Any}("EngineName" => EngineName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_endpoint_settings(
@@ -1127,6 +1184,7 @@ function describe_endpoint_settings(
             mergewith(_merge, Dict{String,Any}("EngineName" => EngineName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1149,13 +1207,18 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Constraints: Minimum 20, maximum 100.
 """
 function describe_endpoint_types(; aws_config::AbstractAWSConfig=global_aws_config())
-    return database_migration_service("DescribeEndpointTypes"; aws_config=aws_config)
+    return database_migration_service(
+        "DescribeEndpointTypes"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_endpoint_types(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return database_migration_service(
-        "DescribeEndpointTypes", params; aws_config=aws_config
+        "DescribeEndpointTypes",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1178,12 +1241,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Constraints: Minimum 20, maximum 100.
 """
 function describe_endpoints(; aws_config::AbstractAWSConfig=global_aws_config())
-    return database_migration_service("DescribeEndpoints"; aws_config=aws_config)
+    return database_migration_service(
+        "DescribeEndpoints"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_endpoints(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return database_migration_service("DescribeEndpoints", params; aws_config=aws_config)
+    return database_migration_service(
+        "DescribeEndpoints", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1201,13 +1268,18 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   replication-instance | replication-task
 """
 function describe_event_categories(; aws_config::AbstractAWSConfig=global_aws_config())
-    return database_migration_service("DescribeEventCategories"; aws_config=aws_config)
+    return database_migration_service(
+        "DescribeEventCategories"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_event_categories(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return database_migration_service(
-        "DescribeEventCategories", params; aws_config=aws_config
+        "DescribeEventCategories",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1233,13 +1305,18 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"SubscriptionName"`: The name of the DMS event subscription to be described.
 """
 function describe_event_subscriptions(; aws_config::AbstractAWSConfig=global_aws_config())
-    return database_migration_service("DescribeEventSubscriptions"; aws_config=aws_config)
+    return database_migration_service(
+        "DescribeEventSubscriptions"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_event_subscriptions(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return database_migration_service(
-        "DescribeEventSubscriptions", params; aws_config=aws_config
+        "DescribeEventSubscriptions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1270,12 +1347,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"StartTime"`: The start time for the events to be listed.
 """
 function describe_events(; aws_config::AbstractAWSConfig=global_aws_config())
-    return database_migration_service("DescribeEvents"; aws_config=aws_config)
+    return database_migration_service(
+        "DescribeEvents"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_events(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return database_migration_service("DescribeEvents", params; aws_config=aws_config)
+    return database_migration_service(
+        "DescribeEvents", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1299,14 +1380,19 @@ function describe_orderable_replication_instances(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
     return database_migration_service(
-        "DescribeOrderableReplicationInstances"; aws_config=aws_config
+        "DescribeOrderableReplicationInstances";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_orderable_replication_instances(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return database_migration_service(
-        "DescribeOrderableReplicationInstances", params; aws_config=aws_config
+        "DescribeOrderableReplicationInstances",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1332,14 +1418,19 @@ function describe_pending_maintenance_actions(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
     return database_migration_service(
-        "DescribePendingMaintenanceActions"; aws_config=aws_config
+        "DescribePendingMaintenanceActions";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_pending_maintenance_actions(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return database_migration_service(
-        "DescribePendingMaintenanceActions", params; aws_config=aws_config
+        "DescribePendingMaintenanceActions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1361,6 +1452,7 @@ function describe_refresh_schemas_status(
         "DescribeRefreshSchemasStatus",
         Dict{String,Any}("EndpointArn" => EndpointArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_refresh_schemas_status(
@@ -1374,6 +1466,7 @@ function describe_refresh_schemas_status(
             mergewith(_merge, Dict{String,Any}("EndpointArn" => EndpointArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1403,6 +1496,7 @@ function describe_replication_instance_task_logs(
         "DescribeReplicationInstanceTaskLogs",
         Dict{String,Any}("ReplicationInstanceArn" => ReplicationInstanceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_replication_instance_task_logs(
@@ -1420,6 +1514,7 @@ function describe_replication_instance_task_logs(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1443,13 +1538,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Constraints: Minimum 20, maximum 100.
 """
 function describe_replication_instances(; aws_config::AbstractAWSConfig=global_aws_config())
-    return database_migration_service("DescribeReplicationInstances"; aws_config=aws_config)
+    return database_migration_service(
+        "DescribeReplicationInstances";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_replication_instances(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return database_migration_service(
-        "DescribeReplicationInstances", params; aws_config=aws_config
+        "DescribeReplicationInstances",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1475,14 +1577,19 @@ function describe_replication_subnet_groups(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
     return database_migration_service(
-        "DescribeReplicationSubnetGroups"; aws_config=aws_config
+        "DescribeReplicationSubnetGroups";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_replication_subnet_groups(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return database_migration_service(
-        "DescribeReplicationSubnetGroups", params; aws_config=aws_config
+        "DescribeReplicationSubnetGroups",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1512,14 +1619,19 @@ function describe_replication_task_assessment_results(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
     return database_migration_service(
-        "DescribeReplicationTaskAssessmentResults"; aws_config=aws_config
+        "DescribeReplicationTaskAssessmentResults";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_replication_task_assessment_results(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return database_migration_service(
-        "DescribeReplicationTaskAssessmentResults", params; aws_config=aws_config
+        "DescribeReplicationTaskAssessmentResults",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1549,14 +1661,19 @@ function describe_replication_task_assessment_runs(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
     return database_migration_service(
-        "DescribeReplicationTaskAssessmentRuns"; aws_config=aws_config
+        "DescribeReplicationTaskAssessmentRuns";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_replication_task_assessment_runs(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return database_migration_service(
-        "DescribeReplicationTaskAssessmentRuns", params; aws_config=aws_config
+        "DescribeReplicationTaskAssessmentRuns",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1584,14 +1701,19 @@ function describe_replication_task_individual_assessments(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
     return database_migration_service(
-        "DescribeReplicationTaskIndividualAssessments"; aws_config=aws_config
+        "DescribeReplicationTaskIndividualAssessments";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_replication_task_individual_assessments(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return database_migration_service(
-        "DescribeReplicationTaskIndividualAssessments", params; aws_config=aws_config
+        "DescribeReplicationTaskIndividualAssessments",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1618,13 +1740,18 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   true; otherwise, choose false (the default).
 """
 function describe_replication_tasks(; aws_config::AbstractAWSConfig=global_aws_config())
-    return database_migration_service("DescribeReplicationTasks"; aws_config=aws_config)
+    return database_migration_service(
+        "DescribeReplicationTasks"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_replication_tasks(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return database_migration_service(
-        "DescribeReplicationTasks", params; aws_config=aws_config
+        "DescribeReplicationTasks",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1653,6 +1780,7 @@ function describe_schemas(EndpointArn; aws_config::AbstractAWSConfig=global_aws_
         "DescribeSchemas",
         Dict{String,Any}("EndpointArn" => EndpointArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_schemas(
@@ -1666,6 +1794,7 @@ function describe_schemas(
             mergewith(_merge, Dict{String,Any}("EndpointArn" => EndpointArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1701,6 +1830,7 @@ function describe_table_statistics(
         "DescribeTableStatistics",
         Dict{String,Any}("ReplicationTaskArn" => ReplicationTaskArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_table_statistics(
@@ -1716,6 +1846,7 @@ function describe_table_statistics(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1745,6 +1876,7 @@ function import_certificate(
         "ImportCertificate",
         Dict{String,Any}("CertificateIdentifier" => CertificateIdentifier);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function import_certificate(
@@ -1762,6 +1894,7 @@ function import_certificate(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1784,12 +1917,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   which each listed tag is created.
 """
 function list_tags_for_resource(; aws_config::AbstractAWSConfig=global_aws_config())
-    return database_migration_service("ListTagsForResource"; aws_config=aws_config)
+    return database_migration_service(
+        "ListTagsForResource"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_tags_for_resource(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return database_migration_service("ListTagsForResource", params; aws_config=aws_config)
+    return database_migration_service(
+        "ListTagsForResource",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1909,6 +2049,7 @@ function modify_endpoint(EndpointArn; aws_config::AbstractAWSConfig=global_aws_c
         "ModifyEndpoint",
         Dict{String,Any}("EndpointArn" => EndpointArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_endpoint(
@@ -1922,6 +2063,7 @@ function modify_endpoint(
             mergewith(_merge, Dict{String,Any}("EndpointArn" => EndpointArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1952,6 +2094,7 @@ function modify_event_subscription(
         "ModifyEventSubscription",
         Dict{String,Any}("SubscriptionName" => SubscriptionName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_event_subscription(
@@ -1967,6 +2110,7 @@ function modify_event_subscription(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2028,6 +2172,7 @@ function modify_replication_instance(
         "ModifyReplicationInstance",
         Dict{String,Any}("ReplicationInstanceArn" => ReplicationInstanceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_replication_instance(
@@ -2045,6 +2190,7 @@ function modify_replication_instance(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2075,6 +2221,7 @@ function modify_replication_subnet_group(
             "SubnetIds" => SubnetIds,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_replication_subnet_group(
@@ -2096,6 +2243,7 @@ function modify_replication_subnet_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2153,6 +2301,7 @@ function modify_replication_task(
         "ModifyReplicationTask",
         Dict{String,Any}("ReplicationTaskArn" => ReplicationTaskArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_replication_task(
@@ -2168,6 +2317,7 @@ function modify_replication_task(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2197,6 +2347,7 @@ function move_replication_task(
             "TargetReplicationInstanceArn" => TargetReplicationInstanceArn,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function move_replication_task(
@@ -2218,6 +2369,7 @@ function move_replication_task(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2248,6 +2400,7 @@ function reboot_replication_instance(
         "RebootReplicationInstance",
         Dict{String,Any}("ReplicationInstanceArn" => ReplicationInstanceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function reboot_replication_instance(
@@ -2265,6 +2418,7 @@ function reboot_replication_instance(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2291,6 +2445,7 @@ function refresh_schemas(
             "EndpointArn" => EndpointArn, "ReplicationInstanceArn" => ReplicationInstanceArn
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function refresh_schemas(
@@ -2312,6 +2467,7 @@ function refresh_schemas(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2343,6 +2499,7 @@ function reload_tables(
             "ReplicationTaskArn" => ReplicationTaskArn, "TablesToReload" => TablesToReload
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function reload_tables(
@@ -2364,6 +2521,7 @@ function reload_tables(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2387,6 +2545,7 @@ function remove_tags_from_resource(
         "RemoveTagsFromResource",
         Dict{String,Any}("ResourceArn" => ResourceArn, "TagKeys" => TagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function remove_tags_from_resource(
@@ -2405,6 +2564,7 @@ function remove_tags_from_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2455,6 +2615,7 @@ function start_replication_task(
             "StartReplicationTaskType" => StartReplicationTaskType,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_replication_task(
@@ -2476,6 +2637,7 @@ function start_replication_task(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2496,6 +2658,7 @@ function start_replication_task_assessment(
         "StartReplicationTaskAssessment",
         Dict{String,Any}("ReplicationTaskArn" => ReplicationTaskArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_replication_task_assessment(
@@ -2511,6 +2674,7 @@ function start_replication_task_assessment(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2578,6 +2742,7 @@ function start_replication_task_assessment_run(
             "ServiceAccessRoleArn" => ServiceAccessRoleArn,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_replication_task_assessment_run(
@@ -2603,6 +2768,7 @@ function start_replication_task_assessment_run(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2624,6 +2790,7 @@ function stop_replication_task(
         "StopReplicationTask",
         Dict{String,Any}("ReplicationTaskArn" => ReplicationTaskArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function stop_replication_task(
@@ -2639,6 +2806,7 @@ function stop_replication_task(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2663,6 +2831,7 @@ function test_connection(
             "EndpointArn" => EndpointArn, "ReplicationInstanceArn" => ReplicationInstanceArn
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function test_connection(
@@ -2684,5 +2853,6 @@ function test_connection(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/databrew.jl
+++ b/src/services/databrew.jl
@@ -33,6 +33,7 @@ function batch_delete_recipe_version(
         "/recipes/$(name)/batchDeleteRecipeVersion",
         Dict{String,Any}("RecipeVersions" => RecipeVersions);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_delete_recipe_version(
@@ -48,6 +49,7 @@ function batch_delete_recipe_version(
             mergewith(_merge, Dict{String,Any}("RecipeVersions" => RecipeVersions), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -76,6 +78,7 @@ function create_dataset(Input, Name; aws_config::AbstractAWSConfig=global_aws_co
         "/datasets",
         Dict{String,Any}("Input" => Input, "Name" => Name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_dataset(
@@ -91,6 +94,7 @@ function create_dataset(
             mergewith(_merge, Dict{String,Any}("Input" => Input, "Name" => Name), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -148,6 +152,7 @@ function create_profile_job(
             "RoleArn" => RoleArn,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_profile_job(
@@ -174,6 +179,7 @@ function create_profile_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -213,6 +219,7 @@ function create_project(
             "RoleArn" => RoleArn,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_project(
@@ -239,6 +246,7 @@ function create_project(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -265,6 +273,7 @@ function create_recipe(Name, Steps; aws_config::AbstractAWSConfig=global_aws_con
         "/recipes",
         Dict{String,Any}("Name" => Name, "Steps" => Steps);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_recipe(
@@ -280,6 +289,7 @@ function create_recipe(
             mergewith(_merge, Dict{String,Any}("Name" => Name, "Steps" => Steps), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -327,6 +337,7 @@ function create_recipe_job(Name, RoleArn; aws_config::AbstractAWSConfig=global_a
         "/recipeJobs",
         Dict{String,Any}("Name" => Name, "RoleArn" => RoleArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_recipe_job(
@@ -344,6 +355,7 @@ function create_recipe_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -373,6 +385,7 @@ function create_schedule(
         "/schedules",
         Dict{String,Any}("CronExpression" => CronExpression, "Name" => Name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_schedule(
@@ -392,6 +405,7 @@ function create_schedule(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -406,12 +420,23 @@ Deletes a dataset from DataBrew.
 
 """
 function delete_dataset(name; aws_config::AbstractAWSConfig=global_aws_config())
-    return databrew("DELETE", "/datasets/$(name)"; aws_config=aws_config)
+    return databrew(
+        "DELETE",
+        "/datasets/$(name)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_dataset(
     name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return databrew("DELETE", "/datasets/$(name)", params; aws_config=aws_config)
+    return databrew(
+        "DELETE",
+        "/datasets/$(name)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -425,12 +450,20 @@ Deletes the specified DataBrew job.
 
 """
 function delete_job(name; aws_config::AbstractAWSConfig=global_aws_config())
-    return databrew("DELETE", "/jobs/$(name)"; aws_config=aws_config)
+    return databrew(
+        "DELETE", "/jobs/$(name)"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function delete_job(
     name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return databrew("DELETE", "/jobs/$(name)", params; aws_config=aws_config)
+    return databrew(
+        "DELETE",
+        "/jobs/$(name)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -444,12 +477,23 @@ Deletes an existing DataBrew project.
 
 """
 function delete_project(name; aws_config::AbstractAWSConfig=global_aws_config())
-    return databrew("DELETE", "/projects/$(name)"; aws_config=aws_config)
+    return databrew(
+        "DELETE",
+        "/projects/$(name)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_project(
     name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return databrew("DELETE", "/projects/$(name)", params; aws_config=aws_config)
+    return databrew(
+        "DELETE",
+        "/projects/$(name)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -468,7 +512,10 @@ function delete_recipe_version(
     name, recipeVersion; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return databrew(
-        "DELETE", "/recipes/$(name)/recipeVersion/$(recipeVersion)"; aws_config=aws_config
+        "DELETE",
+        "/recipes/$(name)/recipeVersion/$(recipeVersion)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_recipe_version(
@@ -482,6 +529,7 @@ function delete_recipe_version(
         "/recipes/$(name)/recipeVersion/$(recipeVersion)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -496,12 +544,23 @@ Deletes the specified DataBrew schedule.
 
 """
 function delete_schedule(name; aws_config::AbstractAWSConfig=global_aws_config())
-    return databrew("DELETE", "/schedules/$(name)"; aws_config=aws_config)
+    return databrew(
+        "DELETE",
+        "/schedules/$(name)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_schedule(
     name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return databrew("DELETE", "/schedules/$(name)", params; aws_config=aws_config)
+    return databrew(
+        "DELETE",
+        "/schedules/$(name)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -515,12 +574,20 @@ Returns the definition of a specific DataBrew dataset.
 
 """
 function describe_dataset(name; aws_config::AbstractAWSConfig=global_aws_config())
-    return databrew("GET", "/datasets/$(name)"; aws_config=aws_config)
+    return databrew(
+        "GET", "/datasets/$(name)"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_dataset(
     name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return databrew("GET", "/datasets/$(name)", params; aws_config=aws_config)
+    return databrew(
+        "GET",
+        "/datasets/$(name)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -534,12 +601,20 @@ Returns the definition of a specific DataBrew job.
 
 """
 function describe_job(name; aws_config::AbstractAWSConfig=global_aws_config())
-    return databrew("GET", "/jobs/$(name)"; aws_config=aws_config)
+    return databrew(
+        "GET", "/jobs/$(name)"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_job(
     name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return databrew("GET", "/jobs/$(name)", params; aws_config=aws_config)
+    return databrew(
+        "GET",
+        "/jobs/$(name)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -554,7 +629,12 @@ Represents one run of a DataBrew job.
 
 """
 function describe_job_run(name, runId; aws_config::AbstractAWSConfig=global_aws_config())
-    return databrew("GET", "/jobs/$(name)/jobRun/$(runId)"; aws_config=aws_config)
+    return databrew(
+        "GET",
+        "/jobs/$(name)/jobRun/$(runId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_job_run(
     name,
@@ -562,7 +642,13 @@ function describe_job_run(
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return databrew("GET", "/jobs/$(name)/jobRun/$(runId)", params; aws_config=aws_config)
+    return databrew(
+        "GET",
+        "/jobs/$(name)/jobRun/$(runId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -576,12 +662,20 @@ Returns the definition of a specific DataBrew project.
 
 """
 function describe_project(name; aws_config::AbstractAWSConfig=global_aws_config())
-    return databrew("GET", "/projects/$(name)"; aws_config=aws_config)
+    return databrew(
+        "GET", "/projects/$(name)"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_project(
     name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return databrew("GET", "/projects/$(name)", params; aws_config=aws_config)
+    return databrew(
+        "GET",
+        "/projects/$(name)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -599,12 +693,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   the latest published version is returned.
 """
 function describe_recipe(name; aws_config::AbstractAWSConfig=global_aws_config())
-    return databrew("GET", "/recipes/$(name)"; aws_config=aws_config)
+    return databrew(
+        "GET", "/recipes/$(name)"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_recipe(
     name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return databrew("GET", "/recipes/$(name)", params; aws_config=aws_config)
+    return databrew(
+        "GET",
+        "/recipes/$(name)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -618,12 +720,20 @@ Returns the definition of a specific DataBrew schedule.
 
 """
 function describe_schedule(name; aws_config::AbstractAWSConfig=global_aws_config())
-    return databrew("GET", "/schedules/$(name)"; aws_config=aws_config)
+    return databrew(
+        "GET", "/schedules/$(name)"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_schedule(
     name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return databrew("GET", "/schedules/$(name)", params; aws_config=aws_config)
+    return databrew(
+        "GET",
+        "/schedules/$(name)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -638,12 +748,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: The token returned by a previous call to retrieve the next set of results.
 """
 function list_datasets(; aws_config::AbstractAWSConfig=global_aws_config())
-    return databrew("GET", "/datasets"; aws_config=aws_config)
+    return databrew(
+        "GET", "/datasets"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_datasets(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return databrew("GET", "/datasets", params; aws_config=aws_config)
+    return databrew(
+        "GET", "/datasets", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -661,12 +775,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: The token returned by a previous call to retrieve the next set of results.
 """
 function list_job_runs(name; aws_config::AbstractAWSConfig=global_aws_config())
-    return databrew("GET", "/jobs/$(name)/jobRuns"; aws_config=aws_config)
+    return databrew(
+        "GET",
+        "/jobs/$(name)/jobRuns";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_job_runs(
     name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return databrew("GET", "/jobs/$(name)/jobRuns", params; aws_config=aws_config)
+    return databrew(
+        "GET",
+        "/jobs/$(name)/jobRuns",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -687,12 +812,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   those jobs that are associated with the specified project.
 """
 function list_jobs(; aws_config::AbstractAWSConfig=global_aws_config())
-    return databrew("GET", "/jobs"; aws_config=aws_config)
+    return databrew("GET", "/jobs"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_jobs(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return databrew("GET", "/jobs", params; aws_config=aws_config)
+    return databrew(
+        "GET", "/jobs", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -707,12 +834,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: The token returned by a previous call to retrieve the next set of results.
 """
 function list_projects(; aws_config::AbstractAWSConfig=global_aws_config())
-    return databrew("GET", "/projects"; aws_config=aws_config)
+    return databrew(
+        "GET", "/projects"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_projects(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return databrew("GET", "/projects", params; aws_config=aws_config)
+    return databrew(
+        "GET", "/projects", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -731,7 +862,11 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function list_recipe_versions(name; aws_config::AbstractAWSConfig=global_aws_config())
     return databrew(
-        "GET", "/recipeVersions", Dict{String,Any}("name" => name); aws_config=aws_config
+        "GET",
+        "/recipeVersions",
+        Dict{String,Any}("name" => name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_recipe_versions(
@@ -742,6 +877,7 @@ function list_recipe_versions(
         "/recipeVersions",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("name" => name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -760,12 +896,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   LATEST_PUBLISHED recipe versions. Valid values: LATEST_WORKING | LATEST_PUBLISHED
 """
 function list_recipes(; aws_config::AbstractAWSConfig=global_aws_config())
-    return databrew("GET", "/recipes"; aws_config=aws_config)
+    return databrew(
+        "GET", "/recipes"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_recipes(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return databrew("GET", "/recipes", params; aws_config=aws_config)
+    return databrew(
+        "GET", "/recipes", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -781,12 +921,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: The token returned by a previous call to retrieve the next set of results.
 """
 function list_schedules(; aws_config::AbstractAWSConfig=global_aws_config())
-    return databrew("GET", "/schedules"; aws_config=aws_config)
+    return databrew(
+        "GET", "/schedules"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_schedules(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return databrew("GET", "/schedules", params; aws_config=aws_config)
+    return databrew(
+        "GET", "/schedules", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -803,14 +947,25 @@ Lists all the tags for a DataBrew resource.
 function list_tags_for_resource(
     ResourceArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return databrew("GET", "/tags/$(ResourceArn)"; aws_config=aws_config)
+    return databrew(
+        "GET",
+        "/tags/$(ResourceArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_tags_for_resource(
     ResourceArn,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return databrew("GET", "/tags/$(ResourceArn)", params; aws_config=aws_config)
+    return databrew(
+        "GET",
+        "/tags/$(ResourceArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -828,12 +983,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   recipe.
 """
 function publish_recipe(name; aws_config::AbstractAWSConfig=global_aws_config())
-    return databrew("POST", "/recipes/$(name)/publishRecipe"; aws_config=aws_config)
+    return databrew(
+        "POST",
+        "/recipes/$(name)/publishRecipe";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function publish_recipe(
     name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return databrew("POST", "/recipes/$(name)/publishRecipe", params; aws_config=aws_config)
+    return databrew(
+        "POST",
+        "/recipes/$(name)/publishRecipe",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -860,14 +1026,21 @@ function send_project_session_action(
     name; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return databrew(
-        "PUT", "/projects/$(name)/sendProjectSessionAction"; aws_config=aws_config
+        "PUT",
+        "/projects/$(name)/sendProjectSessionAction";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function send_project_session_action(
     name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return databrew(
-        "PUT", "/projects/$(name)/sendProjectSessionAction", params; aws_config=aws_config
+        "PUT",
+        "/projects/$(name)/sendProjectSessionAction",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -882,12 +1055,23 @@ Runs a DataBrew job.
 
 """
 function start_job_run(name; aws_config::AbstractAWSConfig=global_aws_config())
-    return databrew("POST", "/jobs/$(name)/startJobRun"; aws_config=aws_config)
+    return databrew(
+        "POST",
+        "/jobs/$(name)/startJobRun";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function start_job_run(
     name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return databrew("POST", "/jobs/$(name)/startJobRun", params; aws_config=aws_config)
+    return databrew(
+        "POST",
+        "/jobs/$(name)/startJobRun",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -905,13 +1089,22 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   if a different client is currently accessing the project.
 """
 function start_project_session(name; aws_config::AbstractAWSConfig=global_aws_config())
-    return databrew("PUT", "/projects/$(name)/startProjectSession"; aws_config=aws_config)
+    return databrew(
+        "PUT",
+        "/projects/$(name)/startProjectSession";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function start_project_session(
     name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return databrew(
-        "PUT", "/projects/$(name)/startProjectSession", params; aws_config=aws_config
+        "PUT",
+        "/projects/$(name)/startProjectSession",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -928,7 +1121,10 @@ Stops a particular run of a job.
 """
 function stop_job_run(name, runId; aws_config::AbstractAWSConfig=global_aws_config())
     return databrew(
-        "POST", "/jobs/$(name)/jobRun/$(runId)/stopJobRun"; aws_config=aws_config
+        "POST",
+        "/jobs/$(name)/jobRun/$(runId)/stopJobRun";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function stop_job_run(
@@ -938,7 +1134,11 @@ function stop_job_run(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return databrew(
-        "POST", "/jobs/$(name)/jobRun/$(runId)/stopJobRun", params; aws_config=aws_config
+        "POST",
+        "/jobs/$(name)/jobRun/$(runId)/stopJobRun",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -962,6 +1162,7 @@ function tag_resource(ResourceArn, Tags; aws_config::AbstractAWSConfig=global_aw
         "/tags/$(ResourceArn)",
         Dict{String,Any}("Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -975,6 +1176,7 @@ function tag_resource(
         "/tags/$(ResourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Tags" => Tags), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -998,6 +1200,7 @@ function untag_resource(
         "/tags/$(ResourceArn)",
         Dict{String,Any}("tagKeys" => tagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -1011,6 +1214,7 @@ function untag_resource(
         "/tags/$(ResourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tagKeys" => tagKeys), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1037,6 +1241,7 @@ function update_dataset(Input, name; aws_config::AbstractAWSConfig=global_aws_co
         "/datasets/$(name)",
         Dict{String,Any}("Input" => Input);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_dataset(
@@ -1050,6 +1255,7 @@ function update_dataset(
         "/datasets/$(name)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Input" => Input), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1095,6 +1301,7 @@ function update_profile_job(
         "/profileJobs/$(name)",
         Dict{String,Any}("OutputLocation" => OutputLocation, "RoleArn" => RoleArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_profile_job(
@@ -1115,6 +1322,7 @@ function update_profile_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1138,6 +1346,7 @@ function update_project(RoleArn, name; aws_config::AbstractAWSConfig=global_aws_
         "/projects/$(name)",
         Dict{String,Any}("RoleArn" => RoleArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_project(
@@ -1151,6 +1360,7 @@ function update_project(
         "/projects/$(name)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("RoleArn" => RoleArn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1170,12 +1380,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   action, and the conditions under which the action should succeed.
 """
 function update_recipe(name; aws_config::AbstractAWSConfig=global_aws_config())
-    return databrew("PUT", "/recipes/$(name)"; aws_config=aws_config)
+    return databrew(
+        "PUT", "/recipes/$(name)"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function update_recipe(
     name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return databrew("PUT", "/recipes/$(name)", params; aws_config=aws_config)
+    return databrew(
+        "PUT",
+        "/recipes/$(name)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1215,6 +1433,7 @@ function update_recipe_job(RoleArn, name; aws_config::AbstractAWSConfig=global_a
         "/recipeJobs/$(name)",
         Dict{String,Any}("RoleArn" => RoleArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_recipe_job(
@@ -1228,6 +1447,7 @@ function update_recipe_job(
         "/recipeJobs/$(name)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("RoleArn" => RoleArn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1254,6 +1474,7 @@ function update_schedule(
         "/schedules/$(name)",
         Dict{String,Any}("CronExpression" => CronExpression);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_schedule(
@@ -1269,5 +1490,6 @@ function update_schedule(
             mergewith(_merge, Dict{String,Any}("CronExpression" => CronExpression), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/dataexchange.jl
+++ b/src/services/dataexchange.jl
@@ -15,12 +15,23 @@ This operation cancels a job. Jobs can be cancelled only when they are in the WA
 
 """
 function cancel_job(JobId; aws_config::AbstractAWSConfig=global_aws_config())
-    return dataexchange("DELETE", "/v1/jobs/$(JobId)"; aws_config=aws_config)
+    return dataexchange(
+        "DELETE",
+        "/v1/jobs/$(JobId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function cancel_job(
     JobId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return dataexchange("DELETE", "/v1/jobs/$(JobId)", params; aws_config=aws_config)
+    return dataexchange(
+        "DELETE",
+        "/v1/jobs/$(JobId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -53,6 +64,7 @@ function create_data_set(
             "AssetType" => AssetType, "Description" => Description, "Name" => Name
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_data_set(
@@ -75,6 +87,7 @@ function create_data_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -95,6 +108,7 @@ function create_job(Details, Type; aws_config::AbstractAWSConfig=global_aws_conf
         "/v1/jobs",
         Dict{String,Any}("Details" => Details, "Type" => Type);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_job(
@@ -112,6 +126,7 @@ function create_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -134,7 +149,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function create_revision(DataSetId; aws_config::AbstractAWSConfig=global_aws_config())
     return dataexchange(
-        "POST", "/v1/data-sets/$(DataSetId)/revisions"; aws_config=aws_config
+        "POST",
+        "/v1/data-sets/$(DataSetId)/revisions";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_revision(
@@ -143,7 +161,11 @@ function create_revision(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return dataexchange(
-        "POST", "/v1/data-sets/$(DataSetId)/revisions", params; aws_config=aws_config
+        "POST",
+        "/v1/data-sets/$(DataSetId)/revisions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -166,6 +188,7 @@ function delete_asset(
         "DELETE",
         "/v1/data-sets/$(DataSetId)/revisions/$(RevisionId)/assets/$(AssetId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_asset(
@@ -180,6 +203,7 @@ function delete_asset(
         "/v1/data-sets/$(DataSetId)/revisions/$(RevisionId)/assets/$(AssetId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -194,7 +218,12 @@ This operation deletes a data set.
 
 """
 function delete_data_set(DataSetId; aws_config::AbstractAWSConfig=global_aws_config())
-    return dataexchange("DELETE", "/v1/data-sets/$(DataSetId)"; aws_config=aws_config)
+    return dataexchange(
+        "DELETE",
+        "/v1/data-sets/$(DataSetId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_data_set(
     DataSetId,
@@ -202,7 +231,11 @@ function delete_data_set(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return dataexchange(
-        "DELETE", "/v1/data-sets/$(DataSetId)", params; aws_config=aws_config
+        "DELETE",
+        "/v1/data-sets/$(DataSetId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -224,6 +257,7 @@ function delete_revision(
         "DELETE",
         "/v1/data-sets/$(DataSetId)/revisions/$(RevisionId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_revision(
@@ -237,6 +271,7 @@ function delete_revision(
         "/v1/data-sets/$(DataSetId)/revisions/$(RevisionId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -259,6 +294,7 @@ function get_asset(
         "GET",
         "/v1/data-sets/$(DataSetId)/revisions/$(RevisionId)/assets/$(AssetId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_asset(
@@ -273,6 +309,7 @@ function get_asset(
         "/v1/data-sets/$(DataSetId)/revisions/$(RevisionId)/assets/$(AssetId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -287,14 +324,25 @@ This operation returns information about a data set.
 
 """
 function get_data_set(DataSetId; aws_config::AbstractAWSConfig=global_aws_config())
-    return dataexchange("GET", "/v1/data-sets/$(DataSetId)"; aws_config=aws_config)
+    return dataexchange(
+        "GET",
+        "/v1/data-sets/$(DataSetId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_data_set(
     DataSetId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return dataexchange("GET", "/v1/data-sets/$(DataSetId)", params; aws_config=aws_config)
+    return dataexchange(
+        "GET",
+        "/v1/data-sets/$(DataSetId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -308,12 +356,20 @@ This operation returns information about a job.
 
 """
 function get_job(JobId; aws_config::AbstractAWSConfig=global_aws_config())
-    return dataexchange("GET", "/v1/jobs/$(JobId)"; aws_config=aws_config)
+    return dataexchange(
+        "GET", "/v1/jobs/$(JobId)"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_job(
     JobId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return dataexchange("GET", "/v1/jobs/$(JobId)", params; aws_config=aws_config)
+    return dataexchange(
+        "GET",
+        "/v1/jobs/$(JobId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -331,7 +387,10 @@ function get_revision(
     DataSetId, RevisionId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return dataexchange(
-        "GET", "/v1/data-sets/$(DataSetId)/revisions/$(RevisionId)"; aws_config=aws_config
+        "GET",
+        "/v1/data-sets/$(DataSetId)/revisions/$(RevisionId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_revision(
@@ -345,6 +404,7 @@ function get_revision(
         "/v1/data-sets/$(DataSetId)/revisions/$(RevisionId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -367,7 +427,10 @@ function list_data_set_revisions(
     DataSetId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return dataexchange(
-        "GET", "/v1/data-sets/$(DataSetId)/revisions"; aws_config=aws_config
+        "GET",
+        "/v1/data-sets/$(DataSetId)/revisions";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_data_set_revisions(
@@ -376,7 +439,11 @@ function list_data_set_revisions(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return dataexchange(
-        "GET", "/v1/data-sets/$(DataSetId)/revisions", params; aws_config=aws_config
+        "GET",
+        "/v1/data-sets/$(DataSetId)/revisions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -397,12 +464,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   or ENTITLED to the account (for subscribers).
 """
 function list_data_sets(; aws_config::AbstractAWSConfig=global_aws_config())
-    return dataexchange("GET", "/v1/data-sets"; aws_config=aws_config)
+    return dataexchange(
+        "GET", "/v1/data-sets"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_data_sets(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return dataexchange("GET", "/v1/data-sets", params; aws_config=aws_config)
+    return dataexchange(
+        "GET",
+        "/v1/data-sets",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -420,12 +495,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"revisionId"`: The unique identifier for a revision.
 """
 function list_jobs(; aws_config::AbstractAWSConfig=global_aws_config())
-    return dataexchange("GET", "/v1/jobs"; aws_config=aws_config)
+    return dataexchange(
+        "GET", "/v1/jobs"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_jobs(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return dataexchange("GET", "/v1/jobs", params; aws_config=aws_config)
+    return dataexchange(
+        "GET", "/v1/jobs", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -451,6 +530,7 @@ function list_revision_assets(
         "GET",
         "/v1/data-sets/$(DataSetId)/revisions/$(RevisionId)/assets";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_revision_assets(
@@ -464,6 +544,7 @@ function list_revision_assets(
         "/v1/data-sets/$(DataSetId)/revisions/$(RevisionId)/assets",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -480,14 +561,25 @@ This operation lists the tags on the resource.
 function list_tags_for_resource(
     resource_arn; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return dataexchange("GET", "/tags/$(resource-arn)"; aws_config=aws_config)
+    return dataexchange(
+        "GET",
+        "/tags/$(resource-arn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_tags_for_resource(
     resource_arn,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return dataexchange("GET", "/tags/$(resource-arn)", params; aws_config=aws_config)
+    return dataexchange(
+        "GET",
+        "/tags/$(resource-arn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -501,12 +593,20 @@ This operation starts a job.
 
 """
 function start_job(JobId; aws_config::AbstractAWSConfig=global_aws_config())
-    return dataexchange("PATCH", "/v1/jobs/$(JobId)"; aws_config=aws_config)
+    return dataexchange(
+        "PATCH", "/v1/jobs/$(JobId)"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function start_job(
     JobId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return dataexchange("PATCH", "/v1/jobs/$(JobId)", params; aws_config=aws_config)
+    return dataexchange(
+        "PATCH",
+        "/v1/jobs/$(JobId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -526,6 +626,7 @@ function tag_resource(resource_arn, tags; aws_config::AbstractAWSConfig=global_a
         "/tags/$(resource-arn)",
         Dict{String,Any}("tags" => tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -539,6 +640,7 @@ function tag_resource(
         "/tags/$(resource-arn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tags" => tags), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -561,6 +663,7 @@ function untag_resource(
         "/tags/$(resource-arn)",
         Dict{String,Any}("tagKeys" => tagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -574,6 +677,7 @@ function untag_resource(
         "/tags/$(resource-arn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tagKeys" => tagKeys), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -600,6 +704,7 @@ function update_asset(
         "/v1/data-sets/$(DataSetId)/revisions/$(RevisionId)/assets/$(AssetId)",
         Dict{String,Any}("Name" => Name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_asset(
@@ -615,6 +720,7 @@ function update_asset(
         "/v1/data-sets/$(DataSetId)/revisions/$(RevisionId)/assets/$(AssetId)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -633,7 +739,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"Name"`: The name of the data set.
 """
 function update_data_set(DataSetId; aws_config::AbstractAWSConfig=global_aws_config())
-    return dataexchange("PATCH", "/v1/data-sets/$(DataSetId)"; aws_config=aws_config)
+    return dataexchange(
+        "PATCH",
+        "/v1/data-sets/$(DataSetId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function update_data_set(
     DataSetId,
@@ -641,7 +752,11 @@ function update_data_set(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return dataexchange(
-        "PATCH", "/v1/data-sets/$(DataSetId)", params; aws_config=aws_config
+        "PATCH",
+        "/v1/data-sets/$(DataSetId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -666,7 +781,10 @@ function update_revision(
     DataSetId, RevisionId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return dataexchange(
-        "PATCH", "/v1/data-sets/$(DataSetId)/revisions/$(RevisionId)"; aws_config=aws_config
+        "PATCH",
+        "/v1/data-sets/$(DataSetId)/revisions/$(RevisionId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_revision(
@@ -680,5 +798,6 @@ function update_revision(
         "/v1/data-sets/$(DataSetId)/revisions/$(RevisionId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/datasync.jl
+++ b/src/services/datasync.jl
@@ -27,6 +27,7 @@ function cancel_task_execution(
         "CancelTaskExecution",
         Dict{String,Any}("TaskExecutionArn" => TaskExecutionArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function cancel_task_execution(
@@ -42,6 +43,7 @@ function cancel_task_execution(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -98,6 +100,7 @@ function create_agent(ActivationKey; aws_config::AbstractAWSConfig=global_aws_co
         "CreateAgent",
         Dict{String,Any}("ActivationKey" => ActivationKey);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_agent(
@@ -111,6 +114,7 @@ function create_agent(
             mergewith(_merge, Dict{String,Any}("ActivationKey" => ActivationKey), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -152,6 +156,7 @@ function create_location_efs(
         "CreateLocationEfs",
         Dict{String,Any}("Ec2Config" => Ec2Config, "EfsFilesystemArn" => EfsFilesystemArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_location_efs(
@@ -172,6 +177,7 @@ function create_location_efs(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -220,6 +226,7 @@ function create_location_fsx_windows(
             "User" => User,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_location_fsx_windows(
@@ -245,6 +252,7 @@ function create_location_fsx_windows(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -300,6 +308,7 @@ function create_location_nfs(
             "Subdirectory" => Subdirectory,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_location_nfs(
@@ -323,6 +332,7 @@ function create_location_nfs(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -373,6 +383,7 @@ function create_location_object_storage(
             "ServerHostname" => ServerHostname,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_location_object_storage(
@@ -396,6 +407,7 @@ function create_location_object_storage(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -436,6 +448,7 @@ function create_location_s3(
         "CreateLocationS3",
         Dict{String,Any}("S3BucketArn" => S3BucketArn, "S3Config" => S3Config);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_location_s3(
@@ -454,6 +467,7 @@ function create_location_s3(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -514,6 +528,7 @@ function create_location_smb(
             "User" => User,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_location_smb(
@@ -541,6 +556,7 @@ function create_location_smb(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -604,6 +620,7 @@ function create_task(
             "SourceLocationArn" => SourceLocationArn,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_task(
@@ -625,6 +642,7 @@ function create_task(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -644,7 +662,10 @@ on-premises environment.
 """
 function delete_agent(AgentArn; aws_config::AbstractAWSConfig=global_aws_config())
     return datasync(
-        "DeleteAgent", Dict{String,Any}("AgentArn" => AgentArn); aws_config=aws_config
+        "DeleteAgent",
+        Dict{String,Any}("AgentArn" => AgentArn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_agent(
@@ -658,6 +679,7 @@ function delete_agent(
             mergewith(_merge, Dict{String,Any}("AgentArn" => AgentArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -676,6 +698,7 @@ function delete_location(LocationArn; aws_config::AbstractAWSConfig=global_aws_c
         "DeleteLocation",
         Dict{String,Any}("LocationArn" => LocationArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_location(
@@ -689,6 +712,7 @@ function delete_location(
             mergewith(_merge, Dict{String,Any}("LocationArn" => LocationArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -704,7 +728,10 @@ Deletes a task.
 """
 function delete_task(TaskArn; aws_config::AbstractAWSConfig=global_aws_config())
     return datasync(
-        "DeleteTask", Dict{String,Any}("TaskArn" => TaskArn); aws_config=aws_config
+        "DeleteTask",
+        Dict{String,Any}("TaskArn" => TaskArn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_task(
@@ -714,6 +741,7 @@ function delete_task(
         "DeleteTask",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("TaskArn" => TaskArn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -731,7 +759,10 @@ Amazon Resource Name (ARN) of the agent in your request.
 """
 function describe_agent(AgentArn; aws_config::AbstractAWSConfig=global_aws_config())
     return datasync(
-        "DescribeAgent", Dict{String,Any}("AgentArn" => AgentArn); aws_config=aws_config
+        "DescribeAgent",
+        Dict{String,Any}("AgentArn" => AgentArn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_agent(
@@ -745,6 +776,7 @@ function describe_agent(
             mergewith(_merge, Dict{String,Any}("AgentArn" => AgentArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -765,6 +797,7 @@ function describe_location_efs(
         "DescribeLocationEfs",
         Dict{String,Any}("LocationArn" => LocationArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_location_efs(
@@ -778,6 +811,7 @@ function describe_location_efs(
             mergewith(_merge, Dict{String,Any}("LocationArn" => LocationArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -800,6 +834,7 @@ function describe_location_fsx_windows(
         "DescribeLocationFsxWindows",
         Dict{String,Any}("LocationArn" => LocationArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_location_fsx_windows(
@@ -813,6 +848,7 @@ function describe_location_fsx_windows(
             mergewith(_merge, Dict{String,Any}("LocationArn" => LocationArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -833,6 +869,7 @@ function describe_location_nfs(
         "DescribeLocationNfs",
         Dict{String,Any}("LocationArn" => LocationArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_location_nfs(
@@ -846,6 +883,7 @@ function describe_location_nfs(
             mergewith(_merge, Dict{String,Any}("LocationArn" => LocationArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -868,6 +906,7 @@ function describe_location_object_storage(
         "DescribeLocationObjectStorage",
         Dict{String,Any}("LocationArn" => LocationArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_location_object_storage(
@@ -881,6 +920,7 @@ function describe_location_object_storage(
             mergewith(_merge, Dict{String,Any}("LocationArn" => LocationArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -902,6 +942,7 @@ function describe_location_s3(
         "DescribeLocationS3",
         Dict{String,Any}("LocationArn" => LocationArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_location_s3(
@@ -915,6 +956,7 @@ function describe_location_s3(
             mergewith(_merge, Dict{String,Any}("LocationArn" => LocationArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -935,6 +977,7 @@ function describe_location_smb(
         "DescribeLocationSmb",
         Dict{String,Any}("LocationArn" => LocationArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_location_smb(
@@ -948,6 +991,7 @@ function describe_location_smb(
             mergewith(_merge, Dict{String,Any}("LocationArn" => LocationArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -963,7 +1007,10 @@ Returns metadata about a task.
 """
 function describe_task(TaskArn; aws_config::AbstractAWSConfig=global_aws_config())
     return datasync(
-        "DescribeTask", Dict{String,Any}("TaskArn" => TaskArn); aws_config=aws_config
+        "DescribeTask",
+        Dict{String,Any}("TaskArn" => TaskArn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_task(
@@ -973,6 +1020,7 @@ function describe_task(
         "DescribeTask",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("TaskArn" => TaskArn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -993,6 +1041,7 @@ function describe_task_execution(
         "DescribeTaskExecution",
         Dict{String,Any}("TaskExecutionArn" => TaskExecutionArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_task_execution(
@@ -1008,6 +1057,7 @@ function describe_task_execution(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1030,12 +1080,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   list of agents.
 """
 function list_agents(; aws_config::AbstractAWSConfig=global_aws_config())
-    return datasync("ListAgents"; aws_config=aws_config)
+    return datasync("ListAgents"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_agents(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return datasync("ListAgents", params; aws_config=aws_config)
+    return datasync(
+        "ListAgents", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1057,12 +1109,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   list of locations.
 """
 function list_locations(; aws_config::AbstractAWSConfig=global_aws_config())
-    return datasync("ListLocations"; aws_config=aws_config)
+    return datasync("ListLocations"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_locations(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return datasync("ListLocations", params; aws_config=aws_config)
+    return datasync(
+        "ListLocations", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1087,6 +1141,7 @@ function list_tags_for_resource(
         "ListTagsForResource",
         Dict{String,Any}("ResourceArn" => ResourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags_for_resource(
@@ -1100,6 +1155,7 @@ function list_tags_for_resource(
             mergewith(_merge, Dict{String,Any}("ResourceArn" => ResourceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1117,12 +1173,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"TaskArn"`: The Amazon Resource Name (ARN) of the task whose tasks you want to list.
 """
 function list_task_executions(; aws_config::AbstractAWSConfig=global_aws_config())
-    return datasync("ListTaskExecutions"; aws_config=aws_config)
+    return datasync(
+        "ListTaskExecutions"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_task_executions(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return datasync("ListTaskExecutions", params; aws_config=aws_config)
+    return datasync(
+        "ListTaskExecutions", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1141,12 +1201,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   list of tasks.
 """
 function list_tasks(; aws_config::AbstractAWSConfig=global_aws_config())
-    return datasync("ListTasks"; aws_config=aws_config)
+    return datasync("ListTasks"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_tasks(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return datasync("ListTasks", params; aws_config=aws_config)
+    return datasync(
+        "ListTasks", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1175,7 +1237,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function start_task_execution(TaskArn; aws_config::AbstractAWSConfig=global_aws_config())
     return datasync(
-        "StartTaskExecution", Dict{String,Any}("TaskArn" => TaskArn); aws_config=aws_config
+        "StartTaskExecution",
+        Dict{String,Any}("TaskArn" => TaskArn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_task_execution(
@@ -1185,6 +1250,7 @@ function start_task_execution(
         "StartTaskExecution",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("TaskArn" => TaskArn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1204,6 +1270,7 @@ function tag_resource(ResourceArn, Tags; aws_config::AbstractAWSConfig=global_aw
         "TagResource",
         Dict{String,Any}("ResourceArn" => ResourceArn, "Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -1222,6 +1289,7 @@ function tag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1243,6 +1311,7 @@ function untag_resource(
         "UntagResource",
         Dict{String,Any}("Keys" => Keys, "ResourceArn" => ResourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -1261,6 +1330,7 @@ function untag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1279,7 +1349,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function update_agent(AgentArn; aws_config::AbstractAWSConfig=global_aws_config())
     return datasync(
-        "UpdateAgent", Dict{String,Any}("AgentArn" => AgentArn); aws_config=aws_config
+        "UpdateAgent",
+        Dict{String,Any}("AgentArn" => AgentArn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_agent(
@@ -1293,6 +1366,7 @@ function update_agent(
             mergewith(_merge, Dict{String,Any}("AgentArn" => AgentArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1332,6 +1406,7 @@ function update_location_nfs(LocationArn; aws_config::AbstractAWSConfig=global_a
         "UpdateLocationNfs",
         Dict{String,Any}("LocationArn" => LocationArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_location_nfs(
@@ -1345,6 +1420,7 @@ function update_location_nfs(
             mergewith(_merge, Dict{String,Any}("LocationArn" => LocationArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1387,6 +1463,7 @@ function update_location_object_storage(
         "UpdateLocationObjectStorage",
         Dict{String,Any}("LocationArn" => LocationArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_location_object_storage(
@@ -1400,6 +1477,7 @@ function update_location_object_storage(
             mergewith(_merge, Dict{String,Any}("LocationArn" => LocationArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1442,6 +1520,7 @@ function update_location_smb(LocationArn; aws_config::AbstractAWSConfig=global_a
         "UpdateLocationSmb",
         Dict{String,Any}("LocationArn" => LocationArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_location_smb(
@@ -1455,6 +1534,7 @@ function update_location_smb(
             mergewith(_merge, Dict{String,Any}("LocationArn" => LocationArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1487,7 +1567,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function update_task(TaskArn; aws_config::AbstractAWSConfig=global_aws_config())
     return datasync(
-        "UpdateTask", Dict{String,Any}("TaskArn" => TaskArn); aws_config=aws_config
+        "UpdateTask",
+        Dict{String,Any}("TaskArn" => TaskArn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_task(
@@ -1497,6 +1580,7 @@ function update_task(
         "UpdateTask",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("TaskArn" => TaskArn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1522,6 +1606,7 @@ function update_task_execution(
         "UpdateTaskExecution",
         Dict{String,Any}("Options" => Options, "TaskExecutionArn" => TaskExecutionArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_task_execution(
@@ -1542,5 +1627,6 @@ function update_task_execution(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/dax.jl
+++ b/src/services/dax.jl
@@ -73,6 +73,7 @@ function create_cluster(
             "ReplicationFactor" => ReplicationFactor,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_cluster(
@@ -98,6 +99,7 @@ function create_cluster(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -123,6 +125,7 @@ function create_parameter_group(
         "CreateParameterGroup",
         Dict{String,Any}("ParameterGroupName" => ParameterGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_parameter_group(
@@ -138,6 +141,7 @@ function create_parameter_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -163,6 +167,7 @@ function create_subnet_group(
         "CreateSubnetGroup",
         Dict{String,Any}("SubnetGroupName" => SubnetGroupName, "SubnetIds" => SubnetIds);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_subnet_group(
@@ -183,6 +188,7 @@ function create_subnet_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -211,6 +217,7 @@ function decrease_replication_factor(
             "ClusterName" => ClusterName, "NewReplicationFactor" => NewReplicationFactor
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function decrease_replication_factor(
@@ -232,6 +239,7 @@ function decrease_replication_factor(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -253,6 +261,7 @@ function delete_cluster(ClusterName; aws_config::AbstractAWSConfig=global_aws_co
         "DeleteCluster",
         Dict{String,Any}("ClusterName" => ClusterName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_cluster(
@@ -266,6 +275,7 @@ function delete_cluster(
             mergewith(_merge, Dict{String,Any}("ClusterName" => ClusterName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -287,6 +297,7 @@ function delete_parameter_group(
         "DeleteParameterGroup",
         Dict{String,Any}("ParameterGroupName" => ParameterGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_parameter_group(
@@ -302,6 +313,7 @@ function delete_parameter_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -323,6 +335,7 @@ function delete_subnet_group(
         "DeleteSubnetGroup",
         Dict{String,Any}("SubnetGroupName" => SubnetGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_subnet_group(
@@ -338,6 +351,7 @@ function delete_subnet_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -366,12 +380,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   includes only results beyond the token, up to the value specified by MaxResults.
 """
 function describe_clusters(; aws_config::AbstractAWSConfig=global_aws_config())
-    return dax("DescribeClusters"; aws_config=aws_config)
+    return dax("DescribeClusters"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function describe_clusters(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return dax("DescribeClusters", params; aws_config=aws_config)
+    return dax(
+        "DescribeClusters", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -390,12 +406,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   includes only results beyond the token, up to the value specified by MaxResults.
 """
 function describe_default_parameters(; aws_config::AbstractAWSConfig=global_aws_config())
-    return dax("DescribeDefaultParameters"; aws_config=aws_config)
+    return dax(
+        "DescribeDefaultParameters"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_default_parameters(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return dax("DescribeDefaultParameters", params; aws_config=aws_config)
+    return dax(
+        "DescribeDefaultParameters",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -426,12 +449,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   ISO 8601 format.
 """
 function describe_events(; aws_config::AbstractAWSConfig=global_aws_config())
-    return dax("DescribeEvents"; aws_config=aws_config)
+    return dax("DescribeEvents"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function describe_events(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return dax("DescribeEvents", params; aws_config=aws_config)
+    return dax(
+        "DescribeEvents", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -452,12 +477,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"ParameterGroupNames"`: The names of the parameter groups.
 """
 function describe_parameter_groups(; aws_config::AbstractAWSConfig=global_aws_config())
-    return dax("DescribeParameterGroups"; aws_config=aws_config)
+    return dax(
+        "DescribeParameterGroups"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_parameter_groups(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return dax("DescribeParameterGroups", params; aws_config=aws_config)
+    return dax(
+        "DescribeParameterGroups",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -487,6 +519,7 @@ function describe_parameters(
         "DescribeParameters",
         Dict{String,Any}("ParameterGroupName" => ParameterGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_parameters(
@@ -502,6 +535,7 @@ function describe_parameters(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -523,12 +557,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"SubnetGroupNames"`: The name of the subnet group.
 """
 function describe_subnet_groups(; aws_config::AbstractAWSConfig=global_aws_config())
-    return dax("DescribeSubnetGroups"; aws_config=aws_config)
+    return dax(
+        "DescribeSubnetGroups"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_subnet_groups(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return dax("DescribeSubnetGroups", params; aws_config=aws_config)
+    return dax(
+        "DescribeSubnetGroups",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -556,6 +597,7 @@ function increase_replication_factor(
             "ClusterName" => ClusterName, "NewReplicationFactor" => NewReplicationFactor
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function increase_replication_factor(
@@ -577,6 +619,7 @@ function increase_replication_factor(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -598,7 +641,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function list_tags(ResourceName; aws_config::AbstractAWSConfig=global_aws_config())
     return dax(
-        "ListTags", Dict{String,Any}("ResourceName" => ResourceName); aws_config=aws_config
+        "ListTags",
+        Dict{String,Any}("ResourceName" => ResourceName);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags(
@@ -612,6 +658,7 @@ function list_tags(
             mergewith(_merge, Dict{String,Any}("ResourceName" => ResourceName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -633,6 +680,7 @@ function reboot_node(ClusterName, NodeId; aws_config::AbstractAWSConfig=global_a
         "RebootNode",
         Dict{String,Any}("ClusterName" => ClusterName, "NodeId" => NodeId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function reboot_node(
@@ -651,6 +699,7 @@ function reboot_node(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -671,6 +720,7 @@ function tag_resource(ResourceName, Tags; aws_config::AbstractAWSConfig=global_a
         "TagResource",
         Dict{String,Any}("ResourceName" => ResourceName, "Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -689,6 +739,7 @@ function tag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -712,6 +763,7 @@ function untag_resource(
         "UntagResource",
         Dict{String,Any}("ResourceName" => ResourceName, "TagKeys" => TagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -730,6 +782,7 @@ function untag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -763,6 +816,7 @@ function update_cluster(ClusterName; aws_config::AbstractAWSConfig=global_aws_co
         "UpdateCluster",
         Dict{String,Any}("ClusterName" => ClusterName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_cluster(
@@ -776,6 +830,7 @@ function update_cluster(
             mergewith(_merge, Dict{String,Any}("ClusterName" => ClusterName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -806,6 +861,7 @@ function update_parameter_group(
             "ParameterNameValues" => ParameterNameValues,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_parameter_group(
@@ -827,6 +883,7 @@ function update_parameter_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -851,6 +908,7 @@ function update_subnet_group(
         "UpdateSubnetGroup",
         Dict{String,Any}("SubnetGroupName" => SubnetGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_subnet_group(
@@ -866,5 +924,6 @@ function update_subnet_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/detective.jl
+++ b/src/services/detective.jl
@@ -23,6 +23,7 @@ function accept_invitation(GraphArn; aws_config::AbstractAWSConfig=global_aws_co
         "/invitation",
         Dict{String,Any}("GraphArn" => GraphArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function accept_invitation(
@@ -37,6 +38,7 @@ function accept_invitation(
             mergewith(_merge, Dict{String,Any}("GraphArn" => GraphArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -65,12 +67,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   characters. Each tag value can contain up to 256 characters.
 """
 function create_graph(; aws_config::AbstractAWSConfig=global_aws_config())
-    return detective("POST", "/graph"; aws_config=aws_config)
+    return detective(
+        "POST", "/graph"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function create_graph(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return detective("POST", "/graph", params; aws_config=aws_config)
+    return detective(
+        "POST", "/graph", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -112,6 +118,7 @@ function create_members(
         "/graph/members",
         Dict{String,Any}("Accounts" => Accounts, "GraphArn" => GraphArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_members(
@@ -131,6 +138,7 @@ function create_members(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -152,6 +160,7 @@ function delete_graph(GraphArn; aws_config::AbstractAWSConfig=global_aws_config(
         "/graph/removal",
         Dict{String,Any}("GraphArn" => GraphArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_graph(
@@ -166,6 +175,7 @@ function delete_graph(
             mergewith(_merge, Dict{String,Any}("GraphArn" => GraphArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -192,6 +202,7 @@ function delete_members(
         "/graph/members/removal",
         Dict{String,Any}("AccountIds" => AccountIds, "GraphArn" => GraphArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_members(
@@ -211,6 +222,7 @@ function delete_members(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -234,6 +246,7 @@ function disassociate_membership(
         "/membership/removal",
         Dict{String,Any}("GraphArn" => GraphArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disassociate_membership(
@@ -248,6 +261,7 @@ function disassociate_membership(
             mergewith(_merge, Dict{String,Any}("GraphArn" => GraphArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -273,6 +287,7 @@ function get_members(
         "/graph/members/get",
         Dict{String,Any}("AccountIds" => AccountIds, "GraphArn" => GraphArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_members(
@@ -292,6 +307,7 @@ function get_members(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -313,12 +329,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   pagination token.
 """
 function list_graphs(; aws_config::AbstractAWSConfig=global_aws_config())
-    return detective("POST", "/graphs/list"; aws_config=aws_config)
+    return detective(
+        "POST", "/graphs/list"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_graphs(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return detective("POST", "/graphs/list", params; aws_config=aws_config)
+    return detective(
+        "POST",
+        "/graphs/list",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -341,12 +365,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   pagination token.
 """
 function list_invitations(; aws_config::AbstractAWSConfig=global_aws_config())
-    return detective("POST", "/invitations/list"; aws_config=aws_config)
+    return detective(
+        "POST", "/invitations/list"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_invitations(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return detective("POST", "/invitations/list", params; aws_config=aws_config)
+    return detective(
+        "POST",
+        "/invitations/list",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -375,6 +407,7 @@ function list_members(GraphArn; aws_config::AbstractAWSConfig=global_aws_config(
         "/graph/members/list",
         Dict{String,Any}("GraphArn" => GraphArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_members(
@@ -389,6 +422,7 @@ function list_members(
             mergewith(_merge, Dict{String,Any}("GraphArn" => GraphArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -405,14 +439,25 @@ Returns the tag values that are assigned to a behavior graph.
 function list_tags_for_resource(
     ResourceArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return detective("GET", "/tags/$(ResourceArn)"; aws_config=aws_config)
+    return detective(
+        "GET",
+        "/tags/$(ResourceArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_tags_for_resource(
     ResourceArn,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return detective("GET", "/tags/$(ResourceArn)", params; aws_config=aws_config)
+    return detective(
+        "GET",
+        "/tags/$(ResourceArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -433,6 +478,7 @@ function reject_invitation(GraphArn; aws_config::AbstractAWSConfig=global_aws_co
         "/invitation/removal",
         Dict{String,Any}("GraphArn" => GraphArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function reject_invitation(
@@ -447,6 +493,7 @@ function reject_invitation(
             mergewith(_merge, Dict{String,Any}("GraphArn" => GraphArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -473,6 +520,7 @@ function start_monitoring_member(
         "/graph/member/monitoringstate",
         Dict{String,Any}("AccountId" => AccountId, "GraphArn" => GraphArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_monitoring_member(
@@ -492,6 +540,7 @@ function start_monitoring_member(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -514,6 +563,7 @@ function tag_resource(ResourceArn, Tags; aws_config::AbstractAWSConfig=global_aw
         "/tags/$(ResourceArn)",
         Dict{String,Any}("Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -527,6 +577,7 @@ function tag_resource(
         "/tags/$(ResourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Tags" => Tags), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -550,6 +601,7 @@ function untag_resource(
         "/tags/$(ResourceArn)",
         Dict{String,Any}("tagKeys" => tagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -563,5 +615,6 @@ function untag_resource(
         "/tags/$(ResourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tagKeys" => tagKeys), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/device_farm.jl
+++ b/src/services/device_farm.jl
@@ -31,6 +31,7 @@ function create_device_pool(
         "CreateDevicePool",
         Dict{String,Any}("name" => name, "projectArn" => projectArn, "rules" => rules);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_device_pool(
@@ -52,6 +53,7 @@ function create_device_pool(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -77,7 +79,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function create_instance_profile(name; aws_config::AbstractAWSConfig=global_aws_config())
     return device_farm(
-        "CreateInstanceProfile", Dict{String,Any}("name" => name); aws_config=aws_config
+        "CreateInstanceProfile",
+        Dict{String,Any}("name" => name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_instance_profile(
@@ -87,6 +92,7 @@ function create_instance_profile(
         "CreateInstanceProfile",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("name" => name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -129,6 +135,7 @@ function create_network_profile(
         "CreateNetworkProfile",
         Dict{String,Any}("name" => name, "projectArn" => projectArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_network_profile(
@@ -145,6 +152,7 @@ function create_network_profile(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -165,7 +173,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function create_project(name; aws_config::AbstractAWSConfig=global_aws_config())
     return device_farm(
-        "CreateProject", Dict{String,Any}("name" => name); aws_config=aws_config
+        "CreateProject",
+        Dict{String,Any}("name" => name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_project(
@@ -175,6 +186,7 @@ function create_project(
         "CreateProject",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("name" => name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -227,6 +239,7 @@ function create_remote_access_session(
         "CreateRemoteAccessSession",
         Dict{String,Any}("deviceArn" => deviceArn, "projectArn" => projectArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_remote_access_session(
@@ -245,6 +258,7 @@ function create_remote_access_session(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -264,7 +278,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function create_test_grid_project(name; aws_config::AbstractAWSConfig=global_aws_config())
     return device_farm(
-        "CreateTestGridProject", Dict{String,Any}("name" => name); aws_config=aws_config
+        "CreateTestGridProject",
+        Dict{String,Any}("name" => name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_test_grid_project(
@@ -274,6 +291,7 @@ function create_test_grid_project(
         "CreateTestGridProject",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("name" => name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -299,6 +317,7 @@ function create_test_grid_url(
             "expiresInSeconds" => expiresInSeconds, "projectArn" => projectArn
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_test_grid_url(
@@ -319,6 +338,7 @@ function create_test_grid_url(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -359,6 +379,7 @@ function create_upload(
         "CreateUpload",
         Dict{String,Any}("name" => name, "projectArn" => projectArn, "type" => type);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_upload(
@@ -380,6 +401,7 @@ function create_upload(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -417,6 +439,7 @@ function create_vpceconfiguration(
             "vpceServiceName" => vpceServiceName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_vpceconfiguration(
@@ -440,6 +463,7 @@ function create_vpceconfiguration(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -456,7 +480,10 @@ the system.
 """
 function delete_device_pool(arn; aws_config::AbstractAWSConfig=global_aws_config())
     return device_farm(
-        "DeleteDevicePool", Dict{String,Any}("arn" => arn); aws_config=aws_config
+        "DeleteDevicePool",
+        Dict{String,Any}("arn" => arn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_device_pool(
@@ -466,6 +493,7 @@ function delete_device_pool(
         "DeleteDevicePool",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("arn" => arn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -482,7 +510,10 @@ Deletes a profile that can be applied to one or more private device instances.
 """
 function delete_instance_profile(arn; aws_config::AbstractAWSConfig=global_aws_config())
     return device_farm(
-        "DeleteInstanceProfile", Dict{String,Any}("arn" => arn); aws_config=aws_config
+        "DeleteInstanceProfile",
+        Dict{String,Any}("arn" => arn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_instance_profile(
@@ -492,6 +523,7 @@ function delete_instance_profile(
         "DeleteInstanceProfile",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("arn" => arn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -507,7 +539,10 @@ Deletes a network profile.
 """
 function delete_network_profile(arn; aws_config::AbstractAWSConfig=global_aws_config())
     return device_farm(
-        "DeleteNetworkProfile", Dict{String,Any}("arn" => arn); aws_config=aws_config
+        "DeleteNetworkProfile",
+        Dict{String,Any}("arn" => arn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_network_profile(
@@ -517,6 +552,7 @@ function delete_network_profile(
         "DeleteNetworkProfile",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("arn" => arn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -533,7 +569,10 @@ stop an in-progress run.
 """
 function delete_project(arn; aws_config::AbstractAWSConfig=global_aws_config())
     return device_farm(
-        "DeleteProject", Dict{String,Any}("arn" => arn); aws_config=aws_config
+        "DeleteProject",
+        Dict{String,Any}("arn" => arn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_project(
@@ -543,6 +582,7 @@ function delete_project(
         "DeleteProject",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("arn" => arn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -561,7 +601,10 @@ function delete_remote_access_session(
     arn; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return device_farm(
-        "DeleteRemoteAccessSession", Dict{String,Any}("arn" => arn); aws_config=aws_config
+        "DeleteRemoteAccessSession",
+        Dict{String,Any}("arn" => arn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_remote_access_session(
@@ -571,6 +614,7 @@ function delete_remote_access_session(
         "DeleteRemoteAccessSession",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("arn" => arn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -586,7 +630,12 @@ run.
 
 """
 function delete_run(arn; aws_config::AbstractAWSConfig=global_aws_config())
-    return device_farm("DeleteRun", Dict{String,Any}("arn" => arn); aws_config=aws_config)
+    return device_farm(
+        "DeleteRun",
+        Dict{String,Any}("arn" => arn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_run(
     arn, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -595,6 +644,7 @@ function delete_run(
         "DeleteRun",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("arn" => arn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -617,6 +667,7 @@ function delete_test_grid_project(
         "DeleteTestGridProject",
         Dict{String,Any}("projectArn" => projectArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_test_grid_project(
@@ -630,6 +681,7 @@ function delete_test_grid_project(
             mergewith(_merge, Dict{String,Any}("projectArn" => projectArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -645,7 +697,10 @@ Deletes an upload given the upload ARN.
 """
 function delete_upload(arn; aws_config::AbstractAWSConfig=global_aws_config())
     return device_farm(
-        "DeleteUpload", Dict{String,Any}("arn" => arn); aws_config=aws_config
+        "DeleteUpload",
+        Dict{String,Any}("arn" => arn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_upload(
@@ -655,6 +710,7 @@ function delete_upload(
         "DeleteUpload",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("arn" => arn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -671,7 +727,10 @@ Deletes a configuration for your Amazon Virtual Private Cloud (VPC) endpoint.
 """
 function delete_vpceconfiguration(arn; aws_config::AbstractAWSConfig=global_aws_config())
     return device_farm(
-        "DeleteVPCEConfiguration", Dict{String,Any}("arn" => arn); aws_config=aws_config
+        "DeleteVPCEConfiguration",
+        Dict{String,Any}("arn" => arn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_vpceconfiguration(
@@ -681,6 +740,7 @@ function delete_vpceconfiguration(
         "DeleteVPCEConfiguration",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("arn" => arn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -693,12 +753,16 @@ by the account.
 
 """
 function get_account_settings(; aws_config::AbstractAWSConfig=global_aws_config())
-    return device_farm("GetAccountSettings"; aws_config=aws_config)
+    return device_farm(
+        "GetAccountSettings"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_account_settings(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return device_farm("GetAccountSettings", params; aws_config=aws_config)
+    return device_farm(
+        "GetAccountSettings", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -712,7 +776,12 @@ Gets information about a unique device type.
 
 """
 function get_device(arn; aws_config::AbstractAWSConfig=global_aws_config())
-    return device_farm("GetDevice", Dict{String,Any}("arn" => arn); aws_config=aws_config)
+    return device_farm(
+        "GetDevice",
+        Dict{String,Any}("arn" => arn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_device(
     arn, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -721,6 +790,7 @@ function get_device(
         "GetDevice",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("arn" => arn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -736,7 +806,10 @@ Returns information about a device instance that belongs to a private device fle
 """
 function get_device_instance(arn; aws_config::AbstractAWSConfig=global_aws_config())
     return device_farm(
-        "GetDeviceInstance", Dict{String,Any}("arn" => arn); aws_config=aws_config
+        "GetDeviceInstance",
+        Dict{String,Any}("arn" => arn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_device_instance(
@@ -746,6 +819,7 @@ function get_device_instance(
         "GetDeviceInstance",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("arn" => arn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -761,7 +835,10 @@ Gets information about a device pool.
 """
 function get_device_pool(arn; aws_config::AbstractAWSConfig=global_aws_config())
     return device_farm(
-        "GetDevicePool", Dict{String,Any}("arn" => arn); aws_config=aws_config
+        "GetDevicePool",
+        Dict{String,Any}("arn" => arn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_device_pool(
@@ -771,6 +848,7 @@ function get_device_pool(
         "GetDevicePool",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("arn" => arn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -803,6 +881,7 @@ function get_device_pool_compatibility(
         "GetDevicePoolCompatibility",
         Dict{String,Any}("devicePoolArn" => devicePoolArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_device_pool_compatibility(
@@ -816,6 +895,7 @@ function get_device_pool_compatibility(
             mergewith(_merge, Dict{String,Any}("devicePoolArn" => devicePoolArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -831,7 +911,10 @@ Returns information about the specified instance profile.
 """
 function get_instance_profile(arn; aws_config::AbstractAWSConfig=global_aws_config())
     return device_farm(
-        "GetInstanceProfile", Dict{String,Any}("arn" => arn); aws_config=aws_config
+        "GetInstanceProfile",
+        Dict{String,Any}("arn" => arn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_instance_profile(
@@ -841,6 +924,7 @@ function get_instance_profile(
         "GetInstanceProfile",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("arn" => arn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -855,7 +939,12 @@ Gets information about a job.
 
 """
 function get_job(arn; aws_config::AbstractAWSConfig=global_aws_config())
-    return device_farm("GetJob", Dict{String,Any}("arn" => arn); aws_config=aws_config)
+    return device_farm(
+        "GetJob",
+        Dict{String,Any}("arn" => arn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_job(
     arn, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -864,6 +953,7 @@ function get_job(
         "GetJob",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("arn" => arn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -879,7 +969,10 @@ Returns information about a network profile.
 """
 function get_network_profile(arn; aws_config::AbstractAWSConfig=global_aws_config())
     return device_farm(
-        "GetNetworkProfile", Dict{String,Any}("arn" => arn); aws_config=aws_config
+        "GetNetworkProfile",
+        Dict{String,Any}("arn" => arn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_network_profile(
@@ -889,6 +982,7 @@ function get_network_profile(
         "GetNetworkProfile",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("arn" => arn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -908,12 +1002,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   which can be used to return the next set of items in the list.
 """
 function get_offering_status(; aws_config::AbstractAWSConfig=global_aws_config())
-    return device_farm("GetOfferingStatus"; aws_config=aws_config)
+    return device_farm(
+        "GetOfferingStatus"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_offering_status(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return device_farm("GetOfferingStatus", params; aws_config=aws_config)
+    return device_farm(
+        "GetOfferingStatus", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -927,7 +1025,12 @@ Gets information about a project.
 
 """
 function get_project(arn; aws_config::AbstractAWSConfig=global_aws_config())
-    return device_farm("GetProject", Dict{String,Any}("arn" => arn); aws_config=aws_config)
+    return device_farm(
+        "GetProject",
+        Dict{String,Any}("arn" => arn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_project(
     arn, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -936,6 +1039,7 @@ function get_project(
         "GetProject",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("arn" => arn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -952,7 +1056,10 @@ Returns a link to a currently running remote access session.
 """
 function get_remote_access_session(arn; aws_config::AbstractAWSConfig=global_aws_config())
     return device_farm(
-        "GetRemoteAccessSession", Dict{String,Any}("arn" => arn); aws_config=aws_config
+        "GetRemoteAccessSession",
+        Dict{String,Any}("arn" => arn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_remote_access_session(
@@ -962,6 +1069,7 @@ function get_remote_access_session(
         "GetRemoteAccessSession",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("arn" => arn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -976,7 +1084,12 @@ Gets information about a run.
 
 """
 function get_run(arn; aws_config::AbstractAWSConfig=global_aws_config())
-    return device_farm("GetRun", Dict{String,Any}("arn" => arn); aws_config=aws_config)
+    return device_farm(
+        "GetRun",
+        Dict{String,Any}("arn" => arn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_run(
     arn, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -985,6 +1098,7 @@ function get_run(
         "GetRun",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("arn" => arn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -999,7 +1113,12 @@ Gets information about a suite.
 
 """
 function get_suite(arn; aws_config::AbstractAWSConfig=global_aws_config())
-    return device_farm("GetSuite", Dict{String,Any}("arn" => arn); aws_config=aws_config)
+    return device_farm(
+        "GetSuite",
+        Dict{String,Any}("arn" => arn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_suite(
     arn, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -1008,6 +1127,7 @@ function get_suite(
         "GetSuite",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("arn" => arn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1022,7 +1142,12 @@ Gets information about a test.
 
 """
 function get_test(arn; aws_config::AbstractAWSConfig=global_aws_config())
-    return device_farm("GetTest", Dict{String,Any}("arn" => arn); aws_config=aws_config)
+    return device_farm(
+        "GetTest",
+        Dict{String,Any}("arn" => arn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_test(
     arn, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -1031,6 +1156,7 @@ function get_test(
         "GetTest",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("arn" => arn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1052,6 +1178,7 @@ function get_test_grid_project(
         "GetTestGridProject",
         Dict{String,Any}("projectArn" => projectArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_test_grid_project(
@@ -1065,6 +1192,7 @@ function get_test_grid_project(
             mergewith(_merge, Dict{String,Any}("projectArn" => projectArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1085,12 +1213,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"sessionId"`: An ID associated with this session.
 """
 function get_test_grid_session(; aws_config::AbstractAWSConfig=global_aws_config())
-    return device_farm("GetTestGridSession"; aws_config=aws_config)
+    return device_farm(
+        "GetTestGridSession"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_test_grid_session(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return device_farm("GetTestGridSession", params; aws_config=aws_config)
+    return device_farm(
+        "GetTestGridSession", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1104,7 +1236,12 @@ Gets information about an upload.
 
 """
 function get_upload(arn; aws_config::AbstractAWSConfig=global_aws_config())
-    return device_farm("GetUpload", Dict{String,Any}("arn" => arn); aws_config=aws_config)
+    return device_farm(
+        "GetUpload",
+        Dict{String,Any}("arn" => arn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_upload(
     arn, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -1113,6 +1250,7 @@ function get_upload(
         "GetUpload",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("arn" => arn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1130,7 +1268,10 @@ Returns information about the configuration settings for your Amazon Virtual Pri
 """
 function get_vpceconfiguration(arn; aws_config::AbstractAWSConfig=global_aws_config())
     return device_farm(
-        "GetVPCEConfiguration", Dict{String,Any}("arn" => arn); aws_config=aws_config
+        "GetVPCEConfiguration",
+        Dict{String,Any}("arn" => arn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_vpceconfiguration(
@@ -1140,6 +1281,7 @@ function get_vpceconfiguration(
         "GetVPCEConfiguration",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("arn" => arn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1165,6 +1307,7 @@ function install_to_remote_access_session(
             "appArn" => appArn, "remoteAccessSessionArn" => remoteAccessSessionArn
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function install_to_remote_access_session(
@@ -1185,6 +1328,7 @@ function install_to_remote_access_session(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1208,6 +1352,7 @@ function list_artifacts(arn, type; aws_config::AbstractAWSConfig=global_aws_conf
         "ListArtifacts",
         Dict{String,Any}("arn" => arn, "type" => type);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_artifacts(
@@ -1222,6 +1367,7 @@ function list_artifacts(
             mergewith(_merge, Dict{String,Any}("arn" => arn, "type" => type), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1240,12 +1386,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   which can be used to return the next set of items in the list.
 """
 function list_device_instances(; aws_config::AbstractAWSConfig=global_aws_config())
-    return device_farm("ListDeviceInstances"; aws_config=aws_config)
+    return device_farm(
+        "ListDeviceInstances"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_device_instances(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return device_farm("ListDeviceInstances", params; aws_config=aws_config)
+    return device_farm(
+        "ListDeviceInstances",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1267,7 +1420,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function list_device_pools(arn; aws_config::AbstractAWSConfig=global_aws_config())
     return device_farm(
-        "ListDevicePools", Dict{String,Any}("arn" => arn); aws_config=aws_config
+        "ListDevicePools",
+        Dict{String,Any}("arn" => arn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_device_pools(
@@ -1277,6 +1433,7 @@ function list_device_pools(
         "ListDevicePools",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("arn" => arn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1318,12 +1475,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   which can be used to return the next set of items in the list.
 """
 function list_devices(; aws_config::AbstractAWSConfig=global_aws_config())
-    return device_farm("ListDevices"; aws_config=aws_config)
+    return device_farm(
+        "ListDevices"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_devices(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return device_farm("ListDevices", params; aws_config=aws_config)
+    return device_farm(
+        "ListDevices", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1340,12 +1501,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   which can be used to return the next set of items in the list.
 """
 function list_instance_profiles(; aws_config::AbstractAWSConfig=global_aws_config())
-    return device_farm("ListInstanceProfiles"; aws_config=aws_config)
+    return device_farm(
+        "ListInstanceProfiles"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_instance_profiles(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return device_farm("ListInstanceProfiles", params; aws_config=aws_config)
+    return device_farm(
+        "ListInstanceProfiles",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1363,7 +1531,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   which can be used to return the next set of items in the list.
 """
 function list_jobs(arn; aws_config::AbstractAWSConfig=global_aws_config())
-    return device_farm("ListJobs", Dict{String,Any}("arn" => arn); aws_config=aws_config)
+    return device_farm(
+        "ListJobs",
+        Dict{String,Any}("arn" => arn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_jobs(
     arn, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -1372,6 +1545,7 @@ function list_jobs(
         "ListJobs",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("arn" => arn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1394,7 +1568,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function list_network_profiles(arn; aws_config::AbstractAWSConfig=global_aws_config())
     return device_farm(
-        "ListNetworkProfiles", Dict{String,Any}("arn" => arn); aws_config=aws_config
+        "ListNetworkProfiles",
+        Dict{String,Any}("arn" => arn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_network_profiles(
@@ -1404,6 +1581,7 @@ function list_network_profiles(
         "ListNetworkProfiles",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("arn" => arn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1422,12 +1600,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   which can be used to return the next set of items in the list.
 """
 function list_offering_promotions(; aws_config::AbstractAWSConfig=global_aws_config())
-    return device_farm("ListOfferingPromotions"; aws_config=aws_config)
+    return device_farm(
+        "ListOfferingPromotions"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_offering_promotions(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return device_farm("ListOfferingPromotions", params; aws_config=aws_config)
+    return device_farm(
+        "ListOfferingPromotions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1446,12 +1631,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   which can be used to return the next set of items in the list.
 """
 function list_offering_transactions(; aws_config::AbstractAWSConfig=global_aws_config())
-    return device_farm("ListOfferingTransactions"; aws_config=aws_config)
+    return device_farm(
+        "ListOfferingTransactions"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_offering_transactions(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return device_farm("ListOfferingTransactions", params; aws_config=aws_config)
+    return device_farm(
+        "ListOfferingTransactions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1469,12 +1661,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   which can be used to return the next set of items in the list.
 """
 function list_offerings(; aws_config::AbstractAWSConfig=global_aws_config())
-    return device_farm("ListOfferings"; aws_config=aws_config)
+    return device_farm(
+        "ListOfferings"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_offerings(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return device_farm("ListOfferings", params; aws_config=aws_config)
+    return device_farm(
+        "ListOfferings", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1491,12 +1687,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   which can be used to return the next set of items in the list.
 """
 function list_projects(; aws_config::AbstractAWSConfig=global_aws_config())
-    return device_farm("ListProjects"; aws_config=aws_config)
+    return device_farm(
+        "ListProjects"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_projects(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return device_farm("ListProjects", params; aws_config=aws_config)
+    return device_farm(
+        "ListProjects", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1516,7 +1716,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function list_remote_access_sessions(arn; aws_config::AbstractAWSConfig=global_aws_config())
     return device_farm(
-        "ListRemoteAccessSessions", Dict{String,Any}("arn" => arn); aws_config=aws_config
+        "ListRemoteAccessSessions",
+        Dict{String,Any}("arn" => arn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_remote_access_sessions(
@@ -1526,6 +1729,7 @@ function list_remote_access_sessions(
         "ListRemoteAccessSessions",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("arn" => arn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1544,7 +1748,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   which can be used to return the next set of items in the list.
 """
 function list_runs(arn; aws_config::AbstractAWSConfig=global_aws_config())
-    return device_farm("ListRuns", Dict{String,Any}("arn" => arn); aws_config=aws_config)
+    return device_farm(
+        "ListRuns",
+        Dict{String,Any}("arn" => arn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_runs(
     arn, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -1553,6 +1762,7 @@ function list_runs(
         "ListRuns",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("arn" => arn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1571,7 +1781,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   which can be used to return the next set of items in the list.
 """
 function list_samples(arn; aws_config::AbstractAWSConfig=global_aws_config())
-    return device_farm("ListSamples", Dict{String,Any}("arn" => arn); aws_config=aws_config)
+    return device_farm(
+        "ListSamples",
+        Dict{String,Any}("arn" => arn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_samples(
     arn, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -1580,6 +1795,7 @@ function list_samples(
         "ListSamples",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("arn" => arn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1598,7 +1814,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   which can be used to return the next set of items in the list.
 """
 function list_suites(arn; aws_config::AbstractAWSConfig=global_aws_config())
-    return device_farm("ListSuites", Dict{String,Any}("arn" => arn); aws_config=aws_config)
+    return device_farm(
+        "ListSuites",
+        Dict{String,Any}("arn" => arn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_suites(
     arn, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -1607,6 +1828,7 @@ function list_suites(
         "ListSuites",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("arn" => arn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1630,6 +1852,7 @@ function list_tags_for_resource(
         "ListTagsForResource",
         Dict{String,Any}("ResourceARN" => ResourceARN);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags_for_resource(
@@ -1643,6 +1866,7 @@ function list_tags_for_resource(
             mergewith(_merge, Dict{String,Any}("ResourceARN" => ResourceARN), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1658,12 +1882,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: From a response, used to continue a paginated listing.
 """
 function list_test_grid_projects(; aws_config::AbstractAWSConfig=global_aws_config())
-    return device_farm("ListTestGridProjects"; aws_config=aws_config)
+    return device_farm(
+        "ListTestGridProjects"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_test_grid_projects(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return device_farm("ListTestGridProjects", params; aws_config=aws_config)
+    return device_farm(
+        "ListTestGridProjects",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1687,6 +1918,7 @@ function list_test_grid_session_actions(
         "ListTestGridSessionActions",
         Dict{String,Any}("sessionArn" => sessionArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_test_grid_session_actions(
@@ -1700,6 +1932,7 @@ function list_test_grid_session_actions(
             mergewith(_merge, Dict{String,Any}("sessionArn" => sessionArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1725,6 +1958,7 @@ function list_test_grid_session_artifacts(
         "ListTestGridSessionArtifacts",
         Dict{String,Any}("sessionArn" => sessionArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_test_grid_session_artifacts(
@@ -1738,6 +1972,7 @@ function list_test_grid_session_artifacts(
             mergewith(_merge, Dict{String,Any}("sessionArn" => sessionArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1767,6 +2002,7 @@ function list_test_grid_sessions(
         "ListTestGridSessions",
         Dict{String,Any}("projectArn" => projectArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_test_grid_sessions(
@@ -1780,6 +2016,7 @@ function list_test_grid_sessions(
             mergewith(_merge, Dict{String,Any}("projectArn" => projectArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1798,7 +2035,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   which can be used to return the next set of items in the list.
 """
 function list_tests(arn; aws_config::AbstractAWSConfig=global_aws_config())
-    return device_farm("ListTests", Dict{String,Any}("arn" => arn); aws_config=aws_config)
+    return device_farm(
+        "ListTests",
+        Dict{String,Any}("arn" => arn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_tests(
     arn, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -1807,6 +2049,7 @@ function list_tests(
         "ListTests",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("arn" => arn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1830,7 +2073,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function list_unique_problems(arn; aws_config::AbstractAWSConfig=global_aws_config())
     return device_farm(
-        "ListUniqueProblems", Dict{String,Any}("arn" => arn); aws_config=aws_config
+        "ListUniqueProblems",
+        Dict{String,Any}("arn" => arn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_unique_problems(
@@ -1840,6 +2086,7 @@ function list_unique_problems(
         "ListUniqueProblems",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("arn" => arn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1870,7 +2117,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   INSTRUMENTATION_TEST_SPEC   XCTEST_UI_TEST_SPEC
 """
 function list_uploads(arn; aws_config::AbstractAWSConfig=global_aws_config())
-    return device_farm("ListUploads", Dict{String,Any}("arn" => arn); aws_config=aws_config)
+    return device_farm(
+        "ListUploads",
+        Dict{String,Any}("arn" => arn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_uploads(
     arn, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -1879,6 +2131,7 @@ function list_uploads(
         "ListUploads",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("arn" => arn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1897,12 +2150,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   which can be used to return the next set of items in the list.
 """
 function list_vpceconfigurations(; aws_config::AbstractAWSConfig=global_aws_config())
-    return device_farm("ListVPCEConfigurations"; aws_config=aws_config)
+    return device_farm(
+        "ListVPCEConfigurations"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_vpceconfigurations(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return device_farm("ListVPCEConfigurations", params; aws_config=aws_config)
+    return device_farm(
+        "ListVPCEConfigurations",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1929,6 +2189,7 @@ function purchase_offering(
         "PurchaseOffering",
         Dict{String,Any}("offeringId" => offeringId, "quantity" => quantity);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function purchase_offering(
@@ -1947,6 +2208,7 @@ function purchase_offering(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1971,6 +2233,7 @@ function renew_offering(
         "RenewOffering",
         Dict{String,Any}("offeringId" => offeringId, "quantity" => quantity);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function renew_offering(
@@ -1989,6 +2252,7 @@ function renew_offering(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2020,6 +2284,7 @@ function schedule_run(projectArn, test; aws_config::AbstractAWSConfig=global_aws
         "ScheduleRun",
         Dict{String,Any}("projectArn" => projectArn, "test" => test);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function schedule_run(
@@ -2036,6 +2301,7 @@ function schedule_run(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2054,7 +2320,12 @@ completed.
 
 """
 function stop_job(arn; aws_config::AbstractAWSConfig=global_aws_config())
-    return device_farm("StopJob", Dict{String,Any}("arn" => arn); aws_config=aws_config)
+    return device_farm(
+        "StopJob",
+        Dict{String,Any}("arn" => arn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function stop_job(
     arn, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -2063,6 +2334,7 @@ function stop_job(
         "StopJob",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("arn" => arn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2078,7 +2350,10 @@ Ends a specified remote access session.
 """
 function stop_remote_access_session(arn; aws_config::AbstractAWSConfig=global_aws_config())
     return device_farm(
-        "StopRemoteAccessSession", Dict{String,Any}("arn" => arn); aws_config=aws_config
+        "StopRemoteAccessSession",
+        Dict{String,Any}("arn" => arn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function stop_remote_access_session(
@@ -2088,6 +2363,7 @@ function stop_remote_access_session(
         "StopRemoteAccessSession",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("arn" => arn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2106,7 +2382,12 @@ progress or already completed.
 
 """
 function stop_run(arn; aws_config::AbstractAWSConfig=global_aws_config())
-    return device_farm("StopRun", Dict{String,Any}("arn" => arn); aws_config=aws_config)
+    return device_farm(
+        "StopRun",
+        Dict{String,Any}("arn" => arn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function stop_run(
     arn, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -2115,6 +2396,7 @@ function stop_run(
         "StopRun",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("arn" => arn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2141,6 +2423,7 @@ function tag_resource(ResourceARN, Tags; aws_config::AbstractAWSConfig=global_aw
         "TagResource",
         Dict{String,Any}("ResourceARN" => ResourceARN, "Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -2159,6 +2442,7 @@ function tag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2183,6 +2467,7 @@ function untag_resource(
         "UntagResource",
         Dict{String,Any}("ResourceARN" => ResourceARN, "TagKeys" => TagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -2201,6 +2486,7 @@ function untag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2221,7 +2507,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function update_device_instance(arn; aws_config::AbstractAWSConfig=global_aws_config())
     return device_farm(
-        "UpdateDeviceInstance", Dict{String,Any}("arn" => arn); aws_config=aws_config
+        "UpdateDeviceInstance",
+        Dict{String,Any}("arn" => arn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_device_instance(
@@ -2231,6 +2520,7 @@ function update_device_instance(
         "UpdateDeviceInstance",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("arn" => arn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2267,7 +2557,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function update_device_pool(arn; aws_config::AbstractAWSConfig=global_aws_config())
     return device_farm(
-        "UpdateDevicePool", Dict{String,Any}("arn" => arn); aws_config=aws_config
+        "UpdateDevicePool",
+        Dict{String,Any}("arn" => arn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_device_pool(
@@ -2277,6 +2570,7 @@ function update_device_pool(
         "UpdateDevicePool",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("arn" => arn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2303,7 +2597,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function update_instance_profile(arn; aws_config::AbstractAWSConfig=global_aws_config())
     return device_farm(
-        "UpdateInstanceProfile", Dict{String,Any}("arn" => arn); aws_config=aws_config
+        "UpdateInstanceProfile",
+        Dict{String,Any}("arn" => arn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_instance_profile(
@@ -2313,6 +2610,7 @@ function update_instance_profile(
         "UpdateInstanceProfile",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("arn" => arn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2352,7 +2650,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function update_network_profile(arn; aws_config::AbstractAWSConfig=global_aws_config())
     return device_farm(
-        "UpdateNetworkProfile", Dict{String,Any}("arn" => arn); aws_config=aws_config
+        "UpdateNetworkProfile",
+        Dict{String,Any}("arn" => arn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_network_profile(
@@ -2362,6 +2663,7 @@ function update_network_profile(
         "UpdateNetworkProfile",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("arn" => arn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2382,7 +2684,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function update_project(arn; aws_config::AbstractAWSConfig=global_aws_config())
     return device_farm(
-        "UpdateProject", Dict{String,Any}("arn" => arn); aws_config=aws_config
+        "UpdateProject",
+        Dict{String,Any}("arn" => arn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_project(
@@ -2392,6 +2697,7 @@ function update_project(
         "UpdateProject",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("arn" => arn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2417,6 +2723,7 @@ function update_test_grid_project(
         "UpdateTestGridProject",
         Dict{String,Any}("projectArn" => projectArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_test_grid_project(
@@ -2430,6 +2737,7 @@ function update_test_grid_project(
             mergewith(_merge, Dict{String,Any}("projectArn" => projectArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2452,7 +2760,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function update_upload(arn; aws_config::AbstractAWSConfig=global_aws_config())
     return device_farm(
-        "UpdateUpload", Dict{String,Any}("arn" => arn); aws_config=aws_config
+        "UpdateUpload",
+        Dict{String,Any}("arn" => arn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_upload(
@@ -2462,6 +2773,7 @@ function update_upload(
         "UpdateUpload",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("arn" => arn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2488,7 +2800,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function update_vpceconfiguration(arn; aws_config::AbstractAWSConfig=global_aws_config())
     return device_farm(
-        "UpdateVPCEConfiguration", Dict{String,Any}("arn" => arn); aws_config=aws_config
+        "UpdateVPCEConfiguration",
+        Dict{String,Any}("arn" => arn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_vpceconfiguration(
@@ -2498,5 +2813,6 @@ function update_vpceconfiguration(
         "UpdateVPCEConfiguration",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("arn" => arn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/devops_guru.jl
+++ b/src/services/devops_guru.jl
@@ -25,7 +25,11 @@ CMK. For more information, see Permissions for AWS KMS–encrypted Amazon SNS to
 """
 function add_notification_channel(Config; aws_config::AbstractAWSConfig=global_aws_config())
     return devops_guru(
-        "PUT", "/channels", Dict{String,Any}("Config" => Config); aws_config=aws_config
+        "PUT",
+        "/channels",
+        Dict{String,Any}("Config" => Config);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function add_notification_channel(
@@ -36,6 +40,7 @@ function add_notification_channel(
         "/channels",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Config" => Config), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -49,12 +54,20 @@ of operations in your AWS account.
 
 """
 function describe_account_health(; aws_config::AbstractAWSConfig=global_aws_config())
-    return devops_guru("GET", "/accounts/health"; aws_config=aws_config)
+    return devops_guru(
+        "GET", "/accounts/health"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_account_health(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return devops_guru("GET", "/accounts/health", params; aws_config=aws_config)
+    return devops_guru(
+        "GET",
+        "/accounts/health",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -84,6 +97,7 @@ function describe_account_overview(
         "/accounts/overview",
         Dict{String,Any}("FromTime" => FromTime);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_account_overview(
@@ -98,6 +112,7 @@ function describe_account_overview(
             mergewith(_merge, Dict{String,Any}("FromTime" => FromTime), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -112,12 +127,20 @@ end
 
 """
 function describe_anomaly(Id; aws_config::AbstractAWSConfig=global_aws_config())
-    return devops_guru("GET", "/anomalies/$(Id)"; aws_config=aws_config)
+    return devops_guru(
+        "GET", "/anomalies/$(Id)"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_anomaly(
     Id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return devops_guru("GET", "/anomalies/$(Id)", params; aws_config=aws_config)
+    return devops_guru(
+        "GET",
+        "/anomalies/$(Id)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -131,12 +154,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"InsightId"`:  The ID of the insight for which the feedback was provided.
 """
 function describe_feedback(; aws_config::AbstractAWSConfig=global_aws_config())
-    return devops_guru("POST", "/feedback"; aws_config=aws_config)
+    return devops_guru(
+        "POST", "/feedback"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_feedback(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return devops_guru("POST", "/feedback", params; aws_config=aws_config)
+    return devops_guru(
+        "POST", "/feedback", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -150,12 +177,20 @@ end
 
 """
 function describe_insight(Id; aws_config::AbstractAWSConfig=global_aws_config())
-    return devops_guru("GET", "/insights/$(Id)"; aws_config=aws_config)
+    return devops_guru(
+        "GET", "/insights/$(Id)"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_insight(
     Id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return devops_guru("GET", "/insights/$(Id)", params; aws_config=aws_config)
+    return devops_guru(
+        "GET",
+        "/insights/$(Id)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -187,6 +222,7 @@ function describe_resource_collection_health(
         "GET",
         "/accounts/health/resource-collection/$(ResourceCollectionType)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_resource_collection_health(
@@ -199,6 +235,7 @@ function describe_resource_collection_health(
         "/accounts/health/resource-collection/$(ResourceCollectionType)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -212,12 +249,23 @@ to create an OpsItem for each generated insight.
 
 """
 function describe_service_integration(; aws_config::AbstractAWSConfig=global_aws_config())
-    return devops_guru("GET", "/service-integrations"; aws_config=aws_config)
+    return devops_guru(
+        "GET",
+        "/service-integrations";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_service_integration(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return devops_guru("GET", "/service-integrations", params; aws_config=aws_config)
+    return devops_guru(
+        "GET",
+        "/service-integrations",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -233,12 +281,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   operation. If this value is null, it retrieves the first page.
 """
 function get_cost_estimation(; aws_config::AbstractAWSConfig=global_aws_config())
-    return devops_guru("GET", "/cost-estimation"; aws_config=aws_config)
+    return devops_guru(
+        "GET", "/cost-estimation"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_cost_estimation(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return devops_guru("GET", "/cost-estimation", params; aws_config=aws_config)
+    return devops_guru(
+        "GET",
+        "/cost-estimation",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -263,7 +319,10 @@ function get_resource_collection(
     ResourceCollectionType; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return devops_guru(
-        "GET", "/resource-collections/$(ResourceCollectionType)"; aws_config=aws_config
+        "GET",
+        "/resource-collections/$(ResourceCollectionType)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_resource_collection(
@@ -276,6 +335,7 @@ function get_resource_collection(
         "/resource-collections/$(ResourceCollectionType)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -300,7 +360,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function list_anomalies_for_insight(
     InsightId; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return devops_guru("POST", "/anomalies/insight/$(InsightId)"; aws_config=aws_config)
+    return devops_guru(
+        "POST",
+        "/anomalies/insight/$(InsightId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_anomalies_for_insight(
     InsightId,
@@ -308,7 +373,11 @@ function list_anomalies_for_insight(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return devops_guru(
-        "POST", "/anomalies/insight/$(InsightId)", params; aws_config=aws_config
+        "POST",
+        "/anomalies/insight/$(InsightId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -331,7 +400,11 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function list_events(Filters; aws_config::AbstractAWSConfig=global_aws_config())
     return devops_guru(
-        "POST", "/events", Dict{String,Any}("Filters" => Filters); aws_config=aws_config
+        "POST",
+        "/events",
+        Dict{String,Any}("Filters" => Filters);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_events(
@@ -342,6 +415,7 @@ function list_events(
         "/events",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Filters" => Filters), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -369,6 +443,7 @@ function list_insights(StatusFilter; aws_config::AbstractAWSConfig=global_aws_co
         "/insights",
         Dict{String,Any}("StatusFilter" => StatusFilter);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_insights(
@@ -383,6 +458,7 @@ function list_insights(
             mergewith(_merge, Dict{String,Any}("StatusFilter" => StatusFilter), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -401,12 +477,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   operation. If this value is null, it retrieves the first page.
 """
 function list_notification_channels(; aws_config::AbstractAWSConfig=global_aws_config())
-    return devops_guru("POST", "/channels"; aws_config=aws_config)
+    return devops_guru(
+        "POST", "/channels"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_notification_channels(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return devops_guru("POST", "/channels", params; aws_config=aws_config)
+    return devops_guru(
+        "POST", "/channels", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -431,6 +511,7 @@ function list_recommendations(InsightId; aws_config::AbstractAWSConfig=global_aw
         "/recommendations",
         Dict{String,Any}("InsightId" => InsightId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_recommendations(
@@ -445,6 +526,7 @@ function list_recommendations(
             mergewith(_merge, Dict{String,Any}("InsightId" => InsightId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -460,12 +542,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   insight.
 """
 function put_feedback(; aws_config::AbstractAWSConfig=global_aws_config())
-    return devops_guru("PUT", "/feedback"; aws_config=aws_config)
+    return devops_guru(
+        "PUT", "/feedback"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function put_feedback(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return devops_guru("PUT", "/feedback", params; aws_config=aws_config)
+    return devops_guru(
+        "PUT", "/feedback", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -481,12 +567,20 @@ your operations.
 
 """
 function remove_notification_channel(Id; aws_config::AbstractAWSConfig=global_aws_config())
-    return devops_guru("DELETE", "/channels/$(Id)"; aws_config=aws_config)
+    return devops_guru(
+        "DELETE", "/channels/$(Id)"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function remove_notification_channel(
     Id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return devops_guru("DELETE", "/channels/$(Id)", params; aws_config=aws_config)
+    return devops_guru(
+        "DELETE",
+        "/channels/$(Id)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -521,6 +615,7 @@ function search_insights(
         "/insights/search",
         Dict{String,Any}("StartTimeRange" => StartTimeRange, "Type" => Type);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function search_insights(
@@ -540,6 +635,7 @@ function search_insights(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -567,6 +663,7 @@ function start_cost_estimation(
             "ResourceCollection" => ResourceCollection, "ClientToken" => string(uuid4())
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_cost_estimation(
@@ -588,6 +685,7 @@ function start_cost_estimation(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -615,6 +713,7 @@ function update_resource_collection(
         "/resource-collections",
         Dict{String,Any}("Action" => Action, "ResourceCollection" => ResourceCollection);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_resource_collection(
@@ -636,6 +735,7 @@ function update_resource_collection(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -660,6 +760,7 @@ function update_service_integration(
         "/service-integrations",
         Dict{String,Any}("ServiceIntegration" => ServiceIntegration);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_service_integration(
@@ -676,5 +777,6 @@ function update_service_integration(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/direct_connect.jl
+++ b/src/services/direct_connect.jl
@@ -37,6 +37,7 @@ function accept_direct_connect_gateway_association_proposal(
             "proposalId" => proposalId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function accept_direct_connect_gateway_association_proposal(
@@ -60,6 +61,7 @@ function accept_direct_connect_gateway_association_proposal(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -102,6 +104,7 @@ function allocate_connection_on_interconnect(
             "vlan" => vlan,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function allocate_connection_on_interconnect(
@@ -129,6 +132,7 @@ function allocate_connection_on_interconnect(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -175,6 +179,7 @@ function allocate_hosted_connection(
             "vlan" => vlan,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function allocate_hosted_connection(
@@ -202,6 +207,7 @@ function allocate_hosted_connection(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -236,6 +242,7 @@ function allocate_private_virtual_interface(
             "ownerAccount" => ownerAccount,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function allocate_private_virtual_interface(
@@ -260,6 +267,7 @@ function allocate_private_virtual_interface(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -297,6 +305,7 @@ function allocate_public_virtual_interface(
             "ownerAccount" => ownerAccount,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function allocate_public_virtual_interface(
@@ -321,6 +330,7 @@ function allocate_public_virtual_interface(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -357,6 +367,7 @@ function allocate_transit_virtual_interface(
             "ownerAccount" => ownerAccount,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function allocate_transit_virtual_interface(
@@ -381,6 +392,7 @@ function allocate_transit_virtual_interface(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -413,6 +425,7 @@ function associate_connection_with_lag(
         "AssociateConnectionWithLag",
         Dict{String,Any}("connectionId" => connectionId, "lagId" => lagId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_connection_with_lag(
@@ -431,6 +444,7 @@ function associate_connection_with_lag(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -458,6 +472,7 @@ function associate_hosted_connection(
             "connectionId" => connectionId, "parentConnectionId" => parentConnectionId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_hosted_connection(
@@ -479,6 +494,7 @@ function associate_hosted_connection(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -518,6 +534,7 @@ function associate_mac_sec_key(
         "AssociateMacSecKey",
         Dict{String,Any}("connectionId" => connectionId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_mac_sec_key(
@@ -531,6 +548,7 @@ function associate_mac_sec_key(
             mergewith(_merge, Dict{String,Any}("connectionId" => connectionId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -563,6 +581,7 @@ function associate_virtual_interface(
             "connectionId" => connectionId, "virtualInterfaceId" => virtualInterfaceId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_virtual_interface(
@@ -584,6 +603,7 @@ function associate_virtual_interface(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -604,6 +624,7 @@ function confirm_connection(connectionId; aws_config::AbstractAWSConfig=global_a
         "ConfirmConnection",
         Dict{String,Any}("connectionId" => connectionId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function confirm_connection(
@@ -617,6 +638,7 @@ function confirm_connection(
             mergewith(_merge, Dict{String,Any}("connectionId" => connectionId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -644,6 +666,7 @@ function confirm_private_virtual_interface(
         "ConfirmPrivateVirtualInterface",
         Dict{String,Any}("virtualInterfaceId" => virtualInterfaceId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function confirm_private_virtual_interface(
@@ -659,6 +682,7 @@ function confirm_private_virtual_interface(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -681,6 +705,7 @@ function confirm_public_virtual_interface(
         "ConfirmPublicVirtualInterface",
         Dict{String,Any}("virtualInterfaceId" => virtualInterfaceId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function confirm_public_virtual_interface(
@@ -696,6 +721,7 @@ function confirm_public_virtual_interface(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -724,6 +750,7 @@ function confirm_transit_virtual_interface(
             "virtualInterfaceId" => virtualInterfaceId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function confirm_transit_virtual_interface(
@@ -745,6 +772,7 @@ function confirm_transit_virtual_interface(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -768,12 +796,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"virtualInterfaceId"`: The ID of the virtual interface.
 """
 function create_bgppeer(; aws_config::AbstractAWSConfig=global_aws_config())
-    return direct_connect("CreateBGPPeer"; aws_config=aws_config)
+    return direct_connect(
+        "CreateBGPPeer"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function create_bgppeer(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return direct_connect("CreateBGPPeer", params; aws_config=aws_config)
+    return direct_connect(
+        "CreateBGPPeer", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -816,6 +848,7 @@ function create_connection(
             "location" => location,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_connection(
@@ -839,6 +872,7 @@ function create_connection(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -869,6 +903,7 @@ function create_direct_connect_gateway(
         "CreateDirectConnectGateway",
         Dict{String,Any}("directConnectGatewayName" => directConnectGatewayName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_direct_connect_gateway(
@@ -886,6 +921,7 @@ function create_direct_connect_gateway(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -916,6 +952,7 @@ function create_direct_connect_gateway_association(
         "CreateDirectConnectGatewayAssociation",
         Dict{String,Any}("directConnectGatewayId" => directConnectGatewayId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_direct_connect_gateway_association(
@@ -933,6 +970,7 @@ function create_direct_connect_gateway_association(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -971,6 +1009,7 @@ function create_direct_connect_gateway_association_proposal(
             "gatewayId" => gatewayId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_direct_connect_gateway_association_proposal(
@@ -994,6 +1033,7 @@ function create_direct_connect_gateway_association_proposal(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1039,6 +1079,7 @@ function create_interconnect(
             "location" => location,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_interconnect(
@@ -1062,6 +1103,7 @@ function create_interconnect(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1122,6 +1164,7 @@ function create_lag(
             "numberOfConnections" => numberOfConnections,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_lag(
@@ -1147,6 +1190,7 @@ function create_lag(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1183,6 +1227,7 @@ function create_private_virtual_interface(
             "newPrivateVirtualInterface" => newPrivateVirtualInterface,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_private_virtual_interface(
@@ -1204,6 +1249,7 @@ function create_private_virtual_interface(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1234,6 +1280,7 @@ function create_public_virtual_interface(
             "newPublicVirtualInterface" => newPublicVirtualInterface,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_public_virtual_interface(
@@ -1255,6 +1302,7 @@ function create_public_virtual_interface(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1293,6 +1341,7 @@ function create_transit_virtual_interface(
             "newTransitVirtualInterface" => newTransitVirtualInterface,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_transit_virtual_interface(
@@ -1314,6 +1363,7 @@ function create_transit_virtual_interface(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1333,12 +1383,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"virtualInterfaceId"`: The ID of the virtual interface.
 """
 function delete_bgppeer(; aws_config::AbstractAWSConfig=global_aws_config())
-    return direct_connect("DeleteBGPPeer"; aws_config=aws_config)
+    return direct_connect(
+        "DeleteBGPPeer"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function delete_bgppeer(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return direct_connect("DeleteBGPPeer", params; aws_config=aws_config)
+    return direct_connect(
+        "DeleteBGPPeer", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1358,6 +1412,7 @@ function delete_connection(connectionId; aws_config::AbstractAWSConfig=global_aw
         "DeleteConnection",
         Dict{String,Any}("connectionId" => connectionId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_connection(
@@ -1371,6 +1426,7 @@ function delete_connection(
             mergewith(_merge, Dict{String,Any}("connectionId" => connectionId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1393,6 +1449,7 @@ function delete_direct_connect_gateway(
         "DeleteDirectConnectGateway",
         Dict{String,Any}("directConnectGatewayId" => directConnectGatewayId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_direct_connect_gateway(
@@ -1410,6 +1467,7 @@ function delete_direct_connect_gateway(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1431,13 +1489,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function delete_direct_connect_gateway_association(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return direct_connect("DeleteDirectConnectGatewayAssociation"; aws_config=aws_config)
+    return direct_connect(
+        "DeleteDirectConnectGatewayAssociation";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_direct_connect_gateway_association(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return direct_connect(
-        "DeleteDirectConnectGatewayAssociation", params; aws_config=aws_config
+        "DeleteDirectConnectGatewayAssociation",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1459,6 +1524,7 @@ function delete_direct_connect_gateway_association_proposal(
         "DeleteDirectConnectGatewayAssociationProposal",
         Dict{String,Any}("proposalId" => proposalId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_direct_connect_gateway_association_proposal(
@@ -1472,6 +1538,7 @@ function delete_direct_connect_gateway_association_proposal(
             mergewith(_merge, Dict{String,Any}("proposalId" => proposalId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1492,6 +1559,7 @@ function delete_interconnect(
         "DeleteInterconnect",
         Dict{String,Any}("interconnectId" => interconnectId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_interconnect(
@@ -1505,6 +1573,7 @@ function delete_interconnect(
             mergewith(_merge, Dict{String,Any}("interconnectId" => interconnectId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1521,7 +1590,10 @@ active virtual interfaces or hosted connections.
 """
 function delete_lag(lagId; aws_config::AbstractAWSConfig=global_aws_config())
     return direct_connect(
-        "DeleteLag", Dict{String,Any}("lagId" => lagId); aws_config=aws_config
+        "DeleteLag",
+        Dict{String,Any}("lagId" => lagId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_lag(
@@ -1531,6 +1603,7 @@ function delete_lag(
         "DeleteLag",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("lagId" => lagId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1551,6 +1624,7 @@ function delete_virtual_interface(
         "DeleteVirtualInterface",
         Dict{String,Any}("virtualInterfaceId" => virtualInterfaceId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_virtual_interface(
@@ -1566,6 +1640,7 @@ function delete_virtual_interface(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1597,6 +1672,7 @@ function describe_connection_loa(
         "DescribeConnectionLoa",
         Dict{String,Any}("connectionId" => connectionId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_connection_loa(
@@ -1610,6 +1686,7 @@ function describe_connection_loa(
             mergewith(_merge, Dict{String,Any}("connectionId" => connectionId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1624,12 +1701,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"connectionId"`: The ID of the connection.
 """
 function describe_connections(; aws_config::AbstractAWSConfig=global_aws_config())
-    return direct_connect("DescribeConnections"; aws_config=aws_config)
+    return direct_connect(
+        "DescribeConnections"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_connections(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return direct_connect("DescribeConnections", params; aws_config=aws_config)
+    return direct_connect(
+        "DescribeConnections",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1651,6 +1735,7 @@ function describe_connections_on_interconnect(
         "DescribeConnectionsOnInterconnect",
         Dict{String,Any}("interconnectId" => interconnectId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_connections_on_interconnect(
@@ -1664,6 +1749,7 @@ function describe_connections_on_interconnect(
             mergewith(_merge, Dict{String,Any}("interconnectId" => interconnectId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1688,14 +1774,19 @@ function describe_direct_connect_gateway_association_proposals(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
     return direct_connect(
-        "DescribeDirectConnectGatewayAssociationProposals"; aws_config=aws_config
+        "DescribeDirectConnectGatewayAssociationProposals";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_direct_connect_gateway_association_proposals(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return direct_connect(
-        "DescribeDirectConnectGatewayAssociationProposals", params; aws_config=aws_config
+        "DescribeDirectConnectGatewayAssociationProposals",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1727,13 +1818,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_direct_connect_gateway_associations(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return direct_connect("DescribeDirectConnectGatewayAssociations"; aws_config=aws_config)
+    return direct_connect(
+        "DescribeDirectConnectGatewayAssociations";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_direct_connect_gateway_associations(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return direct_connect(
-        "DescribeDirectConnectGatewayAssociations", params; aws_config=aws_config
+        "DescribeDirectConnectGatewayAssociations",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1760,13 +1858,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_direct_connect_gateway_attachments(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return direct_connect("DescribeDirectConnectGatewayAttachments"; aws_config=aws_config)
+    return direct_connect(
+        "DescribeDirectConnectGatewayAttachments";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_direct_connect_gateway_attachments(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return direct_connect(
-        "DescribeDirectConnectGatewayAttachments", params; aws_config=aws_config
+        "DescribeDirectConnectGatewayAttachments",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1788,12 +1893,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_direct_connect_gateways(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return direct_connect("DescribeDirectConnectGateways"; aws_config=aws_config)
+    return direct_connect(
+        "DescribeDirectConnectGateways";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_direct_connect_gateways(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return direct_connect("DescribeDirectConnectGateways", params; aws_config=aws_config)
+    return direct_connect(
+        "DescribeDirectConnectGateways",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1814,6 +1928,7 @@ function describe_hosted_connections(
         "DescribeHostedConnections",
         Dict{String,Any}("connectionId" => connectionId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_hosted_connections(
@@ -1827,6 +1942,7 @@ function describe_hosted_connections(
             mergewith(_merge, Dict{String,Any}("connectionId" => connectionId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1858,6 +1974,7 @@ function describe_interconnect_loa(
         "DescribeInterconnectLoa",
         Dict{String,Any}("interconnectId" => interconnectId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_interconnect_loa(
@@ -1871,6 +1988,7 @@ function describe_interconnect_loa(
             mergewith(_merge, Dict{String,Any}("interconnectId" => interconnectId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1885,12 +2003,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"interconnectId"`: The ID of the interconnect.
 """
 function describe_interconnects(; aws_config::AbstractAWSConfig=global_aws_config())
-    return direct_connect("DescribeInterconnects"; aws_config=aws_config)
+    return direct_connect(
+        "DescribeInterconnects"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_interconnects(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return direct_connect("DescribeInterconnects", params; aws_config=aws_config)
+    return direct_connect(
+        "DescribeInterconnects",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1904,12 +2029,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"lagId"`: The ID of the LAG.
 """
 function describe_lags(; aws_config::AbstractAWSConfig=global_aws_config())
-    return direct_connect("DescribeLags"; aws_config=aws_config)
+    return direct_connect(
+        "DescribeLags"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_lags(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return direct_connect("DescribeLags", params; aws_config=aws_config)
+    return direct_connect(
+        "DescribeLags", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1938,6 +2067,7 @@ function describe_loa(connectionId; aws_config::AbstractAWSConfig=global_aws_con
         "DescribeLoa",
         Dict{String,Any}("connectionId" => connectionId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_loa(
@@ -1951,6 +2081,7 @@ function describe_loa(
             mergewith(_merge, Dict{String,Any}("connectionId" => connectionId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1963,12 +2094,16 @@ be selected when calling CreateConnection or CreateInterconnect.
 
 """
 function describe_locations(; aws_config::AbstractAWSConfig=global_aws_config())
-    return direct_connect("DescribeLocations"; aws_config=aws_config)
+    return direct_connect(
+        "DescribeLocations"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_locations(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return direct_connect("DescribeLocations", params; aws_config=aws_config)
+    return direct_connect(
+        "DescribeLocations", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1986,6 +2121,7 @@ function describe_tags(resourceArns; aws_config::AbstractAWSConfig=global_aws_co
         "DescribeTags",
         Dict{String,Any}("resourceArns" => resourceArns);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_tags(
@@ -1999,6 +2135,7 @@ function describe_tags(
             mergewith(_merge, Dict{String,Any}("resourceArns" => resourceArns), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2011,12 +2148,19 @@ Connect private virtual interfaces linked to a virtual private gateway.
 
 """
 function describe_virtual_gateways(; aws_config::AbstractAWSConfig=global_aws_config())
-    return direct_connect("DescribeVirtualGateways"; aws_config=aws_config)
+    return direct_connect(
+        "DescribeVirtualGateways"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_virtual_gateways(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return direct_connect("DescribeVirtualGateways", params; aws_config=aws_config)
+    return direct_connect(
+        "DescribeVirtualGateways",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2035,12 +2179,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"virtualInterfaceId"`: The ID of the virtual interface.
 """
 function describe_virtual_interfaces(; aws_config::AbstractAWSConfig=global_aws_config())
-    return direct_connect("DescribeVirtualInterfaces"; aws_config=aws_config)
+    return direct_connect(
+        "DescribeVirtualInterfaces"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_virtual_interfaces(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return direct_connect("DescribeVirtualInterfaces", params; aws_config=aws_config)
+    return direct_connect(
+        "DescribeVirtualInterfaces",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2069,6 +2220,7 @@ function disassociate_connection_from_lag(
         "DisassociateConnectionFromLag",
         Dict{String,Any}("connectionId" => connectionId, "lagId" => lagId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disassociate_connection_from_lag(
@@ -2087,6 +2239,7 @@ function disassociate_connection_from_lag(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2111,6 +2264,7 @@ function disassociate_mac_sec_key(
         "DisassociateMacSecKey",
         Dict{String,Any}("connectionId" => connectionId, "secretARN" => secretARN);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disassociate_mac_sec_key(
@@ -2129,6 +2283,7 @@ function disassociate_mac_sec_key(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2153,12 +2308,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function list_virtual_interface_test_history(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return direct_connect("ListVirtualInterfaceTestHistory"; aws_config=aws_config)
+    return direct_connect(
+        "ListVirtualInterfaceTestHistory";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_virtual_interface_test_history(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return direct_connect("ListVirtualInterfaceTestHistory", params; aws_config=aws_config)
+    return direct_connect(
+        "ListVirtualInterfaceTestHistory",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2188,6 +2352,7 @@ function start_bgp_failover_test(
         "StartBgpFailoverTest",
         Dict{String,Any}("virtualInterfaceId" => virtualInterfaceId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_bgp_failover_test(
@@ -2203,6 +2368,7 @@ function start_bgp_failover_test(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2223,6 +2389,7 @@ function stop_bgp_failover_test(
         "StopBgpFailoverTest",
         Dict{String,Any}("virtualInterfaceId" => virtualInterfaceId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function stop_bgp_failover_test(
@@ -2238,6 +2405,7 @@ function stop_bgp_failover_test(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2259,6 +2427,7 @@ function tag_resource(resourceArn, tags; aws_config::AbstractAWSConfig=global_aw
         "TagResource",
         Dict{String,Any}("resourceArn" => resourceArn, "tags" => tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -2277,6 +2446,7 @@ function tag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2298,6 +2468,7 @@ function untag_resource(
         "UntagResource",
         Dict{String,Any}("resourceArn" => resourceArn, "tagKeys" => tagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -2316,6 +2487,7 @@ function untag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2342,6 +2514,7 @@ function update_connection(connectionId; aws_config::AbstractAWSConfig=global_aw
         "UpdateConnection",
         Dict{String,Any}("connectionId" => connectionId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_connection(
@@ -2355,6 +2528,7 @@ function update_connection(
             mergewith(_merge, Dict{String,Any}("connectionId" => connectionId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2376,13 +2550,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function update_direct_connect_gateway_association(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return direct_connect("UpdateDirectConnectGatewayAssociation"; aws_config=aws_config)
+    return direct_connect(
+        "UpdateDirectConnectGatewayAssociation";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function update_direct_connect_gateway_association(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return direct_connect(
-        "UpdateDirectConnectGatewayAssociation", params; aws_config=aws_config
+        "UpdateDirectConnectGatewayAssociation",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2411,7 +2592,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function update_lag(lagId; aws_config::AbstractAWSConfig=global_aws_config())
     return direct_connect(
-        "UpdateLag", Dict{String,Any}("lagId" => lagId); aws_config=aws_config
+        "UpdateLag",
+        Dict{String,Any}("lagId" => lagId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_lag(
@@ -2421,6 +2605,7 @@ function update_lag(
         "UpdateLag",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("lagId" => lagId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2451,6 +2636,7 @@ function update_virtual_interface_attributes(
         "UpdateVirtualInterfaceAttributes",
         Dict{String,Any}("virtualInterfaceId" => virtualInterfaceId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_virtual_interface_attributes(
@@ -2466,5 +2652,6 @@ function update_virtual_interface_attributes(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/directory_service.jl
+++ b/src/services/directory_service.jl
@@ -22,6 +22,7 @@ function accept_shared_directory(
         "AcceptSharedDirectory",
         Dict{String,Any}("SharedDirectoryId" => SharedDirectoryId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function accept_shared_directory(
@@ -37,6 +38,7 @@ function accept_shared_directory(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -87,6 +89,7 @@ function add_ip_routes(
         "AddIpRoutes",
         Dict{String,Any}("DirectoryId" => DirectoryId, "IpRoutes" => IpRoutes);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function add_ip_routes(
@@ -105,6 +108,7 @@ function add_ip_routes(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -133,6 +137,7 @@ function add_region(
             "VPCSettings" => VPCSettings,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function add_region(
@@ -156,6 +161,7 @@ function add_region(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -179,6 +185,7 @@ function add_tags_to_resource(
         "AddTagsToResource",
         Dict{String,Any}("ResourceId" => ResourceId, "Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function add_tags_to_resource(
@@ -195,6 +202,7 @@ function add_tags_to_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -221,6 +229,7 @@ function cancel_schema_extension(
             "DirectoryId" => DirectoryId, "SchemaExtensionId" => SchemaExtensionId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function cancel_schema_extension(
@@ -241,6 +250,7 @@ function cancel_schema_extension(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -279,6 +289,7 @@ function connect_directory(
             "Size" => Size,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function connect_directory(
@@ -304,6 +315,7 @@ function connect_directory(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -328,6 +340,7 @@ function create_alias(Alias, DirectoryId; aws_config::AbstractAWSConfig=global_a
         "CreateAlias",
         Dict{String,Any}("Alias" => Alias, "DirectoryId" => DirectoryId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_alias(
@@ -346,6 +359,7 @@ function create_alias(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -379,6 +393,7 @@ function create_computer(
             "Password" => Password,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_computer(
@@ -402,6 +417,7 @@ function create_computer(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -436,6 +452,7 @@ function create_conditional_forwarder(
             "RemoteDomainName" => RemoteDomainName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_conditional_forwarder(
@@ -459,6 +476,7 @@ function create_conditional_forwarder(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -503,6 +521,7 @@ function create_directory(
         "CreateDirectory",
         Dict{String,Any}("Name" => Name, "Password" => Password, "Size" => Size);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_directory(
@@ -522,6 +541,7 @@ function create_directory(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -546,6 +566,7 @@ function create_log_subscription(
         "CreateLogSubscription",
         Dict{String,Any}("DirectoryId" => DirectoryId, "LogGroupName" => LogGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_log_subscription(
@@ -566,6 +587,7 @@ function create_log_subscription(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -610,6 +632,7 @@ function create_microsoft_ad(
             "Name" => Name, "Password" => Password, "VpcSettings" => VpcSettings
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_microsoft_ad(
@@ -631,6 +654,7 @@ function create_microsoft_ad(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -653,6 +677,7 @@ function create_snapshot(DirectoryId; aws_config::AbstractAWSConfig=global_aws_c
         "CreateSnapshot",
         Dict{String,Any}("DirectoryId" => DirectoryId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_snapshot(
@@ -666,6 +691,7 @@ function create_snapshot(
             mergewith(_merge, Dict{String,Any}("DirectoryId" => DirectoryId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -713,6 +739,7 @@ function create_trust(
             "TrustPassword" => TrustPassword,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_trust(
@@ -738,6 +765,7 @@ function create_trust(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -762,6 +790,7 @@ function delete_conditional_forwarder(
             "DirectoryId" => DirectoryId, "RemoteDomainName" => RemoteDomainName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_conditional_forwarder(
@@ -782,6 +811,7 @@ function delete_conditional_forwarder(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -803,6 +833,7 @@ function delete_directory(DirectoryId; aws_config::AbstractAWSConfig=global_aws_
         "DeleteDirectory",
         Dict{String,Any}("DirectoryId" => DirectoryId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_directory(
@@ -816,6 +847,7 @@ function delete_directory(
             mergewith(_merge, Dict{String,Any}("DirectoryId" => DirectoryId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -836,6 +868,7 @@ function delete_log_subscription(
         "DeleteLogSubscription",
         Dict{String,Any}("DirectoryId" => DirectoryId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_log_subscription(
@@ -849,6 +882,7 @@ function delete_log_subscription(
             mergewith(_merge, Dict{String,Any}("DirectoryId" => DirectoryId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -867,6 +901,7 @@ function delete_snapshot(SnapshotId; aws_config::AbstractAWSConfig=global_aws_co
         "DeleteSnapshot",
         Dict{String,Any}("SnapshotId" => SnapshotId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_snapshot(
@@ -880,6 +915,7 @@ function delete_snapshot(
             mergewith(_merge, Dict{String,Any}("SnapshotId" => SnapshotId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -900,7 +936,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function delete_trust(TrustId; aws_config::AbstractAWSConfig=global_aws_config())
     return directory_service(
-        "DeleteTrust", Dict{String,Any}("TrustId" => TrustId); aws_config=aws_config
+        "DeleteTrust",
+        Dict{String,Any}("TrustId" => TrustId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_trust(
@@ -910,6 +949,7 @@ function delete_trust(
         "DeleteTrust",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("TrustId" => TrustId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -932,6 +972,7 @@ function deregister_certificate(
         "DeregisterCertificate",
         Dict{String,Any}("CertificateId" => CertificateId, "DirectoryId" => DirectoryId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function deregister_certificate(
@@ -952,6 +993,7 @@ function deregister_certificate(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -975,6 +1017,7 @@ function deregister_event_topic(
         "DeregisterEventTopic",
         Dict{String,Any}("DirectoryId" => DirectoryId, "TopicName" => TopicName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function deregister_event_topic(
@@ -993,6 +1036,7 @@ function deregister_event_topic(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1015,6 +1059,7 @@ function describe_certificate(
         "DescribeCertificate",
         Dict{String,Any}("CertificateId" => CertificateId, "DirectoryId" => DirectoryId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_certificate(
@@ -1035,6 +1080,7 @@ function describe_certificate(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1067,6 +1113,7 @@ function describe_client_authentication_settings(
         "DescribeClientAuthenticationSettings",
         Dict{String,Any}("DirectoryId" => DirectoryId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_client_authentication_settings(
@@ -1080,6 +1127,7 @@ function describe_client_authentication_settings(
             mergewith(_merge, Dict{String,Any}("DirectoryId" => DirectoryId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1108,6 +1156,7 @@ function describe_conditional_forwarders(
         "DescribeConditionalForwarders",
         Dict{String,Any}("DirectoryId" => DirectoryId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_conditional_forwarders(
@@ -1121,6 +1170,7 @@ function describe_conditional_forwarders(
             mergewith(_merge, Dict{String,Any}("DirectoryId" => DirectoryId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1148,12 +1198,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   DescribeDirectories. Pass null if this is the first call.
 """
 function describe_directories(; aws_config::AbstractAWSConfig=global_aws_config())
-    return directory_service("DescribeDirectories"; aws_config=aws_config)
+    return directory_service(
+        "DescribeDirectories"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_directories(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return directory_service("DescribeDirectories", params; aws_config=aws_config)
+    return directory_service(
+        "DescribeDirectories",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1181,6 +1238,7 @@ function describe_domain_controllers(
         "DescribeDomainControllers",
         Dict{String,Any}("DirectoryId" => DirectoryId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_domain_controllers(
@@ -1194,6 +1252,7 @@ function describe_domain_controllers(
             mergewith(_merge, Dict{String,Any}("DirectoryId" => DirectoryId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1214,12 +1273,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   list results in an InvalidParameterException being thrown.
 """
 function describe_event_topics(; aws_config::AbstractAWSConfig=global_aws_config())
-    return directory_service("DescribeEventTopics"; aws_config=aws_config)
+    return directory_service(
+        "DescribeEventTopics"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_event_topics(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return directory_service("DescribeEventTopics", params; aws_config=aws_config)
+    return directory_service(
+        "DescribeEventTopics",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1245,6 +1311,7 @@ function describe_ldapssettings(
         "DescribeLDAPSSettings",
         Dict{String,Any}("DirectoryId" => DirectoryId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_ldapssettings(
@@ -1258,6 +1325,7 @@ function describe_ldapssettings(
             mergewith(_merge, Dict{String,Any}("DirectoryId" => DirectoryId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1281,6 +1349,7 @@ function describe_regions(DirectoryId; aws_config::AbstractAWSConfig=global_aws_
         "DescribeRegions",
         Dict{String,Any}("DirectoryId" => DirectoryId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_regions(
@@ -1294,6 +1363,7 @@ function describe_regions(
             mergewith(_merge, Dict{String,Any}("DirectoryId" => DirectoryId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1321,6 +1391,7 @@ function describe_shared_directories(
         "DescribeSharedDirectories",
         Dict{String,Any}("OwnerDirectoryId" => OwnerDirectoryId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_shared_directories(
@@ -1336,6 +1407,7 @@ function describe_shared_directories(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1361,12 +1433,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   members.
 """
 function describe_snapshots(; aws_config::AbstractAWSConfig=global_aws_config())
-    return directory_service("DescribeSnapshots"; aws_config=aws_config)
+    return directory_service(
+        "DescribeSnapshots"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_snapshots(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return directory_service("DescribeSnapshots", params; aws_config=aws_config)
+    return directory_service(
+        "DescribeSnapshots", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1389,12 +1465,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   account are returned. An empty list results in an InvalidParameterException being thrown.
 """
 function describe_trusts(; aws_config::AbstractAWSConfig=global_aws_config())
-    return directory_service("DescribeTrusts"; aws_config=aws_config)
+    return directory_service(
+        "DescribeTrusts"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_trusts(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return directory_service("DescribeTrusts", params; aws_config=aws_config)
+    return directory_service(
+        "DescribeTrusts", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1416,6 +1496,7 @@ function disable_client_authentication(
         "DisableClientAuthentication",
         Dict{String,Any}("DirectoryId" => DirectoryId, "Type" => Type);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disable_client_authentication(
@@ -1434,6 +1515,7 @@ function disable_client_authentication(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1453,6 +1535,7 @@ function disable_ldaps(DirectoryId, Type; aws_config::AbstractAWSConfig=global_a
         "DisableLDAPS",
         Dict{String,Any}("DirectoryId" => DirectoryId, "Type" => Type);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disable_ldaps(
@@ -1471,6 +1554,7 @@ function disable_ldaps(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1490,6 +1574,7 @@ function disable_radius(DirectoryId; aws_config::AbstractAWSConfig=global_aws_co
         "DisableRadius",
         Dict{String,Any}("DirectoryId" => DirectoryId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disable_radius(
@@ -1503,6 +1588,7 @@ function disable_radius(
             mergewith(_merge, Dict{String,Any}("DirectoryId" => DirectoryId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1528,7 +1614,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function disable_sso(DirectoryId; aws_config::AbstractAWSConfig=global_aws_config())
     return directory_service(
-        "DisableSso", Dict{String,Any}("DirectoryId" => DirectoryId); aws_config=aws_config
+        "DisableSso",
+        Dict{String,Any}("DirectoryId" => DirectoryId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disable_sso(
@@ -1542,6 +1631,7 @@ function disable_sso(
             mergewith(_merge, Dict{String,Any}("DirectoryId" => DirectoryId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1565,6 +1655,7 @@ function enable_client_authentication(
         "EnableClientAuthentication",
         Dict{String,Any}("DirectoryId" => DirectoryId, "Type" => Type);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function enable_client_authentication(
@@ -1583,6 +1674,7 @@ function enable_client_authentication(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1602,6 +1694,7 @@ function enable_ldaps(DirectoryId, Type; aws_config::AbstractAWSConfig=global_aw
         "EnableLDAPS",
         Dict{String,Any}("DirectoryId" => DirectoryId, "Type" => Type);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function enable_ldaps(
@@ -1620,6 +1713,7 @@ function enable_ldaps(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1643,6 +1737,7 @@ function enable_radius(
         "EnableRadius",
         Dict{String,Any}("DirectoryId" => DirectoryId, "RadiusSettings" => RadiusSettings);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function enable_radius(
@@ -1663,6 +1758,7 @@ function enable_radius(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1690,7 +1786,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function enable_sso(DirectoryId; aws_config::AbstractAWSConfig=global_aws_config())
     return directory_service(
-        "EnableSso", Dict{String,Any}("DirectoryId" => DirectoryId); aws_config=aws_config
+        "EnableSso",
+        Dict{String,Any}("DirectoryId" => DirectoryId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function enable_sso(
@@ -1704,6 +1803,7 @@ function enable_sso(
             mergewith(_merge, Dict{String,Any}("DirectoryId" => DirectoryId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1715,12 +1815,16 @@ Obtains directory limit information for the current Region.
 
 """
 function get_directory_limits(; aws_config::AbstractAWSConfig=global_aws_config())
-    return directory_service("GetDirectoryLimits"; aws_config=aws_config)
+    return directory_service(
+        "GetDirectoryLimits"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_directory_limits(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return directory_service("GetDirectoryLimits", params; aws_config=aws_config)
+    return directory_service(
+        "GetDirectoryLimits", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1738,6 +1842,7 @@ function get_snapshot_limits(DirectoryId; aws_config::AbstractAWSConfig=global_a
         "GetSnapshotLimits",
         Dict{String,Any}("DirectoryId" => DirectoryId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_snapshot_limits(
@@ -1751,6 +1856,7 @@ function get_snapshot_limits(
             mergewith(_merge, Dict{String,Any}("DirectoryId" => DirectoryId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1777,6 +1883,7 @@ function list_certificates(DirectoryId; aws_config::AbstractAWSConfig=global_aws
         "ListCertificates",
         Dict{String,Any}("DirectoryId" => DirectoryId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_certificates(
@@ -1790,6 +1897,7 @@ function list_certificates(
             mergewith(_merge, Dict{String,Any}("DirectoryId" => DirectoryId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1815,6 +1923,7 @@ function list_ip_routes(DirectoryId; aws_config::AbstractAWSConfig=global_aws_co
         "ListIpRoutes",
         Dict{String,Any}("DirectoryId" => DirectoryId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_ip_routes(
@@ -1828,6 +1937,7 @@ function list_ip_routes(
             mergewith(_merge, Dict{String,Any}("DirectoryId" => DirectoryId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1847,12 +1957,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`: The token for the next set of items to return.
 """
 function list_log_subscriptions(; aws_config::AbstractAWSConfig=global_aws_config())
-    return directory_service("ListLogSubscriptions"; aws_config=aws_config)
+    return directory_service(
+        "ListLogSubscriptions"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_log_subscriptions(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return directory_service("ListLogSubscriptions", params; aws_config=aws_config)
+    return directory_service(
+        "ListLogSubscriptions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1878,6 +1995,7 @@ function list_schema_extensions(
         "ListSchemaExtensions",
         Dict{String,Any}("DirectoryId" => DirectoryId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_schema_extensions(
@@ -1891,6 +2009,7 @@ function list_schema_extensions(
             mergewith(_merge, Dict{String,Any}("DirectoryId" => DirectoryId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1915,6 +2034,7 @@ function list_tags_for_resource(
         "ListTagsForResource",
         Dict{String,Any}("ResourceId" => ResourceId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags_for_resource(
@@ -1928,6 +2048,7 @@ function list_tags_for_resource(
             mergewith(_merge, Dict{String,Any}("ResourceId" => ResourceId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1957,6 +2078,7 @@ function register_certificate(
             "CertificateData" => CertificateData, "DirectoryId" => DirectoryId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function register_certificate(
@@ -1977,6 +2099,7 @@ function register_certificate(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2004,6 +2127,7 @@ function register_event_topic(
         "RegisterEventTopic",
         Dict{String,Any}("DirectoryId" => DirectoryId, "TopicName" => TopicName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function register_event_topic(
@@ -2022,6 +2146,7 @@ function register_event_topic(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2043,6 +2168,7 @@ function reject_shared_directory(
         "RejectSharedDirectory",
         Dict{String,Any}("SharedDirectoryId" => SharedDirectoryId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function reject_shared_directory(
@@ -2058,6 +2184,7 @@ function reject_shared_directory(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2080,6 +2207,7 @@ function remove_ip_routes(
         "RemoveIpRoutes",
         Dict{String,Any}("CidrIps" => CidrIps, "DirectoryId" => DirectoryId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function remove_ip_routes(
@@ -2098,6 +2226,7 @@ function remove_ip_routes(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2118,6 +2247,7 @@ function remove_region(DirectoryId; aws_config::AbstractAWSConfig=global_aws_con
         "RemoveRegion",
         Dict{String,Any}("DirectoryId" => DirectoryId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function remove_region(
@@ -2131,6 +2261,7 @@ function remove_region(
             mergewith(_merge, Dict{String,Any}("DirectoryId" => DirectoryId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2152,6 +2283,7 @@ function remove_tags_from_resource(
         "RemoveTagsFromResource",
         Dict{String,Any}("ResourceId" => ResourceId, "TagKeys" => TagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function remove_tags_from_resource(
@@ -2170,6 +2302,7 @@ function remove_tags_from_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2205,6 +2338,7 @@ function reset_user_password(
             "UserName" => UserName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function reset_user_password(
@@ -2228,6 +2362,7 @@ function reset_user_password(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2253,6 +2388,7 @@ function restore_from_snapshot(
         "RestoreFromSnapshot",
         Dict{String,Any}("SnapshotId" => SnapshotId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function restore_from_snapshot(
@@ -2266,6 +2402,7 @@ function restore_from_snapshot(
             mergewith(_merge, Dict{String,Any}("SnapshotId" => SnapshotId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2313,6 +2450,7 @@ function share_directory(
             "ShareTarget" => ShareTarget,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function share_directory(
@@ -2336,6 +2474,7 @@ function share_directory(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2372,6 +2511,7 @@ function start_schema_extension(
             "LdifContent" => LdifContent,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_schema_extension(
@@ -2398,6 +2538,7 @@ function start_schema_extension(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2421,6 +2562,7 @@ function unshare_directory(
         "UnshareDirectory",
         Dict{String,Any}("DirectoryId" => DirectoryId, "UnshareTarget" => UnshareTarget);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function unshare_directory(
@@ -2441,6 +2583,7 @@ function unshare_directory(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2473,6 +2616,7 @@ function update_conditional_forwarder(
             "RemoteDomainName" => RemoteDomainName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_conditional_forwarder(
@@ -2496,6 +2640,7 @@ function update_conditional_forwarder(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2522,6 +2667,7 @@ function update_number_of_domain_controllers(
         "UpdateNumberOfDomainControllers",
         Dict{String,Any}("DesiredNumber" => DesiredNumber, "DirectoryId" => DirectoryId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_number_of_domain_controllers(
@@ -2542,6 +2688,7 @@ function update_number_of_domain_controllers(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2566,6 +2713,7 @@ function update_radius(
         "UpdateRadius",
         Dict{String,Any}("DirectoryId" => DirectoryId, "RadiusSettings" => RadiusSettings);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_radius(
@@ -2586,6 +2734,7 @@ function update_radius(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2605,7 +2754,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function update_trust(TrustId; aws_config::AbstractAWSConfig=global_aws_config())
     return directory_service(
-        "UpdateTrust", Dict{String,Any}("TrustId" => TrustId); aws_config=aws_config
+        "UpdateTrust",
+        Dict{String,Any}("TrustId" => TrustId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_trust(
@@ -2615,6 +2767,7 @@ function update_trust(
         "UpdateTrust",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("TrustId" => TrustId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2632,7 +2785,10 @@ directory and an external domain.
 """
 function verify_trust(TrustId; aws_config::AbstractAWSConfig=global_aws_config())
     return directory_service(
-        "VerifyTrust", Dict{String,Any}("TrustId" => TrustId); aws_config=aws_config
+        "VerifyTrust",
+        Dict{String,Any}("TrustId" => TrustId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function verify_trust(
@@ -2642,5 +2798,6 @@ function verify_trust(
         "VerifyTrust",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("TrustId" => TrustId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/dlm.jl
+++ b/src/services/dlm.jl
@@ -40,6 +40,7 @@ function create_lifecycle_policy(
             "State" => State,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_lifecycle_policy(
@@ -66,6 +67,7 @@ function create_lifecycle_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -83,14 +85,25 @@ specified.
 function delete_lifecycle_policy(
     policyId; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return dlm("DELETE", "/policies/$(policyId)/"; aws_config=aws_config)
+    return dlm(
+        "DELETE",
+        "/policies/$(policyId)/";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_lifecycle_policy(
     policyId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return dlm("DELETE", "/policies/$(policyId)/", params; aws_config=aws_config)
+    return dlm(
+        "DELETE",
+        "/policies/$(policyId)/",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -111,12 +124,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"targetTags"`: The target tag for a policy. Tags are strings in the format key=value.
 """
 function get_lifecycle_policies(; aws_config::AbstractAWSConfig=global_aws_config())
-    return dlm("GET", "/policies"; aws_config=aws_config)
+    return dlm("GET", "/policies"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function get_lifecycle_policies(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return dlm("GET", "/policies", params; aws_config=aws_config)
+    return dlm(
+        "GET", "/policies", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -130,14 +145,25 @@ Gets detailed information about the specified lifecycle policy.
 
 """
 function get_lifecycle_policy(policyId; aws_config::AbstractAWSConfig=global_aws_config())
-    return dlm("GET", "/policies/$(policyId)/"; aws_config=aws_config)
+    return dlm(
+        "GET",
+        "/policies/$(policyId)/";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_lifecycle_policy(
     policyId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return dlm("GET", "/policies/$(policyId)/", params; aws_config=aws_config)
+    return dlm(
+        "GET",
+        "/policies/$(policyId)/",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -153,14 +179,25 @@ Lists the tags for the specified resource.
 function list_tags_for_resource(
     resourceArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return dlm("GET", "/tags/$(resourceArn)"; aws_config=aws_config)
+    return dlm(
+        "GET",
+        "/tags/$(resourceArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_tags_for_resource(
     resourceArn,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return dlm("GET", "/tags/$(resourceArn)", params; aws_config=aws_config)
+    return dlm(
+        "GET",
+        "/tags/$(resourceArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -180,6 +217,7 @@ function tag_resource(Tags, resourceArn; aws_config::AbstractAWSConfig=global_aw
         "/tags/$(resourceArn)",
         Dict{String,Any}("Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -193,6 +231,7 @@ function tag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Tags" => Tags), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -215,6 +254,7 @@ function untag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}("tagKeys" => tagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -228,6 +268,7 @@ function untag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tagKeys" => tagKeys), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -252,12 +293,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function update_lifecycle_policy(
     policyId; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return dlm("PATCH", "/policies/$(policyId)"; aws_config=aws_config)
+    return dlm(
+        "PATCH",
+        "/policies/$(policyId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function update_lifecycle_policy(
     policyId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return dlm("PATCH", "/policies/$(policyId)", params; aws_config=aws_config)
+    return dlm(
+        "PATCH",
+        "/policies/$(policyId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end

--- a/src/services/docdb.jl
+++ b/src/services/docdb.jl
@@ -29,6 +29,7 @@ function add_source_identifier_to_subscription(
             "SourceIdentifier" => SourceIdentifier, "SubscriptionName" => SubscriptionName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function add_source_identifier_to_subscription(
@@ -50,6 +51,7 @@ function add_source_identifier_to_subscription(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -78,6 +80,7 @@ function add_tags_to_resource(
         "AddTagsToResource",
         Dict{String,Any}("ResourceName" => ResourceName, "Tag" => Tag);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function add_tags_to_resource(
@@ -96,6 +99,7 @@ function add_tags_to_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -132,6 +136,7 @@ function apply_pending_maintenance_action(
             "ResourceIdentifier" => ResourceIdentifier,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function apply_pending_maintenance_action(
@@ -155,6 +160,7 @@ function apply_pending_maintenance_action(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -200,6 +206,7 @@ function copy_dbcluster_parameter_group(
                 TargetDBClusterParameterGroupIdentifier,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function copy_dbcluster_parameter_group(
@@ -226,6 +233,7 @@ function copy_dbcluster_parameter_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -300,6 +308,7 @@ function copy_dbcluster_snapshot(
             "TargetDBClusterSnapshotIdentifier" => TargetDBClusterSnapshotIdentifier,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function copy_dbcluster_snapshot(
@@ -323,6 +332,7 @@ function copy_dbcluster_snapshot(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -401,6 +411,7 @@ function create_dbcluster(
         "CreateDBCluster",
         Dict{String,Any}("DBClusterIdentifier" => DBClusterIdentifier, "Engine" => Engine);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_dbcluster(
@@ -421,6 +432,7 @@ function create_dbcluster(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -464,6 +476,7 @@ function create_dbcluster_parameter_group(
             "Description" => Description,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_dbcluster_parameter_group(
@@ -487,6 +500,7 @@ function create_dbcluster_parameter_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -521,6 +535,7 @@ function create_dbcluster_snapshot(
             "DBClusterSnapshotIdentifier" => DBClusterSnapshotIdentifier,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_dbcluster_snapshot(
@@ -542,6 +557,7 @@ function create_dbcluster_snapshot(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -597,6 +613,7 @@ function create_dbinstance(
             "Engine" => Engine,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_dbinstance(
@@ -622,6 +639,7 @@ function create_dbinstance(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -658,6 +676,7 @@ function create_dbsubnet_group(
             "SubnetIdentifier" => SubnetIdentifier,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_dbsubnet_group(
@@ -681,6 +700,7 @@ function create_dbsubnet_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -740,6 +760,7 @@ function create_event_subscription(
             "SnsTopicArn" => SnsTopicArn, "SubscriptionName" => SubscriptionName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_event_subscription(
@@ -760,6 +781,7 @@ function create_event_subscription(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -799,6 +821,7 @@ function create_global_cluster(
         "CreateGlobalCluster",
         Dict{String,Any}("GlobalClusterIdentifier" => GlobalClusterIdentifier);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_global_cluster(
@@ -816,6 +839,7 @@ function create_global_cluster(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -851,6 +875,7 @@ function delete_dbcluster(
         "DeleteDBCluster",
         Dict{String,Any}("DBClusterIdentifier" => DBClusterIdentifier);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_dbcluster(
@@ -868,6 +893,7 @@ function delete_dbcluster(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -891,6 +917,7 @@ function delete_dbcluster_parameter_group(
         "DeleteDBClusterParameterGroup",
         Dict{String,Any}("DBClusterParameterGroupName" => DBClusterParameterGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_dbcluster_parameter_group(
@@ -910,6 +937,7 @@ function delete_dbcluster_parameter_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -932,6 +960,7 @@ function delete_dbcluster_snapshot(
         "DeleteDBClusterSnapshot",
         Dict{String,Any}("DBClusterSnapshotIdentifier" => DBClusterSnapshotIdentifier);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_dbcluster_snapshot(
@@ -951,6 +980,7 @@ function delete_dbcluster_snapshot(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -973,6 +1003,7 @@ function delete_dbinstance(
         "DeleteDBInstance",
         Dict{String,Any}("DBInstanceIdentifier" => DBInstanceIdentifier);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_dbinstance(
@@ -990,6 +1021,7 @@ function delete_dbinstance(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1013,6 +1045,7 @@ function delete_dbsubnet_group(
         "DeleteDBSubnetGroup",
         Dict{String,Any}("DBSubnetGroupName" => DBSubnetGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_dbsubnet_group(
@@ -1028,6 +1061,7 @@ function delete_dbsubnet_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1049,6 +1083,7 @@ function delete_event_subscription(
         "DeleteEventSubscription",
         Dict{String,Any}("SubscriptionName" => SubscriptionName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_event_subscription(
@@ -1064,6 +1099,7 @@ function delete_event_subscription(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1086,6 +1122,7 @@ function delete_global_cluster(
         "DeleteGlobalCluster",
         Dict{String,Any}("GlobalClusterIdentifier" => GlobalClusterIdentifier);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_global_cluster(
@@ -1103,6 +1140,7 @@ function delete_global_cluster(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1129,12 +1167,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Minimum: 20   Maximum: 100
 """
 function describe_certificates(; aws_config::AbstractAWSConfig=global_aws_config())
-    return docdb("DescribeCertificates"; aws_config=aws_config)
+    return docdb(
+        "DescribeCertificates"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_certificates(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return docdb("DescribeCertificates", params; aws_config=aws_config)
+    return docdb(
+        "DescribeCertificates",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1162,12 +1207,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_dbcluster_parameter_groups(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return docdb("DescribeDBClusterParameterGroups"; aws_config=aws_config)
+    return docdb(
+        "DescribeDBClusterParameterGroups";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_dbcluster_parameter_groups(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return docdb("DescribeDBClusterParameterGroups", params; aws_config=aws_config)
+    return docdb(
+        "DescribeDBClusterParameterGroups",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1201,6 +1255,7 @@ function describe_dbcluster_parameters(
         "DescribeDBClusterParameters",
         Dict{String,Any}("DBClusterParameterGroupName" => DBClusterParameterGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_dbcluster_parameters(
@@ -1220,6 +1275,7 @@ function describe_dbcluster_parameters(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1246,6 +1302,7 @@ function describe_dbcluster_snapshot_attributes(
         "DescribeDBClusterSnapshotAttributes",
         Dict{String,Any}("DBClusterSnapshotIdentifier" => DBClusterSnapshotIdentifier);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_dbcluster_snapshot_attributes(
@@ -1265,6 +1322,7 @@ function describe_dbcluster_snapshot_attributes(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1312,12 +1370,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   The IncludeShared parameter doesn't apply when SnapshotType is set to public.
 """
 function describe_dbcluster_snapshots(; aws_config::AbstractAWSConfig=global_aws_config())
-    return docdb("DescribeDBClusterSnapshots"; aws_config=aws_config)
+    return docdb(
+        "DescribeDBClusterSnapshots"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_dbcluster_snapshots(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return docdb("DescribeDBClusterSnapshots", params; aws_config=aws_config)
+    return docdb(
+        "DescribeDBClusterSnapshots",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1347,12 +1412,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Minimum 20, maximum 100.
 """
 function describe_dbclusters(; aws_config::AbstractAWSConfig=global_aws_config())
-    return docdb("DescribeDBClusters"; aws_config=aws_config)
+    return docdb(
+        "DescribeDBClusters"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_dbclusters(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return docdb("DescribeDBClusters", params; aws_config=aws_config)
+    return docdb(
+        "DescribeDBClusters", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1385,12 +1454,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Minimum 20, maximum 100.
 """
 function describe_dbengine_versions(; aws_config::AbstractAWSConfig=global_aws_config())
-    return docdb("DescribeDBEngineVersions"; aws_config=aws_config)
+    return docdb(
+        "DescribeDBEngineVersions"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_dbengine_versions(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return docdb("DescribeDBEngineVersions", params; aws_config=aws_config)
+    return docdb(
+        "DescribeDBEngineVersions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1421,12 +1497,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Minimum 20, maximum 100.
 """
 function describe_dbinstances(; aws_config::AbstractAWSConfig=global_aws_config())
-    return docdb("DescribeDBInstances"; aws_config=aws_config)
+    return docdb(
+        "DescribeDBInstances"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_dbinstances(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return docdb("DescribeDBInstances", params; aws_config=aws_config)
+    return docdb(
+        "DescribeDBInstances",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1449,12 +1532,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Minimum 20, maximum 100.
 """
 function describe_dbsubnet_groups(; aws_config::AbstractAWSConfig=global_aws_config())
-    return docdb("DescribeDBSubnetGroups"; aws_config=aws_config)
+    return docdb(
+        "DescribeDBSubnetGroups"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_dbsubnet_groups(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return docdb("DescribeDBSubnetGroups", params; aws_config=aws_config)
+    return docdb(
+        "DescribeDBSubnetGroups",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1485,6 +1575,7 @@ function describe_engine_default_cluster_parameters(
         "DescribeEngineDefaultClusterParameters",
         Dict{String,Any}("DBParameterGroupFamily" => DBParameterGroupFamily);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_engine_default_cluster_parameters(
@@ -1502,6 +1593,7 @@ function describe_engine_default_cluster_parameters(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1519,12 +1611,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   db-instance, db-parameter-group, db-security-group
 """
 function describe_event_categories(; aws_config::AbstractAWSConfig=global_aws_config())
-    return docdb("DescribeEventCategories"; aws_config=aws_config)
+    return docdb(
+        "DescribeEventCategories"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_event_categories(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return docdb("DescribeEventCategories", params; aws_config=aws_config)
+    return docdb(
+        "DescribeEventCategories",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1550,12 +1649,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   that you want to describe.
 """
 function describe_event_subscriptions(; aws_config::AbstractAWSConfig=global_aws_config())
-    return docdb("DescribeEventSubscriptions"; aws_config=aws_config)
+    return docdb(
+        "DescribeEventSubscriptions"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_event_subscriptions(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return docdb("DescribeEventSubscriptions", params; aws_config=aws_config)
+    return docdb(
+        "DescribeEventSubscriptions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1596,12 +1702,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   ISO 8601 format.  Example: 2009-07-08T18:00Z
 """
 function describe_events(; aws_config::AbstractAWSConfig=global_aws_config())
-    return docdb("DescribeEvents"; aws_config=aws_config)
+    return docdb("DescribeEvents"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function describe_events(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return docdb("DescribeEvents", params; aws_config=aws_config)
+    return docdb(
+        "DescribeEvents", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1628,12 +1736,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   in the response so that you can retrieve the remaining results.
 """
 function describe_global_clusters(; aws_config::AbstractAWSConfig=global_aws_config())
-    return docdb("DescribeGlobalClusters"; aws_config=aws_config)
+    return docdb(
+        "DescribeGlobalClusters"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_global_clusters(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return docdb("DescribeGlobalClusters", params; aws_config=aws_config)
+    return docdb(
+        "DescribeGlobalClusters",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1671,6 +1786,7 @@ function describe_orderable_dbinstance_options(
         "DescribeOrderableDBInstanceOptions",
         Dict{String,Any}("Engine" => Engine);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_orderable_dbinstance_options(
@@ -1680,6 +1796,7 @@ function describe_orderable_dbinstance_options(
         "DescribeOrderableDBInstanceOptions",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Engine" => Engine), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1710,12 +1827,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_pending_maintenance_actions(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return docdb("DescribePendingMaintenanceActions"; aws_config=aws_config)
+    return docdb(
+        "DescribePendingMaintenanceActions";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_pending_maintenance_actions(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return docdb("DescribePendingMaintenanceActions", params; aws_config=aws_config)
+    return docdb(
+        "DescribePendingMaintenanceActions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1737,12 +1863,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   cluster. For example, mydbcluster-replica1.
 """
 function failover_dbcluster(; aws_config::AbstractAWSConfig=global_aws_config())
-    return docdb("FailoverDBCluster"; aws_config=aws_config)
+    return docdb(
+        "FailoverDBCluster"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function failover_dbcluster(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return docdb("FailoverDBCluster", params; aws_config=aws_config)
+    return docdb(
+        "FailoverDBCluster", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1766,6 +1896,7 @@ function list_tags_for_resource(
         "ListTagsForResource",
         Dict{String,Any}("ResourceName" => ResourceName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags_for_resource(
@@ -1779,6 +1910,7 @@ function list_tags_for_resource(
             mergewith(_merge, Dict{String,Any}("ResourceName" => ResourceName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1850,6 +1982,7 @@ function modify_dbcluster(
         "ModifyDBCluster",
         Dict{String,Any}("DBClusterIdentifier" => DBClusterIdentifier);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_dbcluster(
@@ -1867,6 +2000,7 @@ function modify_dbcluster(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1906,6 +2040,7 @@ function modify_dbcluster_parameter_group(
             "Parameter" => Parameter,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_dbcluster_parameter_group(
@@ -1927,6 +2062,7 @@ function modify_dbcluster_parameter_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1978,6 +2114,7 @@ function modify_dbcluster_snapshot_attribute(
             "DBClusterSnapshotIdentifier" => DBClusterSnapshotIdentifier,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_dbcluster_snapshot_attribute(
@@ -1999,6 +2136,7 @@ function modify_dbcluster_snapshot_attribute(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2056,6 +2194,7 @@ function modify_dbinstance(
         "ModifyDBInstance",
         Dict{String,Any}("DBInstanceIdentifier" => DBInstanceIdentifier);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_dbinstance(
@@ -2073,6 +2212,7 @@ function modify_dbinstance(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2103,6 +2243,7 @@ function modify_dbsubnet_group(
             "DBSubnetGroupName" => DBSubnetGroupName, "SubnetIdentifier" => SubnetIdentifier
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_dbsubnet_group(
@@ -2124,6 +2265,7 @@ function modify_dbsubnet_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2155,6 +2297,7 @@ function modify_event_subscription(
         "ModifyEventSubscription",
         Dict{String,Any}("SubscriptionName" => SubscriptionName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_event_subscription(
@@ -2170,6 +2313,7 @@ function modify_event_subscription(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2203,6 +2347,7 @@ function modify_global_cluster(
         "ModifyGlobalCluster",
         Dict{String,Any}("GlobalClusterIdentifier" => GlobalClusterIdentifier);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_global_cluster(
@@ -2220,6 +2365,7 @@ function modify_global_cluster(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2249,6 +2395,7 @@ function reboot_dbinstance(
         "RebootDBInstance",
         Dict{String,Any}("DBInstanceIdentifier" => DBInstanceIdentifier);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function reboot_dbinstance(
@@ -2266,6 +2413,7 @@ function reboot_dbinstance(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2297,6 +2445,7 @@ function remove_from_global_cluster(
             "GlobalClusterIdentifier" => GlobalClusterIdentifier,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function remove_from_global_cluster(
@@ -2318,6 +2467,7 @@ function remove_from_global_cluster(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2344,6 +2494,7 @@ function remove_source_identifier_from_subscription(
             "SourceIdentifier" => SourceIdentifier, "SubscriptionName" => SubscriptionName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function remove_source_identifier_from_subscription(
@@ -2365,6 +2516,7 @@ function remove_source_identifier_from_subscription(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2387,6 +2539,7 @@ function remove_tags_from_resource(
         "RemoveTagsFromResource",
         Dict{String,Any}("ResourceName" => ResourceName, "TagKeys" => TagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function remove_tags_from_resource(
@@ -2405,6 +2558,7 @@ function remove_tags_from_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2438,6 +2592,7 @@ function reset_dbcluster_parameter_group(
         "ResetDBClusterParameterGroup",
         Dict{String,Any}("DBClusterParameterGroupName" => DBClusterParameterGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function reset_dbcluster_parameter_group(
@@ -2457,6 +2612,7 @@ function reset_dbcluster_parameter_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2526,6 +2682,7 @@ function restore_dbcluster_from_snapshot(
             "SnapshotIdentifier" => SnapshotIdentifier,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function restore_dbcluster_from_snapshot(
@@ -2549,6 +2706,7 @@ function restore_dbcluster_from_snapshot(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2616,6 +2774,7 @@ function restore_dbcluster_to_point_in_time(
             "SourceDBClusterIdentifier" => SourceDBClusterIdentifier,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function restore_dbcluster_to_point_in_time(
@@ -2637,6 +2796,7 @@ function restore_dbcluster_to_point_in_time(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2659,6 +2819,7 @@ function start_dbcluster(
         "StartDBCluster",
         Dict{String,Any}("DBClusterIdentifier" => DBClusterIdentifier);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_dbcluster(
@@ -2676,6 +2837,7 @@ function start_dbcluster(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2699,6 +2861,7 @@ function stop_dbcluster(
         "StopDBCluster",
         Dict{String,Any}("DBClusterIdentifier" => DBClusterIdentifier);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function stop_dbcluster(
@@ -2716,5 +2879,6 @@ function stop_dbcluster(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/dynamodb.jl
+++ b/src/services/dynamodb.jl
@@ -22,6 +22,7 @@ function batch_execute_statement(
         "BatchExecuteStatement",
         Dict{String,Any}("Statements" => Statements);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_execute_statement(
@@ -35,6 +36,7 @@ function batch_execute_statement(
             mergewith(_merge, Dict{String,Any}("Statements" => Statements), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -116,6 +118,7 @@ function batch_get_item(RequestItems; aws_config::AbstractAWSConfig=global_aws_c
         "BatchGetItem",
         Dict{String,Any}("RequestItems" => RequestItems);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_get_item(
@@ -129,6 +132,7 @@ function batch_get_item(
             mergewith(_merge, Dict{String,Any}("RequestItems" => RequestItems), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -210,6 +214,7 @@ function batch_write_item(RequestItems; aws_config::AbstractAWSConfig=global_aws
         "BatchWriteItem",
         Dict{String,Any}("RequestItems" => RequestItems);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_write_item(
@@ -223,6 +228,7 @@ function batch_write_item(
             mergewith(_merge, Dict{String,Any}("RequestItems" => RequestItems), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -257,6 +263,7 @@ function create_backup(
         "CreateBackup",
         Dict{String,Any}("BackupName" => BackupName, "TableName" => TableName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_backup(
@@ -275,6 +282,7 @@ function create_backup(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -316,6 +324,7 @@ function create_global_table(
             "GlobalTableName" => GlobalTableName, "ReplicationGroup" => ReplicationGroup
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_global_table(
@@ -337,6 +346,7 @@ function create_global_table(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -451,6 +461,7 @@ function create_table(
             "TableName" => TableName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_table(
@@ -474,6 +485,7 @@ function create_table(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -490,7 +502,10 @@ times per second.
 """
 function delete_backup(BackupArn; aws_config::AbstractAWSConfig=global_aws_config())
     return dynamodb(
-        "DeleteBackup", Dict{String,Any}("BackupArn" => BackupArn); aws_config=aws_config
+        "DeleteBackup",
+        Dict{String,Any}("BackupArn" => BackupArn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_backup(
@@ -504,6 +519,7 @@ function delete_backup(
             mergewith(_merge, Dict{String,Any}("BackupArn" => BackupArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -582,6 +598,7 @@ function delete_item(Key, TableName; aws_config::AbstractAWSConfig=global_aws_co
         "DeleteItem",
         Dict{String,Any}("Key" => Key, "TableName" => TableName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_item(
@@ -598,6 +615,7 @@ function delete_item(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -623,7 +641,10 @@ on that table goes into the DISABLED state, and the stream is automatically dele
 """
 function delete_table(TableName; aws_config::AbstractAWSConfig=global_aws_config())
     return dynamodb(
-        "DeleteTable", Dict{String,Any}("TableName" => TableName); aws_config=aws_config
+        "DeleteTable",
+        Dict{String,Any}("TableName" => TableName);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_table(
@@ -637,6 +658,7 @@ function delete_table(
             mergewith(_merge, Dict{String,Any}("TableName" => TableName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -653,7 +675,10 @@ Describes an existing backup of a table. You can call DescribeBackup at a maximu
 """
 function describe_backup(BackupArn; aws_config::AbstractAWSConfig=global_aws_config())
     return dynamodb(
-        "DescribeBackup", Dict{String,Any}("BackupArn" => BackupArn); aws_config=aws_config
+        "DescribeBackup",
+        Dict{String,Any}("BackupArn" => BackupArn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_backup(
@@ -667,6 +692,7 @@ function describe_backup(
             mergewith(_merge, Dict{String,Any}("BackupArn" => BackupArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -695,6 +721,7 @@ function describe_continuous_backups(
         "DescribeContinuousBackups",
         Dict{String,Any}("TableName" => TableName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_continuous_backups(
@@ -708,6 +735,7 @@ function describe_continuous_backups(
             mergewith(_merge, Dict{String,Any}("TableName" => TableName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -731,6 +759,7 @@ function describe_contributor_insights(
         "DescribeContributorInsights",
         Dict{String,Any}("TableName" => TableName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_contributor_insights(
@@ -744,6 +773,7 @@ function describe_contributor_insights(
             mergewith(_merge, Dict{String,Any}("TableName" => TableName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -755,12 +785,16 @@ Returns the regional endpoint information.
 
 """
 function describe_endpoints(; aws_config::AbstractAWSConfig=global_aws_config())
-    return dynamodb("DescribeEndpoints"; aws_config=aws_config)
+    return dynamodb(
+        "DescribeEndpoints"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_endpoints(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return dynamodb("DescribeEndpoints", params; aws_config=aws_config)
+    return dynamodb(
+        "DescribeEndpoints", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -775,7 +809,10 @@ Describes an existing table export.
 """
 function describe_export(ExportArn; aws_config::AbstractAWSConfig=global_aws_config())
     return dynamodb(
-        "DescribeExport", Dict{String,Any}("ExportArn" => ExportArn); aws_config=aws_config
+        "DescribeExport",
+        Dict{String,Any}("ExportArn" => ExportArn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_export(
@@ -789,6 +826,7 @@ function describe_export(
             mergewith(_merge, Dict{String,Any}("ExportArn" => ExportArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -811,6 +849,7 @@ function describe_global_table(
         "DescribeGlobalTable",
         Dict{String,Any}("GlobalTableName" => GlobalTableName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_global_table(
@@ -826,6 +865,7 @@ function describe_global_table(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -847,6 +887,7 @@ function describe_global_table_settings(
         "DescribeGlobalTableSettings",
         Dict{String,Any}("GlobalTableName" => GlobalTableName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_global_table_settings(
@@ -862,6 +903,7 @@ function describe_global_table_settings(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -882,6 +924,7 @@ function describe_kinesis_streaming_destination(
         "DescribeKinesisStreamingDestination",
         Dict{String,Any}("TableName" => TableName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_kinesis_streaming_destination(
@@ -895,6 +938,7 @@ function describe_kinesis_streaming_destination(
             mergewith(_merge, Dict{String,Any}("TableName" => TableName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -935,12 +979,16 @@ no content.
 
 """
 function describe_limits(; aws_config::AbstractAWSConfig=global_aws_config())
-    return dynamodb("DescribeLimits"; aws_config=aws_config)
+    return dynamodb(
+        "DescribeLimits"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_limits(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return dynamodb("DescribeLimits", params; aws_config=aws_config)
+    return dynamodb(
+        "DescribeLimits", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -960,7 +1008,10 @@ few seconds, and then try the DescribeTable request again.
 """
 function describe_table(TableName; aws_config::AbstractAWSConfig=global_aws_config())
     return dynamodb(
-        "DescribeTable", Dict{String,Any}("TableName" => TableName); aws_config=aws_config
+        "DescribeTable",
+        Dict{String,Any}("TableName" => TableName);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_table(
@@ -974,6 +1025,7 @@ function describe_table(
             mergewith(_merge, Dict{String,Any}("TableName" => TableName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -995,6 +1047,7 @@ function describe_table_replica_auto_scaling(
         "DescribeTableReplicaAutoScaling",
         Dict{String,Any}("TableName" => TableName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_table_replica_auto_scaling(
@@ -1008,6 +1061,7 @@ function describe_table_replica_auto_scaling(
             mergewith(_merge, Dict{String,Any}("TableName" => TableName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1026,6 +1080,7 @@ function describe_time_to_live(TableName; aws_config::AbstractAWSConfig=global_a
         "DescribeTimeToLive",
         Dict{String,Any}("TableName" => TableName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_time_to_live(
@@ -1039,6 +1094,7 @@ function describe_time_to_live(
             mergewith(_merge, Dict{String,Any}("TableName" => TableName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1061,6 +1117,7 @@ function disable_kinesis_streaming_destination(
         "DisableKinesisStreamingDestination",
         Dict{String,Any}("StreamArn" => StreamArn, "TableName" => TableName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disable_kinesis_streaming_destination(
@@ -1079,6 +1136,7 @@ function disable_kinesis_streaming_destination(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1103,6 +1161,7 @@ function enable_kinesis_streaming_destination(
         "EnableKinesisStreamingDestination",
         Dict{String,Any}("StreamArn" => StreamArn, "TableName" => TableName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function enable_kinesis_streaming_destination(
@@ -1121,6 +1180,7 @@ function enable_kinesis_streaming_destination(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1147,6 +1207,7 @@ function execute_statement(Statement; aws_config::AbstractAWSConfig=global_aws_c
         "ExecuteStatement",
         Dict{String,Any}("Statement" => Statement);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function execute_statement(
@@ -1160,6 +1221,7 @@ function execute_statement(
             mergewith(_merge, Dict{String,Any}("Statement" => Statement), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1189,6 +1251,7 @@ function execute_transaction(
             "ClientRequestToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function execute_transaction(
@@ -1209,6 +1272,7 @@ function execute_transaction(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1256,6 +1320,7 @@ function export_table_to_point_in_time(
             "S3Bucket" => S3Bucket, "TableArn" => TableArn, "ClientToken" => string(uuid4())
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function export_table_to_point_in_time(
@@ -1278,6 +1343,7 @@ function export_table_to_point_in_time(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1335,6 +1401,7 @@ function get_item(Key, TableName; aws_config::AbstractAWSConfig=global_aws_confi
         "GetItem",
         Dict{String,Any}("Key" => Key, "TableName" => TableName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_item(
@@ -1351,6 +1418,7 @@ function get_item(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1383,12 +1451,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   TimeRangeUpperBound is exclusive.
 """
 function list_backups(; aws_config::AbstractAWSConfig=global_aws_config())
-    return dynamodb("ListBackups"; aws_config=aws_config)
+    return dynamodb("ListBackups"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_backups(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return dynamodb("ListBackups", params; aws_config=aws_config)
+    return dynamodb(
+        "ListBackups", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1405,12 +1475,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"TableName"`: The name of the table.
 """
 function list_contributor_insights(; aws_config::AbstractAWSConfig=global_aws_config())
-    return dynamodb("ListContributorInsights"; aws_config=aws_config)
+    return dynamodb(
+        "ListContributorInsights"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_contributor_insights(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return dynamodb("ListContributorInsights", params; aws_config=aws_config)
+    return dynamodb(
+        "ListContributorInsights",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1428,12 +1505,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"TableArn"`: The Amazon Resource Name (ARN) associated with the exported table.
 """
 function list_exports(; aws_config::AbstractAWSConfig=global_aws_config())
-    return dynamodb("ListExports"; aws_config=aws_config)
+    return dynamodb("ListExports"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_exports(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return dynamodb("ListExports", params; aws_config=aws_config)
+    return dynamodb(
+        "ListExports", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1455,12 +1534,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"RegionName"`: Lists the global tables in a specific Region.
 """
 function list_global_tables(; aws_config::AbstractAWSConfig=global_aws_config())
-    return dynamodb("ListGlobalTables"; aws_config=aws_config)
+    return dynamodb(
+        "ListGlobalTables"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_global_tables(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return dynamodb("ListGlobalTables", params; aws_config=aws_config)
+    return dynamodb(
+        "ListGlobalTables", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1479,12 +1562,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   the limit is 100.
 """
 function list_tables(; aws_config::AbstractAWSConfig=global_aws_config())
-    return dynamodb("ListTables"; aws_config=aws_config)
+    return dynamodb("ListTables"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_tables(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return dynamodb("ListTables", params; aws_config=aws_config)
+    return dynamodb(
+        "ListTables", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1512,6 +1597,7 @@ function list_tags_of_resource(
         "ListTagsOfResource",
         Dict{String,Any}("ResourceArn" => ResourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags_of_resource(
@@ -1525,6 +1611,7 @@ function list_tags_of_resource(
             mergewith(_merge, Dict{String,Any}("ResourceArn" => ResourceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1624,6 +1711,7 @@ function put_item(Item, TableName; aws_config::AbstractAWSConfig=global_aws_conf
         "PutItem",
         Dict{String,Any}("Item" => Item, "TableName" => TableName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_item(
@@ -1640,6 +1728,7 @@ function put_item(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1819,7 +1908,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function query(TableName; aws_config::AbstractAWSConfig=global_aws_config())
     return dynamodb(
-        "Query", Dict{String,Any}("TableName" => TableName); aws_config=aws_config
+        "Query",
+        Dict{String,Any}("TableName" => TableName);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function query(
@@ -1833,6 +1925,7 @@ function query(
             mergewith(_merge, Dict{String,Any}("TableName" => TableName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1870,6 +1963,7 @@ function restore_table_from_backup(
         "RestoreTableFromBackup",
         Dict{String,Any}("BackupArn" => BackupArn, "TargetTableName" => TargetTableName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function restore_table_from_backup(
@@ -1890,6 +1984,7 @@ function restore_table_from_backup(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1939,6 +2034,7 @@ function restore_table_to_point_in_time(
         "RestoreTableToPointInTime",
         Dict{String,Any}("TargetTableName" => TargetTableName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function restore_table_to_point_in_time(
@@ -1954,6 +2050,7 @@ function restore_table_to_point_in_time(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2098,7 +2195,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function scan(TableName; aws_config::AbstractAWSConfig=global_aws_config())
     return dynamodb(
-        "Scan", Dict{String,Any}("TableName" => TableName); aws_config=aws_config
+        "Scan",
+        Dict{String,Any}("TableName" => TableName);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function scan(
@@ -2112,6 +2212,7 @@ function scan(
             mergewith(_merge, Dict{String,Any}("TableName" => TableName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2136,6 +2237,7 @@ function tag_resource(ResourceArn, Tags; aws_config::AbstractAWSConfig=global_aw
         "TagResource",
         Dict{String,Any}("ResourceArn" => ResourceArn, "Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -2154,6 +2256,7 @@ function tag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2190,6 +2293,7 @@ function transact_get_items(
         "TransactGetItems",
         Dict{String,Any}("TransactItems" => TransactItems);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function transact_get_items(
@@ -2203,6 +2307,7 @@ function transact_get_items(
             mergewith(_merge, Dict{String,Any}("TransactItems" => TransactItems), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2278,6 +2383,7 @@ function transact_write_items(
             "TransactItems" => TransactItems, "ClientRequestToken" => string(uuid4())
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function transact_write_items(
@@ -2298,6 +2404,7 @@ function transact_write_items(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2323,6 +2430,7 @@ function untag_resource(
         "UntagResource",
         Dict{String,Any}("ResourceArn" => ResourceArn, "TagKeys" => TagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -2341,6 +2449,7 @@ function untag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2375,6 +2484,7 @@ function update_continuous_backups(
             "TableName" => TableName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_continuous_backups(
@@ -2396,6 +2506,7 @@ function update_continuous_backups(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2423,6 +2534,7 @@ function update_contributor_insights(
             "TableName" => TableName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_contributor_insights(
@@ -2444,6 +2556,7 @@ function update_contributor_insights(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2477,6 +2590,7 @@ function update_global_table(
             "GlobalTableName" => GlobalTableName, "ReplicaUpdates" => ReplicaUpdates
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_global_table(
@@ -2497,6 +2611,7 @@ function update_global_table(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2533,6 +2648,7 @@ function update_global_table_settings(
         "UpdateGlobalTableSettings",
         Dict{String,Any}("GlobalTableName" => GlobalTableName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_global_table_settings(
@@ -2548,6 +2664,7 @@ function update_global_table_settings(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2671,6 +2788,7 @@ function update_item(Key, TableName; aws_config::AbstractAWSConfig=global_aws_co
         "UpdateItem",
         Dict{String,Any}("Key" => Key, "TableName" => TableName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_item(
@@ -2687,6 +2805,7 @@ function update_item(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2738,7 +2857,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function update_table(TableName; aws_config::AbstractAWSConfig=global_aws_config())
     return dynamodb(
-        "UpdateTable", Dict{String,Any}("TableName" => TableName); aws_config=aws_config
+        "UpdateTable",
+        Dict{String,Any}("TableName" => TableName);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_table(
@@ -2752,6 +2874,7 @@ function update_table(
             mergewith(_merge, Dict{String,Any}("TableName" => TableName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2780,6 +2903,7 @@ function update_table_replica_auto_scaling(
         "UpdateTableReplicaAutoScaling",
         Dict{String,Any}("TableName" => TableName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_table_replica_auto_scaling(
@@ -2793,6 +2917,7 @@ function update_table_replica_auto_scaling(
             mergewith(_merge, Dict{String,Any}("TableName" => TableName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2832,6 +2957,7 @@ function update_time_to_live(
             "TableName" => TableName, "TimeToLiveSpecification" => TimeToLiveSpecification
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_time_to_live(
@@ -2853,5 +2979,6 @@ function update_time_to_live(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/dynamodb_streams.jl
+++ b/src/services/dynamodb_streams.jl
@@ -28,7 +28,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function describe_stream(StreamArn; aws_config::AbstractAWSConfig=global_aws_config())
     return dynamodb_streams(
-        "DescribeStream", Dict{String,Any}("StreamArn" => StreamArn); aws_config=aws_config
+        "DescribeStream",
+        Dict{String,Any}("StreamArn" => StreamArn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_stream(
@@ -42,6 +45,7 @@ function describe_stream(
             mergewith(_merge, Dict{String,Any}("StreamArn" => StreamArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -71,6 +75,7 @@ function get_records(ShardIterator; aws_config::AbstractAWSConfig=global_aws_con
         "GetRecords",
         Dict{String,Any}("ShardIterator" => ShardIterator);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_records(
@@ -84,6 +89,7 @@ function get_records(
             mergewith(_merge, Dict{String,Any}("ShardIterator" => ShardIterator), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -125,6 +131,7 @@ function get_shard_iterator(
             "StreamArn" => StreamArn,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_shard_iterator(
@@ -148,6 +155,7 @@ function get_shard_iterator(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -169,10 +177,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   table name are returned.
 """
 function list_streams(; aws_config::AbstractAWSConfig=global_aws_config())
-    return dynamodb_streams("ListStreams"; aws_config=aws_config)
+    return dynamodb_streams(
+        "ListStreams"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_streams(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return dynamodb_streams("ListStreams", params; aws_config=aws_config)
+    return dynamodb_streams(
+        "ListStreams", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end

--- a/src/services/ebs.jl
+++ b/src/services/ebs.jl
@@ -39,6 +39,7 @@ function complete_snapshot(
                 Dict{String,Any}("x-amz-ChangedBlocksCount" => x_amz_ChangedBlocksCount),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function complete_snapshot(
@@ -62,6 +63,7 @@ function complete_snapshot(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -87,6 +89,7 @@ function get_snapshot_block(
         "/snapshots/$(snapshotId)/blocks/$(blockIndex)",
         Dict{String,Any}("blockToken" => blockToken);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_snapshot_block(
@@ -103,6 +106,7 @@ function get_snapshot_block(
             mergewith(_merge, Dict{String,Any}("blockToken" => blockToken), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -132,7 +136,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function list_changed_blocks(
     secondSnapshotId; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ebs("GET", "/snapshots/$(secondSnapshotId)/changedblocks"; aws_config=aws_config)
+    return ebs(
+        "GET",
+        "/snapshots/$(secondSnapshotId)/changedblocks";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_changed_blocks(
     secondSnapshotId,
@@ -140,7 +149,11 @@ function list_changed_blocks(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return ebs(
-        "GET", "/snapshots/$(secondSnapshotId)/changedblocks", params; aws_config=aws_config
+        "GET",
+        "/snapshots/$(secondSnapshotId)/changedblocks",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -161,14 +174,25 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   response will start from this block index or the next valid block index in the snapshot.
 """
 function list_snapshot_blocks(snapshotId; aws_config::AbstractAWSConfig=global_aws_config())
-    return ebs("GET", "/snapshots/$(snapshotId)/blocks"; aws_config=aws_config)
+    return ebs(
+        "GET",
+        "/snapshots/$(snapshotId)/blocks";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_snapshot_blocks(
     snapshotId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return ebs("GET", "/snapshots/$(snapshotId)/blocks", params; aws_config=aws_config)
+    return ebs(
+        "GET",
+        "/snapshots/$(snapshotId)/blocks",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -226,6 +250,7 @@ function put_snapshot_block(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_snapshot_block(
@@ -256,6 +281,7 @@ function put_snapshot_block(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -312,6 +338,7 @@ function start_snapshot(VolumeSize; aws_config::AbstractAWSConfig=global_aws_con
         "/snapshots",
         Dict{String,Any}("VolumeSize" => VolumeSize, "ClientToken" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_snapshot(
@@ -332,5 +359,6 @@ function start_snapshot(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/ec2.jl
+++ b/src/services/ec2.jl
@@ -30,6 +30,7 @@ function accept_reserved_instances_exchange_quote(
         "AcceptReservedInstancesExchangeQuote",
         Dict{String,Any}("ReservedInstanceId" => ReservedInstanceId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function accept_reserved_instances_exchange_quote(
@@ -45,6 +46,7 @@ function accept_reserved_instances_exchange_quote(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -67,13 +69,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function accept_transit_gateway_multicast_domain_associations(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("AcceptTransitGatewayMulticastDomainAssociations"; aws_config=aws_config)
+    return ec2(
+        "AcceptTransitGatewayMulticastDomainAssociations";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function accept_transit_gateway_multicast_domain_associations(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return ec2(
-        "AcceptTransitGatewayMulticastDomainAssociations", params; aws_config=aws_config
+        "AcceptTransitGatewayMulticastDomainAssociations",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -100,6 +109,7 @@ function accept_transit_gateway_peering_attachment(
         "AcceptTransitGatewayPeeringAttachment",
         Dict{String,Any}("TransitGatewayAttachmentId" => TransitGatewayAttachmentId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function accept_transit_gateway_peering_attachment(
@@ -119,6 +129,7 @@ function accept_transit_gateway_peering_attachment(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -147,6 +158,7 @@ function accept_transit_gateway_vpc_attachment(
         "AcceptTransitGatewayVpcAttachment",
         Dict{String,Any}("TransitGatewayAttachmentId" => TransitGatewayAttachmentId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function accept_transit_gateway_vpc_attachment(
@@ -166,6 +178,7 @@ function accept_transit_gateway_vpc_attachment(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -192,6 +205,7 @@ function accept_vpc_endpoint_connections(
         "AcceptVpcEndpointConnections",
         Dict{String,Any}("ServiceId" => ServiceId, "VpcEndpointId" => VpcEndpointId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function accept_vpc_endpoint_connections(
@@ -212,6 +226,7 @@ function accept_vpc_endpoint_connections(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -234,12 +249,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   parameter in the request.
 """
 function accept_vpc_peering_connection(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("AcceptVpcPeeringConnection"; aws_config=aws_config)
+    return ec2(
+        "AcceptVpcPeeringConnection"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function accept_vpc_peering_connection(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("AcceptVpcPeeringConnection", params; aws_config=aws_config)
+    return ec2(
+        "AcceptVpcPeeringConnection",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -269,7 +291,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function advertise_byoip_cidr(Cidr; aws_config::AbstractAWSConfig=global_aws_config())
     return ec2(
-        "AdvertiseByoipCidr", Dict{String,Any}("Cidr" => Cidr); aws_config=aws_config
+        "AdvertiseByoipCidr",
+        Dict{String,Any}("Cidr" => Cidr);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function advertise_byoip_cidr(
@@ -279,6 +304,7 @@ function advertise_byoip_cidr(
         "AdvertiseByoipCidr",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Cidr" => Cidr), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -330,12 +356,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   permissions, the error response is DryRunOperation. Otherwise, it is UnauthorizedOperation.
 """
 function allocate_address(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("AllocateAddress"; aws_config=aws_config)
+    return ec2("AllocateAddress"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function allocate_address(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("AllocateAddress", params; aws_config=aws_config)
+    return ec2(
+        "AllocateAddress", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -381,6 +409,7 @@ function allocate_hosts(
         "AllocateHosts",
         Dict{String,Any}("availabilityZone" => availabilityZone, "quantity" => quantity);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function allocate_hosts(
@@ -401,6 +430,7 @@ function allocate_hosts(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -438,6 +468,7 @@ function apply_security_groups_to_client_vpn_target_network(
             "VpcId" => VpcId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function apply_security_groups_to_client_vpn_target_network(
@@ -461,6 +492,7 @@ function apply_security_groups_to_client_vpn_target_network(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -504,6 +536,7 @@ function assign_ipv6_addresses(
         "AssignIpv6Addresses",
         Dict{String,Any}("networkInterfaceId" => networkInterfaceId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function assign_ipv6_addresses(
@@ -519,6 +552,7 @@ function assign_ipv6_addresses(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -571,6 +605,7 @@ function assign_private_ip_addresses(
         "AssignPrivateIpAddresses",
         Dict{String,Any}("networkInterfaceId" => networkInterfaceId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function assign_private_ip_addresses(
@@ -586,6 +621,7 @@ function assign_private_ip_addresses(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -640,12 +676,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   is associated with the primary private IP address.
 """
 function associate_address(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("AssociateAddress"; aws_config=aws_config)
+    return ec2("AssociateAddress"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function associate_address(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("AssociateAddress", params; aws_config=aws_config)
+    return ec2(
+        "AssociateAddress", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -684,6 +722,7 @@ function associate_client_vpn_target_network(
             "ClientToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_client_vpn_target_network(
@@ -706,6 +745,7 @@ function associate_client_vpn_target_network(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -739,6 +779,7 @@ function associate_dhcp_options(
         "AssociateDhcpOptions",
         Dict{String,Any}("DhcpOptionsId" => DhcpOptionsId, "VpcId" => VpcId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_dhcp_options(
@@ -757,6 +798,7 @@ function associate_dhcp_options(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -790,12 +832,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function associate_enclave_certificate_iam_role(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("AssociateEnclaveCertificateIamRole"; aws_config=aws_config)
+    return ec2(
+        "AssociateEnclaveCertificateIamRole";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function associate_enclave_certificate_iam_role(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("AssociateEnclaveCertificateIamRole", params; aws_config=aws_config)
+    return ec2(
+        "AssociateEnclaveCertificateIamRole",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -819,6 +870,7 @@ function associate_iam_instance_profile(
             "IamInstanceProfile" => IamInstanceProfile, "InstanceId" => InstanceId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_iam_instance_profile(
@@ -839,6 +891,7 @@ function associate_iam_instance_profile(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -872,6 +925,7 @@ function associate_instance_event_window(
             "InstanceEventWindowId" => InstanceEventWindowId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_instance_event_window(
@@ -893,6 +947,7 @@ function associate_instance_event_window(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -925,6 +980,7 @@ function associate_route_table(
         "AssociateRouteTable",
         Dict{String,Any}("routeTableId" => routeTableId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_route_table(
@@ -938,6 +994,7 @@ function associate_route_table(
             mergewith(_merge, Dict{String,Any}("routeTableId" => routeTableId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -961,6 +1018,7 @@ function associate_subnet_cidr_block(
         "AssociateSubnetCidrBlock",
         Dict{String,Any}("ipv6CidrBlock" => ipv6CidrBlock, "subnetId" => subnetId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_subnet_cidr_block(
@@ -979,6 +1037,7 @@ function associate_subnet_cidr_block(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1005,12 +1064,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function associate_transit_gateway_multicast_domain(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("AssociateTransitGatewayMulticastDomain"; aws_config=aws_config)
+    return ec2(
+        "AssociateTransitGatewayMulticastDomain";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function associate_transit_gateway_multicast_domain(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("AssociateTransitGatewayMulticastDomain", params; aws_config=aws_config)
+    return ec2(
+        "AssociateTransitGatewayMulticastDomain",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1042,6 +1110,7 @@ function associate_transit_gateway_route_table(
             "TransitGatewayRouteTableId" => TransitGatewayRouteTableId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_transit_gateway_route_table(
@@ -1063,6 +1132,7 @@ function associate_transit_gateway_route_table(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1101,6 +1171,7 @@ function associate_trunk_interface(
             "ClientToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_trunk_interface(
@@ -1123,6 +1194,7 @@ function associate_trunk_interface(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1158,7 +1230,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function associate_vpc_cidr_block(vpcId; aws_config::AbstractAWSConfig=global_aws_config())
     return ec2(
-        "AssociateVpcCidrBlock", Dict{String,Any}("vpcId" => vpcId); aws_config=aws_config
+        "AssociateVpcCidrBlock",
+        Dict{String,Any}("vpcId" => vpcId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_vpc_cidr_block(
@@ -1168,6 +1243,7 @@ function associate_vpc_cidr_block(
         "AssociateVpcCidrBlock",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("vpcId" => vpcId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1207,6 +1283,7 @@ function attach_classic_link_vpc(
             "vpcId" => vpcId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function attach_classic_link_vpc(
@@ -1230,6 +1307,7 @@ function attach_classic_link_vpc(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1258,6 +1336,7 @@ function attach_internet_gateway(
         "AttachInternetGateway",
         Dict{String,Any}("internetGatewayId" => internetGatewayId, "vpcId" => vpcId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function attach_internet_gateway(
@@ -1278,6 +1357,7 @@ function attach_internet_gateway(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1315,6 +1395,7 @@ function attach_network_interface(
             "networkInterfaceId" => networkInterfaceId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function attach_network_interface(
@@ -1338,6 +1419,7 @@ function attach_network_interface(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1379,6 +1461,7 @@ function attach_volume(
             "Device" => Device, "InstanceId" => InstanceId, "VolumeId" => VolumeId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function attach_volume(
@@ -1400,6 +1483,7 @@ function attach_volume(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1428,6 +1512,7 @@ function attach_vpn_gateway(
         "AttachVpnGateway",
         Dict{String,Any}("VpcId" => VpcId, "VpnGatewayId" => VpnGatewayId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function attach_vpn_gateway(
@@ -1446,6 +1531,7 @@ function attach_vpn_gateway(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1491,6 +1577,7 @@ function authorize_client_vpn_ingress(
             "ClientToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function authorize_client_vpn_ingress(
@@ -1513,6 +1600,7 @@ function authorize_client_vpn_ingress(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1558,6 +1646,7 @@ function authorize_security_group_egress(
         "AuthorizeSecurityGroupEgress",
         Dict{String,Any}("groupId" => groupId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function authorize_security_group_egress(
@@ -1567,6 +1656,7 @@ function authorize_security_group_egress(
         "AuthorizeSecurityGroupEgress",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("groupId" => groupId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1628,12 +1718,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function authorize_security_group_ingress(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("AuthorizeSecurityGroupIngress"; aws_config=aws_config)
+    return ec2(
+        "AuthorizeSecurityGroupIngress";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function authorize_security_group_ingress(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("AuthorizeSecurityGroupIngress", params; aws_config=aws_config)
+    return ec2(
+        "AuthorizeSecurityGroupIngress",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1664,6 +1763,7 @@ function bundle_instance(
         "BundleInstance",
         Dict{String,Any}("InstanceId" => InstanceId, "Storage" => Storage);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function bundle_instance(
@@ -1682,6 +1782,7 @@ function bundle_instance(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1702,7 +1803,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function cancel_bundle_task(BundleId; aws_config::AbstractAWSConfig=global_aws_config())
     return ec2(
-        "CancelBundleTask", Dict{String,Any}("BundleId" => BundleId); aws_config=aws_config
+        "CancelBundleTask",
+        Dict{String,Any}("BundleId" => BundleId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function cancel_bundle_task(
@@ -1716,6 +1820,7 @@ function cancel_bundle_task(
             mergewith(_merge, Dict{String,Any}("BundleId" => BundleId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1746,6 +1851,7 @@ function cancel_capacity_reservation(
         "CancelCapacityReservation",
         Dict{String,Any}("CapacityReservationId" => CapacityReservationId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function cancel_capacity_reservation(
@@ -1763,6 +1869,7 @@ function cancel_capacity_reservation(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1793,6 +1900,7 @@ function cancel_conversion_task(
         "CancelConversionTask",
         Dict{String,Any}("conversionTaskId" => conversionTaskId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function cancel_conversion_task(
@@ -1808,6 +1916,7 @@ function cancel_conversion_task(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1829,6 +1938,7 @@ function cancel_export_task(exportTaskId; aws_config::AbstractAWSConfig=global_a
         "CancelExportTask",
         Dict{String,Any}("exportTaskId" => exportTaskId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function cancel_export_task(
@@ -1842,6 +1952,7 @@ function cancel_export_task(
             mergewith(_merge, Dict{String,Any}("exportTaskId" => exportTaskId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1860,12 +1971,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"ImportTaskId"`: The ID of the import image or import snapshot task to be canceled.
 """
 function cancel_import_task(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("CancelImportTask"; aws_config=aws_config)
+    return ec2("CancelImportTask"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function cancel_import_task(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("CancelImportTask", params; aws_config=aws_config)
+    return ec2(
+        "CancelImportTask", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1886,6 +1999,7 @@ function cancel_reserved_instances_listing(
         "CancelReservedInstancesListing",
         Dict{String,Any}("reservedInstancesListingId" => reservedInstancesListingId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function cancel_reserved_instances_listing(
@@ -1905,6 +2019,7 @@ function cancel_reserved_instances_listing(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1942,6 +2057,7 @@ function cancel_spot_fleet_requests(
             "terminateInstances" => terminateInstances,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function cancel_spot_fleet_requests(
@@ -1963,6 +2079,7 @@ function cancel_spot_fleet_requests(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1989,6 +2106,7 @@ function cancel_spot_instance_requests(
         "CancelSpotInstanceRequests",
         Dict{String,Any}("SpotInstanceRequestId" => SpotInstanceRequestId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function cancel_spot_instance_requests(
@@ -2006,6 +2124,7 @@ function cancel_spot_instance_requests(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2034,6 +2153,7 @@ function confirm_product_instance(
         "ConfirmProductInstance",
         Dict{String,Any}("InstanceId" => InstanceId, "ProductCode" => ProductCode);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function confirm_product_instance(
@@ -2052,6 +2172,7 @@ function confirm_product_instance(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2084,6 +2205,7 @@ function copy_fpga_image(
             "SourceFpgaImageId" => SourceFpgaImageId, "SourceRegion" => SourceRegion
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function copy_fpga_image(
@@ -2104,6 +2226,7 @@ function copy_fpga_image(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2173,6 +2296,7 @@ function copy_image(
             "Name" => Name, "SourceImageId" => SourceImageId, "SourceRegion" => SourceRegion
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function copy_image(
@@ -2196,6 +2320,7 @@ function copy_image(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2279,6 +2404,7 @@ function copy_snapshot(
             "SourceRegion" => SourceRegion, "SourceSnapshotId" => SourceSnapshotId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function copy_snapshot(
@@ -2299,6 +2425,7 @@ function copy_snapshot(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2392,6 +2519,7 @@ function create_capacity_reservation(
             "InstanceType" => InstanceType,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_capacity_reservation(
@@ -2415,6 +2543,7 @@ function create_capacity_reservation(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2442,6 +2571,7 @@ function create_carrier_gateway(VpcId; aws_config::AbstractAWSConfig=global_aws_
         "CreateCarrierGateway",
         Dict{String,Any}("VpcId" => VpcId, "ClientToken" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_carrier_gateway(
@@ -2457,6 +2587,7 @@ function create_carrier_gateway(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2529,6 +2660,7 @@ function create_client_vpn_endpoint(
             "ClientToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_client_vpn_endpoint(
@@ -2555,6 +2687,7 @@ function create_client_vpn_endpoint(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2601,6 +2734,7 @@ function create_client_vpn_route(
             "ClientToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_client_vpn_route(
@@ -2625,6 +2759,7 @@ function create_client_vpn_route(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2672,6 +2807,7 @@ function create_customer_gateway(
         "CreateCustomerGateway",
         Dict{String,Any}("BgpAsn" => BgpAsn, "Type" => Type);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_customer_gateway(
@@ -2686,6 +2822,7 @@ function create_customer_gateway(
             mergewith(_merge, Dict{String,Any}("BgpAsn" => BgpAsn, "Type" => Type), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2713,6 +2850,7 @@ function create_default_subnet(
         "CreateDefaultSubnet",
         Dict{String,Any}("AvailabilityZone" => AvailabilityZone);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_default_subnet(
@@ -2728,6 +2866,7 @@ function create_default_subnet(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2752,12 +2891,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   permissions, the error response is DryRunOperation. Otherwise, it is UnauthorizedOperation.
 """
 function create_default_vpc(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("CreateDefaultVpc"; aws_config=aws_config)
+    return ec2("CreateDefaultVpc"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function create_default_vpc(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("CreateDefaultVpc", params; aws_config=aws_config)
+    return ec2(
+        "CreateDefaultVpc", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -2807,6 +2948,7 @@ function create_dhcp_options(
         "CreateDhcpOptions",
         Dict{String,Any}("dhcpConfiguration" => dhcpConfiguration);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_dhcp_options(
@@ -2822,6 +2964,7 @@ function create_dhcp_options(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2853,6 +2996,7 @@ function create_egress_only_internet_gateway(
         "CreateEgressOnlyInternetGateway",
         Dict{String,Any}("VpcId" => VpcId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_egress_only_internet_gateway(
@@ -2862,6 +3006,7 @@ function create_egress_only_internet_gateway(
         "CreateEgressOnlyInternetGateway",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("VpcId" => VpcId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2926,6 +3071,7 @@ function create_fleet(
             "TargetCapacitySpecification" => TargetCapacitySpecification, "item" => item
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_fleet(
@@ -2947,6 +3093,7 @@ function create_fleet(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3026,6 +3173,7 @@ function create_flow_logs(
             "TrafficType" => TrafficType,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_flow_logs(
@@ -3049,6 +3197,7 @@ function create_flow_logs(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3085,6 +3234,7 @@ function create_fpga_image(
         "CreateFpgaImage",
         Dict{String,Any}("InputStorageLocation" => InputStorageLocation);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_fpga_image(
@@ -3102,6 +3252,7 @@ function create_fpga_image(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3149,6 +3300,7 @@ function create_image(instanceId, name; aws_config::AbstractAWSConfig=global_aws
         "CreateImage",
         Dict{String,Any}("instanceId" => instanceId, "name" => name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_image(
@@ -3165,6 +3317,7 @@ function create_image(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3204,12 +3357,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   can't specify a cron expression.
 """
 function create_instance_event_window(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("CreateInstanceEventWindow"; aws_config=aws_config)
+    return ec2(
+        "CreateInstanceEventWindow"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function create_instance_event_window(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("CreateInstanceEventWindow", params; aws_config=aws_config)
+    return ec2(
+        "CreateInstanceEventWindow",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -3246,6 +3406,7 @@ function create_instance_export_task(
             "targetEnvironment" => targetEnvironment,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_instance_export_task(
@@ -3269,6 +3430,7 @@ function create_instance_export_task(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3288,12 +3450,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   permissions, the error response is DryRunOperation. Otherwise, it is UnauthorizedOperation.
 """
 function create_internet_gateway(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("CreateInternetGateway"; aws_config=aws_config)
+    return ec2(
+        "CreateInternetGateway"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function create_internet_gateway(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("CreateInternetGateway", params; aws_config=aws_config)
+    return ec2(
+        "CreateInternetGateway",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -3323,7 +3492,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function create_key_pair(KeyName; aws_config::AbstractAWSConfig=global_aws_config())
     return ec2(
-        "CreateKeyPair", Dict{String,Any}("KeyName" => KeyName); aws_config=aws_config
+        "CreateKeyPair",
+        Dict{String,Any}("KeyName" => KeyName);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_key_pair(
@@ -3333,6 +3505,7 @@ function create_key_pair(
         "CreateKeyPair",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("KeyName" => KeyName), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3372,6 +3545,7 @@ function create_launch_template(
             "LaunchTemplateName" => LaunchTemplateName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_launch_template(
@@ -3393,6 +3567,7 @@ function create_launch_template(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3435,6 +3610,7 @@ function create_launch_template_version(
         "CreateLaunchTemplateVersion",
         Dict{String,Any}("LaunchTemplateData" => LaunchTemplateData);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_launch_template_version(
@@ -3450,6 +3626,7 @@ function create_launch_template_version(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3485,6 +3662,7 @@ function create_local_gateway_route(
             "LocalGatewayVirtualInterfaceGroupId" => LocalGatewayVirtualInterfaceGroupId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_local_gateway_route(
@@ -3509,6 +3687,7 @@ function create_local_gateway_route(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3538,6 +3717,7 @@ function create_local_gateway_route_table_vpc_association(
             "LocalGatewayRouteTableId" => LocalGatewayRouteTableId, "VpcId" => VpcId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_local_gateway_route_table_vpc_association(
@@ -3558,6 +3738,7 @@ function create_local_gateway_route_table_vpc_association(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3600,6 +3781,7 @@ function create_managed_prefix_list(
             "ClientToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_managed_prefix_list(
@@ -3624,6 +3806,7 @@ function create_managed_prefix_list(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3666,6 +3849,7 @@ function create_nat_gateway(SubnetId; aws_config::AbstractAWSConfig=global_aws_c
         "CreateNatGateway",
         Dict{String,Any}("SubnetId" => SubnetId, "ClientToken" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_nat_gateway(
@@ -3683,6 +3867,7 @@ function create_nat_gateway(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3706,7 +3891,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function create_network_acl(vpcId; aws_config::AbstractAWSConfig=global_aws_config())
     return ec2(
-        "CreateNetworkAcl", Dict{String,Any}("vpcId" => vpcId); aws_config=aws_config
+        "CreateNetworkAcl",
+        Dict{String,Any}("vpcId" => vpcId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_network_acl(
@@ -3716,6 +3904,7 @@ function create_network_acl(
         "CreateNetworkAcl",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("vpcId" => vpcId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3783,6 +3972,7 @@ function create_network_acl_entry(
             "ruleNumber" => ruleNumber,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_network_acl_entry(
@@ -3810,6 +4000,7 @@ function create_network_acl_entry(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3856,6 +4047,7 @@ function create_network_insights_path(
             "Source" => Source,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_network_insights_path(
@@ -3881,6 +4073,7 @@ function create_network_insights_path(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3946,6 +4139,7 @@ function create_network_interface(
         "CreateNetworkInterface",
         Dict{String,Any}("subnetId" => subnetId, "ClientToken" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_network_interface(
@@ -3963,6 +4157,7 @@ function create_network_interface(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3995,6 +4190,7 @@ function create_network_interface_permission(
             "NetworkInterfaceId" => NetworkInterfaceId, "Permission" => Permission
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_network_interface_permission(
@@ -4015,6 +4211,7 @@ function create_network_interface_permission(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4044,12 +4241,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"strategy"`: The placement strategy.
 """
 function create_placement_group(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("CreatePlacementGroup"; aws_config=aws_config)
+    return ec2(
+        "CreatePlacementGroup"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function create_placement_group(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("CreatePlacementGroup", params; aws_config=aws_config)
+    return ec2(
+        "CreatePlacementGroup",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -4083,6 +4287,7 @@ function create_replace_root_volume_task(
         "CreateReplaceRootVolumeTask",
         Dict{String,Any}("InstanceId" => InstanceId, "ClientToken" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_replace_root_volume_task(
@@ -4102,6 +4307,7 @@ function create_replace_root_volume_task(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4153,6 +4359,7 @@ function create_reserved_instances_listing(
             "reservedInstancesId" => reservedInstancesId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_reserved_instances_listing(
@@ -4178,6 +4385,7 @@ function create_reserved_instances_listing(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4215,6 +4423,7 @@ function create_restore_image_task(
         "CreateRestoreImageTask",
         Dict{String,Any}("Bucket" => Bucket, "ObjectKey" => ObjectKey);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_restore_image_task(
@@ -4233,6 +4442,7 @@ function create_restore_image_task(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4288,6 +4498,7 @@ function create_route(routeTableId; aws_config::AbstractAWSConfig=global_aws_con
         "CreateRoute",
         Dict{String,Any}("routeTableId" => routeTableId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_route(
@@ -4301,6 +4512,7 @@ function create_route(
             mergewith(_merge, Dict{String,Any}("routeTableId" => routeTableId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4324,7 +4536,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function create_route_table(vpcId; aws_config::AbstractAWSConfig=global_aws_config())
     return ec2(
-        "CreateRouteTable", Dict{String,Any}("vpcId" => vpcId); aws_config=aws_config
+        "CreateRouteTable",
+        Dict{String,Any}("vpcId" => vpcId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_route_table(
@@ -4334,6 +4549,7 @@ function create_route_table(
         "CreateRouteTable",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("vpcId" => vpcId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4380,6 +4596,7 @@ function create_security_group(
         "CreateSecurityGroup",
         Dict{String,Any}("GroupDescription" => GroupDescription, "GroupName" => GroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_security_group(
@@ -4400,6 +4617,7 @@ function create_security_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4452,7 +4670,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function create_snapshot(VolumeId; aws_config::AbstractAWSConfig=global_aws_config())
     return ec2(
-        "CreateSnapshot", Dict{String,Any}("VolumeId" => VolumeId); aws_config=aws_config
+        "CreateSnapshot",
+        Dict{String,Any}("VolumeId" => VolumeId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_snapshot(
@@ -4466,6 +4687,7 @@ function create_snapshot(
             mergewith(_merge, Dict{String,Any}("VolumeId" => VolumeId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4512,6 +4734,7 @@ function create_snapshots(
         "CreateSnapshots",
         Dict{String,Any}("InstanceSpecification" => InstanceSpecification);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_snapshots(
@@ -4529,6 +4752,7 @@ function create_snapshots(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4559,6 +4783,7 @@ function create_spot_datafeed_subscription(
         "CreateSpotDatafeedSubscription",
         Dict{String,Any}("bucket" => bucket);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_spot_datafeed_subscription(
@@ -4568,6 +4793,7 @@ function create_spot_datafeed_subscription(
         "CreateSpotDatafeedSubscription",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("bucket" => bucket), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4601,6 +4827,7 @@ function create_store_image_task(
         "CreateStoreImageTask",
         Dict{String,Any}("Bucket" => Bucket, "ImageId" => ImageId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_store_image_task(
@@ -4617,6 +4844,7 @@ function create_store_image_task(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4667,6 +4895,7 @@ function create_subnet(CidrBlock, VpcId; aws_config::AbstractAWSConfig=global_aw
         "CreateSubnet",
         Dict{String,Any}("CidrBlock" => CidrBlock, "VpcId" => VpcId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_subnet(
@@ -4683,6 +4912,7 @@ function create_subnet(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4720,6 +4950,7 @@ function create_subnet_cidr_reservation(
             "Cidr" => Cidr, "ReservationType" => ReservationType, "SubnetId" => SubnetId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_subnet_cidr_reservation(
@@ -4743,6 +4974,7 @@ function create_subnet_cidr_reservation(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4776,6 +5008,7 @@ function create_tags(ResourceId, Tag; aws_config::AbstractAWSConfig=global_aws_c
         "CreateTags",
         Dict{String,Any}("ResourceId" => ResourceId, "Tag" => Tag);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_tags(
@@ -4792,6 +5025,7 @@ function create_tags(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4820,6 +5054,7 @@ function create_traffic_mirror_filter(; aws_config::AbstractAWSConfig=global_aws
         "CreateTrafficMirrorFilter",
         Dict{String,Any}("ClientToken" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_traffic_mirror_filter(
@@ -4831,6 +5066,7 @@ function create_traffic_mirror_filter(
             mergewith(_merge, Dict{String,Any}("ClientToken" => string(uuid4())), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4886,6 +5122,7 @@ function create_traffic_mirror_filter_rule(
             "ClientToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_traffic_mirror_filter_rule(
@@ -4916,6 +5153,7 @@ function create_traffic_mirror_filter_rule(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4975,6 +5213,7 @@ function create_traffic_mirror_session(
             "ClientToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_traffic_mirror_session(
@@ -5001,6 +5240,7 @@ function create_traffic_mirror_session(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5033,6 +5273,7 @@ function create_traffic_mirror_target(; aws_config::AbstractAWSConfig=global_aws
         "CreateTrafficMirrorTarget",
         Dict{String,Any}("ClientToken" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_traffic_mirror_target(
@@ -5044,6 +5285,7 @@ function create_traffic_mirror_target(
             mergewith(_merge, Dict{String,Any}("ClientToken" => string(uuid4())), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5076,12 +5318,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"TagSpecification"`: The tags to apply to the transit gateway.
 """
 function create_transit_gateway(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("CreateTransitGateway"; aws_config=aws_config)
+    return ec2(
+        "CreateTransitGateway"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function create_transit_gateway(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("CreateTransitGateway", params; aws_config=aws_config)
+    return ec2(
+        "CreateTransitGateway",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -5117,6 +5366,7 @@ function create_transit_gateway_connect(
             "TransportTransitGatewayAttachmentId" => TransportTransitGatewayAttachmentId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_transit_gateway_connect(
@@ -5139,6 +5389,7 @@ function create_transit_gateway_connect(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5190,6 +5441,7 @@ function create_transit_gateway_connect_peer(
             "item" => item,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_transit_gateway_connect_peer(
@@ -5213,6 +5465,7 @@ function create_transit_gateway_connect_peer(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5242,6 +5495,7 @@ function create_transit_gateway_multicast_domain(
         "CreateTransitGatewayMulticastDomain",
         Dict{String,Any}("TransitGatewayId" => TransitGatewayId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_transit_gateway_multicast_domain(
@@ -5257,6 +5511,7 @@ function create_transit_gateway_multicast_domain(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5301,6 +5556,7 @@ function create_transit_gateway_peering_attachment(
             "TransitGatewayId" => TransitGatewayId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_transit_gateway_peering_attachment(
@@ -5326,6 +5582,7 @@ function create_transit_gateway_peering_attachment(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5359,6 +5616,7 @@ function create_transit_gateway_prefix_list_reference(
             "TransitGatewayRouteTableId" => TransitGatewayRouteTableId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_transit_gateway_prefix_list_reference(
@@ -5380,6 +5638,7 @@ function create_transit_gateway_prefix_list_reference(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5414,6 +5673,7 @@ function create_transit_gateway_route(
             "TransitGatewayRouteTableId" => TransitGatewayRouteTableId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_transit_gateway_route(
@@ -5435,6 +5695,7 @@ function create_transit_gateway_route(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5461,6 +5722,7 @@ function create_transit_gateway_route_table(
         "CreateTransitGatewayRouteTable",
         Dict{String,Any}("TransitGatewayId" => TransitGatewayId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_transit_gateway_route_table(
@@ -5476,6 +5738,7 @@ function create_transit_gateway_route_table(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5516,6 +5779,7 @@ function create_transit_gateway_vpc_attachment(
             "TransitGatewayId" => TransitGatewayId, "VpcId" => VpcId, "item" => item
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_transit_gateway_vpc_attachment(
@@ -5537,6 +5801,7 @@ function create_transit_gateway_vpc_attachment(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5619,6 +5884,7 @@ function create_volume(AvailabilityZone; aws_config::AbstractAWSConfig=global_aw
             "AvailabilityZone" => AvailabilityZone, "ClientToken" => string(uuid4())
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_volume(
@@ -5638,6 +5904,7 @@ function create_volume(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5688,7 +5955,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function create_vpc(CidrBlock; aws_config::AbstractAWSConfig=global_aws_config())
     return ec2(
-        "CreateVpc", Dict{String,Any}("CidrBlock" => CidrBlock); aws_config=aws_config
+        "CreateVpc",
+        Dict{String,Any}("CidrBlock" => CidrBlock);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_vpc(
@@ -5702,6 +5972,7 @@ function create_vpc(
             mergewith(_merge, Dict{String,Any}("CidrBlock" => CidrBlock), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5764,6 +6035,7 @@ function create_vpc_endpoint(
         "CreateVpcEndpoint",
         Dict{String,Any}("ServiceName" => ServiceName, "VpcId" => VpcId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_vpc_endpoint(
@@ -5782,6 +6054,7 @@ function create_vpc_endpoint(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5821,6 +6094,7 @@ function create_vpc_endpoint_connection_notification(
             "ConnectionNotificationArn" => ConnectionNotificationArn, "item" => item
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_vpc_endpoint_connection_notification(
@@ -5841,6 +6115,7 @@ function create_vpc_endpoint_connection_notification(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5879,12 +6154,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function create_vpc_endpoint_service_configuration(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("CreateVpcEndpointServiceConfiguration"; aws_config=aws_config)
+    return ec2(
+        "CreateVpcEndpointServiceConfiguration";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function create_vpc_endpoint_service_configuration(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("CreateVpcEndpointServiceConfiguration", params; aws_config=aws_config)
+    return ec2(
+        "CreateVpcEndpointServiceConfiguration",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -5918,12 +6202,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"vpcId"`: The ID of the requester VPC. You must specify this parameter in the request.
 """
 function create_vpc_peering_connection(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("CreateVpcPeeringConnection"; aws_config=aws_config)
+    return ec2(
+        "CreateVpcPeeringConnection"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function create_vpc_peering_connection(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("CreateVpcPeeringConnection", params; aws_config=aws_config)
+    return ec2(
+        "CreateVpcPeeringConnection",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -5964,6 +6255,7 @@ function create_vpn_connection(
         "CreateVpnConnection",
         Dict{String,Any}("CustomerGatewayId" => CustomerGatewayId, "Type" => Type);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_vpn_connection(
@@ -5982,6 +6274,7 @@ function create_vpn_connection(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6010,6 +6303,7 @@ function create_vpn_connection_route(
             "VpnConnectionId" => VpnConnectionId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_vpn_connection_route(
@@ -6031,6 +6325,7 @@ function create_vpn_connection_route(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6058,7 +6353,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   permissions, the error response is DryRunOperation. Otherwise, it is UnauthorizedOperation.
 """
 function create_vpn_gateway(Type; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("CreateVpnGateway", Dict{String,Any}("Type" => Type); aws_config=aws_config)
+    return ec2(
+        "CreateVpnGateway",
+        Dict{String,Any}("Type" => Type);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function create_vpn_gateway(
     Type, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -6067,6 +6367,7 @@ function create_vpn_gateway(
         "CreateVpnGateway",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Type" => Type), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6094,6 +6395,7 @@ function delete_carrier_gateway(
         "DeleteCarrierGateway",
         Dict{String,Any}("CarrierGatewayId" => CarrierGatewayId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_carrier_gateway(
@@ -6109,6 +6411,7 @@ function delete_carrier_gateway(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6135,6 +6438,7 @@ function delete_client_vpn_endpoint(
         "DeleteClientVpnEndpoint",
         Dict{String,Any}("ClientVpnEndpointId" => ClientVpnEndpointId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_client_vpn_endpoint(
@@ -6152,6 +6456,7 @@ function delete_client_vpn_endpoint(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6189,6 +6494,7 @@ function delete_client_vpn_route(
             "DestinationCidrBlock" => DestinationCidrBlock,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_client_vpn_route(
@@ -6210,6 +6516,7 @@ function delete_client_vpn_route(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6236,6 +6543,7 @@ function delete_customer_gateway(
         "DeleteCustomerGateway",
         Dict{String,Any}("CustomerGatewayId" => CustomerGatewayId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_customer_gateway(
@@ -6251,6 +6559,7 @@ function delete_customer_gateway(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6278,6 +6587,7 @@ function delete_dhcp_options(
         "DeleteDhcpOptions",
         Dict{String,Any}("DhcpOptionsId" => DhcpOptionsId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_dhcp_options(
@@ -6291,6 +6601,7 @@ function delete_dhcp_options(
             mergewith(_merge, Dict{String,Any}("DhcpOptionsId" => DhcpOptionsId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6316,6 +6627,7 @@ function delete_egress_only_internet_gateway(
         "DeleteEgressOnlyInternetGateway",
         Dict{String,Any}("EgressOnlyInternetGatewayId" => EgressOnlyInternetGatewayId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_egress_only_internet_gateway(
@@ -6335,6 +6647,7 @@ function delete_egress_only_internet_gateway(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6376,6 +6689,7 @@ function delete_fleets(
         "DeleteFleets",
         Dict{String,Any}("FleetId" => FleetId, "TerminateInstances" => TerminateInstances);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_fleets(
@@ -6396,6 +6710,7 @@ function delete_fleets(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6416,7 +6731,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function delete_flow_logs(FlowLogId; aws_config::AbstractAWSConfig=global_aws_config())
     return ec2(
-        "DeleteFlowLogs", Dict{String,Any}("FlowLogId" => FlowLogId); aws_config=aws_config
+        "DeleteFlowLogs",
+        Dict{String,Any}("FlowLogId" => FlowLogId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_flow_logs(
@@ -6430,6 +6748,7 @@ function delete_flow_logs(
             mergewith(_merge, Dict{String,Any}("FlowLogId" => FlowLogId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6453,6 +6772,7 @@ function delete_fpga_image(FpgaImageId; aws_config::AbstractAWSConfig=global_aws
         "DeleteFpgaImage",
         Dict{String,Any}("FpgaImageId" => FpgaImageId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_fpga_image(
@@ -6466,6 +6786,7 @@ function delete_fpga_image(
             mergewith(_merge, Dict{String,Any}("FpgaImageId" => FpgaImageId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6494,6 +6815,7 @@ function delete_instance_event_window(
         "DeleteInstanceEventWindow",
         Dict{String,Any}("InstanceEventWindowId" => InstanceEventWindowId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_instance_event_window(
@@ -6511,6 +6833,7 @@ function delete_instance_event_window(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6537,6 +6860,7 @@ function delete_internet_gateway(
         "DeleteInternetGateway",
         Dict{String,Any}("internetGatewayId" => internetGatewayId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_internet_gateway(
@@ -6552,6 +6876,7 @@ function delete_internet_gateway(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6570,12 +6895,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   permissions, the error response is DryRunOperation. Otherwise, it is UnauthorizedOperation.
 """
 function delete_key_pair(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("DeleteKeyPair"; aws_config=aws_config)
+    return ec2("DeleteKeyPair"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function delete_key_pair(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DeleteKeyPair", params; aws_config=aws_config)
+    return ec2(
+        "DeleteKeyPair", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -6595,12 +6922,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   launch template ID or launch template name in the request.
 """
 function delete_launch_template(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("DeleteLaunchTemplate"; aws_config=aws_config)
+    return ec2(
+        "DeleteLaunchTemplate"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function delete_launch_template(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DeleteLaunchTemplate", params; aws_config=aws_config)
+    return ec2(
+        "DeleteLaunchTemplate",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -6633,6 +6967,7 @@ function delete_launch_template_versions(
         "DeleteLaunchTemplateVersions",
         Dict{String,Any}("LaunchTemplateVersion" => LaunchTemplateVersion);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_launch_template_versions(
@@ -6650,6 +6985,7 @@ function delete_launch_template_versions(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6682,6 +7018,7 @@ function delete_local_gateway_route(
             "LocalGatewayRouteTableId" => LocalGatewayRouteTableId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_local_gateway_route(
@@ -6703,6 +7040,7 @@ function delete_local_gateway_route(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6732,6 +7070,7 @@ function delete_local_gateway_route_table_vpc_association(
                 LocalGatewayRouteTableVpcAssociationId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_local_gateway_route_table_vpc_association(
@@ -6752,6 +7091,7 @@ function delete_local_gateway_route_table_vpc_association(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6778,6 +7118,7 @@ function delete_managed_prefix_list(
         "DeleteManagedPrefixList",
         Dict{String,Any}("PrefixListId" => PrefixListId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_managed_prefix_list(
@@ -6791,6 +7132,7 @@ function delete_managed_prefix_list(
             mergewith(_merge, Dict{String,Any}("PrefixListId" => PrefixListId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6816,6 +7158,7 @@ function delete_nat_gateway(NatGatewayId; aws_config::AbstractAWSConfig=global_a
         "DeleteNatGateway",
         Dict{String,Any}("NatGatewayId" => NatGatewayId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_nat_gateway(
@@ -6829,6 +7172,7 @@ function delete_nat_gateway(
             mergewith(_merge, Dict{String,Any}("NatGatewayId" => NatGatewayId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6853,6 +7197,7 @@ function delete_network_acl(networkAclId; aws_config::AbstractAWSConfig=global_a
         "DeleteNetworkAcl",
         Dict{String,Any}("networkAclId" => networkAclId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_network_acl(
@@ -6866,6 +7211,7 @@ function delete_network_acl(
             mergewith(_merge, Dict{String,Any}("networkAclId" => networkAclId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6895,6 +7241,7 @@ function delete_network_acl_entry(
             "egress" => egress, "networkAclId" => networkAclId, "ruleNumber" => ruleNumber
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_network_acl_entry(
@@ -6918,6 +7265,7 @@ function delete_network_acl_entry(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6943,6 +7291,7 @@ function delete_network_insights_analysis(
         "DeleteNetworkInsightsAnalysis",
         Dict{String,Any}("NetworkInsightsAnalysisId" => NetworkInsightsAnalysisId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_network_insights_analysis(
@@ -6960,6 +7309,7 @@ function delete_network_insights_analysis(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6985,6 +7335,7 @@ function delete_network_insights_path(
         "DeleteNetworkInsightsPath",
         Dict{String,Any}("NetworkInsightsPathId" => NetworkInsightsPathId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_network_insights_path(
@@ -7002,6 +7353,7 @@ function delete_network_insights_path(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -7028,6 +7380,7 @@ function delete_network_interface(
         "DeleteNetworkInterface",
         Dict{String,Any}("networkInterfaceId" => networkInterfaceId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_network_interface(
@@ -7043,6 +7396,7 @@ function delete_network_interface(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -7072,6 +7426,7 @@ function delete_network_interface_permission(
         "DeleteNetworkInterfacePermission",
         Dict{String,Any}("NetworkInterfacePermissionId" => NetworkInterfacePermissionId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_network_interface_permission(
@@ -7091,6 +7446,7 @@ function delete_network_interface_permission(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -7118,6 +7474,7 @@ function delete_placement_group(
         "DeletePlacementGroup",
         Dict{String,Any}("groupName" => groupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_placement_group(
@@ -7131,6 +7488,7 @@ function delete_placement_group(
             mergewith(_merge, Dict{String,Any}("groupName" => groupName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -7156,6 +7514,7 @@ function delete_queued_reserved_instances(
         "DeleteQueuedReservedInstances",
         Dict{String,Any}("ReservedInstancesId" => ReservedInstancesId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_queued_reserved_instances(
@@ -7173,6 +7532,7 @@ function delete_queued_reserved_instances(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -7201,6 +7561,7 @@ function delete_route(routeTableId; aws_config::AbstractAWSConfig=global_aws_con
         "DeleteRoute",
         Dict{String,Any}("routeTableId" => routeTableId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_route(
@@ -7214,6 +7575,7 @@ function delete_route(
             mergewith(_merge, Dict{String,Any}("routeTableId" => routeTableId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -7238,6 +7600,7 @@ function delete_route_table(routeTableId; aws_config::AbstractAWSConfig=global_a
         "DeleteRouteTable",
         Dict{String,Any}("routeTableId" => routeTableId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_route_table(
@@ -7251,6 +7614,7 @@ function delete_route_table(
             mergewith(_merge, Dict{String,Any}("routeTableId" => routeTableId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -7272,12 +7636,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   permissions, the error response is DryRunOperation. Otherwise, it is UnauthorizedOperation.
 """
 function delete_security_group(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("DeleteSecurityGroup"; aws_config=aws_config)
+    return ec2(
+        "DeleteSecurityGroup"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function delete_security_group(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DeleteSecurityGroup", params; aws_config=aws_config)
+    return ec2(
+        "DeleteSecurityGroup",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -7308,6 +7679,7 @@ function delete_snapshot(SnapshotId; aws_config::AbstractAWSConfig=global_aws_co
         "DeleteSnapshot",
         Dict{String,Any}("SnapshotId" => SnapshotId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_snapshot(
@@ -7321,6 +7693,7 @@ function delete_snapshot(
             mergewith(_merge, Dict{String,Any}("SnapshotId" => SnapshotId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -7339,12 +7712,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function delete_spot_datafeed_subscription(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DeleteSpotDatafeedSubscription"; aws_config=aws_config)
+    return ec2(
+        "DeleteSpotDatafeedSubscription";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_spot_datafeed_subscription(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DeleteSpotDatafeedSubscription", params; aws_config=aws_config)
+    return ec2(
+        "DeleteSpotDatafeedSubscription",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -7365,7 +7747,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function delete_subnet(SubnetId; aws_config::AbstractAWSConfig=global_aws_config())
     return ec2(
-        "DeleteSubnet", Dict{String,Any}("SubnetId" => SubnetId); aws_config=aws_config
+        "DeleteSubnet",
+        Dict{String,Any}("SubnetId" => SubnetId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_subnet(
@@ -7379,6 +7764,7 @@ function delete_subnet(
             mergewith(_merge, Dict{String,Any}("SubnetId" => SubnetId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -7404,6 +7790,7 @@ function delete_subnet_cidr_reservation(
         "DeleteSubnetCidrReservation",
         Dict{String,Any}("SubnetCidrReservationId" => SubnetCidrReservationId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_subnet_cidr_reservation(
@@ -7421,6 +7808,7 @@ function delete_subnet_cidr_reservation(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -7450,7 +7838,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function delete_tags(resourceId; aws_config::AbstractAWSConfig=global_aws_config())
     return ec2(
-        "DeleteTags", Dict{String,Any}("resourceId" => resourceId); aws_config=aws_config
+        "DeleteTags",
+        Dict{String,Any}("resourceId" => resourceId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_tags(
@@ -7464,6 +7855,7 @@ function delete_tags(
             mergewith(_merge, Dict{String,Any}("resourceId" => resourceId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -7490,6 +7882,7 @@ function delete_traffic_mirror_filter(
         "DeleteTrafficMirrorFilter",
         Dict{String,Any}("TrafficMirrorFilterId" => TrafficMirrorFilterId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_traffic_mirror_filter(
@@ -7507,6 +7900,7 @@ function delete_traffic_mirror_filter(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -7532,6 +7926,7 @@ function delete_traffic_mirror_filter_rule(
         "DeleteTrafficMirrorFilterRule",
         Dict{String,Any}("TrafficMirrorFilterRuleId" => TrafficMirrorFilterRuleId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_traffic_mirror_filter_rule(
@@ -7549,6 +7944,7 @@ function delete_traffic_mirror_filter_rule(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -7574,6 +7970,7 @@ function delete_traffic_mirror_session(
         "DeleteTrafficMirrorSession",
         Dict{String,Any}("TrafficMirrorSessionId" => TrafficMirrorSessionId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_traffic_mirror_session(
@@ -7591,6 +7988,7 @@ function delete_traffic_mirror_session(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -7617,6 +8015,7 @@ function delete_traffic_mirror_target(
         "DeleteTrafficMirrorTarget",
         Dict{String,Any}("TrafficMirrorTargetId" => TrafficMirrorTargetId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_traffic_mirror_target(
@@ -7634,6 +8033,7 @@ function delete_traffic_mirror_target(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -7659,6 +8059,7 @@ function delete_transit_gateway(
         "DeleteTransitGateway",
         Dict{String,Any}("TransitGatewayId" => TransitGatewayId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_transit_gateway(
@@ -7674,6 +8075,7 @@ function delete_transit_gateway(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -7700,6 +8102,7 @@ function delete_transit_gateway_connect(
         "DeleteTransitGatewayConnect",
         Dict{String,Any}("TransitGatewayAttachmentId" => TransitGatewayAttachmentId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_transit_gateway_connect(
@@ -7719,6 +8122,7 @@ function delete_transit_gateway_connect(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -7744,6 +8148,7 @@ function delete_transit_gateway_connect_peer(
         "DeleteTransitGatewayConnectPeer",
         Dict{String,Any}("TransitGatewayConnectPeerId" => TransitGatewayConnectPeerId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_transit_gateway_connect_peer(
@@ -7763,6 +8168,7 @@ function delete_transit_gateway_connect_peer(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -7790,6 +8196,7 @@ function delete_transit_gateway_multicast_domain(
             "TransitGatewayMulticastDomainId" => TransitGatewayMulticastDomainId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_transit_gateway_multicast_domain(
@@ -7809,6 +8216,7 @@ function delete_transit_gateway_multicast_domain(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -7834,6 +8242,7 @@ function delete_transit_gateway_peering_attachment(
         "DeleteTransitGatewayPeeringAttachment",
         Dict{String,Any}("TransitGatewayAttachmentId" => TransitGatewayAttachmentId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_transit_gateway_peering_attachment(
@@ -7853,6 +8262,7 @@ function delete_transit_gateway_peering_attachment(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -7884,6 +8294,7 @@ function delete_transit_gateway_prefix_list_reference(
             "TransitGatewayRouteTableId" => TransitGatewayRouteTableId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_transit_gateway_prefix_list_reference(
@@ -7905,6 +8316,7 @@ function delete_transit_gateway_prefix_list_reference(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -7937,6 +8349,7 @@ function delete_transit_gateway_route(
             "TransitGatewayRouteTableId" => TransitGatewayRouteTableId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_transit_gateway_route(
@@ -7958,6 +8371,7 @@ function delete_transit_gateway_route(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -7984,6 +8398,7 @@ function delete_transit_gateway_route_table(
         "DeleteTransitGatewayRouteTable",
         Dict{String,Any}("TransitGatewayRouteTableId" => TransitGatewayRouteTableId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_transit_gateway_route_table(
@@ -8003,6 +8418,7 @@ function delete_transit_gateway_route_table(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -8028,6 +8444,7 @@ function delete_transit_gateway_vpc_attachment(
         "DeleteTransitGatewayVpcAttachment",
         Dict{String,Any}("TransitGatewayAttachmentId" => TransitGatewayAttachmentId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_transit_gateway_vpc_attachment(
@@ -8047,6 +8464,7 @@ function delete_transit_gateway_vpc_attachment(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -8069,7 +8487,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function delete_volume(VolumeId; aws_config::AbstractAWSConfig=global_aws_config())
     return ec2(
-        "DeleteVolume", Dict{String,Any}("VolumeId" => VolumeId); aws_config=aws_config
+        "DeleteVolume",
+        Dict{String,Any}("VolumeId" => VolumeId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_volume(
@@ -8083,6 +8504,7 @@ function delete_volume(
             mergewith(_merge, Dict{String,Any}("VolumeId" => VolumeId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -8106,7 +8528,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   permissions, the error response is DryRunOperation. Otherwise, it is UnauthorizedOperation.
 """
 function delete_vpc(VpcId; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("DeleteVpc", Dict{String,Any}("VpcId" => VpcId); aws_config=aws_config)
+    return ec2(
+        "DeleteVpc",
+        Dict{String,Any}("VpcId" => VpcId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_vpc(
     VpcId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -8115,6 +8542,7 @@ function delete_vpc(
         "DeleteVpc",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("VpcId" => VpcId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -8140,6 +8568,7 @@ function delete_vpc_endpoint_connection_notifications(
         "DeleteVpcEndpointConnectionNotifications",
         Dict{String,Any}("ConnectionNotificationId" => ConnectionNotificationId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_vpc_endpoint_connection_notifications(
@@ -8157,6 +8586,7 @@ function delete_vpc_endpoint_connection_notifications(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -8184,6 +8614,7 @@ function delete_vpc_endpoint_service_configurations(
         "DeleteVpcEndpointServiceConfigurations",
         Dict{String,Any}("ServiceId" => ServiceId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_vpc_endpoint_service_configurations(
@@ -8197,6 +8628,7 @@ function delete_vpc_endpoint_service_configurations(
             mergewith(_merge, Dict{String,Any}("ServiceId" => ServiceId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -8229,6 +8661,7 @@ function delete_vpc_endpoints(
         "DeleteVpcEndpoints",
         Dict{String,Any}("VpcEndpointId" => VpcEndpointId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_vpc_endpoints(
@@ -8242,6 +8675,7 @@ function delete_vpc_endpoints(
             mergewith(_merge, Dict{String,Any}("VpcEndpointId" => VpcEndpointId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -8270,6 +8704,7 @@ function delete_vpc_peering_connection(
         "DeleteVpcPeeringConnection",
         Dict{String,Any}("vpcPeeringConnectionId" => vpcPeeringConnectionId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_vpc_peering_connection(
@@ -8287,6 +8722,7 @@ function delete_vpc_peering_connection(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -8321,6 +8757,7 @@ function delete_vpn_connection(
         "DeleteVpnConnection",
         Dict{String,Any}("VpnConnectionId" => VpnConnectionId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_vpn_connection(
@@ -8336,6 +8773,7 @@ function delete_vpn_connection(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -8363,6 +8801,7 @@ function delete_vpn_connection_route(
             "VpnConnectionId" => VpnConnectionId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_vpn_connection_route(
@@ -8384,6 +8823,7 @@ function delete_vpn_connection_route(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -8409,6 +8849,7 @@ function delete_vpn_gateway(VpnGatewayId; aws_config::AbstractAWSConfig=global_a
         "DeleteVpnGateway",
         Dict{String,Any}("VpnGatewayId" => VpnGatewayId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_vpn_gateway(
@@ -8422,6 +8863,7 @@ function delete_vpn_gateway(
             mergewith(_merge, Dict{String,Any}("VpnGatewayId" => VpnGatewayId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -8447,7 +8889,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function deprovision_byoip_cidr(Cidr; aws_config::AbstractAWSConfig=global_aws_config())
     return ec2(
-        "DeprovisionByoipCidr", Dict{String,Any}("Cidr" => Cidr); aws_config=aws_config
+        "DeprovisionByoipCidr",
+        Dict{String,Any}("Cidr" => Cidr);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function deprovision_byoip_cidr(
@@ -8457,6 +8902,7 @@ function deprovision_byoip_cidr(
         "DeprovisionByoipCidr",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Cidr" => Cidr), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -8483,7 +8929,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function deregister_image(ImageId; aws_config::AbstractAWSConfig=global_aws_config())
     return ec2(
-        "DeregisterImage", Dict{String,Any}("ImageId" => ImageId); aws_config=aws_config
+        "DeregisterImage",
+        Dict{String,Any}("ImageId" => ImageId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function deregister_image(
@@ -8493,6 +8942,7 @@ function deregister_image(
         "DeregisterImage",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("ImageId" => ImageId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -8513,13 +8963,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function deregister_instance_event_notification_attributes(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DeregisterInstanceEventNotificationAttributes"; aws_config=aws_config)
+    return ec2(
+        "DeregisterInstanceEventNotificationAttributes";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function deregister_instance_event_notification_attributes(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return ec2(
-        "DeregisterInstanceEventNotificationAttributes", params; aws_config=aws_config
+        "DeregisterInstanceEventNotificationAttributes",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -8542,13 +8999,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function deregister_transit_gateway_multicast_group_members(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DeregisterTransitGatewayMulticastGroupMembers"; aws_config=aws_config)
+    return ec2(
+        "DeregisterTransitGatewayMulticastGroupMembers";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function deregister_transit_gateway_multicast_group_members(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return ec2(
-        "DeregisterTransitGatewayMulticastGroupMembers", params; aws_config=aws_config
+        "DeregisterTransitGatewayMulticastGroupMembers",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -8571,13 +9035,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function deregister_transit_gateway_multicast_group_sources(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DeregisterTransitGatewayMulticastGroupSources"; aws_config=aws_config)
+    return ec2(
+        "DeregisterTransitGatewayMulticastGroupSources";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function deregister_transit_gateway_multicast_group_sources(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return ec2(
-        "DeregisterTransitGatewayMulticastGroupSources", params; aws_config=aws_config
+        "DeregisterTransitGatewayMulticastGroupSources",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -8604,12 +9075,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   permissions, the error response is DryRunOperation. Otherwise, it is UnauthorizedOperation.
 """
 function describe_account_attributes(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("DescribeAccountAttributes"; aws_config=aws_config)
+    return ec2(
+        "DescribeAccountAttributes"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_account_attributes(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeAccountAttributes", params; aws_config=aws_config)
+    return ec2(
+        "DescribeAccountAttributes",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -8646,12 +9124,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   permissions, the error response is DryRunOperation. Otherwise, it is UnauthorizedOperation.
 """
 function describe_addresses(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("DescribeAddresses"; aws_config=aws_config)
+    return ec2("DescribeAddresses"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function describe_addresses(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeAddresses", params; aws_config=aws_config)
+    return ec2(
+        "DescribeAddresses", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -8673,12 +9153,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`: The token for the next page of results.
 """
 function describe_addresses_attribute(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("DescribeAddressesAttribute"; aws_config=aws_config)
+    return ec2(
+        "DescribeAddressesAttribute"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_addresses_attribute(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeAddressesAttribute", params; aws_config=aws_config)
+    return ec2(
+        "DescribeAddressesAttribute",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -8704,12 +9191,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   permissions, the error response is DryRunOperation. Otherwise, it is UnauthorizedOperation.
 """
 function describe_aggregate_id_format(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("DescribeAggregateIdFormat"; aws_config=aws_config)
+    return ec2(
+        "DescribeAggregateIdFormat"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_aggregate_id_format(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeAggregateIdFormat", params; aws_config=aws_config)
+    return ec2(
+        "DescribeAggregateIdFormat",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -8751,12 +9245,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   permissions, the error response is DryRunOperation. Otherwise, it is UnauthorizedOperation.
 """
 function describe_availability_zones(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("DescribeAvailabilityZones"; aws_config=aws_config)
+    return ec2(
+        "DescribeAvailabilityZones"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_availability_zones(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeAvailabilityZones", params; aws_config=aws_config)
+    return ec2(
+        "DescribeAvailabilityZones",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -8784,12 +9285,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   permissions, the error response is DryRunOperation. Otherwise, it is UnauthorizedOperation.
 """
 function describe_bundle_tasks(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("DescribeBundleTasks"; aws_config=aws_config)
+    return ec2(
+        "DescribeBundleTasks"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_bundle_tasks(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeBundleTasks", params; aws_config=aws_config)
+    return ec2(
+        "DescribeBundleTasks",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -8816,6 +9324,7 @@ function describe_byoip_cidrs(MaxResults; aws_config::AbstractAWSConfig=global_a
         "DescribeByoipCidrs",
         Dict{String,Any}("MaxResults" => MaxResults);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_byoip_cidrs(
@@ -8829,6 +9338,7 @@ function describe_byoip_cidrs(
             mergewith(_merge, Dict{String,Any}("MaxResults" => MaxResults), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -8888,12 +9398,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`: The token to use to retrieve the next page of results.
 """
 function describe_capacity_reservations(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("DescribeCapacityReservations"; aws_config=aws_config)
+    return ec2(
+        "DescribeCapacityReservations";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_capacity_reservations(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeCapacityReservations", params; aws_config=aws_config)
+    return ec2(
+        "DescribeCapacityReservations",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -8923,12 +9442,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`: The token for the next page of results.
 """
 function describe_carrier_gateways(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("DescribeCarrierGateways"; aws_config=aws_config)
+    return ec2(
+        "DescribeCarrierGateways"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_carrier_gateways(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeCarrierGateways", params; aws_config=aws_config)
+    return ec2(
+        "DescribeCarrierGateways",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -8963,12 +9489,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_classic_link_instances(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeClassicLinkInstances"; aws_config=aws_config)
+    return ec2(
+        "DescribeClassicLinkInstances";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_classic_link_instances(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeClassicLinkInstances", params; aws_config=aws_config)
+    return ec2(
+        "DescribeClassicLinkInstances",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -9000,6 +9535,7 @@ function describe_client_vpn_authorization_rules(
         "DescribeClientVpnAuthorizationRules",
         Dict{String,Any}("ClientVpnEndpointId" => ClientVpnEndpointId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_client_vpn_authorization_rules(
@@ -9017,6 +9553,7 @@ function describe_client_vpn_authorization_rules(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -9049,6 +9586,7 @@ function describe_client_vpn_connections(
         "DescribeClientVpnConnections",
         Dict{String,Any}("ClientVpnEndpointId" => ClientVpnEndpointId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_client_vpn_connections(
@@ -9066,6 +9604,7 @@ function describe_client_vpn_connections(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -9089,12 +9628,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`: The token to retrieve the next page of results.
 """
 function describe_client_vpn_endpoints(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("DescribeClientVpnEndpoints"; aws_config=aws_config)
+    return ec2(
+        "DescribeClientVpnEndpoints"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_client_vpn_endpoints(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeClientVpnEndpoints", params; aws_config=aws_config)
+    return ec2(
+        "DescribeClientVpnEndpoints",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -9126,6 +9672,7 @@ function describe_client_vpn_routes(
         "DescribeClientVpnRoutes",
         Dict{String,Any}("ClientVpnEndpointId" => ClientVpnEndpointId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_client_vpn_routes(
@@ -9143,6 +9690,7 @@ function describe_client_vpn_routes(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -9176,6 +9724,7 @@ function describe_client_vpn_target_networks(
         "DescribeClientVpnTargetNetworks",
         Dict{String,Any}("ClientVpnEndpointId" => ClientVpnEndpointId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_client_vpn_target_networks(
@@ -9193,6 +9742,7 @@ function describe_client_vpn_target_networks(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -9216,12 +9766,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"PoolId"`: The IDs of the address pools.
 """
 function describe_coip_pools(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("DescribeCoipPools"; aws_config=aws_config)
+    return ec2("DescribeCoipPools"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function describe_coip_pools(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeCoipPools", params; aws_config=aws_config)
+    return ec2(
+        "DescribeCoipPools", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -9240,12 +9792,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   permissions, the error response is DryRunOperation. Otherwise, it is UnauthorizedOperation.
 """
 function describe_conversion_tasks(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("DescribeConversionTasks"; aws_config=aws_config)
+    return ec2(
+        "DescribeConversionTasks"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_conversion_tasks(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeConversionTasks", params; aws_config=aws_config)
+    return ec2(
+        "DescribeConversionTasks",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -9275,12 +9834,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   permissions, the error response is DryRunOperation. Otherwise, it is UnauthorizedOperation.
 """
 function describe_customer_gateways(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("DescribeCustomerGateways"; aws_config=aws_config)
+    return ec2(
+        "DescribeCustomerGateways"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_customer_gateways(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeCustomerGateways", params; aws_config=aws_config)
+    return ec2(
+        "DescribeCustomerGateways",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -9311,12 +9877,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   permissions, the error response is DryRunOperation. Otherwise, it is UnauthorizedOperation.
 """
 function describe_dhcp_options(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("DescribeDhcpOptions"; aws_config=aws_config)
+    return ec2(
+        "DescribeDhcpOptions"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_dhcp_options(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeDhcpOptions", params; aws_config=aws_config)
+    return ec2(
+        "DescribeDhcpOptions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -9344,12 +9917,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_egress_only_internet_gateways(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeEgressOnlyInternetGateways"; aws_config=aws_config)
+    return ec2(
+        "DescribeEgressOnlyInternetGateways";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_egress_only_internet_gateways(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeEgressOnlyInternetGateways", params; aws_config=aws_config)
+    return ec2(
+        "DescribeEgressOnlyInternetGateways",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -9377,12 +9959,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`: The token to request the next page of results.
 """
 function describe_elastic_gpus(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("DescribeElasticGpus"; aws_config=aws_config)
+    return ec2(
+        "DescribeElasticGpus"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_elastic_gpus(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeElasticGpus", params; aws_config=aws_config)
+    return ec2(
+        "DescribeElasticGpus",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -9403,12 +9992,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`: A token that indicates the next page of results.
 """
 function describe_export_image_tasks(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("DescribeExportImageTasks"; aws_config=aws_config)
+    return ec2(
+        "DescribeExportImageTasks"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_export_image_tasks(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeExportImageTasks", params; aws_config=aws_config)
+    return ec2(
+        "DescribeExportImageTasks",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -9423,12 +10019,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"exportTaskId"`: The export task IDs.
 """
 function describe_export_tasks(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("DescribeExportTasks"; aws_config=aws_config)
+    return ec2(
+        "DescribeExportTasks"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_export_tasks(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeExportTasks", params; aws_config=aws_config)
+    return ec2(
+        "DescribeExportTasks",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -9454,12 +10057,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_fast_snapshot_restores(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeFastSnapshotRestores"; aws_config=aws_config)
+    return ec2(
+        "DescribeFastSnapshotRestores";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_fast_snapshot_restores(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeFastSnapshotRestores", params; aws_config=aws_config)
+    return ec2(
+        "DescribeFastSnapshotRestores",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -9495,6 +10107,7 @@ function describe_fleet_history(
         "DescribeFleetHistory",
         Dict{String,Any}("FleetId" => FleetId, "StartTime" => StartTime);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_fleet_history(
@@ -9513,6 +10126,7 @@ function describe_fleet_history(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -9544,6 +10158,7 @@ function describe_fleet_instances(
         "DescribeFleetInstances",
         Dict{String,Any}("FleetId" => FleetId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_fleet_instances(
@@ -9553,6 +10168,7 @@ function describe_fleet_instances(
         "DescribeFleetInstances",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("FleetId" => FleetId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -9583,12 +10199,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`: The token for the next set of results.
 """
 function describe_fleets(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("DescribeFleets"; aws_config=aws_config)
+    return ec2("DescribeFleets"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function describe_fleets(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeFleets", params; aws_config=aws_config)
+    return ec2(
+        "DescribeFleets", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -9621,12 +10239,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`: The token for the next page of results.
 """
 function describe_flow_logs(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("DescribeFlowLogs"; aws_config=aws_config)
+    return ec2("DescribeFlowLogs"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function describe_flow_logs(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeFlowLogs", params; aws_config=aws_config)
+    return ec2(
+        "DescribeFlowLogs", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -9652,6 +10272,7 @@ function describe_fpga_image_attribute(
         "DescribeFpgaImageAttribute",
         Dict{String,Any}("Attribute" => Attribute, "FpgaImageId" => FpgaImageId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_fpga_image_attribute(
@@ -9670,6 +10291,7 @@ function describe_fpga_image_attribute(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -9705,12 +10327,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   of the request), or an AWS owner alias (valid values are amazon | aws-marketplace).
 """
 function describe_fpga_images(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("DescribeFpgaImages"; aws_config=aws_config)
+    return ec2("DescribeFpgaImages"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function describe_fpga_images(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeFpgaImages", params; aws_config=aws_config)
+    return ec2(
+        "DescribeFpgaImages", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -9747,12 +10371,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_host_reservation_offerings(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeHostReservationOfferings"; aws_config=aws_config)
+    return ec2(
+        "DescribeHostReservationOfferings";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_host_reservation_offerings(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeHostReservationOfferings", params; aws_config=aws_config)
+    return ec2(
+        "DescribeHostReservationOfferings",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -9780,12 +10413,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`: The token to use to retrieve the next page of results.
 """
 function describe_host_reservations(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("DescribeHostReservations"; aws_config=aws_config)
+    return ec2(
+        "DescribeHostReservations"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_host_reservations(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeHostReservations", params; aws_config=aws_config)
+    return ec2(
+        "DescribeHostReservations",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -9818,12 +10458,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: The token to use to retrieve the next page of results.
 """
 function describe_hosts(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("DescribeHosts"; aws_config=aws_config)
+    return ec2("DescribeHosts"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function describe_hosts(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeHosts", params; aws_config=aws_config)
+    return ec2(
+        "DescribeHosts", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -9844,12 +10486,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_iam_instance_profile_associations(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeIamInstanceProfileAssociations"; aws_config=aws_config)
+    return ec2(
+        "DescribeIamInstanceProfileAssociations";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_iam_instance_profile_associations(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeIamInstanceProfileAssociations", params; aws_config=aws_config)
+    return ec2(
+        "DescribeIamInstanceProfileAssociations",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -9884,12 +10535,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   vpc-peering-connection | vpn-connection | vpn-gateway
 """
 function describe_id_format(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("DescribeIdFormat"; aws_config=aws_config)
+    return ec2("DescribeIdFormat"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function describe_id_format(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeIdFormat", params; aws_config=aws_config)
+    return ec2(
+        "DescribeIdFormat", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -9932,6 +10585,7 @@ function describe_identity_id_format(
         "DescribeIdentityIdFormat",
         Dict{String,Any}("principalArn" => principalArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_identity_id_format(
@@ -9945,6 +10599,7 @@ function describe_identity_id_format(
             mergewith(_merge, Dict{String,Any}("principalArn" => principalArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -9974,6 +10629,7 @@ function describe_image_attribute(
         "DescribeImageAttribute",
         Dict{String,Any}("Attribute" => Attribute, "ImageId" => ImageId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_image_attribute(
@@ -9992,6 +10648,7 @@ function describe_image_attribute(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -10059,12 +10716,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   permissions, the error response is DryRunOperation. Otherwise, it is UnauthorizedOperation.
 """
 function describe_images(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("DescribeImages"; aws_config=aws_config)
+    return ec2("DescribeImages"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function describe_images(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeImages", params; aws_config=aws_config)
+    return ec2(
+        "DescribeImages", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -10086,12 +10745,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`: A token that indicates the next page of results.
 """
 function describe_import_image_tasks(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("DescribeImportImageTasks"; aws_config=aws_config)
+    return ec2(
+        "DescribeImportImageTasks"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_import_image_tasks(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeImportImageTasks", params; aws_config=aws_config)
+    return ec2(
+        "DescribeImportImageTasks",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -10112,12 +10778,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`: A token that indicates the next page of results.
 """
 function describe_import_snapshot_tasks(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("DescribeImportSnapshotTasks"; aws_config=aws_config)
+    return ec2(
+        "DescribeImportSnapshotTasks";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_import_snapshot_tasks(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeImportSnapshotTasks", params; aws_config=aws_config)
+    return ec2(
+        "DescribeImportSnapshotTasks",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -10148,6 +10823,7 @@ function describe_instance_attribute(
         "DescribeInstanceAttribute",
         Dict{String,Any}("attribute" => attribute, "instanceId" => instanceId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_instance_attribute(
@@ -10166,6 +10842,7 @@ function describe_instance_attribute(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -10205,12 +10882,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_instance_credit_specifications(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeInstanceCreditSpecifications"; aws_config=aws_config)
+    return ec2(
+        "DescribeInstanceCreditSpecifications";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_instance_credit_specifications(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeInstanceCreditSpecifications", params; aws_config=aws_config)
+    return ec2(
+        "DescribeInstanceCreditSpecifications",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -10229,12 +10915,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_instance_event_notification_attributes(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeInstanceEventNotificationAttributes"; aws_config=aws_config)
+    return ec2(
+        "DescribeInstanceEventNotificationAttributes";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_instance_event_notification_attributes(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeInstanceEventNotificationAttributes", params; aws_config=aws_config)
+    return ec2(
+        "DescribeInstanceEventNotificationAttributes",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -10278,12 +10973,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_instance_event_windows(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeInstanceEventWindows"; aws_config=aws_config)
+    return ec2(
+        "DescribeInstanceEventWindows";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_instance_event_windows(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeInstanceEventWindows", params; aws_config=aws_config)
+    return ec2(
+        "DescribeInstanceEventWindows",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -10338,12 +11042,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   false, includes the health status for running instances only. Default: false
 """
 function describe_instance_status(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("DescribeInstanceStatus"; aws_config=aws_config)
+    return ec2(
+        "DescribeInstanceStatus"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_instance_status(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeInstanceStatus", params; aws_config=aws_config)
+    return ec2(
+        "DescribeInstanceStatus",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -10371,12 +11082,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_instance_type_offerings(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeInstanceTypeOfferings"; aws_config=aws_config)
+    return ec2(
+        "DescribeInstanceTypeOfferings";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_instance_type_offerings(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeInstanceTypeOfferings", params; aws_config=aws_config)
+    return ec2(
+        "DescribeInstanceTypeOfferings",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -10454,12 +11174,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`: The token to retrieve the next page of results.
 """
 function describe_instance_types(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("DescribeInstanceTypes"; aws_config=aws_config)
+    return ec2(
+        "DescribeInstanceTypes"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_instance_types(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeInstanceTypes", params; aws_config=aws_config)
+    return ec2(
+        "DescribeInstanceTypes",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -10606,12 +11333,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: The token to request the next page of results.
 """
 function describe_instances(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("DescribeInstances"; aws_config=aws_config)
+    return ec2("DescribeInstances"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function describe_instances(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeInstances", params; aws_config=aws_config)
+    return ec2(
+        "DescribeInstances", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -10642,12 +11371,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   internet gateways.
 """
 function describe_internet_gateways(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("DescribeInternetGateways"; aws_config=aws_config)
+    return ec2(
+        "DescribeInternetGateways"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_internet_gateways(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeInternetGateways", params; aws_config=aws_config)
+    return ec2(
+        "DescribeInternetGateways",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -10673,12 +11409,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"PoolId"`: The IDs of the IPv6 address pools.
 """
 function describe_ipv6_pools(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("DescribeIpv6Pools"; aws_config=aws_config)
+    return ec2("DescribeIpv6Pools"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function describe_ipv6_pools(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeIpv6Pools", params; aws_config=aws_config)
+    return ec2(
+        "DescribeIpv6Pools", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -10705,12 +11443,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   permissions, the error response is DryRunOperation. Otherwise, it is UnauthorizedOperation.
 """
 function describe_key_pairs(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("DescribeKeyPairs"; aws_config=aws_config)
+    return ec2("DescribeKeyPairs"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function describe_key_pairs(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeKeyPairs", params; aws_config=aws_config)
+    return ec2(
+        "DescribeKeyPairs", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -10758,12 +11498,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_launch_template_versions(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeLaunchTemplateVersions"; aws_config=aws_config)
+    return ec2(
+        "DescribeLaunchTemplateVersions";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_launch_template_versions(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeLaunchTemplateVersions", params; aws_config=aws_config)
+    return ec2(
+        "DescribeLaunchTemplateVersions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -10793,12 +11542,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`: The token to request the next page of results.
 """
 function describe_launch_templates(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("DescribeLaunchTemplates"; aws_config=aws_config)
+    return ec2(
+        "DescribeLaunchTemplates"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_launch_templates(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeLaunchTemplates", params; aws_config=aws_config)
+    return ec2(
+        "DescribeLaunchTemplates",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -10828,6 +11584,7 @@ function describe_local_gateway_route_table_virtual_interface_group_associations
     return ec2(
         "DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociations";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_local_gateway_route_table_virtual_interface_group_associations(
@@ -10837,6 +11594,7 @@ function describe_local_gateway_route_table_virtual_interface_group_associations
         "DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociations",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -10863,13 +11621,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_local_gateway_route_table_vpc_associations(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeLocalGatewayRouteTableVpcAssociations"; aws_config=aws_config)
+    return ec2(
+        "DescribeLocalGatewayRouteTableVpcAssociations";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_local_gateway_route_table_vpc_associations(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return ec2(
-        "DescribeLocalGatewayRouteTableVpcAssociations", params; aws_config=aws_config
+        "DescribeLocalGatewayRouteTableVpcAssociations",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -10897,12 +11662,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_local_gateway_route_tables(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeLocalGatewayRouteTables"; aws_config=aws_config)
+    return ec2(
+        "DescribeLocalGatewayRouteTables";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_local_gateway_route_tables(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeLocalGatewayRouteTables", params; aws_config=aws_config)
+    return ec2(
+        "DescribeLocalGatewayRouteTables",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -10927,12 +11701,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_local_gateway_virtual_interface_groups(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeLocalGatewayVirtualInterfaceGroups"; aws_config=aws_config)
+    return ec2(
+        "DescribeLocalGatewayVirtualInterfaceGroups";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_local_gateway_virtual_interface_groups(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeLocalGatewayVirtualInterfaceGroups", params; aws_config=aws_config)
+    return ec2(
+        "DescribeLocalGatewayVirtualInterfaceGroups",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -10955,12 +11738,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_local_gateway_virtual_interfaces(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeLocalGatewayVirtualInterfaces"; aws_config=aws_config)
+    return ec2(
+        "DescribeLocalGatewayVirtualInterfaces";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_local_gateway_virtual_interfaces(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeLocalGatewayVirtualInterfaces", params; aws_config=aws_config)
+    return ec2(
+        "DescribeLocalGatewayVirtualInterfaces",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -10987,12 +11779,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`: The token for the next page of results.
 """
 function describe_local_gateways(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("DescribeLocalGateways"; aws_config=aws_config)
+    return ec2(
+        "DescribeLocalGateways"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_local_gateways(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeLocalGateways", params; aws_config=aws_config)
+    return ec2(
+        "DescribeLocalGateways",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -11016,12 +11815,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"PrefixListId"`: One or more prefix list IDs.
 """
 function describe_managed_prefix_lists(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("DescribeManagedPrefixLists"; aws_config=aws_config)
+    return ec2(
+        "DescribeManagedPrefixLists"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_managed_prefix_lists(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeManagedPrefixLists", params; aws_config=aws_config)
+    return ec2(
+        "DescribeManagedPrefixLists",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -11048,12 +11854,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"publicIp"`: One or more Elastic IP addresses.
 """
 function describe_moving_addresses(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("DescribeMovingAddresses"; aws_config=aws_config)
+    return ec2(
+        "DescribeMovingAddresses"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_moving_addresses(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeMovingAddresses", params; aws_config=aws_config)
+    return ec2(
+        "DescribeMovingAddresses",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -11082,12 +11895,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`: The token for the next page of results.
 """
 function describe_nat_gateways(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("DescribeNatGateways"; aws_config=aws_config)
+    return ec2(
+        "DescribeNatGateways"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_nat_gateways(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeNatGateways", params; aws_config=aws_config)
+    return ec2(
+        "DescribeNatGateways",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -11127,12 +11947,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   permissions, the error response is DryRunOperation. Otherwise, it is UnauthorizedOperation.
 """
 function describe_network_acls(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("DescribeNetworkAcls"; aws_config=aws_config)
+    return ec2(
+        "DescribeNetworkAcls"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_network_acls(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeNetworkAcls", params; aws_config=aws_config)
+    return ec2(
+        "DescribeNetworkAcls",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -11162,12 +11989,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_network_insights_analyses(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeNetworkInsightsAnalyses"; aws_config=aws_config)
+    return ec2(
+        "DescribeNetworkInsightsAnalyses";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_network_insights_analyses(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeNetworkInsightsAnalyses", params; aws_config=aws_config)
+    return ec2(
+        "DescribeNetworkInsightsAnalyses",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -11192,12 +12028,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_network_insights_paths(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeNetworkInsightsPaths"; aws_config=aws_config)
+    return ec2(
+        "DescribeNetworkInsightsPaths";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_network_insights_paths(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeNetworkInsightsPaths", params; aws_config=aws_config)
+    return ec2(
+        "DescribeNetworkInsightsPaths",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -11223,6 +12068,7 @@ function describe_network_interface_attribute(
         "DescribeNetworkInterfaceAttribute",
         Dict{String,Any}("networkInterfaceId" => networkInterfaceId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_network_interface_attribute(
@@ -11238,6 +12084,7 @@ function describe_network_interface_attribute(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -11265,12 +12112,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_network_interface_permissions(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeNetworkInterfacePermissions"; aws_config=aws_config)
+    return ec2(
+        "DescribeNetworkInterfacePermissions";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_network_interface_permissions(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeNetworkInterfacePermissions", params; aws_config=aws_config)
+    return ec2(
+        "DescribeNetworkInterfacePermissions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -11338,12 +12194,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   network interface.
 """
 function describe_network_interfaces(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("DescribeNetworkInterfaces"; aws_config=aws_config)
+    return ec2(
+        "DescribeNetworkInterfaces"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_network_interfaces(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeNetworkInterfaces", params; aws_config=aws_config)
+    return ec2(
+        "DescribeNetworkInterfaces",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -11371,12 +12234,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   groups, or only those otherwise specified.
 """
 function describe_placement_groups(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("DescribePlacementGroups"; aws_config=aws_config)
+    return ec2(
+        "DescribePlacementGroups"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_placement_groups(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribePlacementGroups", params; aws_config=aws_config)
+    return ec2(
+        "DescribePlacementGroups",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -11400,12 +12270,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"PrefixListId"`: One or more prefix list IDs.
 """
 function describe_prefix_lists(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("DescribePrefixLists"; aws_config=aws_config)
+    return ec2(
+        "DescribePrefixLists"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_prefix_lists(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribePrefixLists", params; aws_config=aws_config)
+    return ec2(
+        "DescribePrefixLists",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -11442,12 +12319,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   vpc-peering-connection | vpn-connection | vpn-gateway
 """
 function describe_principal_id_format(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("DescribePrincipalIdFormat"; aws_config=aws_config)
+    return ec2(
+        "DescribePrincipalIdFormat"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_principal_id_format(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribePrincipalIdFormat", params; aws_config=aws_config)
+    return ec2(
+        "DescribePrincipalIdFormat",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -11470,12 +12354,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"PoolId"`: The IDs of the address pools.
 """
 function describe_public_ipv4_pools(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("DescribePublicIpv4Pools"; aws_config=aws_config)
+    return ec2(
+        "DescribePublicIpv4Pools"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_public_ipv4_pools(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribePublicIpv4Pools", params; aws_config=aws_config)
+    return ec2(
+        "DescribePublicIpv4Pools",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -11502,12 +12393,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   permissions, the error response is DryRunOperation. Otherwise, it is UnauthorizedOperation.
 """
 function describe_regions(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("DescribeRegions"; aws_config=aws_config)
+    return ec2("DescribeRegions"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function describe_regions(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeRegions", params; aws_config=aws_config)
+    return ec2(
+        "DescribeRegions", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -11532,12 +12425,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_replace_root_volume_tasks(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeReplaceRootVolumeTasks"; aws_config=aws_config)
+    return ec2(
+        "DescribeReplaceRootVolumeTasks";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_replace_root_volume_tasks(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeReplaceRootVolumeTasks", params; aws_config=aws_config)
+    return ec2(
+        "DescribeReplaceRootVolumeTasks",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -11584,12 +12486,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Instance offering type.
 """
 function describe_reserved_instances(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("DescribeReservedInstances"; aws_config=aws_config)
+    return ec2(
+        "DescribeReservedInstances"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_reserved_instances(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeReservedInstances", params; aws_config=aws_config)
+    return ec2(
+        "DescribeReservedInstances",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -11622,12 +12531,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_reserved_instances_listings(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeReservedInstancesListings"; aws_config=aws_config)
+    return ec2(
+        "DescribeReservedInstancesListings";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_reserved_instances_listings(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeReservedInstancesListings", params; aws_config=aws_config)
+    return ec2(
+        "DescribeReservedInstancesListings",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -11663,12 +12581,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_reserved_instances_modifications(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeReservedInstancesModifications"; aws_config=aws_config)
+    return ec2(
+        "DescribeReservedInstancesModifications";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_reserved_instances_modifications(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeReservedInstancesModifications", params; aws_config=aws_config)
+    return ec2(
+        "DescribeReservedInstancesModifications",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -11737,12 +12664,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_reserved_instances_offerings(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeReservedInstancesOfferings"; aws_config=aws_config)
+    return ec2(
+        "DescribeReservedInstancesOfferings";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_reserved_instances_offerings(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeReservedInstancesOfferings", params; aws_config=aws_config)
+    return ec2(
+        "DescribeReservedInstancesOfferings",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -11795,12 +12731,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   permissions, the error response is DryRunOperation. Otherwise, it is UnauthorizedOperation.
 """
 function describe_route_tables(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("DescribeRouteTables"; aws_config=aws_config)
+    return ec2(
+        "DescribeRouteTables"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_route_tables(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeRouteTables", params; aws_config=aws_config)
+    return ec2(
+        "DescribeRouteTables",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -11847,6 +12790,7 @@ function describe_scheduled_instance_availability(
             "FirstSlotStartTimeRange" => FirstSlotStartTimeRange, "Recurrence" => Recurrence
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_scheduled_instance_availability(
@@ -11868,6 +12812,7 @@ function describe_scheduled_instance_availability(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -11894,12 +12839,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"SlotStartTimeRange"`: The time period for the first schedule to start.
 """
 function describe_scheduled_instances(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("DescribeScheduledInstances"; aws_config=aws_config)
+    return ec2(
+        "DescribeScheduledInstances"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_scheduled_instances(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeScheduledInstances", params; aws_config=aws_config)
+    return ec2(
+        "DescribeScheduledInstances",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -11926,6 +12878,7 @@ function describe_security_group_references(
         "DescribeSecurityGroupReferences",
         Dict{String,Any}("item" => item);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_security_group_references(
@@ -11935,6 +12888,7 @@ function describe_security_group_references(
         "DescribeSecurityGroupReferences",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("item" => item), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -11962,12 +12916,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"SecurityGroupRuleId"`: The IDs of the security group rules.
 """
 function describe_security_group_rules(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("DescribeSecurityGroupRules"; aws_config=aws_config)
+    return ec2(
+        "DescribeSecurityGroupRules"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_security_group_rules(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeSecurityGroupRules", params; aws_config=aws_config)
+    return ec2(
+        "DescribeSecurityGroupRules",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -12032,12 +12993,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   permissions, the error response is DryRunOperation. Otherwise, it is UnauthorizedOperation.
 """
 function describe_security_groups(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("DescribeSecurityGroups"; aws_config=aws_config)
+    return ec2(
+        "DescribeSecurityGroups"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_security_groups(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeSecurityGroups", params; aws_config=aws_config)
+    return ec2(
+        "DescribeSecurityGroups",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -12065,6 +13033,7 @@ function describe_snapshot_attribute(
         "DescribeSnapshotAttribute",
         Dict{String,Any}("Attribute" => Attribute, "SnapshotId" => SnapshotId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_snapshot_attribute(
@@ -12083,6 +13052,7 @@ function describe_snapshot_attribute(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -12162,12 +13132,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   permissions, the error response is DryRunOperation. Otherwise, it is UnauthorizedOperation.
 """
 function describe_snapshots(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("DescribeSnapshots"; aws_config=aws_config)
+    return ec2("DescribeSnapshots"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function describe_snapshots(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeSnapshots", params; aws_config=aws_config)
+    return ec2(
+        "DescribeSnapshots", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -12186,12 +13158,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_spot_datafeed_subscription(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeSpotDatafeedSubscription"; aws_config=aws_config)
+    return ec2(
+        "DescribeSpotDatafeedSubscription";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_spot_datafeed_subscription(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeSpotDatafeedSubscription", params; aws_config=aws_config)
+    return ec2(
+        "DescribeSpotDatafeedSubscription",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -12220,6 +13201,7 @@ function describe_spot_fleet_instances(
         "DescribeSpotFleetInstances",
         Dict{String,Any}("spotFleetRequestId" => spotFleetRequestId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_spot_fleet_instances(
@@ -12235,6 +13217,7 @@ function describe_spot_fleet_instances(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -12272,6 +13255,7 @@ function describe_spot_fleet_request_history(
             "spotFleetRequestId" => spotFleetRequestId, "startTime" => startTime
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_spot_fleet_request_history(
@@ -12292,6 +13276,7 @@ function describe_spot_fleet_request_history(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -12314,12 +13299,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"spotFleetRequestId"`: The IDs of the Spot Fleet requests.
 """
 function describe_spot_fleet_requests(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("DescribeSpotFleetRequests"; aws_config=aws_config)
+    return ec2(
+        "DescribeSpotFleetRequests"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_spot_fleet_requests(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeSpotFleetRequests", params; aws_config=aws_config)
+    return ec2(
+        "DescribeSpotFleetRequests",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -12397,12 +13389,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_spot_instance_requests(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeSpotInstanceRequests"; aws_config=aws_config)
+    return ec2(
+        "DescribeSpotInstanceRequests";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_spot_instance_requests(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeSpotInstanceRequests", params; aws_config=aws_config)
+    return ec2(
+        "DescribeSpotInstanceRequests",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -12442,12 +13443,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   the price history data, in UTC format (for example, YYYY-MM-DDTHH:MM:SSZ).
 """
 function describe_spot_price_history(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("DescribeSpotPriceHistory"; aws_config=aws_config)
+    return ec2(
+        "DescribeSpotPriceHistory"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_spot_price_history(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeSpotPriceHistory", params; aws_config=aws_config)
+    return ec2(
+        "DescribeSpotPriceHistory",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -12478,6 +13486,7 @@ function describe_stale_security_groups(
         "DescribeStaleSecurityGroups",
         Dict{String,Any}("VpcId" => VpcId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_stale_security_groups(
@@ -12487,6 +13496,7 @@ function describe_stale_security_groups(
         "DescribeStaleSecurityGroups",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("VpcId" => VpcId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -12521,12 +13531,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`: The token for the next page of results.
 """
 function describe_store_image_tasks(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("DescribeStoreImageTasks"; aws_config=aws_config)
+    return ec2(
+        "DescribeStoreImageTasks"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_store_image_tasks(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeStoreImageTasks", params; aws_config=aws_config)
+    return ec2(
+        "DescribeStoreImageTasks",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -12569,12 +13586,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   permissions, the error response is DryRunOperation. Otherwise, it is UnauthorizedOperation.
 """
 function describe_subnets(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("DescribeSubnets"; aws_config=aws_config)
+    return ec2("DescribeSubnets"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function describe_subnets(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeSubnets", params; aws_config=aws_config)
+    return ec2(
+        "DescribeSubnets", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -12604,12 +13623,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: The token to retrieve the next page of results.
 """
 function describe_tags(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("DescribeTags"; aws_config=aws_config)
+    return ec2("DescribeTags"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function describe_tags(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeTags", params; aws_config=aws_config)
+    return ec2(
+        "DescribeTags", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -12634,12 +13655,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_traffic_mirror_filters(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeTrafficMirrorFilters"; aws_config=aws_config)
+    return ec2(
+        "DescribeTrafficMirrorFilters";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_traffic_mirror_filters(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeTrafficMirrorFilters", params; aws_config=aws_config)
+    return ec2(
+        "DescribeTrafficMirrorFilters",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -12670,12 +13700,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_traffic_mirror_sessions(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeTrafficMirrorSessions"; aws_config=aws_config)
+    return ec2(
+        "DescribeTrafficMirrorSessions";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_traffic_mirror_sessions(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeTrafficMirrorSessions", params; aws_config=aws_config)
+    return ec2(
+        "DescribeTrafficMirrorSessions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -12703,12 +13742,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_traffic_mirror_targets(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeTrafficMirrorTargets"; aws_config=aws_config)
+    return ec2(
+        "DescribeTrafficMirrorTargets";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_traffic_mirror_targets(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeTrafficMirrorTargets", params; aws_config=aws_config)
+    return ec2(
+        "DescribeTrafficMirrorTargets",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -12743,12 +13791,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_transit_gateway_attachments(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeTransitGatewayAttachments"; aws_config=aws_config)
+    return ec2(
+        "DescribeTransitGatewayAttachments";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_transit_gateway_attachments(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeTransitGatewayAttachments", params; aws_config=aws_config)
+    return ec2(
+        "DescribeTransitGatewayAttachments",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -12773,12 +13830,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_transit_gateway_connect_peers(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeTransitGatewayConnectPeers"; aws_config=aws_config)
+    return ec2(
+        "DescribeTransitGatewayConnectPeers";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_transit_gateway_connect_peers(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeTransitGatewayConnectPeers", params; aws_config=aws_config)
+    return ec2(
+        "DescribeTransitGatewayConnectPeers",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -12807,12 +13873,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_transit_gateway_connects(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeTransitGatewayConnects"; aws_config=aws_config)
+    return ec2(
+        "DescribeTransitGatewayConnects";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_transit_gateway_connects(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeTransitGatewayConnects", params; aws_config=aws_config)
+    return ec2(
+        "DescribeTransitGatewayConnects",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -12838,12 +13913,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_transit_gateway_multicast_domains(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeTransitGatewayMulticastDomains"; aws_config=aws_config)
+    return ec2(
+        "DescribeTransitGatewayMulticastDomains";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_transit_gateway_multicast_domains(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeTransitGatewayMulticastDomains", params; aws_config=aws_config)
+    return ec2(
+        "DescribeTransitGatewayMulticastDomains",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -12879,12 +13963,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_transit_gateway_peering_attachments(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeTransitGatewayPeeringAttachments"; aws_config=aws_config)
+    return ec2(
+        "DescribeTransitGatewayPeeringAttachments";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_transit_gateway_peering_attachments(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeTransitGatewayPeeringAttachments", params; aws_config=aws_config)
+    return ec2(
+        "DescribeTransitGatewayPeeringAttachments",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -12914,12 +14007,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_transit_gateway_route_tables(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeTransitGatewayRouteTables"; aws_config=aws_config)
+    return ec2(
+        "DescribeTransitGatewayRouteTables";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_transit_gateway_route_tables(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeTransitGatewayRouteTables", params; aws_config=aws_config)
+    return ec2(
+        "DescribeTransitGatewayRouteTables",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -12947,12 +14049,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_transit_gateway_vpc_attachments(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeTransitGatewayVpcAttachments"; aws_config=aws_config)
+    return ec2(
+        "DescribeTransitGatewayVpcAttachments";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_transit_gateway_vpc_attachments(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeTransitGatewayVpcAttachments", params; aws_config=aws_config)
+    return ec2(
+        "DescribeTransitGatewayVpcAttachments",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -12988,12 +14099,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"TransitGatewayIds"`: The IDs of the transit gateways.
 """
 function describe_transit_gateways(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("DescribeTransitGateways"; aws_config=aws_config)
+    return ec2(
+        "DescribeTransitGateways"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_transit_gateways(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeTransitGateways", params; aws_config=aws_config)
+    return ec2(
+        "DescribeTransitGateways",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -13019,12 +14137,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_trunk_interface_associations(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeTrunkInterfaceAssociations"; aws_config=aws_config)
+    return ec2(
+        "DescribeTrunkInterfaceAssociations";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_trunk_interface_associations(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeTrunkInterfaceAssociations", params; aws_config=aws_config)
+    return ec2(
+        "DescribeTrunkInterfaceAssociations",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -13052,6 +14179,7 @@ function describe_volume_attribute(
         "DescribeVolumeAttribute",
         Dict{String,Any}("Attribute" => Attribute, "VolumeId" => VolumeId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_volume_attribute(
@@ -13070,6 +14198,7 @@ function describe_volume_attribute(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -13135,12 +14264,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   permissions, the error response is DryRunOperation. Otherwise, it is UnauthorizedOperation.
 """
 function describe_volume_status(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("DescribeVolumeStatus"; aws_config=aws_config)
+    return ec2(
+        "DescribeVolumeStatus"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_volume_status(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeVolumeStatus", params; aws_config=aws_config)
+    return ec2(
+        "DescribeVolumeStatus",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -13195,12 +14331,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   value. This value is null when there are no more results to return.
 """
 function describe_volumes(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("DescribeVolumes"; aws_config=aws_config)
+    return ec2("DescribeVolumes"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function describe_volumes(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeVolumes", params; aws_config=aws_config)
+    return ec2(
+        "DescribeVolumes", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -13236,12 +14374,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"VolumeId"`: The IDs of the volumes.
 """
 function describe_volumes_modifications(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("DescribeVolumesModifications"; aws_config=aws_config)
+    return ec2(
+        "DescribeVolumesModifications";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_volumes_modifications(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeVolumesModifications", params; aws_config=aws_config)
+    return ec2(
+        "DescribeVolumesModifications",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -13268,6 +14415,7 @@ function describe_vpc_attribute(
         "DescribeVpcAttribute",
         Dict{String,Any}("Attribute" => Attribute, "VpcId" => VpcId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_vpc_attribute(
@@ -13284,6 +14432,7 @@ function describe_vpc_attribute(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -13308,12 +14457,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   permissions, the error response is DryRunOperation. Otherwise, it is UnauthorizedOperation.
 """
 function describe_vpc_classic_link(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("DescribeVpcClassicLink"; aws_config=aws_config)
+    return ec2(
+        "DescribeVpcClassicLink"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_vpc_classic_link(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeVpcClassicLink", params; aws_config=aws_config)
+    return ec2(
+        "DescribeVpcClassicLink",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -13337,12 +14493,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_vpc_classic_link_dns_support(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeVpcClassicLinkDnsSupport"; aws_config=aws_config)
+    return ec2(
+        "DescribeVpcClassicLinkDnsSupport";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_vpc_classic_link_dns_support(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeVpcClassicLinkDnsSupport", params; aws_config=aws_config)
+    return ec2(
+        "DescribeVpcClassicLinkDnsSupport",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -13369,12 +14534,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_vpc_endpoint_connection_notifications(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeVpcEndpointConnectionNotifications"; aws_config=aws_config)
+    return ec2(
+        "DescribeVpcEndpointConnectionNotifications";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_vpc_endpoint_connection_notifications(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeVpcEndpointConnectionNotifications", params; aws_config=aws_config)
+    return ec2(
+        "DescribeVpcEndpointConnectionNotifications",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -13402,12 +14576,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_vpc_endpoint_connections(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeVpcEndpointConnections"; aws_config=aws_config)
+    return ec2(
+        "DescribeVpcEndpointConnections";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_vpc_endpoint_connections(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeVpcEndpointConnections", params; aws_config=aws_config)
+    return ec2(
+        "DescribeVpcEndpointConnections",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -13439,12 +14622,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_vpc_endpoint_service_configurations(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeVpcEndpointServiceConfigurations"; aws_config=aws_config)
+    return ec2(
+        "DescribeVpcEndpointServiceConfigurations";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_vpc_endpoint_service_configurations(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeVpcEndpointServiceConfigurations", params; aws_config=aws_config)
+    return ec2(
+        "DescribeVpcEndpointServiceConfigurations",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -13478,6 +14670,7 @@ function describe_vpc_endpoint_service_permissions(
         "DescribeVpcEndpointServicePermissions",
         Dict{String,Any}("ServiceId" => ServiceId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_vpc_endpoint_service_permissions(
@@ -13491,6 +14684,7 @@ function describe_vpc_endpoint_service_permissions(
             mergewith(_merge, Dict{String,Any}("ServiceId" => ServiceId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -13525,12 +14719,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"ServiceName"`: One or more service names.
 """
 function describe_vpc_endpoint_services(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("DescribeVpcEndpointServices"; aws_config=aws_config)
+    return ec2(
+        "DescribeVpcEndpointServices";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_vpc_endpoint_services(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeVpcEndpointServices", params; aws_config=aws_config)
+    return ec2(
+        "DescribeVpcEndpointServices",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -13562,12 +14765,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"VpcEndpointId"`: One or more endpoint IDs.
 """
 function describe_vpc_endpoints(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("DescribeVpcEndpoints"; aws_config=aws_config)
+    return ec2(
+        "DescribeVpcEndpoints"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_vpc_endpoints(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeVpcEndpoints", params; aws_config=aws_config)
+    return ec2(
+        "DescribeVpcEndpoints",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -13607,12 +14817,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_vpc_peering_connections(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeVpcPeeringConnections"; aws_config=aws_config)
+    return ec2(
+        "DescribeVpcPeeringConnections";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_vpc_peering_connections(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeVpcPeeringConnections", params; aws_config=aws_config)
+    return ec2(
+        "DescribeVpcPeeringConnections",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -13652,12 +14871,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   permissions, the error response is DryRunOperation. Otherwise, it is UnauthorizedOperation.
 """
 function describe_vpcs(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("DescribeVpcs"; aws_config=aws_config)
+    return ec2("DescribeVpcs"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function describe_vpcs(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeVpcs", params; aws_config=aws_config)
+    return ec2(
+        "DescribeVpcs", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -13693,12 +14914,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   permissions, the error response is DryRunOperation. Otherwise, it is UnauthorizedOperation.
 """
 function describe_vpn_connections(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("DescribeVpnConnections"; aws_config=aws_config)
+    return ec2(
+        "DescribeVpnConnections"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_vpn_connections(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeVpnConnections", params; aws_config=aws_config)
+    return ec2(
+        "DescribeVpnConnections",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -13730,12 +14958,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   permissions, the error response is DryRunOperation. Otherwise, it is UnauthorizedOperation.
 """
 function describe_vpn_gateways(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("DescribeVpnGateways"; aws_config=aws_config)
+    return ec2(
+        "DescribeVpnGateways"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_vpn_gateways(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DescribeVpnGateways", params; aws_config=aws_config)
+    return ec2(
+        "DescribeVpnGateways",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -13763,6 +14998,7 @@ function detach_classic_link_vpc(
         "DetachClassicLinkVpc",
         Dict{String,Any}("instanceId" => instanceId, "vpcId" => vpcId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function detach_classic_link_vpc(
@@ -13781,6 +15017,7 @@ function detach_classic_link_vpc(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -13809,6 +15046,7 @@ function detach_internet_gateway(
         "DetachInternetGateway",
         Dict{String,Any}("internetGatewayId" => internetGatewayId, "vpcId" => vpcId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function detach_internet_gateway(
@@ -13829,6 +15067,7 @@ function detach_internet_gateway(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -13862,6 +15101,7 @@ function detach_network_interface(
         "DetachNetworkInterface",
         Dict{String,Any}("attachmentId" => attachmentId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function detach_network_interface(
@@ -13875,6 +15115,7 @@ function detach_network_interface(
             mergewith(_merge, Dict{String,Any}("attachmentId" => attachmentId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -13913,7 +15154,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function detach_volume(VolumeId; aws_config::AbstractAWSConfig=global_aws_config())
     return ec2(
-        "DetachVolume", Dict{String,Any}("VolumeId" => VolumeId); aws_config=aws_config
+        "DetachVolume",
+        Dict{String,Any}("VolumeId" => VolumeId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function detach_volume(
@@ -13927,6 +15171,7 @@ function detach_volume(
             mergewith(_merge, Dict{String,Any}("VolumeId" => VolumeId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -13958,6 +15203,7 @@ function detach_vpn_gateway(
         "DetachVpnGateway",
         Dict{String,Any}("VpcId" => VpcId, "VpnGatewayId" => VpnGatewayId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function detach_vpn_gateway(
@@ -13976,6 +15222,7 @@ function detach_vpn_gateway(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -13998,12 +15245,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function disable_ebs_encryption_by_default(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DisableEbsEncryptionByDefault"; aws_config=aws_config)
+    return ec2(
+        "DisableEbsEncryptionByDefault";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function disable_ebs_encryption_by_default(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DisableEbsEncryptionByDefault", params; aws_config=aws_config)
+    return ec2(
+        "DisableEbsEncryptionByDefault",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -14033,6 +15289,7 @@ function disable_fast_snapshot_restores(
             "AvailabilityZone" => AvailabilityZone, "SourceSnapshotId" => SourceSnapshotId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disable_fast_snapshot_restores(
@@ -14054,6 +15311,7 @@ function disable_fast_snapshot_restores(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -14080,6 +15338,7 @@ function disable_image_deprecation(
         "DisableImageDeprecation",
         Dict{String,Any}("ImageId" => ImageId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disable_image_deprecation(
@@ -14089,6 +15348,7 @@ function disable_image_deprecation(
         "DisableImageDeprecation",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("ImageId" => ImageId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -14107,12 +15367,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   permissions, the error response is DryRunOperation. Otherwise, it is UnauthorizedOperation.
 """
 function disable_serial_console_access(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("DisableSerialConsoleAccess"; aws_config=aws_config)
+    return ec2(
+        "DisableSerialConsoleAccess"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function disable_serial_console_access(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DisableSerialConsoleAccess", params; aws_config=aws_config)
+    return ec2(
+        "DisableSerialConsoleAccess",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -14144,6 +15411,7 @@ function disable_transit_gateway_route_table_propagation(
             "TransitGatewayRouteTableId" => TransitGatewayRouteTableId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disable_transit_gateway_route_table_propagation(
@@ -14165,6 +15433,7 @@ function disable_transit_gateway_route_table_propagation(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -14192,6 +15461,7 @@ function disable_vgw_route_propagation(
         "DisableVgwRoutePropagation",
         Dict{String,Any}("GatewayId" => GatewayId, "RouteTableId" => RouteTableId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disable_vgw_route_propagation(
@@ -14210,6 +15480,7 @@ function disable_vgw_route_propagation(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -14231,7 +15502,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function disable_vpc_classic_link(vpcId; aws_config::AbstractAWSConfig=global_aws_config())
     return ec2(
-        "DisableVpcClassicLink", Dict{String,Any}("vpcId" => vpcId); aws_config=aws_config
+        "DisableVpcClassicLink",
+        Dict{String,Any}("vpcId" => vpcId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disable_vpc_classic_link(
@@ -14241,6 +15515,7 @@ function disable_vpc_classic_link(
         "DisableVpcClassicLink",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("vpcId" => vpcId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -14260,12 +15535,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function disable_vpc_classic_link_dns_support(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DisableVpcClassicLinkDnsSupport"; aws_config=aws_config)
+    return ec2(
+        "DisableVpcClassicLinkDnsSupport";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function disable_vpc_classic_link_dns_support(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DisableVpcClassicLinkDnsSupport", params; aws_config=aws_config)
+    return ec2(
+        "DisableVpcClassicLinkDnsSupport",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -14287,12 +15571,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   permissions, the error response is DryRunOperation. Otherwise, it is UnauthorizedOperation.
 """
 function disassociate_address(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("DisassociateAddress"; aws_config=aws_config)
+    return ec2(
+        "DisassociateAddress"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function disassociate_address(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DisassociateAddress", params; aws_config=aws_config)
+    return ec2(
+        "DisassociateAddress",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -14325,6 +15616,7 @@ function disassociate_client_vpn_target_network(
             "AssociationId" => AssociationId, "ClientVpnEndpointId" => ClientVpnEndpointId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disassociate_client_vpn_target_network(
@@ -14346,6 +15638,7 @@ function disassociate_client_vpn_target_network(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -14371,12 +15664,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function disassociate_enclave_certificate_iam_role(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DisassociateEnclaveCertificateIamRole"; aws_config=aws_config)
+    return ec2(
+        "DisassociateEnclaveCertificateIamRole";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function disassociate_enclave_certificate_iam_role(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DisassociateEnclaveCertificateIamRole", params; aws_config=aws_config)
+    return ec2(
+        "DisassociateEnclaveCertificateIamRole",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -14397,6 +15699,7 @@ function disassociate_iam_instance_profile(
         "DisassociateIamInstanceProfile",
         Dict{String,Any}("AssociationId" => AssociationId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disassociate_iam_instance_profile(
@@ -14410,6 +15713,7 @@ function disassociate_iam_instance_profile(
             mergewith(_merge, Dict{String,Any}("AssociationId" => AssociationId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -14442,6 +15746,7 @@ function disassociate_instance_event_window(
             "InstanceEventWindowId" => InstanceEventWindowId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disassociate_instance_event_window(
@@ -14463,6 +15768,7 @@ function disassociate_instance_event_window(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -14492,6 +15798,7 @@ function disassociate_route_table(
         "DisassociateRouteTable",
         Dict{String,Any}("associationId" => associationId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disassociate_route_table(
@@ -14505,6 +15812,7 @@ function disassociate_route_table(
             mergewith(_merge, Dict{String,Any}("associationId" => associationId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -14527,6 +15835,7 @@ function disassociate_subnet_cidr_block(
         "DisassociateSubnetCidrBlock",
         Dict{String,Any}("associationId" => associationId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disassociate_subnet_cidr_block(
@@ -14540,6 +15849,7 @@ function disassociate_subnet_cidr_block(
             mergewith(_merge, Dict{String,Any}("associationId" => associationId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -14561,12 +15871,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function disassociate_transit_gateway_multicast_domain(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DisassociateTransitGatewayMulticastDomain"; aws_config=aws_config)
+    return ec2(
+        "DisassociateTransitGatewayMulticastDomain";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function disassociate_transit_gateway_multicast_domain(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("DisassociateTransitGatewayMulticastDomain", params; aws_config=aws_config)
+    return ec2(
+        "DisassociateTransitGatewayMulticastDomain",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -14597,6 +15916,7 @@ function disassociate_transit_gateway_route_table(
             "TransitGatewayRouteTableId" => TransitGatewayRouteTableId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disassociate_transit_gateway_route_table(
@@ -14618,6 +15938,7 @@ function disassociate_transit_gateway_route_table(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -14649,6 +15970,7 @@ function disassociate_trunk_interface(
             "AssociationId" => AssociationId, "ClientToken" => string(uuid4())
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disassociate_trunk_interface(
@@ -14668,6 +15990,7 @@ function disassociate_trunk_interface(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -14692,6 +16015,7 @@ function disassociate_vpc_cidr_block(
         "DisassociateVpcCidrBlock",
         Dict{String,Any}("associationId" => associationId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disassociate_vpc_cidr_block(
@@ -14705,6 +16029,7 @@ function disassociate_vpc_cidr_block(
             mergewith(_merge, Dict{String,Any}("associationId" => associationId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -14731,12 +16056,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function enable_ebs_encryption_by_default(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("EnableEbsEncryptionByDefault"; aws_config=aws_config)
+    return ec2(
+        "EnableEbsEncryptionByDefault";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function enable_ebs_encryption_by_default(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("EnableEbsEncryptionByDefault", params; aws_config=aws_config)
+    return ec2(
+        "EnableEbsEncryptionByDefault",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -14771,6 +16105,7 @@ function enable_fast_snapshot_restores(
             "AvailabilityZone" => AvailabilityZone, "SourceSnapshotId" => SourceSnapshotId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function enable_fast_snapshot_restores(
@@ -14792,6 +16127,7 @@ function enable_fast_snapshot_restores(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -14822,6 +16158,7 @@ function enable_image_deprecation(
         "EnableImageDeprecation",
         Dict{String,Any}("DeprecateAt" => DeprecateAt, "ImageId" => ImageId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function enable_image_deprecation(
@@ -14840,6 +16177,7 @@ function enable_image_deprecation(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -14858,12 +16196,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   permissions, the error response is DryRunOperation. Otherwise, it is UnauthorizedOperation.
 """
 function enable_serial_console_access(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("EnableSerialConsoleAccess"; aws_config=aws_config)
+    return ec2(
+        "EnableSerialConsoleAccess"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function enable_serial_console_access(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("EnableSerialConsoleAccess", params; aws_config=aws_config)
+    return ec2(
+        "EnableSerialConsoleAccess",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -14895,6 +16240,7 @@ function enable_transit_gateway_route_table_propagation(
             "TransitGatewayRouteTableId" => TransitGatewayRouteTableId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function enable_transit_gateway_route_table_propagation(
@@ -14916,6 +16262,7 @@ function enable_transit_gateway_route_table_propagation(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -14946,6 +16293,7 @@ function enable_vgw_route_propagation(
         "EnableVgwRoutePropagation",
         Dict{String,Any}("GatewayId" => GatewayId, "RouteTableId" => RouteTableId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function enable_vgw_route_propagation(
@@ -14964,6 +16312,7 @@ function enable_vgw_route_propagation(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -14985,7 +16334,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function enable_volume_io(volumeId; aws_config::AbstractAWSConfig=global_aws_config())
     return ec2(
-        "EnableVolumeIO", Dict{String,Any}("volumeId" => volumeId); aws_config=aws_config
+        "EnableVolumeIO",
+        Dict{String,Any}("volumeId" => volumeId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function enable_volume_io(
@@ -14999,6 +16351,7 @@ function enable_volume_io(
             mergewith(_merge, Dict{String,Any}("volumeId" => volumeId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -15024,7 +16377,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function enable_vpc_classic_link(vpcId; aws_config::AbstractAWSConfig=global_aws_config())
     return ec2(
-        "EnableVpcClassicLink", Dict{String,Any}("vpcId" => vpcId); aws_config=aws_config
+        "EnableVpcClassicLink",
+        Dict{String,Any}("vpcId" => vpcId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function enable_vpc_classic_link(
@@ -15034,6 +16390,7 @@ function enable_vpc_classic_link(
         "EnableVpcClassicLink",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("vpcId" => vpcId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -15055,12 +16412,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function enable_vpc_classic_link_dns_support(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("EnableVpcClassicLinkDnsSupport"; aws_config=aws_config)
+    return ec2(
+        "EnableVpcClassicLinkDnsSupport";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function enable_vpc_classic_link_dns_support(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("EnableVpcClassicLinkDnsSupport", params; aws_config=aws_config)
+    return ec2(
+        "EnableVpcClassicLinkDnsSupport",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -15085,6 +16451,7 @@ function export_client_vpn_client_certificate_revocation_list(
         "ExportClientVpnClientCertificateRevocationList",
         Dict{String,Any}("ClientVpnEndpointId" => ClientVpnEndpointId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function export_client_vpn_client_certificate_revocation_list(
@@ -15102,6 +16469,7 @@ function export_client_vpn_client_certificate_revocation_list(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -15130,6 +16498,7 @@ function export_client_vpn_client_configuration(
         "ExportClientVpnClientConfiguration",
         Dict{String,Any}("ClientVpnEndpointId" => ClientVpnEndpointId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function export_client_vpn_client_configuration(
@@ -15147,6 +16516,7 @@ function export_client_vpn_client_configuration(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -15192,6 +16562,7 @@ function export_image(
             "ClientToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function export_image(
@@ -15216,6 +16587,7 @@ function export_image(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -15260,6 +16632,7 @@ function export_transit_gateway_routes(
             "TransitGatewayRouteTableId" => TransitGatewayRouteTableId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function export_transit_gateway_routes(
@@ -15281,6 +16654,7 @@ function export_transit_gateway_routes(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -15304,12 +16678,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function get_associated_enclave_certificate_iam_roles(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("GetAssociatedEnclaveCertificateIamRoles"; aws_config=aws_config)
+    return ec2(
+        "GetAssociatedEnclaveCertificateIamRoles";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_associated_enclave_certificate_iam_roles(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("GetAssociatedEnclaveCertificateIamRoles", params; aws_config=aws_config)
+    return ec2(
+        "GetAssociatedEnclaveCertificateIamRoles",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -15337,6 +16720,7 @@ function get_associated_ipv6_pool_cidrs(
         "GetAssociatedIpv6PoolCidrs",
         Dict{String,Any}("PoolId" => PoolId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_associated_ipv6_pool_cidrs(
@@ -15346,6 +16730,7 @@ function get_associated_ipv6_pool_cidrs(
         "GetAssociatedIpv6PoolCidrs",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("PoolId" => PoolId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -15379,6 +16764,7 @@ function get_capacity_reservation_usage(
         "GetCapacityReservationUsage",
         Dict{String,Any}("CapacityReservationId" => CapacityReservationId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_capacity_reservation_usage(
@@ -15396,6 +16782,7 @@ function get_capacity_reservation_usage(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -15422,7 +16809,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function get_coip_pool_usage(PoolId; aws_config::AbstractAWSConfig=global_aws_config())
     return ec2(
-        "GetCoipPoolUsage", Dict{String,Any}("PoolId" => PoolId); aws_config=aws_config
+        "GetCoipPoolUsage",
+        Dict{String,Any}("PoolId" => PoolId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_coip_pool_usage(
@@ -15432,6 +16822,7 @@ function get_coip_pool_usage(
         "GetCoipPoolUsage",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("PoolId" => PoolId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -15466,6 +16857,7 @@ function get_console_output(InstanceId; aws_config::AbstractAWSConfig=global_aws
         "GetConsoleOutput",
         Dict{String,Any}("InstanceId" => InstanceId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_console_output(
@@ -15479,6 +16871,7 @@ function get_console_output(
             mergewith(_merge, Dict{String,Any}("InstanceId" => InstanceId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -15507,6 +16900,7 @@ function get_console_screenshot(
         "GetConsoleScreenshot",
         Dict{String,Any}("InstanceId" => InstanceId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_console_screenshot(
@@ -15520,6 +16914,7 @@ function get_console_screenshot(
             mergewith(_merge, Dict{String,Any}("InstanceId" => InstanceId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -15547,6 +16942,7 @@ function get_default_credit_specification(
         "GetDefaultCreditSpecification",
         Dict{String,Any}("InstanceFamily" => InstanceFamily);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_default_credit_specification(
@@ -15560,6 +16956,7 @@ function get_default_credit_specification(
             mergewith(_merge, Dict{String,Any}("InstanceFamily" => InstanceFamily), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -15579,12 +16976,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   permissions, the error response is DryRunOperation. Otherwise, it is UnauthorizedOperation.
 """
 function get_ebs_default_kms_key_id(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("GetEbsDefaultKmsKeyId"; aws_config=aws_config)
+    return ec2(
+        "GetEbsDefaultKmsKeyId"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_ebs_default_kms_key_id(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("GetEbsDefaultKmsKeyId", params; aws_config=aws_config)
+    return ec2(
+        "GetEbsDefaultKmsKeyId",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -15602,12 +17006,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   permissions, the error response is DryRunOperation. Otherwise, it is UnauthorizedOperation.
 """
 function get_ebs_encryption_by_default(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("GetEbsEncryptionByDefault"; aws_config=aws_config)
+    return ec2(
+        "GetEbsEncryptionByDefault"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_ebs_encryption_by_default(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("GetEbsEncryptionByDefault", params; aws_config=aws_config)
+    return ec2(
+        "GetEbsEncryptionByDefault",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -15648,6 +17059,7 @@ function get_flow_logs_integration_template(
             "IntegrateService" => IntegrateService,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_flow_logs_integration_template(
@@ -15671,6 +17083,7 @@ function get_flow_logs_integration_template(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -15701,6 +17114,7 @@ function get_groups_for_capacity_reservation(
         "GetGroupsForCapacityReservation",
         Dict{String,Any}("CapacityReservationId" => CapacityReservationId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_groups_for_capacity_reservation(
@@ -15718,6 +17132,7 @@ function get_groups_for_capacity_reservation(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -15745,6 +17160,7 @@ function get_host_reservation_purchase_preview(
         "GetHostReservationPurchasePreview",
         Dict{String,Any}("OfferingId" => OfferingId, "item" => item);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_host_reservation_purchase_preview(
@@ -15761,6 +17177,7 @@ function get_host_reservation_purchase_preview(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -15791,6 +17208,7 @@ function get_launch_template_data(
         "GetLaunchTemplateData",
         Dict{String,Any}("InstanceId" => InstanceId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_launch_template_data(
@@ -15804,6 +17222,7 @@ function get_launch_template_data(
             mergewith(_merge, Dict{String,Any}("InstanceId" => InstanceId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -15833,6 +17252,7 @@ function get_managed_prefix_list_associations(
         "GetManagedPrefixListAssociations",
         Dict{String,Any}("PrefixListId" => PrefixListId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_managed_prefix_list_associations(
@@ -15846,6 +17266,7 @@ function get_managed_prefix_list_associations(
             mergewith(_merge, Dict{String,Any}("PrefixListId" => PrefixListId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -15876,6 +17297,7 @@ function get_managed_prefix_list_entries(
         "GetManagedPrefixListEntries",
         Dict{String,Any}("PrefixListId" => PrefixListId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_managed_prefix_list_entries(
@@ -15889,6 +17311,7 @@ function get_managed_prefix_list_entries(
             mergewith(_merge, Dict{String,Any}("PrefixListId" => PrefixListId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -15922,6 +17345,7 @@ function get_password_data(InstanceId; aws_config::AbstractAWSConfig=global_aws_
         "GetPasswordData",
         Dict{String,Any}("InstanceId" => InstanceId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_password_data(
@@ -15935,6 +17359,7 @@ function get_password_data(
             mergewith(_merge, Dict{String,Any}("InstanceId" => InstanceId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -15965,6 +17390,7 @@ function get_reserved_instances_exchange_quote(
         "GetReservedInstancesExchangeQuote",
         Dict{String,Any}("ReservedInstanceId" => ReservedInstanceId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_reserved_instances_exchange_quote(
@@ -15980,6 +17406,7 @@ function get_reserved_instances_exchange_quote(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -16001,12 +17428,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function get_serial_console_access_status(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("GetSerialConsoleAccessStatus"; aws_config=aws_config)
+    return ec2(
+        "GetSerialConsoleAccessStatus";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_serial_console_access_status(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("GetSerialConsoleAccessStatus", params; aws_config=aws_config)
+    return ec2(
+        "GetSerialConsoleAccessStatus",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -16041,6 +17477,7 @@ function get_subnet_cidr_reservations(
         "GetSubnetCidrReservations",
         Dict{String,Any}("SubnetId" => SubnetId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_subnet_cidr_reservations(
@@ -16054,6 +17491,7 @@ function get_subnet_cidr_reservations(
             mergewith(_merge, Dict{String,Any}("SubnetId" => SubnetId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -16084,6 +17522,7 @@ function get_transit_gateway_attachment_propagations(
         "GetTransitGatewayAttachmentPropagations",
         Dict{String,Any}("TransitGatewayAttachmentId" => TransitGatewayAttachmentId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_transit_gateway_attachment_propagations(
@@ -16103,6 +17542,7 @@ function get_transit_gateway_attachment_propagations(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -16130,13 +17570,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function get_transit_gateway_multicast_domain_associations(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("GetTransitGatewayMulticastDomainAssociations"; aws_config=aws_config)
+    return ec2(
+        "GetTransitGatewayMulticastDomainAssociations";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_transit_gateway_multicast_domain_associations(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return ec2(
-        "GetTransitGatewayMulticastDomainAssociations", params; aws_config=aws_config
+        "GetTransitGatewayMulticastDomainAssociations",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -16173,6 +17620,7 @@ function get_transit_gateway_prefix_list_references(
         "GetTransitGatewayPrefixListReferences",
         Dict{String,Any}("TransitGatewayRouteTableId" => TransitGatewayRouteTableId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_transit_gateway_prefix_list_references(
@@ -16192,6 +17640,7 @@ function get_transit_gateway_prefix_list_references(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -16224,6 +17673,7 @@ function get_transit_gateway_route_table_associations(
         "GetTransitGatewayRouteTableAssociations",
         Dict{String,Any}("TransitGatewayRouteTableId" => TransitGatewayRouteTableId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_transit_gateway_route_table_associations(
@@ -16243,6 +17693,7 @@ function get_transit_gateway_route_table_associations(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -16276,6 +17727,7 @@ function get_transit_gateway_route_table_propagations(
         "GetTransitGatewayRouteTablePropagations",
         Dict{String,Any}("TransitGatewayRouteTableId" => TransitGatewayRouteTableId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_transit_gateway_route_table_propagations(
@@ -16295,6 +17747,7 @@ function get_transit_gateway_route_table_propagations(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -16332,6 +17785,7 @@ function get_vpn_connection_device_sample_configuration(
             "VpnConnectionId" => VpnConnectionId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_vpn_connection_device_sample_configuration(
@@ -16353,6 +17807,7 @@ function get_vpn_connection_device_sample_configuration(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -16384,12 +17839,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function get_vpn_connection_device_types(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("GetVpnConnectionDeviceTypes"; aws_config=aws_config)
+    return ec2(
+        "GetVpnConnectionDeviceTypes";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_vpn_connection_device_types(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("GetVpnConnectionDeviceTypes", params; aws_config=aws_config)
+    return ec2(
+        "GetVpnConnectionDeviceTypes",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -16426,6 +17890,7 @@ function import_client_vpn_client_certificate_revocation_list(
             "ClientVpnEndpointId" => ClientVpnEndpointId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function import_client_vpn_client_certificate_revocation_list(
@@ -16447,6 +17912,7 @@ function import_client_vpn_client_certificate_revocation_list(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -16508,12 +17974,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   information fields in the Amazon Elastic Compute Cloud User Guide.
 """
 function import_image(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("ImportImage"; aws_config=aws_config)
+    return ec2("ImportImage"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function import_image(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("ImportImage", params; aws_config=aws_config)
+    return ec2(
+        "ImportImage", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -16541,7 +18009,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function import_instance(platform; aws_config::AbstractAWSConfig=global_aws_config())
     return ec2(
-        "ImportInstance", Dict{String,Any}("platform" => platform); aws_config=aws_config
+        "ImportInstance",
+        Dict{String,Any}("platform" => platform);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function import_instance(
@@ -16555,6 +18026,7 @@ function import_instance(
             mergewith(_merge, Dict{String,Any}("platform" => platform), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -16589,6 +18061,7 @@ function import_key_pair(
         "ImportKeyPair",
         Dict{String,Any}("keyName" => keyName, "publicKeyMaterial" => publicKeyMaterial);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function import_key_pair(
@@ -16609,6 +18082,7 @@ function import_key_pair(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -16654,12 +18128,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"TagSpecification"`: The tags to apply to the import snapshot task during creation.
 """
 function import_snapshot(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("ImportSnapshot"; aws_config=aws_config)
+    return ec2("ImportSnapshot"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function import_snapshot(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("ImportSnapshot", params; aws_config=aws_config)
+    return ec2(
+        "ImportSnapshot", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -16695,6 +18171,7 @@ function import_volume(
             "availabilityZone" => availabilityZone, "image" => image, "volume" => volume
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function import_volume(
@@ -16718,6 +18195,7 @@ function import_volume(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -16745,6 +18223,7 @@ function modify_address_attribute(
         "ModifyAddressAttribute",
         Dict{String,Any}("AllocationId" => AllocationId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_address_attribute(
@@ -16758,6 +18237,7 @@ function modify_address_attribute(
             mergewith(_merge, Dict{String,Any}("AllocationId" => AllocationId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -16788,6 +18268,7 @@ function modify_availability_zone_group(
         "ModifyAvailabilityZoneGroup",
         Dict{String,Any}("GroupName" => GroupName, "OptInStatus" => OptInStatus);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_availability_zone_group(
@@ -16806,6 +18287,7 @@ function modify_availability_zone_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -16850,6 +18332,7 @@ function modify_capacity_reservation(
         "ModifyCapacityReservation",
         Dict{String,Any}("CapacityReservationId" => CapacityReservationId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_capacity_reservation(
@@ -16867,6 +18350,7 @@ function modify_capacity_reservation(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -16915,6 +18399,7 @@ function modify_client_vpn_endpoint(
         "ModifyClientVpnEndpoint",
         Dict{String,Any}("ClientVpnEndpointId" => ClientVpnEndpointId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_client_vpn_endpoint(
@@ -16932,6 +18417,7 @@ function modify_client_vpn_endpoint(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -16968,6 +18454,7 @@ function modify_default_credit_specification(
         "ModifyDefaultCreditSpecification",
         Dict{String,Any}("CpuCredits" => CpuCredits, "InstanceFamily" => InstanceFamily);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_default_credit_specification(
@@ -16988,6 +18475,7 @@ function modify_default_credit_specification(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -17031,6 +18519,7 @@ function modify_ebs_default_kms_key_id(
         "ModifyEbsDefaultKmsKeyId",
         Dict{String,Any}("KmsKeyId" => KmsKeyId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_ebs_default_kms_key_id(
@@ -17044,6 +18533,7 @@ function modify_ebs_default_kms_key_id(
             mergewith(_merge, Dict{String,Any}("KmsKeyId" => KmsKeyId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -17088,7 +18578,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"TargetCapacitySpecification"`: The size of the EC2 Fleet.
 """
 function modify_fleet(FleetId; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("ModifyFleet", Dict{String,Any}("FleetId" => FleetId); aws_config=aws_config)
+    return ec2(
+        "ModifyFleet",
+        Dict{String,Any}("FleetId" => FleetId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function modify_fleet(
     FleetId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -17097,6 +18592,7 @@ function modify_fleet(
         "ModifyFleet",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("FleetId" => FleetId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -17133,6 +18629,7 @@ function modify_fpga_image_attribute(
         "ModifyFpgaImageAttribute",
         Dict{String,Any}("FpgaImageId" => FpgaImageId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_fpga_image_attribute(
@@ -17146,6 +18643,7 @@ function modify_fpga_image_attribute(
             mergewith(_merge, Dict{String,Any}("FpgaImageId" => FpgaImageId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -17182,7 +18680,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"autoPlacement"`: Specify whether to enable or disable auto-placement.
 """
 function modify_hosts(hostId; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("ModifyHosts", Dict{String,Any}("hostId" => hostId); aws_config=aws_config)
+    return ec2(
+        "ModifyHosts",
+        Dict{String,Any}("hostId" => hostId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function modify_hosts(
     hostId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -17191,6 +18694,7 @@ function modify_hosts(
         "ModifyHosts",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("hostId" => hostId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -17235,6 +18739,7 @@ function modify_id_format(
         "ModifyIdFormat",
         Dict{String,Any}("Resource" => Resource, "UseLongIds" => UseLongIds);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_id_format(
@@ -17253,6 +18758,7 @@ function modify_id_format(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -17303,6 +18809,7 @@ function modify_identity_id_format(
             "useLongIds" => useLongIds,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_identity_id_format(
@@ -17326,6 +18833,7 @@ function modify_identity_id_format(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -17367,6 +18875,7 @@ function modify_image_attribute(ImageId; aws_config::AbstractAWSConfig=global_aw
         "ModifyImageAttribute",
         Dict{String,Any}("ImageId" => ImageId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_image_attribute(
@@ -17376,6 +18885,7 @@ function modify_image_attribute(
         "ModifyImageAttribute",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("ImageId" => ImageId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -17453,6 +18963,7 @@ function modify_instance_attribute(
         "ModifyInstanceAttribute",
         Dict{String,Any}("instanceId" => instanceId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_instance_attribute(
@@ -17466,6 +18977,7 @@ function modify_instance_attribute(
             mergewith(_merge, Dict{String,Any}("instanceId" => instanceId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -17500,6 +19012,7 @@ function modify_instance_capacity_reservation_attributes(
             "InstanceId" => InstanceId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_instance_capacity_reservation_attributes(
@@ -17521,6 +19034,7 @@ function modify_instance_capacity_reservation_attributes(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -17550,6 +19064,7 @@ function modify_instance_credit_specification(
         "ModifyInstanceCreditSpecification",
         Dict{String,Any}("InstanceCreditSpecification" => InstanceCreditSpecification);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_instance_credit_specification(
@@ -17569,6 +19084,7 @@ function modify_instance_credit_specification(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -17603,6 +19119,7 @@ function modify_instance_event_start_time(
             "NotBefore" => NotBefore,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_instance_event_start_time(
@@ -17626,6 +19143,7 @@ function modify_instance_event_start_time(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -17666,6 +19184,7 @@ function modify_instance_event_window(
         "ModifyInstanceEventWindow",
         Dict{String,Any}("InstanceEventWindowId" => InstanceEventWindowId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_instance_event_window(
@@ -17683,6 +19202,7 @@ function modify_instance_event_window(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -17732,6 +19252,7 @@ function modify_instance_metadata_options(
         "ModifyInstanceMetadataOptions",
         Dict{String,Any}("InstanceId" => InstanceId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_instance_metadata_options(
@@ -17745,6 +19266,7 @@ function modify_instance_metadata_options(
             mergewith(_merge, Dict{String,Any}("InstanceId" => InstanceId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -17788,6 +19310,7 @@ function modify_instance_placement(
         "ModifyInstancePlacement",
         Dict{String,Any}("instanceId" => instanceId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_instance_placement(
@@ -17801,6 +19324,7 @@ function modify_instance_placement(
             mergewith(_merge, Dict{String,Any}("instanceId" => instanceId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -17828,12 +19352,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   version.
 """
 function modify_launch_template(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("ModifyLaunchTemplate"; aws_config=aws_config)
+    return ec2(
+        "ModifyLaunchTemplate"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function modify_launch_template(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("ModifyLaunchTemplate", params; aws_config=aws_config)
+    return ec2(
+        "ModifyLaunchTemplate",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -17870,6 +19401,7 @@ function modify_managed_prefix_list(
         "ModifyManagedPrefixList",
         Dict{String,Any}("PrefixListId" => PrefixListId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_managed_prefix_list(
@@ -17883,6 +19415,7 @@ function modify_managed_prefix_list(
             mergewith(_merge, Dict{String,Any}("PrefixListId" => PrefixListId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -17922,6 +19455,7 @@ function modify_network_interface_attribute(
         "ModifyNetworkInterfaceAttribute",
         Dict{String,Any}("networkInterfaceId" => networkInterfaceId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_network_interface_attribute(
@@ -17937,6 +19471,7 @@ function modify_network_interface_attribute(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -17972,6 +19507,7 @@ function modify_reserved_instances(
             "ReservedInstancesId" => ReservedInstancesId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_reserved_instances(
@@ -17994,6 +19530,7 @@ function modify_reserved_instances(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -18020,6 +19557,7 @@ function modify_security_group_rules(
         "ModifySecurityGroupRules",
         Dict{String,Any}("GroupId" => GroupId, "SecurityGroupRule" => SecurityGroupRule);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_security_group_rules(
@@ -18040,6 +19578,7 @@ function modify_security_group_rules(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -18079,6 +19618,7 @@ function modify_snapshot_attribute(
         "ModifySnapshotAttribute",
         Dict{String,Any}("SnapshotId" => SnapshotId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_snapshot_attribute(
@@ -18092,6 +19632,7 @@ function modify_snapshot_attribute(
             mergewith(_merge, Dict{String,Any}("SnapshotId" => SnapshotId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -18143,6 +19684,7 @@ function modify_spot_fleet_request(
         "ModifySpotFleetRequest",
         Dict{String,Any}("spotFleetRequestId" => spotFleetRequestId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_spot_fleet_request(
@@ -18158,6 +19700,7 @@ function modify_spot_fleet_request(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -18194,6 +19737,7 @@ function modify_subnet_attribute(
         "ModifySubnetAttribute",
         Dict{String,Any}("subnetId" => subnetId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_subnet_attribute(
@@ -18207,6 +19751,7 @@ function modify_subnet_attribute(
             mergewith(_merge, Dict{String,Any}("subnetId" => subnetId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -18242,6 +19787,7 @@ function modify_traffic_mirror_filter_network_services(
         "ModifyTrafficMirrorFilterNetworkServices",
         Dict{String,Any}("TrafficMirrorFilterId" => TrafficMirrorFilterId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_traffic_mirror_filter_network_services(
@@ -18259,6 +19805,7 @@ function modify_traffic_mirror_filter_network_services(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -18300,6 +19847,7 @@ function modify_traffic_mirror_filter_rule(
         "ModifyTrafficMirrorFilterRule",
         Dict{String,Any}("TrafficMirrorFilterRuleId" => TrafficMirrorFilterRuleId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_traffic_mirror_filter_rule(
@@ -18317,6 +19865,7 @@ function modify_traffic_mirror_filter_rule(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -18358,6 +19907,7 @@ function modify_traffic_mirror_session(
         "ModifyTrafficMirrorSession",
         Dict{String,Any}("TrafficMirrorSessionId" => TrafficMirrorSessionId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_traffic_mirror_session(
@@ -18375,6 +19925,7 @@ function modify_traffic_mirror_session(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -18404,6 +19955,7 @@ function modify_transit_gateway(
         "ModifyTransitGateway",
         Dict{String,Any}("TransitGatewayId" => TransitGatewayId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_transit_gateway(
@@ -18419,6 +19971,7 @@ function modify_transit_gateway(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -18452,6 +20005,7 @@ function modify_transit_gateway_prefix_list_reference(
             "TransitGatewayRouteTableId" => TransitGatewayRouteTableId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_transit_gateway_prefix_list_reference(
@@ -18473,6 +20027,7 @@ function modify_transit_gateway_prefix_list_reference(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -18502,6 +20057,7 @@ function modify_transit_gateway_vpc_attachment(
         "ModifyTransitGatewayVpcAttachment",
         Dict{String,Any}("TransitGatewayAttachmentId" => TransitGatewayAttachmentId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_transit_gateway_vpc_attachment(
@@ -18521,6 +20077,7 @@ function modify_transit_gateway_vpc_attachment(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -18576,7 +20133,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function modify_volume(VolumeId; aws_config::AbstractAWSConfig=global_aws_config())
     return ec2(
-        "ModifyVolume", Dict{String,Any}("VolumeId" => VolumeId); aws_config=aws_config
+        "ModifyVolume",
+        Dict{String,Any}("VolumeId" => VolumeId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_volume(
@@ -18590,6 +20150,7 @@ function modify_volume(
             mergewith(_merge, Dict{String,Any}("VolumeId" => VolumeId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -18621,6 +20182,7 @@ function modify_volume_attribute(
         "ModifyVolumeAttribute",
         Dict{String,Any}("VolumeId" => VolumeId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_volume_attribute(
@@ -18634,6 +20196,7 @@ function modify_volume_attribute(
             mergewith(_merge, Dict{String,Any}("VolumeId" => VolumeId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -18662,7 +20225,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function modify_vpc_attribute(vpcId; aws_config::AbstractAWSConfig=global_aws_config())
     return ec2(
-        "ModifyVpcAttribute", Dict{String,Any}("vpcId" => vpcId); aws_config=aws_config
+        "ModifyVpcAttribute",
+        Dict{String,Any}("vpcId" => vpcId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_vpc_attribute(
@@ -18672,6 +20238,7 @@ function modify_vpc_attribute(
         "ModifyVpcAttribute",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("vpcId" => vpcId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -18718,6 +20285,7 @@ function modify_vpc_endpoint(
         "ModifyVpcEndpoint",
         Dict{String,Any}("VpcEndpointId" => VpcEndpointId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_vpc_endpoint(
@@ -18731,6 +20299,7 @@ function modify_vpc_endpoint(
             mergewith(_merge, Dict{String,Any}("VpcEndpointId" => VpcEndpointId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -18760,6 +20329,7 @@ function modify_vpc_endpoint_connection_notification(
         "ModifyVpcEndpointConnectionNotification",
         Dict{String,Any}("ConnectionNotificationId" => ConnectionNotificationId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_vpc_endpoint_connection_notification(
@@ -18777,6 +20347,7 @@ function modify_vpc_endpoint_connection_notification(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -18821,6 +20392,7 @@ function modify_vpc_endpoint_service_configuration(
         "ModifyVpcEndpointServiceConfiguration",
         Dict{String,Any}("ServiceId" => ServiceId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_vpc_endpoint_service_configuration(
@@ -18834,6 +20406,7 @@ function modify_vpc_endpoint_service_configuration(
             mergewith(_merge, Dict{String,Any}("ServiceId" => ServiceId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -18868,6 +20441,7 @@ function modify_vpc_endpoint_service_permissions(
         "ModifyVpcEndpointServicePermissions",
         Dict{String,Any}("ServiceId" => ServiceId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_vpc_endpoint_service_permissions(
@@ -18881,6 +20455,7 @@ function modify_vpc_endpoint_service_permissions(
             mergewith(_merge, Dict{String,Any}("ServiceId" => ServiceId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -18925,6 +20500,7 @@ function modify_vpc_peering_connection_options(
         "ModifyVpcPeeringConnectionOptions",
         Dict{String,Any}("VpcPeeringConnectionId" => VpcPeeringConnectionId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_vpc_peering_connection_options(
@@ -18942,6 +20518,7 @@ function modify_vpc_peering_connection_options(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -18973,6 +20550,7 @@ function modify_vpc_tenancy(
         "ModifyVpcTenancy",
         Dict{String,Any}("InstanceTenancy" => InstanceTenancy, "VpcId" => VpcId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_vpc_tenancy(
@@ -18991,6 +20569,7 @@ function modify_vpc_tenancy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -19040,6 +20619,7 @@ function modify_vpn_connection(
         "ModifyVpnConnection",
         Dict{String,Any}("VpnConnectionId" => VpnConnectionId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_vpn_connection(
@@ -19055,6 +20635,7 @@ function modify_vpn_connection(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -19091,6 +20672,7 @@ function modify_vpn_connection_options(
         "ModifyVpnConnectionOptions",
         Dict{String,Any}("VpnConnectionId" => VpnConnectionId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_vpn_connection_options(
@@ -19106,6 +20688,7 @@ function modify_vpn_connection_options(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -19137,6 +20720,7 @@ function modify_vpn_tunnel_certificate(
             "VpnTunnelOutsideIpAddress" => VpnTunnelOutsideIpAddress,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_vpn_tunnel_certificate(
@@ -19158,6 +20742,7 @@ function modify_vpn_tunnel_certificate(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -19195,6 +20780,7 @@ function modify_vpn_tunnel_options(
             "VpnTunnelOutsideIpAddress" => VpnTunnelOutsideIpAddress,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_vpn_tunnel_options(
@@ -19218,6 +20804,7 @@ function modify_vpn_tunnel_options(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -19243,6 +20830,7 @@ function monitor_instances(InstanceId; aws_config::AbstractAWSConfig=global_aws_
         "MonitorInstances",
         Dict{String,Any}("InstanceId" => InstanceId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function monitor_instances(
@@ -19256,6 +20844,7 @@ function monitor_instances(
             mergewith(_merge, Dict{String,Any}("InstanceId" => InstanceId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -19281,7 +20870,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function move_address_to_vpc(publicIp; aws_config::AbstractAWSConfig=global_aws_config())
     return ec2(
-        "MoveAddressToVpc", Dict{String,Any}("publicIp" => publicIp); aws_config=aws_config
+        "MoveAddressToVpc",
+        Dict{String,Any}("publicIp" => publicIp);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function move_address_to_vpc(
@@ -19295,6 +20887,7 @@ function move_address_to_vpc(
             mergewith(_merge, Dict{String,Any}("publicIp" => publicIp), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -19337,7 +20930,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function provision_byoip_cidr(Cidr; aws_config::AbstractAWSConfig=global_aws_config())
     return ec2(
-        "ProvisionByoipCidr", Dict{String,Any}("Cidr" => Cidr); aws_config=aws_config
+        "ProvisionByoipCidr",
+        Dict{String,Any}("Cidr" => Cidr);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function provision_byoip_cidr(
@@ -19347,6 +20943,7 @@ function provision_byoip_cidr(
         "ProvisionByoipCidr",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Cidr" => Cidr), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -19385,6 +20982,7 @@ function purchase_host_reservation(
         "PurchaseHostReservation",
         Dict{String,Any}("OfferingId" => OfferingId, "item" => item);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function purchase_host_reservation(
@@ -19401,6 +20999,7 @@ function purchase_host_reservation(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -19443,6 +21042,7 @@ function purchase_reserved_instances_offering(
             "ReservedInstancesOfferingId" => ReservedInstancesOfferingId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function purchase_reserved_instances_offering(
@@ -19464,6 +21064,7 @@ function purchase_reserved_instances_offering(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -19498,6 +21099,7 @@ function purchase_scheduled_instances(
             "PurchaseRequest" => PurchaseRequest, "ClientToken" => string(uuid4())
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function purchase_scheduled_instances(
@@ -19517,6 +21119,7 @@ function purchase_scheduled_instances(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -19545,6 +21148,7 @@ function reboot_instances(InstanceId; aws_config::AbstractAWSConfig=global_aws_c
         "RebootInstances",
         Dict{String,Any}("InstanceId" => InstanceId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function reboot_instances(
@@ -19558,6 +21162,7 @@ function reboot_instances(
             mergewith(_merge, Dict{String,Any}("InstanceId" => InstanceId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -19637,7 +21242,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   paravirtual
 """
 function register_image(name; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("RegisterImage", Dict{String,Any}("name" => name); aws_config=aws_config)
+    return ec2(
+        "RegisterImage",
+        Dict{String,Any}("name" => name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function register_image(
     name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -19646,6 +21256,7 @@ function register_image(
         "RegisterImage",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("name" => name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -19666,12 +21277,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function register_instance_event_notification_attributes(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("RegisterInstanceEventNotificationAttributes"; aws_config=aws_config)
+    return ec2(
+        "RegisterInstanceEventNotificationAttributes";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function register_instance_event_notification_attributes(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("RegisterInstanceEventNotificationAttributes", params; aws_config=aws_config)
+    return ec2(
+        "RegisterInstanceEventNotificationAttributes",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -19697,12 +21317,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function register_transit_gateway_multicast_group_members(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("RegisterTransitGatewayMulticastGroupMembers"; aws_config=aws_config)
+    return ec2(
+        "RegisterTransitGatewayMulticastGroupMembers";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function register_transit_gateway_multicast_group_members(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("RegisterTransitGatewayMulticastGroupMembers", params; aws_config=aws_config)
+    return ec2(
+        "RegisterTransitGatewayMulticastGroupMembers",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -19729,12 +21358,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function register_transit_gateway_multicast_group_sources(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("RegisterTransitGatewayMulticastGroupSources"; aws_config=aws_config)
+    return ec2(
+        "RegisterTransitGatewayMulticastGroupSources";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function register_transit_gateway_multicast_group_sources(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("RegisterTransitGatewayMulticastGroupSources", params; aws_config=aws_config)
+    return ec2(
+        "RegisterTransitGatewayMulticastGroupSources",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -19757,13 +21395,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function reject_transit_gateway_multicast_domain_associations(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("RejectTransitGatewayMulticastDomainAssociations"; aws_config=aws_config)
+    return ec2(
+        "RejectTransitGatewayMulticastDomainAssociations";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function reject_transit_gateway_multicast_domain_associations(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return ec2(
-        "RejectTransitGatewayMulticastDomainAssociations", params; aws_config=aws_config
+        "RejectTransitGatewayMulticastDomainAssociations",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -19789,6 +21434,7 @@ function reject_transit_gateway_peering_attachment(
         "RejectTransitGatewayPeeringAttachment",
         Dict{String,Any}("TransitGatewayAttachmentId" => TransitGatewayAttachmentId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function reject_transit_gateway_peering_attachment(
@@ -19808,6 +21454,7 @@ function reject_transit_gateway_peering_attachment(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -19836,6 +21483,7 @@ function reject_transit_gateway_vpc_attachment(
         "RejectTransitGatewayVpcAttachment",
         Dict{String,Any}("TransitGatewayAttachmentId" => TransitGatewayAttachmentId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function reject_transit_gateway_vpc_attachment(
@@ -19855,6 +21503,7 @@ function reject_transit_gateway_vpc_attachment(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -19881,6 +21530,7 @@ function reject_vpc_endpoint_connections(
         "RejectVpcEndpointConnections",
         Dict{String,Any}("ServiceId" => ServiceId, "VpcEndpointId" => VpcEndpointId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function reject_vpc_endpoint_connections(
@@ -19901,6 +21551,7 @@ function reject_vpc_endpoint_connections(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -19930,6 +21581,7 @@ function reject_vpc_peering_connection(
         "RejectVpcPeeringConnection",
         Dict{String,Any}("vpcPeeringConnectionId" => vpcPeeringConnectionId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function reject_vpc_peering_connection(
@@ -19947,6 +21599,7 @@ function reject_vpc_peering_connection(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -19981,12 +21634,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   permissions, the error response is DryRunOperation. Otherwise, it is UnauthorizedOperation.
 """
 function release_address(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("ReleaseAddress"; aws_config=aws_config)
+    return ec2("ReleaseAddress"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function release_address(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("ReleaseAddress", params; aws_config=aws_config)
+    return ec2(
+        "ReleaseAddress", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -20007,7 +21662,12 @@ DescribeHosts response.
 
 """
 function release_hosts(hostId; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("ReleaseHosts", Dict{String,Any}("hostId" => hostId); aws_config=aws_config)
+    return ec2(
+        "ReleaseHosts",
+        Dict{String,Any}("hostId" => hostId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function release_hosts(
     hostId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -20016,6 +21676,7 @@ function release_hosts(
         "ReleaseHosts",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("hostId" => hostId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -20042,6 +21703,7 @@ function replace_iam_instance_profile_association(
             "AssociationId" => AssociationId, "IamInstanceProfile" => IamInstanceProfile
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function replace_iam_instance_profile_association(
@@ -20063,6 +21725,7 @@ function replace_iam_instance_profile_association(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -20093,6 +21756,7 @@ function replace_network_acl_association(
         "ReplaceNetworkAclAssociation",
         Dict{String,Any}("associationId" => associationId, "networkAclId" => networkAclId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function replace_network_acl_association(
@@ -20113,6 +21777,7 @@ function replace_network_acl_association(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -20168,6 +21833,7 @@ function replace_network_acl_entry(
             "ruleNumber" => ruleNumber,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function replace_network_acl_entry(
@@ -20195,6 +21861,7 @@ function replace_network_acl_entry(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -20239,6 +21906,7 @@ function replace_route(routeTableId; aws_config::AbstractAWSConfig=global_aws_co
         "ReplaceRoute",
         Dict{String,Any}("routeTableId" => routeTableId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function replace_route(
@@ -20252,6 +21920,7 @@ function replace_route(
             mergewith(_merge, Dict{String,Any}("routeTableId" => routeTableId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -20283,6 +21952,7 @@ function replace_route_table_association(
         "ReplaceRouteTableAssociation",
         Dict{String,Any}("associationId" => associationId, "routeTableId" => routeTableId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function replace_route_table_association(
@@ -20303,6 +21973,7 @@ function replace_route_table_association(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -20337,6 +22008,7 @@ function replace_transit_gateway_route(
             "TransitGatewayRouteTableId" => TransitGatewayRouteTableId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function replace_transit_gateway_route(
@@ -20358,6 +22030,7 @@ function replace_transit_gateway_route(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -20403,6 +22076,7 @@ function report_instance_status(
             "instanceId" => instanceId, "reasonCode" => reasonCode, "status" => status
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function report_instance_status(
@@ -20426,6 +22100,7 @@ function report_instance_status(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -20464,6 +22139,7 @@ function request_spot_fleet(
         "RequestSpotFleet",
         Dict{String,Any}("spotFleetRequestConfig" => spotFleetRequestConfig);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function request_spot_fleet(
@@ -20481,6 +22157,7 @@ function request_spot_fleet(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -20541,12 +22218,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   the date the request was created.
 """
 function request_spot_instances(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("RequestSpotInstances"; aws_config=aws_config)
+    return ec2(
+        "RequestSpotInstances"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function request_spot_instances(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("RequestSpotInstances", params; aws_config=aws_config)
+    return ec2(
+        "RequestSpotInstances",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -20573,6 +22257,7 @@ function reset_address_attribute(
         "ResetAddressAttribute",
         Dict{String,Any}("AllocationId" => AllocationId, "Attribute" => Attribute);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function reset_address_attribute(
@@ -20591,6 +22276,7 @@ function reset_address_attribute(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -20611,12 +22297,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   permissions, the error response is DryRunOperation. Otherwise, it is UnauthorizedOperation.
 """
 function reset_ebs_default_kms_key_id(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("ResetEbsDefaultKmsKeyId"; aws_config=aws_config)
+    return ec2(
+        "ResetEbsDefaultKmsKeyId"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function reset_ebs_default_kms_key_id(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("ResetEbsDefaultKmsKeyId", params; aws_config=aws_config)
+    return ec2(
+        "ResetEbsDefaultKmsKeyId",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -20643,6 +22336,7 @@ function reset_fpga_image_attribute(
         "ResetFpgaImageAttribute",
         Dict{String,Any}("FpgaImageId" => FpgaImageId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function reset_fpga_image_attribute(
@@ -20656,6 +22350,7 @@ function reset_fpga_image_attribute(
             mergewith(_merge, Dict{String,Any}("FpgaImageId" => FpgaImageId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -20683,6 +22378,7 @@ function reset_image_attribute(
         "ResetImageAttribute",
         Dict{String,Any}("Attribute" => Attribute, "ImageId" => ImageId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function reset_image_attribute(
@@ -20701,6 +22397,7 @@ function reset_image_attribute(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -20733,6 +22430,7 @@ function reset_instance_attribute(
         "ResetInstanceAttribute",
         Dict{String,Any}("attribute" => attribute, "instanceId" => instanceId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function reset_instance_attribute(
@@ -20751,6 +22449,7 @@ function reset_instance_attribute(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -20777,6 +22476,7 @@ function reset_network_interface_attribute(
         "ResetNetworkInterfaceAttribute",
         Dict{String,Any}("networkInterfaceId" => networkInterfaceId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function reset_network_interface_attribute(
@@ -20792,6 +22492,7 @@ function reset_network_interface_attribute(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -20820,6 +22521,7 @@ function reset_snapshot_attribute(
         "ResetSnapshotAttribute",
         Dict{String,Any}("Attribute" => Attribute, "SnapshotId" => SnapshotId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function reset_snapshot_attribute(
@@ -20838,6 +22540,7 @@ function reset_snapshot_attribute(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -20866,6 +22569,7 @@ function restore_address_to_classic(
         "RestoreAddressToClassic",
         Dict{String,Any}("publicIp" => publicIp);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function restore_address_to_classic(
@@ -20879,6 +22583,7 @@ function restore_address_to_classic(
             mergewith(_merge, Dict{String,Any}("publicIp" => publicIp), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -20914,6 +22619,7 @@ function restore_managed_prefix_list_version(
             "PreviousVersion" => PreviousVersion,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function restore_managed_prefix_list_version(
@@ -20937,6 +22643,7 @@ function restore_managed_prefix_list_version(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -20972,6 +22679,7 @@ function revoke_client_vpn_ingress(
             "TargetNetworkCidr" => TargetNetworkCidr,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function revoke_client_vpn_ingress(
@@ -20993,6 +22701,7 @@ function revoke_client_vpn_ingress(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -21042,6 +22751,7 @@ function revoke_security_group_egress(
         "RevokeSecurityGroupEgress",
         Dict{String,Any}("groupId" => groupId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function revoke_security_group_egress(
@@ -21051,6 +22761,7 @@ function revoke_security_group_egress(
         "RevokeSecurityGroupEgress",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("groupId" => groupId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -21105,12 +22816,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   permissions, the error response is DryRunOperation. Otherwise, it is UnauthorizedOperation.
 """
 function revoke_security_group_ingress(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("RevokeSecurityGroupIngress"; aws_config=aws_config)
+    return ec2(
+        "RevokeSecurityGroupIngress"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function revoke_security_group_ingress(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("RevokeSecurityGroupIngress", params; aws_config=aws_config)
+    return ec2(
+        "RevokeSecurityGroupIngress",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -21282,6 +23000,7 @@ function run_instances(
             "MaxCount" => MaxCount, "MinCount" => MinCount, "clientToken" => string(uuid4())
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function run_instances(
@@ -21304,6 +23023,7 @@ function run_instances(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -21345,6 +23065,7 @@ function run_scheduled_instances(
             "ClientToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function run_scheduled_instances(
@@ -21367,6 +23088,7 @@ function run_scheduled_instances(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -21398,6 +23120,7 @@ function search_local_gateway_routes(
             "Filter" => Filter, "LocalGatewayRouteTableId" => LocalGatewayRouteTableId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function search_local_gateway_routes(
@@ -21419,6 +23142,7 @@ function search_local_gateway_routes(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -21450,12 +23174,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function search_transit_gateway_multicast_groups(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("SearchTransitGatewayMulticastGroups"; aws_config=aws_config)
+    return ec2(
+        "SearchTransitGatewayMulticastGroups";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function search_transit_gateway_multicast_groups(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("SearchTransitGatewayMulticastGroups", params; aws_config=aws_config)
+    return ec2(
+        "SearchTransitGatewayMulticastGroups",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -21496,6 +23229,7 @@ function search_transit_gateway_routes(
             "Filter" => Filter, "TransitGatewayRouteTableId" => TransitGatewayRouteTableId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function search_transit_gateway_routes(
@@ -21517,6 +23251,7 @@ function search_transit_gateway_routes(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -21552,6 +23287,7 @@ function send_diagnostic_interrupt(
         "SendDiagnosticInterrupt",
         Dict{String,Any}("InstanceId" => InstanceId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function send_diagnostic_interrupt(
@@ -21565,6 +23301,7 @@ function send_diagnostic_interrupt(
             mergewith(_merge, Dict{String,Any}("InstanceId" => InstanceId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -21602,6 +23339,7 @@ function start_instances(InstanceId; aws_config::AbstractAWSConfig=global_aws_co
         "StartInstances",
         Dict{String,Any}("InstanceId" => InstanceId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_instances(
@@ -21615,6 +23353,7 @@ function start_instances(
             mergewith(_merge, Dict{String,Any}("InstanceId" => InstanceId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -21648,6 +23387,7 @@ function start_network_insights_analysis(
             "ClientToken" => ClientToken, "NetworkInsightsPathId" => NetworkInsightsPathId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_network_insights_analysis(
@@ -21669,6 +23409,7 @@ function start_network_insights_analysis(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -21698,6 +23439,7 @@ function start_vpc_endpoint_service_private_dns_verification(
         "StartVpcEndpointServicePrivateDnsVerification",
         Dict{String,Any}("ServiceId" => ServiceId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_vpc_endpoint_service_private_dns_verification(
@@ -21711,6 +23453,7 @@ function start_vpc_endpoint_service_private_dns_verification(
             mergewith(_merge, Dict{String,Any}("ServiceId" => ServiceId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -21761,7 +23504,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function stop_instances(InstanceId; aws_config::AbstractAWSConfig=global_aws_config())
     return ec2(
-        "StopInstances", Dict{String,Any}("InstanceId" => InstanceId); aws_config=aws_config
+        "StopInstances",
+        Dict{String,Any}("InstanceId" => InstanceId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function stop_instances(
@@ -21775,6 +23521,7 @@ function stop_instances(
             mergewith(_merge, Dict{String,Any}("InstanceId" => InstanceId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -21806,6 +23553,7 @@ function terminate_client_vpn_connections(
         "TerminateClientVpnConnections",
         Dict{String,Any}("ClientVpnEndpointId" => ClientVpnEndpointId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function terminate_client_vpn_connections(
@@ -21823,6 +23571,7 @@ function terminate_client_vpn_connections(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -21873,6 +23622,7 @@ function terminate_instances(InstanceId; aws_config::AbstractAWSConfig=global_aw
         "TerminateInstances",
         Dict{String,Any}("InstanceId" => InstanceId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function terminate_instances(
@@ -21886,6 +23636,7 @@ function terminate_instances(
             mergewith(_merge, Dict{String,Any}("InstanceId" => InstanceId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -21911,6 +23662,7 @@ function unassign_ipv6_addresses(
         "UnassignIpv6Addresses",
         Dict{String,Any}("networkInterfaceId" => networkInterfaceId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function unassign_ipv6_addresses(
@@ -21926,6 +23678,7 @@ function unassign_ipv6_addresses(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -21952,6 +23705,7 @@ function unassign_private_ip_addresses(
         "UnassignPrivateIpAddresses",
         Dict{String,Any}("networkInterfaceId" => networkInterfaceId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function unassign_private_ip_addresses(
@@ -21967,6 +23721,7 @@ function unassign_private_ip_addresses(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -21991,6 +23746,7 @@ function unmonitor_instances(InstanceId; aws_config::AbstractAWSConfig=global_aw
         "UnmonitorInstances",
         Dict{String,Any}("InstanceId" => InstanceId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function unmonitor_instances(
@@ -22004,6 +23760,7 @@ function unmonitor_instances(
             mergewith(_merge, Dict{String,Any}("InstanceId" => InstanceId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -22034,12 +23791,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function update_security_group_rule_descriptions_egress(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("UpdateSecurityGroupRuleDescriptionsEgress"; aws_config=aws_config)
+    return ec2(
+        "UpdateSecurityGroupRuleDescriptionsEgress";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function update_security_group_rule_descriptions_egress(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("UpdateSecurityGroupRuleDescriptionsEgress", params; aws_config=aws_config)
+    return ec2(
+        "UpdateSecurityGroupRuleDescriptionsEgress",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -22069,12 +23835,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function update_security_group_rule_descriptions_ingress(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("UpdateSecurityGroupRuleDescriptionsIngress"; aws_config=aws_config)
+    return ec2(
+        "UpdateSecurityGroupRuleDescriptionsIngress";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function update_security_group_rule_descriptions_ingress(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ec2("UpdateSecurityGroupRuleDescriptionsIngress", params; aws_config=aws_config)
+    return ec2(
+        "UpdateSecurityGroupRuleDescriptionsIngress",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -22096,7 +23871,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   permissions, the error response is DryRunOperation. Otherwise, it is UnauthorizedOperation.
 """
 function withdraw_byoip_cidr(Cidr; aws_config::AbstractAWSConfig=global_aws_config())
-    return ec2("WithdrawByoipCidr", Dict{String,Any}("Cidr" => Cidr); aws_config=aws_config)
+    return ec2(
+        "WithdrawByoipCidr",
+        Dict{String,Any}("Cidr" => Cidr);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function withdraw_byoip_cidr(
     Cidr, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -22105,5 +23885,6 @@ function withdraw_byoip_cidr(
         "WithdrawByoipCidr",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Cidr" => Cidr), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/ec2_instance_connect.jl
+++ b/src/services/ec2_instance_connect.jl
@@ -30,6 +30,7 @@ function send_serial_console_sshpublic_key(
         "SendSerialConsoleSSHPublicKey",
         Dict{String,Any}("InstanceId" => InstanceId, "SSHPublicKey" => SSHPublicKey);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function send_serial_console_sshpublic_key(
@@ -50,6 +51,7 @@ function send_serial_console_sshpublic_key(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -86,6 +88,7 @@ function send_sshpublic_key(
             "SSHPublicKey" => SSHPublicKey,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function send_sshpublic_key(
@@ -111,5 +114,6 @@ function send_sshpublic_key(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/ecr.jl
+++ b/src/services/ecr.jl
@@ -34,6 +34,7 @@ function batch_check_layer_availability(
             "layerDigests" => layerDigests, "repositoryName" => repositoryName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_check_layer_availability(
@@ -54,6 +55,7 @@ function batch_check_layer_availability(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -85,6 +87,7 @@ function batch_delete_image(
         "BatchDeleteImage",
         Dict{String,Any}("imageIds" => imageIds, "repositoryName" => repositoryName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_delete_image(
@@ -105,6 +108,7 @@ function batch_delete_image(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -138,6 +142,7 @@ function batch_get_image(
         "BatchGetImage",
         Dict{String,Any}("imageIds" => imageIds, "repositoryName" => repositoryName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_get_image(
@@ -158,6 +163,7 @@ function batch_get_image(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -198,6 +204,7 @@ function complete_layer_upload(
             "uploadId" => uploadId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function complete_layer_upload(
@@ -221,6 +228,7 @@ function complete_layer_upload(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -261,6 +269,7 @@ function create_repository(
         "CreateRepository",
         Dict{String,Any}("repositoryName" => repositoryName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_repository(
@@ -274,6 +283,7 @@ function create_repository(
             mergewith(_merge, Dict{String,Any}("repositoryName" => repositoryName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -298,6 +308,7 @@ function delete_lifecycle_policy(
         "DeleteLifecyclePolicy",
         Dict{String,Any}("repositoryName" => repositoryName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_lifecycle_policy(
@@ -311,6 +322,7 @@ function delete_lifecycle_policy(
             mergewith(_merge, Dict{String,Any}("repositoryName" => repositoryName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -322,12 +334,19 @@ Deletes the registry permissions policy.
 
 """
 function delete_registry_policy(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ecr("DeleteRegistryPolicy"; aws_config=aws_config)
+    return ecr(
+        "DeleteRegistryPolicy"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function delete_registry_policy(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ecr("DeleteRegistryPolicy", params; aws_config=aws_config)
+    return ecr(
+        "DeleteRegistryPolicy",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -354,6 +373,7 @@ function delete_repository(
         "DeleteRepository",
         Dict{String,Any}("repositoryName" => repositoryName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_repository(
@@ -367,6 +387,7 @@ function delete_repository(
             mergewith(_merge, Dict{String,Any}("repositoryName" => repositoryName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -393,6 +414,7 @@ function delete_repository_policy(
         "DeleteRepositoryPolicy",
         Dict{String,Any}("repositoryName" => repositoryName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_repository_policy(
@@ -406,6 +428,7 @@ function delete_repository_policy(
             mergewith(_merge, Dict{String,Any}("repositoryName" => repositoryName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -431,6 +454,7 @@ function describe_image_replication_status(
         "DescribeImageReplicationStatus",
         Dict{String,Any}("imageId" => imageId, "repositoryName" => repositoryName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_image_replication_status(
@@ -449,6 +473,7 @@ function describe_image_replication_status(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -486,6 +511,7 @@ function describe_image_scan_findings(
         "DescribeImageScanFindings",
         Dict{String,Any}("imageId" => imageId, "repositoryName" => repositoryName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_image_scan_findings(
@@ -504,6 +530,7 @@ function describe_image_scan_findings(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -544,6 +571,7 @@ function describe_images(repositoryName; aws_config::AbstractAWSConfig=global_aw
         "DescribeImages",
         Dict{String,Any}("repositoryName" => repositoryName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_images(
@@ -557,6 +585,7 @@ function describe_images(
             mergewith(_merge, Dict{String,Any}("repositoryName" => repositoryName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -569,12 +598,14 @@ be created or updated with the PutReplicationConfiguration API action.
 
 """
 function describe_registry(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ecr("DescribeRegistry"; aws_config=aws_config)
+    return ecr("DescribeRegistry"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function describe_registry(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ecr("DescribeRegistry", params; aws_config=aws_config)
+    return ecr(
+        "DescribeRegistry", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -606,12 +637,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   then all repositories in a registry are described.
 """
 function describe_repositories(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ecr("DescribeRepositories"; aws_config=aws_config)
+    return ecr(
+        "DescribeRepositories"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_repositories(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ecr("DescribeRepositories", params; aws_config=aws_config)
+    return ecr(
+        "DescribeRepositories",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -633,12 +671,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   the default registry is assumed.
 """
 function get_authorization_token(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ecr("GetAuthorizationToken"; aws_config=aws_config)
+    return ecr(
+        "GetAuthorizationToken"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_authorization_token(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ecr("GetAuthorizationToken", params; aws_config=aws_config)
+    return ecr(
+        "GetAuthorizationToken",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -670,6 +715,7 @@ function get_download_url_for_layer(
         "GetDownloadUrlForLayer",
         Dict{String,Any}("layerDigest" => layerDigest, "repositoryName" => repositoryName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_download_url_for_layer(
@@ -690,6 +736,7 @@ function get_download_url_for_layer(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -714,6 +761,7 @@ function get_lifecycle_policy(
         "GetLifecyclePolicy",
         Dict{String,Any}("repositoryName" => repositoryName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_lifecycle_policy(
@@ -727,6 +775,7 @@ function get_lifecycle_policy(
             mergewith(_merge, Dict{String,Any}("repositoryName" => repositoryName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -769,6 +818,7 @@ function get_lifecycle_policy_preview(
         "GetLifecyclePolicyPreview",
         Dict{String,Any}("repositoryName" => repositoryName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_lifecycle_policy_preview(
@@ -782,6 +832,7 @@ function get_lifecycle_policy_preview(
             mergewith(_merge, Dict{String,Any}("repositoryName" => repositoryName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -793,12 +844,14 @@ Retrieves the permissions policy for a registry.
 
 """
 function get_registry_policy(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ecr("GetRegistryPolicy"; aws_config=aws_config)
+    return ecr("GetRegistryPolicy"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function get_registry_policy(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ecr("GetRegistryPolicy", params; aws_config=aws_config)
+    return ecr(
+        "GetRegistryPolicy", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -822,6 +875,7 @@ function get_repository_policy(
         "GetRepositoryPolicy",
         Dict{String,Any}("repositoryName" => repositoryName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_repository_policy(
@@ -835,6 +889,7 @@ function get_repository_policy(
             mergewith(_merge, Dict{String,Any}("repositoryName" => repositoryName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -865,6 +920,7 @@ function initiate_layer_upload(
         "InitiateLayerUpload",
         Dict{String,Any}("repositoryName" => repositoryName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function initiate_layer_upload(
@@ -878,6 +934,7 @@ function initiate_layer_upload(
             mergewith(_merge, Dict{String,Any}("repositoryName" => repositoryName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -918,6 +975,7 @@ function list_images(repositoryName; aws_config::AbstractAWSConfig=global_aws_co
         "ListImages",
         Dict{String,Any}("repositoryName" => repositoryName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_images(
@@ -931,6 +989,7 @@ function list_images(
             mergewith(_merge, Dict{String,Any}("repositoryName" => repositoryName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -952,6 +1011,7 @@ function list_tags_for_resource(
         "ListTagsForResource",
         Dict{String,Any}("resourceArn" => resourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags_for_resource(
@@ -965,6 +1025,7 @@ function list_tags_for_resource(
             mergewith(_merge, Dict{String,Any}("resourceArn" => resourceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1003,6 +1064,7 @@ function put_image(
             "imageManifest" => imageManifest, "repositoryName" => repositoryName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_image(
@@ -1023,6 +1085,7 @@ function put_image(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1057,6 +1120,7 @@ function put_image_scanning_configuration(
             "repositoryName" => repositoryName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_image_scanning_configuration(
@@ -1078,6 +1142,7 @@ function put_image_scanning_configuration(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1110,6 +1175,7 @@ function put_image_tag_mutability(
             "imageTagMutability" => imageTagMutability, "repositoryName" => repositoryName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_image_tag_mutability(
@@ -1131,6 +1197,7 @@ function put_image_tag_mutability(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1160,6 +1227,7 @@ function put_lifecycle_policy(
             "lifecyclePolicyText" => lifecyclePolicyText, "repositoryName" => repositoryName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_lifecycle_policy(
@@ -1181,6 +1249,7 @@ function put_lifecycle_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1204,6 +1273,7 @@ function put_registry_policy(policyText; aws_config::AbstractAWSConfig=global_aw
         "PutRegistryPolicy",
         Dict{String,Any}("policyText" => policyText);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_registry_policy(
@@ -1217,6 +1287,7 @@ function put_registry_policy(
             mergewith(_merge, Dict{String,Any}("policyText" => policyText), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1245,6 +1316,7 @@ function put_replication_configuration(
         "PutReplicationConfiguration",
         Dict{String,Any}("replicationConfiguration" => replicationConfiguration);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_replication_configuration(
@@ -1262,6 +1334,7 @@ function put_replication_configuration(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1294,6 +1367,7 @@ function set_repository_policy(
         "SetRepositoryPolicy",
         Dict{String,Any}("policyText" => policyText, "repositoryName" => repositoryName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function set_repository_policy(
@@ -1314,6 +1388,7 @@ function set_repository_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1342,6 +1417,7 @@ function start_image_scan(
         "StartImageScan",
         Dict{String,Any}("imageId" => imageId, "repositoryName" => repositoryName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_image_scan(
@@ -1360,6 +1436,7 @@ function start_image_scan(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1387,6 +1464,7 @@ function start_lifecycle_policy_preview(
         "StartLifecyclePolicyPreview",
         Dict{String,Any}("repositoryName" => repositoryName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_lifecycle_policy_preview(
@@ -1400,6 +1478,7 @@ function start_lifecycle_policy_preview(
             mergewith(_merge, Dict{String,Any}("repositoryName" => repositoryName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1423,6 +1502,7 @@ function tag_resource(resourceArn, tags; aws_config::AbstractAWSConfig=global_aw
         "TagResource",
         Dict{String,Any}("resourceArn" => resourceArn, "tags" => tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -1441,6 +1521,7 @@ function tag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1463,6 +1544,7 @@ function untag_resource(
         "UntagResource",
         Dict{String,Any}("resourceArn" => resourceArn, "tagKeys" => tagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -1481,6 +1563,7 @@ function untag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1529,6 +1612,7 @@ function upload_layer_part(
             "uploadId" => uploadId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function upload_layer_part(
@@ -1556,5 +1640,6 @@ function upload_layer_part(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/ecr_public.jl
+++ b/src/services/ecr_public.jl
@@ -35,6 +35,7 @@ function batch_check_layer_availability(
             "layerDigests" => layerDigests, "repositoryName" => repositoryName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_check_layer_availability(
@@ -55,6 +56,7 @@ function batch_check_layer_availability(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -85,6 +87,7 @@ function batch_delete_image(
         "BatchDeleteImage",
         Dict{String,Any}("imageIds" => imageIds, "repositoryName" => repositoryName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_delete_image(
@@ -105,6 +108,7 @@ function batch_delete_image(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -146,6 +150,7 @@ function complete_layer_upload(
             "uploadId" => uploadId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function complete_layer_upload(
@@ -169,6 +174,7 @@ function complete_layer_upload(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -201,6 +207,7 @@ function create_repository(
         "CreateRepository",
         Dict{String,Any}("repositoryName" => repositoryName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_repository(
@@ -214,6 +221,7 @@ function create_repository(
             mergewith(_merge, Dict{String,Any}("repositoryName" => repositoryName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -242,6 +250,7 @@ function delete_repository(
         "DeleteRepository",
         Dict{String,Any}("repositoryName" => repositoryName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_repository(
@@ -255,6 +264,7 @@ function delete_repository(
             mergewith(_merge, Dict{String,Any}("repositoryName" => repositoryName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -281,6 +291,7 @@ function delete_repository_policy(
         "DeleteRepositoryPolicy",
         Dict{String,Any}("repositoryName" => repositoryName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_repository_policy(
@@ -294,6 +305,7 @@ function delete_repository_policy(
             mergewith(_merge, Dict{String,Any}("repositoryName" => repositoryName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -332,6 +344,7 @@ function describe_image_tags(
         "DescribeImageTags",
         Dict{String,Any}("repositoryName" => repositoryName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_image_tags(
@@ -345,6 +358,7 @@ function describe_image_tags(
             mergewith(_merge, Dict{String,Any}("repositoryName" => repositoryName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -384,6 +398,7 @@ function describe_images(repositoryName; aws_config::AbstractAWSConfig=global_aw
         "DescribeImages",
         Dict{String,Any}("repositoryName" => repositoryName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_images(
@@ -397,6 +412,7 @@ function describe_images(
             mergewith(_merge, Dict{String,Any}("repositoryName" => repositoryName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -423,12 +439,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   not for other programmatic purposes.
 """
 function describe_registries(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ecr_public("DescribeRegistries"; aws_config=aws_config)
+    return ecr_public(
+        "DescribeRegistries"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_registries(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ecr_public("DescribeRegistries", params; aws_config=aws_config)
+    return ecr_public(
+        "DescribeRegistries", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -460,12 +480,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   then all repositories in a registry are described.
 """
 function describe_repositories(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ecr_public("DescribeRepositories"; aws_config=aws_config)
+    return ecr_public(
+        "DescribeRepositories"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_repositories(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ecr_public("DescribeRepositories", params; aws_config=aws_config)
+    return ecr_public(
+        "DescribeRepositories",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -479,12 +506,19 @@ ecr-public:GetAuthorizationToken and sts:GetServiceBearerToken permissions.
 
 """
 function get_authorization_token(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ecr_public("GetAuthorizationToken"; aws_config=aws_config)
+    return ecr_public(
+        "GetAuthorizationToken"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_authorization_token(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ecr_public("GetAuthorizationToken", params; aws_config=aws_config)
+    return ecr_public(
+        "GetAuthorizationToken",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -495,12 +529,19 @@ Retrieves catalog metadata for a public registry.
 
 """
 function get_registry_catalog_data(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ecr_public("GetRegistryCatalogData"; aws_config=aws_config)
+    return ecr_public(
+        "GetRegistryCatalogData"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_registry_catalog_data(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ecr_public("GetRegistryCatalogData", params; aws_config=aws_config)
+    return ecr_public(
+        "GetRegistryCatalogData",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -526,6 +567,7 @@ function get_repository_catalog_data(
         "GetRepositoryCatalogData",
         Dict{String,Any}("repositoryName" => repositoryName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_repository_catalog_data(
@@ -539,6 +581,7 @@ function get_repository_catalog_data(
             mergewith(_merge, Dict{String,Any}("repositoryName" => repositoryName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -563,6 +606,7 @@ function get_repository_policy(
         "GetRepositoryPolicy",
         Dict{String,Any}("repositoryName" => repositoryName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_repository_policy(
@@ -576,6 +620,7 @@ function get_repository_policy(
             mergewith(_merge, Dict{String,Any}("repositoryName" => repositoryName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -605,6 +650,7 @@ function initiate_layer_upload(
         "InitiateLayerUpload",
         Dict{String,Any}("repositoryName" => repositoryName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function initiate_layer_upload(
@@ -618,6 +664,7 @@ function initiate_layer_upload(
             mergewith(_merge, Dict{String,Any}("repositoryName" => repositoryName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -639,6 +686,7 @@ function list_tags_for_resource(
         "ListTagsForResource",
         Dict{String,Any}("resourceArn" => resourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags_for_resource(
@@ -652,6 +700,7 @@ function list_tags_for_resource(
             mergewith(_merge, Dict{String,Any}("resourceArn" => resourceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -690,6 +739,7 @@ function put_image(
             "imageManifest" => imageManifest, "repositoryName" => repositoryName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_image(
@@ -710,6 +760,7 @@ function put_image(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -726,12 +777,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   publicly visible in the Amazon ECR Public Gallery for verified accounts.
 """
 function put_registry_catalog_data(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ecr_public("PutRegistryCatalogData"; aws_config=aws_config)
+    return ecr_public(
+        "PutRegistryCatalogData"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function put_registry_catalog_data(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ecr_public("PutRegistryCatalogData", params; aws_config=aws_config)
+    return ecr_public(
+        "PutRegistryCatalogData",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -757,6 +815,7 @@ function put_repository_catalog_data(
         "PutRepositoryCatalogData",
         Dict{String,Any}("catalogData" => catalogData, "repositoryName" => repositoryName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_repository_catalog_data(
@@ -777,6 +836,7 @@ function put_repository_catalog_data(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -809,6 +869,7 @@ function set_repository_policy(
         "SetRepositoryPolicy",
         Dict{String,Any}("policyText" => policyText, "repositoryName" => repositoryName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function set_repository_policy(
@@ -829,6 +890,7 @@ function set_repository_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -853,6 +915,7 @@ function tag_resource(resourceArn, tags; aws_config::AbstractAWSConfig=global_aw
         "TagResource",
         Dict{String,Any}("resourceArn" => resourceArn, "tags" => tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -871,6 +934,7 @@ function tag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -893,6 +957,7 @@ function untag_resource(
         "UntagResource",
         Dict{String,Any}("resourceArn" => resourceArn, "tagKeys" => tagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -911,6 +976,7 @@ function untag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -959,6 +1025,7 @@ function upload_layer_part(
             "uploadId" => uploadId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function upload_layer_part(
@@ -986,5 +1053,6 @@ function upload_layer_part(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/ecs.jl
+++ b/src/services/ecs.jl
@@ -46,6 +46,7 @@ function create_capacity_provider(
             "autoScalingGroupProvider" => autoScalingGroupProvider, "name" => name
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_capacity_provider(
@@ -66,6 +67,7 @@ function create_capacity_provider(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -123,12 +125,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   resource limit.
 """
 function create_cluster(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ecs("CreateCluster"; aws_config=aws_config)
+    return ecs("CreateCluster"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function create_cluster(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ecs("CreateCluster", params; aws_config=aws_config)
+    return ecs(
+        "CreateCluster", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -360,6 +364,7 @@ function create_service(serviceName; aws_config::AbstractAWSConfig=global_aws_co
         "CreateService",
         Dict{String,Any}("serviceName" => serviceName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_service(
@@ -373,6 +378,7 @@ function create_service(
             mergewith(_merge, Dict{String,Any}("serviceName" => serviceName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -450,6 +456,7 @@ function create_task_set(
             "cluster" => cluster, "service" => service, "taskDefinition" => taskDefinition
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_task_set(
@@ -473,6 +480,7 @@ function create_task_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -501,7 +509,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function delete_account_setting(name; aws_config::AbstractAWSConfig=global_aws_config())
     return ecs(
-        "DeleteAccountSetting", Dict{String,Any}("name" => name); aws_config=aws_config
+        "DeleteAccountSetting",
+        Dict{String,Any}("name" => name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_account_setting(
@@ -511,6 +522,7 @@ function delete_account_setting(
         "DeleteAccountSetting",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("name" => name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -537,6 +549,7 @@ function delete_attributes(attributes; aws_config::AbstractAWSConfig=global_aws_
         "DeleteAttributes",
         Dict{String,Any}("attributes" => attributes);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_attributes(
@@ -550,6 +563,7 @@ function delete_attributes(
             mergewith(_merge, Dict{String,Any}("attributes" => attributes), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -581,6 +595,7 @@ function delete_capacity_provider(
         "DeleteCapacityProvider",
         Dict{String,Any}("capacityProvider" => capacityProvider);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_capacity_provider(
@@ -596,6 +611,7 @@ function delete_capacity_provider(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -616,7 +632,10 @@ ListContainerInstances and deregister them with DeregisterContainerInstance.
 """
 function delete_cluster(cluster; aws_config::AbstractAWSConfig=global_aws_config())
     return ecs(
-        "DeleteCluster", Dict{String,Any}("cluster" => cluster); aws_config=aws_config
+        "DeleteCluster",
+        Dict{String,Any}("cluster" => cluster);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_cluster(
@@ -626,6 +645,7 @@ function delete_cluster(
         "DeleteCluster",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("cluster" => cluster), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -660,7 +680,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function delete_service(service; aws_config::AbstractAWSConfig=global_aws_config())
     return ecs(
-        "DeleteService", Dict{String,Any}("service" => service); aws_config=aws_config
+        "DeleteService",
+        Dict{String,Any}("service" => service);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_service(
@@ -670,6 +693,7 @@ function delete_service(
         "DeleteService",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("service" => service), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -700,6 +724,7 @@ function delete_task_set(
         "DeleteTaskSet",
         Dict{String,Any}("cluster" => cluster, "service" => service, "taskSet" => taskSet);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_task_set(
@@ -721,6 +746,7 @@ function delete_task_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -768,6 +794,7 @@ function deregister_container_instance(
         "DeregisterContainerInstance",
         Dict{String,Any}("containerInstance" => containerInstance);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function deregister_container_instance(
@@ -783,6 +810,7 @@ function deregister_container_instance(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -814,6 +842,7 @@ function deregister_task_definition(
         "DeregisterTaskDefinition",
         Dict{String,Any}("taskDefinition" => taskDefinition);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function deregister_task_definition(
@@ -827,6 +856,7 @@ function deregister_task_definition(
             mergewith(_merge, Dict{String,Any}("taskDefinition" => taskDefinition), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -857,12 +887,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   only used to retrieve the next items in a list and not for other programmatic purposes.
 """
 function describe_capacity_providers(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ecs("DescribeCapacityProviders"; aws_config=aws_config)
+    return ecs(
+        "DescribeCapacityProviders"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_capacity_providers(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ecs("DescribeCapacityProviders", params; aws_config=aws_config)
+    return ecs(
+        "DescribeCapacityProviders",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -884,12 +921,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   specified, the metadata tags associated with the cluster are included.
 """
 function describe_clusters(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ecs("DescribeClusters"; aws_config=aws_config)
+    return ecs("DescribeClusters"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function describe_clusters(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ecs("DescribeClusters", params; aws_config=aws_config)
+    return ecs(
+        "DescribeClusters", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -920,6 +959,7 @@ function describe_container_instances(
         "DescribeContainerInstances",
         Dict{String,Any}("containerInstances" => containerInstances);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_container_instances(
@@ -935,6 +975,7 @@ function describe_container_instances(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -960,7 +1001,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function describe_services(services; aws_config::AbstractAWSConfig=global_aws_config())
     return ecs(
-        "DescribeServices", Dict{String,Any}("services" => services); aws_config=aws_config
+        "DescribeServices",
+        Dict{String,Any}("services" => services);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_services(
@@ -974,6 +1018,7 @@ function describe_services(
             mergewith(_merge, Dict{String,Any}("services" => services), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1004,6 +1049,7 @@ function describe_task_definition(
         "DescribeTaskDefinition",
         Dict{String,Any}("taskDefinition" => taskDefinition);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_task_definition(
@@ -1017,6 +1063,7 @@ function describe_task_definition(
             mergewith(_merge, Dict{String,Any}("taskDefinition" => taskDefinition), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1048,6 +1095,7 @@ function describe_task_sets(
         "DescribeTaskSets",
         Dict{String,Any}("cluster" => cluster, "service" => service);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_task_sets(
@@ -1064,6 +1112,7 @@ function describe_task_sets(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1087,7 +1136,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   included in the response.
 """
 function describe_tasks(tasks; aws_config::AbstractAWSConfig=global_aws_config())
-    return ecs("DescribeTasks", Dict{String,Any}("tasks" => tasks); aws_config=aws_config)
+    return ecs(
+        "DescribeTasks",
+        Dict{String,Any}("tasks" => tasks);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_tasks(
     tasks, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -1096,6 +1150,7 @@ function describe_tasks(
         "DescribeTasks",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tasks" => tasks), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1117,12 +1172,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   arn:aws:ecs:region:aws_account_id:container-instance/container_instance_ID.
 """
 function discover_poll_endpoint(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ecs("DiscoverPollEndpoint"; aws_config=aws_config)
+    return ecs(
+        "DiscoverPollEndpoint"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function discover_poll_endpoint(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ecs("DiscoverPollEndpoint", params; aws_config=aws_config)
+    return ecs(
+        "DiscoverPollEndpoint",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1152,6 +1214,7 @@ function execute_command(
             "command" => command, "interactive" => interactive, "task" => task
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function execute_command(
@@ -1173,6 +1236,7 @@ function execute_command(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1209,12 +1273,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   specify an account setting name to use this parameter.
 """
 function list_account_settings(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ecs("ListAccountSettings"; aws_config=aws_config)
+    return ecs(
+        "ListAccountSettings"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_account_settings(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ecs("ListAccountSettings", params; aws_config=aws_config)
+    return ecs(
+        "ListAccountSettings",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1255,6 +1326,7 @@ function list_attributes(targetType; aws_config::AbstractAWSConfig=global_aws_co
         "ListAttributes",
         Dict{String,Any}("targetType" => targetType);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_attributes(
@@ -1268,6 +1340,7 @@ function list_attributes(
             mergewith(_merge, Dict{String,Any}("targetType" => targetType), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1292,12 +1365,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   items in a list and not for other programmatic purposes.
 """
 function list_clusters(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ecs("ListClusters"; aws_config=aws_config)
+    return ecs("ListClusters"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_clusters(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ecs("ListClusters", params; aws_config=aws_config)
+    return ecs(
+        "ListClusters", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1335,12 +1410,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   default is to include container instances set to all states other than INACTIVE.
 """
 function list_container_instances(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ecs("ListContainerInstances"; aws_config=aws_config)
+    return ecs(
+        "ListContainerInstances"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_container_instances(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ecs("ListContainerInstances", params; aws_config=aws_config)
+    return ecs(
+        "ListContainerInstances",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1371,12 +1453,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   results.
 """
 function list_services(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ecs("ListServices"; aws_config=aws_config)
+    return ecs("ListServices"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_services(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ecs("ListServices", params; aws_config=aws_config)
+    return ecs(
+        "ListServices", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1398,6 +1482,7 @@ function list_tags_for_resource(
         "ListTagsForResource",
         Dict{String,Any}("resourceArn" => resourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags_for_resource(
@@ -1411,6 +1496,7 @@ function list_tags_for_resource(
             mergewith(_merge, Dict{String,Any}("resourceArn" => resourceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1450,12 +1536,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   in each subsequent request.
 """
 function list_task_definition_families(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ecs("ListTaskDefinitionFamilies"; aws_config=aws_config)
+    return ecs(
+        "ListTaskDefinitionFamilies"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_task_definition_families(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ecs("ListTaskDefinitionFamilies", params; aws_config=aws_config)
+    return ecs(
+        "ListTaskDefinitionFamilies",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1495,12 +1588,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   status value constant in each subsequent request.
 """
 function list_task_definitions(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ecs("ListTaskDefinitions"; aws_config=aws_config)
+    return ecs(
+        "ListTaskDefinitions"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_task_definitions(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ecs("ListTaskDefinitions", params; aws_config=aws_config)
+    return ecs(
+        "ListTaskDefinitions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1548,12 +1648,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   startedBy value limits the results to tasks that were started with that value.
 """
 function list_tasks(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ecs("ListTasks"; aws_config=aws_config)
+    return ecs("ListTasks"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_tasks(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ecs("ListTasks", params; aws_config=aws_config)
+    return ecs("ListTasks", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 
 """
@@ -1607,6 +1707,7 @@ function put_account_setting(name, value; aws_config::AbstractAWSConfig=global_a
         "PutAccountSetting",
         Dict{String,Any}("name" => name, "value" => value);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_account_setting(
@@ -1621,6 +1722,7 @@ function put_account_setting(
             mergewith(_merge, Dict{String,Any}("name" => name, "value" => value), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1650,6 +1752,7 @@ function put_account_setting_default(
         "PutAccountSettingDefault",
         Dict{String,Any}("name" => name, "value" => value);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_account_setting_default(
@@ -1664,6 +1767,7 @@ function put_account_setting_default(
             mergewith(_merge, Dict{String,Any}("name" => name, "value" => value), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1688,7 +1792,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function put_attributes(attributes; aws_config::AbstractAWSConfig=global_aws_config())
     return ecs(
-        "PutAttributes", Dict{String,Any}("attributes" => attributes); aws_config=aws_config
+        "PutAttributes",
+        Dict{String,Any}("attributes" => attributes);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_attributes(
@@ -1702,6 +1809,7 @@ function put_attributes(
             mergewith(_merge, Dict{String,Any}("attributes" => attributes), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1760,6 +1868,7 @@ function put_cluster_capacity_providers(
             "defaultCapacityProviderStrategy" => defaultCapacityProviderStrategy,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_cluster_capacity_providers(
@@ -1783,6 +1892,7 @@ function put_cluster_capacity_providers(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1828,12 +1938,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   daemon running on the container instance.
 """
 function register_container_instance(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ecs("RegisterContainerInstance"; aws_config=aws_config)
+    return ecs(
+        "RegisterContainerInstance"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function register_container_instance(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ecs("RegisterContainerInstance", params; aws_config=aws_config)
+    return ecs(
+        "RegisterContainerInstance",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1997,6 +2114,7 @@ function register_task_definition(
             "containerDefinitions" => containerDefinitions, "family" => family
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function register_task_definition(
@@ -2017,6 +2135,7 @@ function register_task_definition(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2132,6 +2251,7 @@ function run_task(taskDefinition; aws_config::AbstractAWSConfig=global_aws_confi
         "RunTask",
         Dict{String,Any}("taskDefinition" => taskDefinition);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function run_task(
@@ -2145,6 +2265,7 @@ function run_task(
             mergewith(_merge, Dict{String,Any}("taskDefinition" => taskDefinition), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2217,6 +2338,7 @@ function start_task(
             "containerInstances" => containerInstances, "taskDefinition" => taskDefinition
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_task(
@@ -2238,6 +2360,7 @@ function start_task(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2267,7 +2390,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Up to 255 characters are allowed in this message.
 """
 function stop_task(task; aws_config::AbstractAWSConfig=global_aws_config())
-    return ecs("StopTask", Dict{String,Any}("task" => task); aws_config=aws_config)
+    return ecs(
+        "StopTask",
+        Dict{String,Any}("task" => task);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function stop_task(
     task, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -2276,6 +2404,7 @@ function stop_task(
         "StopTask",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("task" => task), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2301,6 +2430,7 @@ function submit_attachment_state_changes(
         "SubmitAttachmentStateChanges",
         Dict{String,Any}("attachments" => attachments);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function submit_attachment_state_changes(
@@ -2314,6 +2444,7 @@ function submit_attachment_state_changes(
             mergewith(_merge, Dict{String,Any}("attachments" => attachments), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2337,12 +2468,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   container.
 """
 function submit_container_state_change(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ecs("SubmitContainerStateChange"; aws_config=aws_config)
+    return ecs(
+        "SubmitContainerStateChange"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function submit_container_state_change(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ecs("SubmitContainerStateChange", params; aws_config=aws_config)
+    return ecs(
+        "SubmitContainerStateChange",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2367,12 +2505,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"task"`: The task ID or full ARN of the task in the state change request.
 """
 function submit_task_state_change(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ecs("SubmitTaskStateChange"; aws_config=aws_config)
+    return ecs(
+        "SubmitTaskStateChange"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function submit_task_state_change(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ecs("SubmitTaskStateChange", params; aws_config=aws_config)
+    return ecs(
+        "SubmitTaskStateChange",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2406,6 +2551,7 @@ function tag_resource(resourceArn, tags; aws_config::AbstractAWSConfig=global_aw
         "TagResource",
         Dict{String,Any}("resourceArn" => resourceArn, "tags" => tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -2424,6 +2570,7 @@ function tag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2447,6 +2594,7 @@ function untag_resource(
         "UntagResource",
         Dict{String,Any}("resourceArn" => resourceArn, "tagKeys" => tagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -2465,6 +2613,7 @@ function untag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2489,6 +2638,7 @@ function update_capacity_provider(
             "autoScalingGroupProvider" => autoScalingGroupProvider, "name" => name
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_capacity_provider(
@@ -2509,6 +2659,7 @@ function update_capacity_provider(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2528,7 +2679,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function update_cluster(cluster; aws_config::AbstractAWSConfig=global_aws_config())
     return ecs(
-        "UpdateCluster", Dict{String,Any}("cluster" => cluster); aws_config=aws_config
+        "UpdateCluster",
+        Dict{String,Any}("cluster" => cluster);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_cluster(
@@ -2538,6 +2692,7 @@ function update_cluster(
         "UpdateCluster",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("cluster" => cluster), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2561,6 +2716,7 @@ function update_cluster_settings(
         "UpdateClusterSettings",
         Dict{String,Any}("cluster" => cluster, "settings" => settings);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_cluster_settings(
@@ -2579,6 +2735,7 @@ function update_cluster_settings(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2616,6 +2773,7 @@ function update_container_agent(
         "UpdateContainerAgent",
         Dict{String,Any}("containerInstance" => containerInstance);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_container_agent(
@@ -2631,6 +2789,7 @@ function update_container_agent(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2691,6 +2850,7 @@ function update_container_instances_state(
         "UpdateContainerInstancesState",
         Dict{String,Any}("containerInstances" => containerInstances, "status" => status);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_container_instances_state(
@@ -2711,6 +2871,7 @@ function update_container_instances_state(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2851,7 +3012,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function update_service(service; aws_config::AbstractAWSConfig=global_aws_config())
     return ecs(
-        "UpdateService", Dict{String,Any}("service" => service); aws_config=aws_config
+        "UpdateService",
+        Dict{String,Any}("service" => service);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_service(
@@ -2861,6 +3025,7 @@ function update_service(
         "UpdateService",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("service" => service), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2891,6 +3056,7 @@ function update_service_primary_task_set(
             "cluster" => cluster, "primaryTaskSet" => primaryTaskSet, "service" => service
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_service_primary_task_set(
@@ -2914,6 +3080,7 @@ function update_service_primary_task_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2947,6 +3114,7 @@ function update_task_set(
             "taskSet" => taskSet,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_task_set(
@@ -2972,5 +3140,6 @@ function update_task_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/efs.jl
+++ b/src/services/efs.jl
@@ -48,6 +48,7 @@ function create_access_point(
         "/2015-02-01/access-points",
         Dict{String,Any}("ClientToken" => ClientToken, "FileSystemId" => FileSystemId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_access_point(
@@ -69,6 +70,7 @@ function create_access_point(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -173,6 +175,7 @@ function create_file_system(
         "/2015-02-01/file-systems",
         Dict{String,Any}("CreationToken" => CreationToken);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_file_system(
@@ -187,6 +190,7 @@ function create_file_system(
             mergewith(_merge, Dict{String,Any}("CreationToken" => CreationToken), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -271,6 +275,7 @@ function create_mount_target(
         "/2015-02-01/mount-targets",
         Dict{String,Any}("FileSystemId" => FileSystemId, "SubnetId" => SubnetId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_mount_target(
@@ -290,6 +295,7 @@ function create_mount_target(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -317,6 +323,7 @@ function create_tags(FileSystemId, Tags; aws_config::AbstractAWSConfig=global_aw
         "/2015-02-01/create-tags/$(FileSystemId)",
         Dict{String,Any}("Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_tags(
@@ -330,6 +337,7 @@ function create_tags(
         "/2015-02-01/create-tags/$(FileSystemId)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Tags" => Tags), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -350,7 +358,10 @@ function delete_access_point(
     AccessPointId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return efs(
-        "DELETE", "/2015-02-01/access-points/$(AccessPointId)"; aws_config=aws_config
+        "DELETE",
+        "/2015-02-01/access-points/$(AccessPointId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_access_point(
@@ -363,6 +374,7 @@ function delete_access_point(
         "/2015-02-01/access-points/$(AccessPointId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -386,7 +398,12 @@ elasticfilesystem:DeleteFileSystem action.
 
 """
 function delete_file_system(FileSystemId; aws_config::AbstractAWSConfig=global_aws_config())
-    return efs("DELETE", "/2015-02-01/file-systems/$(FileSystemId)"; aws_config=aws_config)
+    return efs(
+        "DELETE",
+        "/2015-02-01/file-systems/$(FileSystemId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_file_system(
     FileSystemId,
@@ -394,7 +411,11 @@ function delete_file_system(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return efs(
-        "DELETE", "/2015-02-01/file-systems/$(FileSystemId)", params; aws_config=aws_config
+        "DELETE",
+        "/2015-02-01/file-systems/$(FileSystemId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -415,7 +436,10 @@ function delete_file_system_policy(
     FileSystemId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return efs(
-        "DELETE", "/2015-02-01/file-systems/$(FileSystemId)/policy"; aws_config=aws_config
+        "DELETE",
+        "/2015-02-01/file-systems/$(FileSystemId)/policy";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_file_system_policy(
@@ -428,6 +452,7 @@ function delete_file_system_policy(
         "/2015-02-01/file-systems/$(FileSystemId)/policy",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -457,7 +482,10 @@ function delete_mount_target(
     MountTargetId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return efs(
-        "DELETE", "/2015-02-01/mount-targets/$(MountTargetId)"; aws_config=aws_config
+        "DELETE",
+        "/2015-02-01/mount-targets/$(MountTargetId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_mount_target(
@@ -470,6 +498,7 @@ function delete_mount_target(
         "/2015-02-01/mount-targets/$(MountTargetId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -497,6 +526,7 @@ function delete_tags(
         "/2015-02-01/delete-tags/$(FileSystemId)",
         Dict{String,Any}("TagKeys" => TagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_tags(
@@ -510,6 +540,7 @@ function delete_tags(
         "/2015-02-01/delete-tags/$(FileSystemId)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("TagKeys" => TagKeys), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -536,12 +567,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   in the subsequent request to fetch the next page of access point descriptions.
 """
 function describe_access_points(; aws_config::AbstractAWSConfig=global_aws_config())
-    return efs("GET", "/2015-02-01/access-points"; aws_config=aws_config)
+    return efs(
+        "GET",
+        "/2015-02-01/access-points";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_access_points(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return efs("GET", "/2015-02-01/access-points", params; aws_config=aws_config)
+    return efs(
+        "GET",
+        "/2015-02-01/access-points",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -561,12 +603,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   page of Amazon Web Services account preferences if the response payload was paginated.
 """
 function describe_account_preferences(; aws_config::AbstractAWSConfig=global_aws_config())
-    return efs("GET", "/2015-02-01/account-preferences"; aws_config=aws_config)
+    return efs(
+        "GET",
+        "/2015-02-01/account-preferences";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_account_preferences(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return efs("GET", "/2015-02-01/account-preferences", params; aws_config=aws_config)
+    return efs(
+        "GET",
+        "/2015-02-01/account-preferences",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -586,6 +639,7 @@ function describe_backup_policy(
         "GET",
         "/2015-02-01/file-systems/$(FileSystemId)/backup-policy";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_backup_policy(
@@ -598,6 +652,7 @@ function describe_backup_policy(
         "/2015-02-01/file-systems/$(FileSystemId)/backup-policy",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -616,7 +671,10 @@ function describe_file_system_policy(
     FileSystemId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return efs(
-        "GET", "/2015-02-01/file-systems/$(FileSystemId)/policy"; aws_config=aws_config
+        "GET",
+        "/2015-02-01/file-systems/$(FileSystemId)/policy";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_file_system_policy(
@@ -629,6 +687,7 @@ function describe_file_system_policy(
         "/2015-02-01/file-systems/$(FileSystemId)/policy",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -667,12 +726,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   100 per page if you have more than 100 file systems.
 """
 function describe_file_systems(; aws_config::AbstractAWSConfig=global_aws_config())
-    return efs("GET", "/2015-02-01/file-systems"; aws_config=aws_config)
+    return efs(
+        "GET",
+        "/2015-02-01/file-systems";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_file_systems(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return efs("GET", "/2015-02-01/file-systems", params; aws_config=aws_config)
+    return efs(
+        "GET",
+        "/2015-02-01/file-systems",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -699,6 +769,7 @@ function describe_lifecycle_configuration(
         "GET",
         "/2015-02-01/file-systems/$(FileSystemId)/lifecycle-configuration";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_lifecycle_configuration(
@@ -711,6 +782,7 @@ function describe_lifecycle_configuration(
         "/2015-02-01/file-systems/$(FileSystemId)/lifecycle-configuration",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -736,6 +808,7 @@ function describe_mount_target_security_groups(
         "GET",
         "/2015-02-01/mount-targets/$(MountTargetId)/security-groups";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_mount_target_security_groups(
@@ -748,6 +821,7 @@ function describe_mount_target_security_groups(
         "/2015-02-01/mount-targets/$(MountTargetId)/security-groups",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -781,12 +855,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   either a mount target ID or ARN as input.
 """
 function describe_mount_targets(; aws_config::AbstractAWSConfig=global_aws_config())
-    return efs("GET", "/2015-02-01/mount-targets"; aws_config=aws_config)
+    return efs(
+        "GET",
+        "/2015-02-01/mount-targets";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_mount_targets(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return efs("GET", "/2015-02-01/mount-targets", params; aws_config=aws_config)
+    return efs(
+        "GET",
+        "/2015-02-01/mount-targets",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -813,14 +898,25 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   The response is paginated at 100 per page if you have more than 100 tags.
 """
 function describe_tags(FileSystemId; aws_config::AbstractAWSConfig=global_aws_config())
-    return efs("GET", "/2015-02-01/tags/$(FileSystemId)/"; aws_config=aws_config)
+    return efs(
+        "GET",
+        "/2015-02-01/tags/$(FileSystemId)/";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_tags(
     FileSystemId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return efs("GET", "/2015-02-01/tags/$(FileSystemId)/", params; aws_config=aws_config)
+    return efs(
+        "GET",
+        "/2015-02-01/tags/$(FileSystemId)/",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -845,7 +941,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function list_tags_for_resource(
     ResourceId; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return efs("GET", "/2015-02-01/resource-tags/$(ResourceId)"; aws_config=aws_config)
+    return efs(
+        "GET",
+        "/2015-02-01/resource-tags/$(ResourceId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_tags_for_resource(
     ResourceId,
@@ -853,7 +954,11 @@ function list_tags_for_resource(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return efs(
-        "GET", "/2015-02-01/resource-tags/$(ResourceId)", params; aws_config=aws_config
+        "GET",
+        "/2015-02-01/resource-tags/$(ResourceId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -885,6 +990,7 @@ function modify_mount_target_security_groups(
         "PUT",
         "/2015-02-01/mount-targets/$(MountTargetId)/security-groups";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_mount_target_security_groups(
@@ -897,6 +1003,7 @@ function modify_mount_target_security_groups(
         "/2015-02-01/mount-targets/$(MountTargetId)/security-groups",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -924,6 +1031,7 @@ function put_account_preferences(
         "/2015-02-01/account-preferences",
         Dict{String,Any}("ResourceIdType" => ResourceIdType);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_account_preferences(
@@ -938,6 +1046,7 @@ function put_account_preferences(
             mergewith(_merge, Dict{String,Any}("ResourceIdType" => ResourceIdType), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -961,6 +1070,7 @@ function put_backup_policy(
         "/2015-02-01/file-systems/$(FileSystemId)/backup-policy",
         Dict{String,Any}("BackupPolicy" => BackupPolicy);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_backup_policy(
@@ -976,6 +1086,7 @@ function put_backup_policy(
             mergewith(_merge, Dict{String,Any}("BackupPolicy" => BackupPolicy), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1017,6 +1128,7 @@ function put_file_system_policy(
         "/2015-02-01/file-systems/$(FileSystemId)/policy",
         Dict{String,Any}("Policy" => Policy);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_file_system_policy(
@@ -1030,6 +1142,7 @@ function put_file_system_policy(
         "/2015-02-01/file-systems/$(FileSystemId)/policy",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Policy" => Policy), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1073,6 +1186,7 @@ function put_lifecycle_configuration(
         "/2015-02-01/file-systems/$(FileSystemId)/lifecycle-configuration",
         Dict{String,Any}("LifecyclePolicies" => LifecyclePolicies);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_lifecycle_configuration(
@@ -1090,6 +1204,7 @@ function put_lifecycle_configuration(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1112,6 +1227,7 @@ function tag_resource(ResourceId, Tags; aws_config::AbstractAWSConfig=global_aws
         "/2015-02-01/resource-tags/$(ResourceId)",
         Dict{String,Any}("Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -1125,6 +1241,7 @@ function tag_resource(
         "/2015-02-01/resource-tags/$(ResourceId)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Tags" => Tags), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1150,6 +1267,7 @@ function untag_resource(
         "/2015-02-01/resource-tags/$(ResourceId)",
         Dict{String,Any}("tagKeys" => tagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -1163,6 +1281,7 @@ function untag_resource(
         "/2015-02-01/resource-tags/$(ResourceId)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tagKeys" => tagKeys), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1188,7 +1307,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   ProvisionedThroughputInMibps.
 """
 function update_file_system(FileSystemId; aws_config::AbstractAWSConfig=global_aws_config())
-    return efs("PUT", "/2015-02-01/file-systems/$(FileSystemId)"; aws_config=aws_config)
+    return efs(
+        "PUT",
+        "/2015-02-01/file-systems/$(FileSystemId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function update_file_system(
     FileSystemId,
@@ -1196,6 +1320,10 @@ function update_file_system(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return efs(
-        "PUT", "/2015-02-01/file-systems/$(FileSystemId)", params; aws_config=aws_config
+        "PUT",
+        "/2015-02-01/file-systems/$(FileSystemId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/eks.jl
+++ b/src/services/eks.jl
@@ -32,6 +32,7 @@ function associate_encryption_config(
             "encryptionConfig" => encryptionConfig, "clientRequestToken" => string(uuid4())
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_encryption_config(
@@ -54,6 +55,7 @@ function associate_encryption_config(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -88,6 +90,7 @@ function associate_identity_provider_config(
         "/clusters/$(name)/identity-provider-configs/associate",
         Dict{String,Any}("oidc" => oidc, "clientRequestToken" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_identity_provider_config(
@@ -107,6 +110,7 @@ function associate_identity_provider_config(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -149,6 +153,7 @@ function create_addon(addonName, name; aws_config::AbstractAWSConfig=global_aws_
         "/clusters/$(name)/addons",
         Dict{String,Any}("addonName" => addonName, "clientRequestToken" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_addon(
@@ -170,6 +175,7 @@ function create_addon(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -235,6 +241,7 @@ function create_cluster(
             "clientRequestToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_cluster(
@@ -260,6 +267,7 @@ function create_cluster(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -327,6 +335,7 @@ function create_fargate_profile(
             "clientRequestToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_fargate_profile(
@@ -351,6 +360,7 @@ function create_fargate_profile(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -457,6 +467,7 @@ function create_nodegroup(
             "clientRequestToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_nodegroup(
@@ -483,6 +494,7 @@ function create_nodegroup(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -505,7 +517,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   the add-on, it is not removed.
 """
 function delete_addon(addonName, name; aws_config::AbstractAWSConfig=global_aws_config())
-    return eks("DELETE", "/clusters/$(name)/addons/$(addonName)"; aws_config=aws_config)
+    return eks(
+        "DELETE",
+        "/clusters/$(name)/addons/$(addonName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_addon(
     addonName,
@@ -514,7 +531,11 @@ function delete_addon(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return eks(
-        "DELETE", "/clusters/$(name)/addons/$(addonName)", params; aws_config=aws_config
+        "DELETE",
+        "/clusters/$(name)/addons/$(addonName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -535,12 +556,23 @@ information, see DeleteNodegroup and DeleteFargateProfile.
 
 """
 function delete_cluster(name; aws_config::AbstractAWSConfig=global_aws_config())
-    return eks("DELETE", "/clusters/$(name)"; aws_config=aws_config)
+    return eks(
+        "DELETE",
+        "/clusters/$(name)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_cluster(
     name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return eks("DELETE", "/clusters/$(name)", params; aws_config=aws_config)
+    return eks(
+        "DELETE",
+        "/clusters/$(name)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -567,6 +599,7 @@ function delete_fargate_profile(
         "DELETE",
         "/clusters/$(name)/fargate-profiles/$(fargateProfileName)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_fargate_profile(
@@ -580,6 +613,7 @@ function delete_fargate_profile(
         "/clusters/$(name)/fargate-profiles/$(fargateProfileName)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -598,7 +632,10 @@ function delete_nodegroup(
     name, nodegroupName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return eks(
-        "DELETE", "/clusters/$(name)/node-groups/$(nodegroupName)"; aws_config=aws_config
+        "DELETE",
+        "/clusters/$(name)/node-groups/$(nodegroupName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_nodegroup(
@@ -612,6 +649,7 @@ function delete_nodegroup(
         "/clusters/$(name)/node-groups/$(nodegroupName)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -626,12 +664,23 @@ Deregisters a connected cluster to remove it from the Amazon EKS control plane.
 
 """
 function deregister_cluster(name; aws_config::AbstractAWSConfig=global_aws_config())
-    return eks("DELETE", "/cluster-registrations/$(name)"; aws_config=aws_config)
+    return eks(
+        "DELETE",
+        "/cluster-registrations/$(name)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function deregister_cluster(
     name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return eks("DELETE", "/cluster-registrations/$(name)", params; aws_config=aws_config)
+    return eks(
+        "DELETE",
+        "/cluster-registrations/$(name)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -647,7 +696,12 @@ Describes an Amazon EKS add-on.
 
 """
 function describe_addon(addonName, name; aws_config::AbstractAWSConfig=global_aws_config())
-    return eks("GET", "/clusters/$(name)/addons/$(addonName)"; aws_config=aws_config)
+    return eks(
+        "GET",
+        "/clusters/$(name)/addons/$(addonName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_addon(
     addonName,
@@ -656,7 +710,11 @@ function describe_addon(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return eks(
-        "GET", "/clusters/$(name)/addons/$(addonName)", params; aws_config=aws_config
+        "GET",
+        "/clusters/$(name)/addons/$(addonName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -679,12 +737,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   only to retrieve the next items in a list and not for other programmatic purposes.
 """
 function describe_addon_versions(; aws_config::AbstractAWSConfig=global_aws_config())
-    return eks("GET", "/addons/supported-versions"; aws_config=aws_config)
+    return eks(
+        "GET",
+        "/addons/supported-versions";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_addon_versions(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return eks("GET", "/addons/supported-versions", params; aws_config=aws_config)
+    return eks(
+        "GET",
+        "/addons/supported-versions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -702,12 +771,20 @@ available until the cluster reaches the ACTIVE state.
 
 """
 function describe_cluster(name; aws_config::AbstractAWSConfig=global_aws_config())
-    return eks("GET", "/clusters/$(name)"; aws_config=aws_config)
+    return eks(
+        "GET", "/clusters/$(name)"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_cluster(
     name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return eks("GET", "/clusters/$(name)", params; aws_config=aws_config)
+    return eks(
+        "GET",
+        "/clusters/$(name)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -728,6 +805,7 @@ function describe_fargate_profile(
         "GET",
         "/clusters/$(name)/fargate-profiles/$(fargateProfileName)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_fargate_profile(
@@ -741,6 +819,7 @@ function describe_fargate_profile(
         "/clusters/$(name)/fargate-profiles/$(fargateProfileName)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -763,6 +842,7 @@ function describe_identity_provider_config(
         "/clusters/$(name)/identity-provider-configs/describe",
         Dict{String,Any}("identityProviderConfig" => identityProviderConfig);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_identity_provider_config(
@@ -782,6 +862,7 @@ function describe_identity_provider_config(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -800,7 +881,10 @@ function describe_nodegroup(
     name, nodegroupName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return eks(
-        "GET", "/clusters/$(name)/node-groups/$(nodegroupName)"; aws_config=aws_config
+        "GET",
+        "/clusters/$(name)/node-groups/$(nodegroupName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_nodegroup(
@@ -814,6 +898,7 @@ function describe_nodegroup(
         "/clusters/$(name)/node-groups/$(nodegroupName)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -837,7 +922,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nodegroupName"`: The name of the Amazon EKS node group associated with the update.
 """
 function describe_update(name, updateId; aws_config::AbstractAWSConfig=global_aws_config())
-    return eks("GET", "/clusters/$(name)/updates/$(updateId)"; aws_config=aws_config)
+    return eks(
+        "GET",
+        "/clusters/$(name)/updates/$(updateId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_update(
     name,
@@ -846,7 +936,11 @@ function describe_update(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return eks(
-        "GET", "/clusters/$(name)/updates/$(updateId)", params; aws_config=aws_config
+        "GET",
+        "/clusters/$(name)/updates/$(updateId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -878,6 +972,7 @@ function disassociate_identity_provider_config(
             "clientRequestToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disassociate_identity_provider_config(
@@ -900,6 +995,7 @@ function disassociate_identity_provider_config(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -927,12 +1023,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   items in a list and not for other programmatic purposes.
 """
 function list_addons(name; aws_config::AbstractAWSConfig=global_aws_config())
-    return eks("GET", "/clusters/$(name)/addons"; aws_config=aws_config)
+    return eks(
+        "GET",
+        "/clusters/$(name)/addons";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_addons(
     name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return eks("GET", "/clusters/$(name)/addons", params; aws_config=aws_config)
+    return eks(
+        "GET",
+        "/clusters/$(name)/addons",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -958,12 +1065,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   the next items in a list and not for other programmatic purposes.
 """
 function list_clusters(; aws_config::AbstractAWSConfig=global_aws_config())
-    return eks("GET", "/clusters"; aws_config=aws_config)
+    return eks("GET", "/clusters"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_clusters(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return eks("GET", "/clusters", params; aws_config=aws_config)
+    return eks(
+        "GET", "/clusters", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -991,12 +1100,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Pagination continues from the end of the previous results that returned the nextToken value.
 """
 function list_fargate_profiles(name; aws_config::AbstractAWSConfig=global_aws_config())
-    return eks("GET", "/clusters/$(name)/fargate-profiles"; aws_config=aws_config)
+    return eks(
+        "GET",
+        "/clusters/$(name)/fargate-profiles";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_fargate_profiles(
     name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return eks("GET", "/clusters/$(name)/fargate-profiles", params; aws_config=aws_config)
+    return eks(
+        "GET",
+        "/clusters/$(name)/fargate-profiles",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1025,13 +1145,22 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function list_identity_provider_configs(
     name; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return eks("GET", "/clusters/$(name)/identity-provider-configs"; aws_config=aws_config)
+    return eks(
+        "GET",
+        "/clusters/$(name)/identity-provider-configs";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_identity_provider_configs(
     name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return eks(
-        "GET", "/clusters/$(name)/identity-provider-configs", params; aws_config=aws_config
+        "GET",
+        "/clusters/$(name)/identity-provider-configs",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1059,12 +1188,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Pagination continues from the end of the previous results that returned the nextToken value.
 """
 function list_nodegroups(name; aws_config::AbstractAWSConfig=global_aws_config())
-    return eks("GET", "/clusters/$(name)/node-groups"; aws_config=aws_config)
+    return eks(
+        "GET",
+        "/clusters/$(name)/node-groups";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_nodegroups(
     name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return eks("GET", "/clusters/$(name)/node-groups", params; aws_config=aws_config)
+    return eks(
+        "GET",
+        "/clusters/$(name)/node-groups",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1082,14 +1222,25 @@ List the tags for an Amazon EKS resource.
 function list_tags_for_resource(
     resourceArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return eks("GET", "/tags/$(resourceArn)"; aws_config=aws_config)
+    return eks(
+        "GET",
+        "/tags/$(resourceArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_tags_for_resource(
     resourceArn,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return eks("GET", "/tags/$(resourceArn)", params; aws_config=aws_config)
+    return eks(
+        "GET",
+        "/tags/$(resourceArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1117,12 +1268,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nodegroupName"`: The name of the Amazon EKS managed node group to list updates for.
 """
 function list_updates(name; aws_config::AbstractAWSConfig=global_aws_config())
-    return eks("GET", "/clusters/$(name)/updates"; aws_config=aws_config)
+    return eks(
+        "GET",
+        "/clusters/$(name)/updates";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_updates(
     name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return eks("GET", "/clusters/$(name)/updates", params; aws_config=aws_config)
+    return eks(
+        "GET",
+        "/clusters/$(name)/updates",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1161,6 +1323,7 @@ function register_cluster(
             "clientRequestToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function register_cluster(
@@ -1184,6 +1347,7 @@ function register_cluster(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1210,6 +1374,7 @@ function tag_resource(resourceArn, tags; aws_config::AbstractAWSConfig=global_aw
         "/tags/$(resourceArn)",
         Dict{String,Any}("tags" => tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -1223,6 +1388,7 @@ function tag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tags" => tags), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1246,6 +1412,7 @@ function untag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}("tagKeys" => tagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -1259,6 +1426,7 @@ function untag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tagKeys" => tagKeys), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1295,6 +1463,7 @@ function update_addon(addonName, name; aws_config::AbstractAWSConfig=global_aws_
         "/clusters/$(name)/addons/$(addonName)/update",
         Dict{String,Any}("clientRequestToken" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_addon(
@@ -1312,6 +1481,7 @@ function update_addon(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1356,6 +1526,7 @@ function update_cluster_config(name; aws_config::AbstractAWSConfig=global_aws_co
         "/clusters/$(name)/update-config",
         Dict{String,Any}("clientRequestToken" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_cluster_config(
@@ -1370,6 +1541,7 @@ function update_cluster_config(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1404,6 +1576,7 @@ function update_cluster_version(
         "/clusters/$(name)/updates",
         Dict{String,Any}("version" => version, "clientRequestToken" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_cluster_version(
@@ -1425,6 +1598,7 @@ function update_cluster_version(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1461,6 +1635,7 @@ function update_nodegroup_config(
         "/clusters/$(name)/node-groups/$(nodegroupName)/update-config",
         Dict{String,Any}("clientRequestToken" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_nodegroup_config(
@@ -1478,6 +1653,7 @@ function update_nodegroup_config(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1540,6 +1716,7 @@ function update_nodegroup_version(
         "/clusters/$(name)/node-groups/$(nodegroupName)/update-version",
         Dict{String,Any}("clientRequestToken" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_nodegroup_version(
@@ -1557,5 +1734,6 @@ function update_nodegroup_version(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/elastic_beanstalk.jl
+++ b/src/services/elastic_beanstalk.jl
@@ -18,12 +18,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   update that you want to cancel.
 """
 function abort_environment_update(; aws_config::AbstractAWSConfig=global_aws_config())
-    return elastic_beanstalk("AbortEnvironmentUpdate"; aws_config=aws_config)
+    return elastic_beanstalk(
+        "AbortEnvironmentUpdate"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function abort_environment_update(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return elastic_beanstalk("AbortEnvironmentUpdate", params; aws_config=aws_config)
+    return elastic_beanstalk(
+        "AbortEnvironmentUpdate",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -49,6 +56,7 @@ function apply_environment_managed_action(
         "ApplyEnvironmentManagedAction",
         Dict{String,Any}("ActionId" => ActionId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function apply_environment_managed_action(
@@ -62,6 +70,7 @@ function apply_environment_managed_action(
             mergewith(_merge, Dict{String,Any}("ActionId" => ActionId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -89,6 +98,7 @@ function associate_environment_operations_role(
             "EnvironmentName" => EnvironmentName, "OperationsRole" => OperationsRole
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_environment_operations_role(
@@ -109,6 +119,7 @@ function associate_environment_operations_role(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -129,6 +140,7 @@ function check_dnsavailability(
         "CheckDNSAvailability",
         Dict{String,Any}("CNAMEPrefix" => CNAMEPrefix);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function check_dnsavailability(
@@ -142,6 +154,7 @@ function check_dnsavailability(
             mergewith(_merge, Dict{String,Any}("CNAMEPrefix" => CNAMEPrefix), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -168,12 +181,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   solution stack to use, and optionally can specify environment links to create.
 """
 function compose_environments(; aws_config::AbstractAWSConfig=global_aws_config())
-    return elastic_beanstalk("ComposeEnvironments"; aws_config=aws_config)
+    return elastic_beanstalk(
+        "ComposeEnvironments"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function compose_environments(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return elastic_beanstalk("ComposeEnvironments", params; aws_config=aws_config)
+    return elastic_beanstalk(
+        "ComposeEnvironments",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -202,6 +222,7 @@ function create_application(
         "CreateApplication",
         Dict{String,Any}("ApplicationName" => ApplicationName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_application(
@@ -217,6 +238,7 @@ function create_application(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -275,6 +297,7 @@ function create_application_version(
             "ApplicationName" => ApplicationName, "VersionLabel" => VersionLabel
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_application_version(
@@ -295,6 +318,7 @@ function create_application_version(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -356,6 +380,7 @@ function create_configuration_template(
             "ApplicationName" => ApplicationName, "TemplateName" => TemplateName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_configuration_template(
@@ -376,6 +401,7 @@ function create_configuration_template(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -442,6 +468,7 @@ function create_environment(
         "CreateEnvironment",
         Dict{String,Any}("ApplicationName" => ApplicationName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_environment(
@@ -457,6 +484,7 @@ function create_environment(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -494,6 +522,7 @@ function create_platform_version(
             "PlatformVersion" => PlatformVersion,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_platform_version(
@@ -517,6 +546,7 @@ function create_platform_version(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -531,12 +561,19 @@ CreateStorageLocation still returns the bucket name but does not create a new bu
 
 """
 function create_storage_location(; aws_config::AbstractAWSConfig=global_aws_config())
-    return elastic_beanstalk("CreateStorageLocation"; aws_config=aws_config)
+    return elastic_beanstalk(
+        "CreateStorageLocation"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function create_storage_location(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return elastic_beanstalk("CreateStorageLocation", params; aws_config=aws_config)
+    return elastic_beanstalk(
+        "CreateStorageLocation",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -562,6 +599,7 @@ function delete_application(
         "DeleteApplication",
         Dict{String,Any}("ApplicationName" => ApplicationName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_application(
@@ -577,6 +615,7 @@ function delete_application(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -606,6 +645,7 @@ function delete_application_version(
             "ApplicationName" => ApplicationName, "VersionLabel" => VersionLabel
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_application_version(
@@ -626,6 +666,7 @@ function delete_application_version(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -651,6 +692,7 @@ function delete_configuration_template(
             "ApplicationName" => ApplicationName, "TemplateName" => TemplateName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_configuration_template(
@@ -671,6 +713,7 @@ function delete_configuration_template(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -699,6 +742,7 @@ function delete_environment_configuration(
             "ApplicationName" => ApplicationName, "EnvironmentName" => EnvironmentName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_environment_configuration(
@@ -720,6 +764,7 @@ function delete_environment_configuration(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -734,12 +779,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"PlatformArn"`: The ARN of the version of the custom platform.
 """
 function delete_platform_version(; aws_config::AbstractAWSConfig=global_aws_config())
-    return elastic_beanstalk("DeletePlatformVersion"; aws_config=aws_config)
+    return elastic_beanstalk(
+        "DeletePlatformVersion"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function delete_platform_version(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return elastic_beanstalk("DeletePlatformVersion", params; aws_config=aws_config)
+    return elastic_beanstalk(
+        "DeletePlatformVersion",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -751,12 +803,19 @@ AWS account. The result currently has one set of attributes—resource quotas.
 
 """
 function describe_account_attributes(; aws_config::AbstractAWSConfig=global_aws_config())
-    return elastic_beanstalk("DescribeAccountAttributes"; aws_config=aws_config)
+    return elastic_beanstalk(
+        "DescribeAccountAttributes"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_account_attributes(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return elastic_beanstalk("DescribeAccountAttributes", params; aws_config=aws_config)
+    return elastic_beanstalk(
+        "DescribeAccountAttributes",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -778,12 +837,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"VersionLabels"`: Specify a version label to show a specific application version.
 """
 function describe_application_versions(; aws_config::AbstractAWSConfig=global_aws_config())
-    return elastic_beanstalk("DescribeApplicationVersions"; aws_config=aws_config)
+    return elastic_beanstalk(
+        "DescribeApplicationVersions";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_application_versions(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return elastic_beanstalk("DescribeApplicationVersions", params; aws_config=aws_config)
+    return elastic_beanstalk(
+        "DescribeApplicationVersions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -798,12 +866,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   descriptions to only include those with the specified names.
 """
 function describe_applications(; aws_config::AbstractAWSConfig=global_aws_config())
-    return elastic_beanstalk("DescribeApplications"; aws_config=aws_config)
+    return elastic_beanstalk(
+        "DescribeApplications"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_applications(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return elastic_beanstalk("DescribeApplications", params; aws_config=aws_config)
+    return elastic_beanstalk(
+        "DescribeApplications",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -830,12 +905,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   want to describe.
 """
 function describe_configuration_options(; aws_config::AbstractAWSConfig=global_aws_config())
-    return elastic_beanstalk("DescribeConfigurationOptions"; aws_config=aws_config)
+    return elastic_beanstalk(
+        "DescribeConfigurationOptions";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_configuration_options(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return elastic_beanstalk("DescribeConfigurationOptions", params; aws_config=aws_config)
+    return elastic_beanstalk(
+        "DescribeConfigurationOptions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -871,6 +955,7 @@ function describe_configuration_settings(
         "DescribeConfigurationSettings",
         Dict{String,Any}("ApplicationName" => ApplicationName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_configuration_settings(
@@ -886,6 +971,7 @@ function describe_configuration_settings(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -907,12 +993,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   EnvironmentName, or both.
 """
 function describe_environment_health(; aws_config::AbstractAWSConfig=global_aws_config())
-    return elastic_beanstalk("DescribeEnvironmentHealth"; aws_config=aws_config)
+    return elastic_beanstalk(
+        "DescribeEnvironmentHealth"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_environment_health(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return elastic_beanstalk("DescribeEnvironmentHealth", params; aws_config=aws_config)
+    return elastic_beanstalk(
+        "DescribeEnvironmentHealth",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -932,14 +1025,19 @@ function describe_environment_managed_action_history(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
     return elastic_beanstalk(
-        "DescribeEnvironmentManagedActionHistory"; aws_config=aws_config
+        "DescribeEnvironmentManagedActionHistory";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_environment_managed_action_history(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return elastic_beanstalk(
-        "DescribeEnvironmentManagedActionHistory", params; aws_config=aws_config
+        "DescribeEnvironmentManagedActionHistory",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -958,13 +1056,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_environment_managed_actions(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return elastic_beanstalk("DescribeEnvironmentManagedActions"; aws_config=aws_config)
+    return elastic_beanstalk(
+        "DescribeEnvironmentManagedActions";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_environment_managed_actions(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return elastic_beanstalk(
-        "DescribeEnvironmentManagedActions", params; aws_config=aws_config
+        "DescribeEnvironmentManagedActions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -984,12 +1089,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   either, AWS Elastic Beanstalk returns MissingRequiredParameter error.
 """
 function describe_environment_resources(; aws_config::AbstractAWSConfig=global_aws_config())
-    return elastic_beanstalk("DescribeEnvironmentResources"; aws_config=aws_config)
+    return elastic_beanstalk(
+        "DescribeEnvironmentResources";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_environment_resources(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return elastic_beanstalk("DescribeEnvironmentResources", params; aws_config=aws_config)
+    return elastic_beanstalk(
+        "DescribeEnvironmentResources",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1021,12 +1135,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   to include only those that are associated with this application version.
 """
 function describe_environments(; aws_config::AbstractAWSConfig=global_aws_config())
-    return elastic_beanstalk("DescribeEnvironments"; aws_config=aws_config)
+    return elastic_beanstalk(
+        "DescribeEnvironments"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_environments(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return elastic_beanstalk("DescribeEnvironments", params; aws_config=aws_config)
+    return elastic_beanstalk(
+        "DescribeEnvironments",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1065,12 +1186,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   to those associated with this application version.
 """
 function describe_events(; aws_config::AbstractAWSConfig=global_aws_config())
-    return elastic_beanstalk("DescribeEvents"; aws_config=aws_config)
+    return elastic_beanstalk(
+        "DescribeEvents"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_events(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return elastic_beanstalk("DescribeEvents", params; aws_config=aws_config)
+    return elastic_beanstalk(
+        "DescribeEvents", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1089,12 +1214,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`: Specify the pagination token returned by a previous call.
 """
 function describe_instances_health(; aws_config::AbstractAWSConfig=global_aws_config())
-    return elastic_beanstalk("DescribeInstancesHealth"; aws_config=aws_config)
+    return elastic_beanstalk(
+        "DescribeInstancesHealth"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_instances_health(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return elastic_beanstalk("DescribeInstancesHealth", params; aws_config=aws_config)
+    return elastic_beanstalk(
+        "DescribeInstancesHealth",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1110,12 +1242,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"PlatformArn"`: The ARN of the platform version.
 """
 function describe_platform_version(; aws_config::AbstractAWSConfig=global_aws_config())
-    return elastic_beanstalk("DescribePlatformVersion"; aws_config=aws_config)
+    return elastic_beanstalk(
+        "DescribePlatformVersion"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_platform_version(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return elastic_beanstalk("DescribePlatformVersion", params; aws_config=aws_config)
+    return elastic_beanstalk(
+        "DescribePlatformVersion",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1139,6 +1278,7 @@ function disassociate_environment_operations_role(
         "DisassociateEnvironmentOperationsRole",
         Dict{String,Any}("EnvironmentName" => EnvironmentName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disassociate_environment_operations_role(
@@ -1154,6 +1294,7 @@ function disassociate_environment_operations_role(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1166,12 +1307,21 @@ then in reverse chronological order.
 
 """
 function list_available_solution_stacks(; aws_config::AbstractAWSConfig=global_aws_config())
-    return elastic_beanstalk("ListAvailableSolutionStacks"; aws_config=aws_config)
+    return elastic_beanstalk(
+        "ListAvailableSolutionStacks";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_available_solution_stacks(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return elastic_beanstalk("ListAvailableSolutionStacks", params; aws_config=aws_config)
+    return elastic_beanstalk(
+        "ListAvailableSolutionStacks",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1201,12 +1351,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   specified in the initial request. If no NextToken is specified, the first page is retrieved.
 """
 function list_platform_branches(; aws_config::AbstractAWSConfig=global_aws_config())
-    return elastic_beanstalk("ListPlatformBranches"; aws_config=aws_config)
+    return elastic_beanstalk(
+        "ListPlatformBranches"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_platform_branches(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return elastic_beanstalk("ListPlatformBranches", params; aws_config=aws_config)
+    return elastic_beanstalk(
+        "ListPlatformBranches",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1228,12 +1385,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   specified in the initial request. If no NextToken is specified, the first page is retrieved.
 """
 function list_platform_versions(; aws_config::AbstractAWSConfig=global_aws_config())
-    return elastic_beanstalk("ListPlatformVersions"; aws_config=aws_config)
+    return elastic_beanstalk(
+        "ListPlatformVersions"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_platform_versions(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return elastic_beanstalk("ListPlatformVersions", params; aws_config=aws_config)
+    return elastic_beanstalk(
+        "ListPlatformVersions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1256,6 +1420,7 @@ function list_tags_for_resource(
         "ListTagsForResource",
         Dict{String,Any}("ResourceArn" => ResourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags_for_resource(
@@ -1269,6 +1434,7 @@ function list_tags_for_resource(
             mergewith(_merge, Dict{String,Any}("ResourceArn" => ResourceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1289,12 +1455,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Beanstalk returns MissingRequiredParameter error.
 """
 function rebuild_environment(; aws_config::AbstractAWSConfig=global_aws_config())
-    return elastic_beanstalk("RebuildEnvironment"; aws_config=aws_config)
+    return elastic_beanstalk(
+        "RebuildEnvironment"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function rebuild_environment(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return elastic_beanstalk("RebuildEnvironment", params; aws_config=aws_config)
+    return elastic_beanstalk(
+        "RebuildEnvironment", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1330,6 +1500,7 @@ function request_environment_info(
         "RequestEnvironmentInfo",
         Dict{String,Any}("InfoType" => InfoType);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function request_environment_info(
@@ -1343,6 +1514,7 @@ function request_environment_info(
             mergewith(_merge, Dict{String,Any}("InfoType" => InfoType), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1363,12 +1535,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   AWS Elastic Beanstalk returns MissingRequiredParameter error.
 """
 function restart_app_server(; aws_config::AbstractAWSConfig=global_aws_config())
-    return elastic_beanstalk("RestartAppServer"; aws_config=aws_config)
+    return elastic_beanstalk(
+        "RestartAppServer"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function restart_app_server(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return elastic_beanstalk("RestartAppServer", params; aws_config=aws_config)
+    return elastic_beanstalk(
+        "RestartAppServer", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1399,6 +1575,7 @@ function retrieve_environment_info(
         "RetrieveEnvironmentInfo",
         Dict{String,Any}("InfoType" => InfoType);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function retrieve_environment_info(
@@ -1412,6 +1589,7 @@ function retrieve_environment_info(
             mergewith(_merge, Dict{String,Any}("InfoType" => InfoType), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1440,12 +1618,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   DestinationEnvironmentName.
 """
 function swap_environment_cnames(; aws_config::AbstractAWSConfig=global_aws_config())
-    return elastic_beanstalk("SwapEnvironmentCNAMEs"; aws_config=aws_config)
+    return elastic_beanstalk(
+        "SwapEnvironmentCNAMEs"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function swap_environment_cnames(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return elastic_beanstalk("SwapEnvironmentCNAMEs", params; aws_config=aws_config)
+    return elastic_beanstalk(
+        "SwapEnvironmentCNAMEs",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1472,12 +1657,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   User Guide.    Default: true   Valid Values: true | false
 """
 function terminate_environment(; aws_config::AbstractAWSConfig=global_aws_config())
-    return elastic_beanstalk("TerminateEnvironment"; aws_config=aws_config)
+    return elastic_beanstalk(
+        "TerminateEnvironment"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function terminate_environment(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return elastic_beanstalk("TerminateEnvironment", params; aws_config=aws_config)
+    return elastic_beanstalk(
+        "TerminateEnvironment",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1504,6 +1696,7 @@ function update_application(
         "UpdateApplication",
         Dict{String,Any}("ApplicationName" => ApplicationName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_application(
@@ -1519,6 +1712,7 @@ function update_application(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1545,6 +1739,7 @@ function update_application_resource_lifecycle(
             "ResourceLifecycleConfig" => ResourceLifecycleConfig,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_application_resource_lifecycle(
@@ -1566,6 +1761,7 @@ function update_application_resource_lifecycle(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1597,6 +1793,7 @@ function update_application_version(
             "ApplicationName" => ApplicationName, "VersionLabel" => VersionLabel
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_application_version(
@@ -1617,6 +1814,7 @@ function update_application_version(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1654,6 +1852,7 @@ function update_configuration_template(
             "ApplicationName" => ApplicationName, "TemplateName" => TemplateName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_configuration_template(
@@ -1674,6 +1873,7 @@ function update_configuration_template(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1726,12 +1926,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   InvalidParameterValue error.
 """
 function update_environment(; aws_config::AbstractAWSConfig=global_aws_config())
-    return elastic_beanstalk("UpdateEnvironment"; aws_config=aws_config)
+    return elastic_beanstalk(
+        "UpdateEnvironment"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function update_environment(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return elastic_beanstalk("UpdateEnvironment", params; aws_config=aws_config)
+    return elastic_beanstalk(
+        "UpdateEnvironment", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1767,6 +1971,7 @@ function update_tags_for_resource(
         "UpdateTagsForResource",
         Dict{String,Any}("ResourceArn" => ResourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_tags_for_resource(
@@ -1780,6 +1985,7 @@ function update_tags_for_resource(
             mergewith(_merge, Dict{String,Any}("ResourceArn" => ResourceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1812,6 +2018,7 @@ function validate_configuration_settings(
             "ApplicationName" => ApplicationName, "OptionSettings" => OptionSettings
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function validate_configuration_settings(
@@ -1832,5 +2039,6 @@ function validate_configuration_settings(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/elastic_inference.jl
+++ b/src/services/elastic_inference.jl
@@ -30,6 +30,7 @@ function describe_accelerator_offerings(
         "/describe-accelerator-offerings",
         Dict{String,Any}("locationType" => locationType);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_accelerator_offerings(
@@ -44,6 +45,7 @@ function describe_accelerator_offerings(
             mergewith(_merge, Dict{String,Any}("locationType" => locationType), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -56,13 +58,22 @@ characteristics, such as memory and throughput.
 
 """
 function describe_accelerator_types(; aws_config::AbstractAWSConfig=global_aws_config())
-    return elastic_inference("GET", "/describe-accelerator-types"; aws_config=aws_config)
+    return elastic_inference(
+        "GET",
+        "/describe-accelerator-types";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_accelerator_types(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return elastic_inference(
-        "GET", "/describe-accelerator-types", params; aws_config=aws_config
+        "GET",
+        "/describe-accelerator-types",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -87,13 +98,22 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   a previously truncated response.
 """
 function describe_accelerators(; aws_config::AbstractAWSConfig=global_aws_config())
-    return elastic_inference("POST", "/describe-accelerators"; aws_config=aws_config)
+    return elastic_inference(
+        "POST",
+        "/describe-accelerators";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_accelerators(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return elastic_inference(
-        "POST", "/describe-accelerators", params; aws_config=aws_config
+        "POST",
+        "/describe-accelerators",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -110,14 +130,25 @@ end
 function list_tags_for_resource(
     resourceArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return elastic_inference("GET", "/tags/$(resourceArn)"; aws_config=aws_config)
+    return elastic_inference(
+        "GET",
+        "/tags/$(resourceArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_tags_for_resource(
     resourceArn,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return elastic_inference("GET", "/tags/$(resourceArn)", params; aws_config=aws_config)
+    return elastic_inference(
+        "GET",
+        "/tags/$(resourceArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -137,6 +168,7 @@ function tag_resource(resourceArn, tags; aws_config::AbstractAWSConfig=global_aw
         "/tags/$(resourceArn)",
         Dict{String,Any}("tags" => tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -150,6 +182,7 @@ function tag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tags" => tags), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -172,6 +205,7 @@ function untag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}("tagKeys" => tagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -185,5 +219,6 @@ function untag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tagKeys" => tagKeys), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/elastic_load_balancing.jl
+++ b/src/services/elastic_load_balancing.jl
@@ -26,6 +26,7 @@ function add_tags(
         "AddTags",
         Dict{String,Any}("LoadBalancerNames" => LoadBalancerNames, "Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function add_tags(
@@ -44,6 +45,7 @@ function add_tags(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -71,6 +73,7 @@ function apply_security_groups_to_load_balancer(
             "LoadBalancerName" => LoadBalancerName, "SecurityGroups" => SecurityGroups
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function apply_security_groups_to_load_balancer(
@@ -92,6 +95,7 @@ function apply_security_groups_to_load_balancer(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -117,6 +121,7 @@ function attach_load_balancer_to_subnets(
         "AttachLoadBalancerToSubnets",
         Dict{String,Any}("LoadBalancerName" => LoadBalancerName, "Subnets" => Subnets);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function attach_load_balancer_to_subnets(
@@ -137,6 +142,7 @@ function attach_load_balancer_to_subnets(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -162,6 +168,7 @@ function configure_health_check(
             "HealthCheck" => HealthCheck, "LoadBalancerName" => LoadBalancerName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function configure_health_check(
@@ -182,6 +189,7 @@ function configure_health_check(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -221,6 +229,7 @@ function create_app_cookie_stickiness_policy(
             "PolicyName" => PolicyName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_app_cookie_stickiness_policy(
@@ -244,6 +253,7 @@ function create_app_cookie_stickiness_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -284,6 +294,7 @@ function create_lbcookie_stickiness_policy(
             "LoadBalancerName" => LoadBalancerName, "PolicyName" => PolicyName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_lbcookie_stickiness_policy(
@@ -304,6 +315,7 @@ function create_lbcookie_stickiness_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -352,6 +364,7 @@ function create_load_balancer(
         "CreateLoadBalancer",
         Dict{String,Any}("Listeners" => Listeners, "LoadBalancerName" => LoadBalancerName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_load_balancer(
@@ -372,6 +385,7 @@ function create_load_balancer(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -396,6 +410,7 @@ function create_load_balancer_listeners(
         "CreateLoadBalancerListeners",
         Dict{String,Any}("Listeners" => Listeners, "LoadBalancerName" => LoadBalancerName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_load_balancer_listeners(
@@ -416,6 +431,7 @@ function create_load_balancer_listeners(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -452,6 +468,7 @@ function create_load_balancer_policy(
             "PolicyTypeName" => PolicyTypeName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_load_balancer_policy(
@@ -475,6 +492,7 @@ function create_load_balancer_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -500,6 +518,7 @@ function delete_load_balancer(
         "DeleteLoadBalancer",
         Dict{String,Any}("LoadBalancerName" => LoadBalancerName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_load_balancer(
@@ -515,6 +534,7 @@ function delete_load_balancer(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -538,6 +558,7 @@ function delete_load_balancer_listeners(
             "LoadBalancerName" => LoadBalancerName, "LoadBalancerPorts" => LoadBalancerPorts
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_load_balancer_listeners(
@@ -559,6 +580,7 @@ function delete_load_balancer_listeners(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -583,6 +605,7 @@ function delete_load_balancer_policy(
             "LoadBalancerName" => LoadBalancerName, "PolicyName" => PolicyName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_load_balancer_policy(
@@ -603,6 +626,7 @@ function delete_load_balancer_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -628,6 +652,7 @@ function deregister_instances_from_load_balancer(
         "DeregisterInstancesFromLoadBalancer",
         Dict{String,Any}("Instances" => Instances, "LoadBalancerName" => LoadBalancerName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function deregister_instances_from_load_balancer(
@@ -648,6 +673,7 @@ function deregister_instances_from_load_balancer(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -665,12 +691,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"PageSize"`: The maximum number of results to return with this call.
 """
 function describe_account_limits(; aws_config::AbstractAWSConfig=global_aws_config())
-    return elastic_load_balancing("DescribeAccountLimits"; aws_config=aws_config)
+    return elastic_load_balancing(
+        "DescribeAccountLimits"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_account_limits(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return elastic_load_balancing("DescribeAccountLimits", params; aws_config=aws_config)
+    return elastic_load_balancing(
+        "DescribeAccountLimits",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -697,6 +730,7 @@ function describe_instance_health(
         "DescribeInstanceHealth",
         Dict{String,Any}("LoadBalancerName" => LoadBalancerName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_instance_health(
@@ -712,6 +746,7 @@ function describe_instance_health(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -732,6 +767,7 @@ function describe_load_balancer_attributes(
         "DescribeLoadBalancerAttributes",
         Dict{String,Any}("LoadBalancerName" => LoadBalancerName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_load_balancer_attributes(
@@ -747,6 +783,7 @@ function describe_load_balancer_attributes(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -769,13 +806,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_load_balancer_policies(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return elastic_load_balancing("DescribeLoadBalancerPolicies"; aws_config=aws_config)
+    return elastic_load_balancing(
+        "DescribeLoadBalancerPolicies";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_load_balancer_policies(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return elastic_load_balancing(
-        "DescribeLoadBalancerPolicies", params; aws_config=aws_config
+        "DescribeLoadBalancerPolicies",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -799,13 +843,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_load_balancer_policy_types(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return elastic_load_balancing("DescribeLoadBalancerPolicyTypes"; aws_config=aws_config)
+    return elastic_load_balancing(
+        "DescribeLoadBalancerPolicyTypes";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_load_balancer_policy_types(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return elastic_load_balancing(
-        "DescribeLoadBalancerPolicyTypes", params; aws_config=aws_config
+        "DescribeLoadBalancerPolicyTypes",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -825,12 +876,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   400). The default is 400.
 """
 function describe_load_balancers(; aws_config::AbstractAWSConfig=global_aws_config())
-    return elastic_load_balancing("DescribeLoadBalancers"; aws_config=aws_config)
+    return elastic_load_balancing(
+        "DescribeLoadBalancers"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_load_balancers(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return elastic_load_balancing("DescribeLoadBalancers", params; aws_config=aws_config)
+    return elastic_load_balancing(
+        "DescribeLoadBalancers",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -848,6 +906,7 @@ function describe_tags(LoadBalancerNames; aws_config::AbstractAWSConfig=global_a
         "DescribeTags",
         Dict{String,Any}("LoadBalancerNames" => LoadBalancerNames);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_tags(
@@ -863,6 +922,7 @@ function describe_tags(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -887,6 +947,7 @@ function detach_load_balancer_from_subnets(
         "DetachLoadBalancerFromSubnets",
         Dict{String,Any}("LoadBalancerName" => LoadBalancerName, "Subnets" => Subnets);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function detach_load_balancer_from_subnets(
@@ -907,6 +968,7 @@ function detach_load_balancer_from_subnets(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -937,6 +999,7 @@ function disable_availability_zones_for_load_balancer(
             "AvailabilityZones" => AvailabilityZones, "LoadBalancerName" => LoadBalancerName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disable_availability_zones_for_load_balancer(
@@ -958,6 +1021,7 @@ function disable_availability_zones_for_load_balancer(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -986,6 +1050,7 @@ function enable_availability_zones_for_load_balancer(
             "AvailabilityZones" => AvailabilityZones, "LoadBalancerName" => LoadBalancerName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function enable_availability_zones_for_load_balancer(
@@ -1007,6 +1072,7 @@ function enable_availability_zones_for_load_balancer(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1038,6 +1104,7 @@ function modify_load_balancer_attributes(
             "LoadBalancerName" => LoadBalancerName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_load_balancer_attributes(
@@ -1059,6 +1126,7 @@ function modify_load_balancer_attributes(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1093,6 +1161,7 @@ function register_instances_with_load_balancer(
         "RegisterInstancesWithLoadBalancer",
         Dict{String,Any}("Instances" => Instances, "LoadBalancerName" => LoadBalancerName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function register_instances_with_load_balancer(
@@ -1113,6 +1182,7 @@ function register_instances_with_load_balancer(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1135,6 +1205,7 @@ function remove_tags(
         "RemoveTags",
         Dict{String,Any}("LoadBalancerNames" => LoadBalancerNames, "Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function remove_tags(
@@ -1153,6 +1224,7 @@ function remove_tags(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1185,6 +1257,7 @@ function set_load_balancer_listener_sslcertificate(
             "SSLCertificateId" => SSLCertificateId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function set_load_balancer_listener_sslcertificate(
@@ -1208,6 +1281,7 @@ function set_load_balancer_listener_sslcertificate(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1248,6 +1322,7 @@ function set_load_balancer_policies_for_backend_server(
             "PolicyNames" => PolicyNames,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function set_load_balancer_policies_for_backend_server(
@@ -1271,6 +1346,7 @@ function set_load_balancer_policies_for_backend_server(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1306,6 +1382,7 @@ function set_load_balancer_policies_of_listener(
             "PolicyNames" => PolicyNames,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function set_load_balancer_policies_of_listener(
@@ -1329,5 +1406,6 @@ function set_load_balancer_policies_of_listener(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/elastic_load_balancing_v2.jl
+++ b/src/services/elastic_load_balancing_v2.jl
@@ -27,6 +27,7 @@ function add_listener_certificates(
         "AddListenerCertificates",
         Dict{String,Any}("Certificates" => Certificates, "ListenerArn" => ListenerArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function add_listener_certificates(
@@ -47,6 +48,7 @@ function add_listener_certificates(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -69,6 +71,7 @@ function add_tags(ResourceArns, Tags; aws_config::AbstractAWSConfig=global_aws_c
         "AddTags",
         Dict{String,Any}("ResourceArns" => ResourceArns, "Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function add_tags(
@@ -87,6 +90,7 @@ function add_tags(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -135,6 +139,7 @@ function create_listener(
             "DefaultActions" => DefaultActions, "LoadBalancerArn" => LoadBalancerArn
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_listener(
@@ -155,6 +160,7 @@ function create_listener(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -214,7 +220,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function create_load_balancer(Name; aws_config::AbstractAWSConfig=global_aws_config())
     return elastic_load_balancing_v2(
-        "CreateLoadBalancer", Dict{String,Any}("Name" => Name); aws_config=aws_config
+        "CreateLoadBalancer",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_load_balancer(
@@ -224,6 +233,7 @@ function create_load_balancer(
         "CreateLoadBalancer",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -265,6 +275,7 @@ function create_rule(
             "Priority" => Priority,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_rule(
@@ -290,6 +301,7 @@ function create_rule(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -312,7 +324,7 @@ settings, each call succeeds.
 Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys are:
 - `"HealthCheckEnabled"`: Indicates whether health checks are enabled. If the target type
   is lambda, health checks are disabled by default but can be enabled. If the target type is
-  instance or ip, health checks are always enabled and cannot be disabled.
+  instance, ip, or alb, health checks are always enabled and cannot be disabled.
 - `"HealthCheckIntervalSeconds"`: The approximate amount of time, in seconds, between
   health checks of an individual target. If the target group protocol is TCP, TLS, UDP, or
   TCP_UDP, the supported values are 10 and 30 seconds. If the target group protocol is HTTP
@@ -361,7 +373,7 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   virtual private cloud (VPC) for the target group, the RFC 1918 range (10.0.0.0/8,
   172.16.0.0/12, and 192.168.0.0/16), and the RFC 6598 range (100.64.0.0/10). You can't
   specify publicly routable IP addresses.    lambda - Register a single Lambda function as a
-  target.
+  target.    alb - Register a single Application Load Balancer as a target.
 - `"UnhealthyThresholdCount"`: The number of consecutive health check failures required
   before considering a target unhealthy. If the target group protocol is HTTP or HTTPS, the
   default is 2. If the target group protocol is TCP or TLS, this value must be the same as
@@ -372,7 +384,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function create_target_group(Name; aws_config::AbstractAWSConfig=global_aws_config())
     return elastic_load_balancing_v2(
-        "CreateTargetGroup", Dict{String,Any}("Name" => Name); aws_config=aws_config
+        "CreateTargetGroup",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_target_group(
@@ -382,6 +397,7 @@ function create_target_group(
         "CreateTargetGroup",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -401,6 +417,7 @@ function delete_listener(ListenerArn; aws_config::AbstractAWSConfig=global_aws_c
         "DeleteListener",
         Dict{String,Any}("ListenerArn" => ListenerArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_listener(
@@ -414,6 +431,7 @@ function delete_listener(
             mergewith(_merge, Dict{String,Any}("ListenerArn" => ListenerArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -440,6 +458,7 @@ function delete_load_balancer(
         "DeleteLoadBalancer",
         Dict{String,Any}("LoadBalancerArn" => LoadBalancerArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_load_balancer(
@@ -455,6 +474,7 @@ function delete_load_balancer(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -470,7 +490,10 @@ Deletes the specified rule. You can't delete the default rule.
 """
 function delete_rule(RuleArn; aws_config::AbstractAWSConfig=global_aws_config())
     return elastic_load_balancing_v2(
-        "DeleteRule", Dict{String,Any}("RuleArn" => RuleArn); aws_config=aws_config
+        "DeleteRule",
+        Dict{String,Any}("RuleArn" => RuleArn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_rule(
@@ -480,6 +503,7 @@ function delete_rule(
         "DeleteRule",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("RuleArn" => RuleArn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -503,6 +527,7 @@ function delete_target_group(
         "DeleteTargetGroup",
         Dict{String,Any}("TargetGroupArn" => TargetGroupArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_target_group(
@@ -516,6 +541,7 @@ function delete_target_group(
             mergewith(_merge, Dict{String,Any}("TargetGroupArn" => TargetGroupArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -539,6 +565,7 @@ function deregister_targets(
         "DeregisterTargets",
         Dict{String,Any}("TargetGroupArn" => TargetGroupArn, "Targets" => Targets);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function deregister_targets(
@@ -557,6 +584,7 @@ function deregister_targets(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -576,12 +604,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"PageSize"`: The maximum number of results to return with this call.
 """
 function describe_account_limits(; aws_config::AbstractAWSConfig=global_aws_config())
-    return elastic_load_balancing_v2("DescribeAccountLimits"; aws_config=aws_config)
+    return elastic_load_balancing_v2(
+        "DescribeAccountLimits"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_account_limits(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return elastic_load_balancing_v2("DescribeAccountLimits", params; aws_config=aws_config)
+    return elastic_load_balancing_v2(
+        "DescribeAccountLimits",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -610,6 +645,7 @@ function describe_listener_certificates(
         "DescribeListenerCertificates",
         Dict{String,Any}("ListenerArn" => ListenerArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_listener_certificates(
@@ -623,6 +659,7 @@ function describe_listener_certificates(
             mergewith(_merge, Dict{String,Any}("ListenerArn" => ListenerArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -643,12 +680,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"PageSize"`: The maximum number of results to return with this call.
 """
 function describe_listeners(; aws_config::AbstractAWSConfig=global_aws_config())
-    return elastic_load_balancing_v2("DescribeListeners"; aws_config=aws_config)
+    return elastic_load_balancing_v2(
+        "DescribeListeners"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_listeners(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return elastic_load_balancing_v2("DescribeListeners", params; aws_config=aws_config)
+    return elastic_load_balancing_v2(
+        "DescribeListeners", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -672,6 +713,7 @@ function describe_load_balancer_attributes(
         "DescribeLoadBalancerAttributes",
         Dict{String,Any}("LoadBalancerArn" => LoadBalancerArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_load_balancer_attributes(
@@ -687,6 +729,7 @@ function describe_load_balancer_attributes(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -706,12 +749,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"PageSize"`: The maximum number of results to return with this call.
 """
 function describe_load_balancers(; aws_config::AbstractAWSConfig=global_aws_config())
-    return elastic_load_balancing_v2("DescribeLoadBalancers"; aws_config=aws_config)
+    return elastic_load_balancing_v2(
+        "DescribeLoadBalancers"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_load_balancers(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return elastic_load_balancing_v2("DescribeLoadBalancers", params; aws_config=aws_config)
+    return elastic_load_balancing_v2(
+        "DescribeLoadBalancers",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -730,12 +780,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"RuleArns"`: The Amazon Resource Names (ARN) of the rules.
 """
 function describe_rules(; aws_config::AbstractAWSConfig=global_aws_config())
-    return elastic_load_balancing_v2("DescribeRules"; aws_config=aws_config)
+    return elastic_load_balancing_v2(
+        "DescribeRules"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_rules(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return elastic_load_balancing_v2("DescribeRules", params; aws_config=aws_config)
+    return elastic_load_balancing_v2(
+        "DescribeRules", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -754,12 +808,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"PageSize"`: The maximum number of results to return with this call.
 """
 function describe_sslpolicies(; aws_config::AbstractAWSConfig=global_aws_config())
-    return elastic_load_balancing_v2("DescribeSSLPolicies"; aws_config=aws_config)
+    return elastic_load_balancing_v2(
+        "DescribeSSLPolicies"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_sslpolicies(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return elastic_load_balancing_v2("DescribeSSLPolicies", params; aws_config=aws_config)
+    return elastic_load_balancing_v2(
+        "DescribeSSLPolicies",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -780,6 +841,7 @@ function describe_tags(ResourceArns; aws_config::AbstractAWSConfig=global_aws_co
         "DescribeTags",
         Dict{String,Any}("ResourceArns" => ResourceArns);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_tags(
@@ -793,6 +855,7 @@ function describe_tags(
             mergewith(_merge, Dict{String,Any}("ResourceArns" => ResourceArns), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -816,6 +879,7 @@ function describe_target_group_attributes(
         "DescribeTargetGroupAttributes",
         Dict{String,Any}("TargetGroupArn" => TargetGroupArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_target_group_attributes(
@@ -829,6 +893,7 @@ function describe_target_group_attributes(
             mergewith(_merge, Dict{String,Any}("TargetGroupArn" => TargetGroupArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -851,12 +916,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"TargetGroupArns"`: The Amazon Resource Names (ARN) of the target groups.
 """
 function describe_target_groups(; aws_config::AbstractAWSConfig=global_aws_config())
-    return elastic_load_balancing_v2("DescribeTargetGroups"; aws_config=aws_config)
+    return elastic_load_balancing_v2(
+        "DescribeTargetGroups"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_target_groups(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return elastic_load_balancing_v2("DescribeTargetGroups", params; aws_config=aws_config)
+    return elastic_load_balancing_v2(
+        "DescribeTargetGroups",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -879,6 +951,7 @@ function describe_target_health(
         "DescribeTargetHealth",
         Dict{String,Any}("TargetGroupArn" => TargetGroupArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_target_health(
@@ -892,6 +965,7 @@ function describe_target_health(
             mergewith(_merge, Dict{String,Any}("TargetGroupArn" => TargetGroupArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -935,6 +1009,7 @@ function modify_listener(ListenerArn; aws_config::AbstractAWSConfig=global_aws_c
         "ModifyListener",
         Dict{String,Any}("ListenerArn" => ListenerArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_listener(
@@ -948,6 +1023,7 @@ function modify_listener(
             mergewith(_merge, Dict{String,Any}("ListenerArn" => ListenerArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -972,6 +1048,7 @@ function modify_load_balancer_attributes(
         "ModifyLoadBalancerAttributes",
         Dict{String,Any}("Attributes" => Attributes, "LoadBalancerArn" => LoadBalancerArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_load_balancer_attributes(
@@ -992,6 +1069,7 @@ function modify_load_balancer_attributes(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1014,7 +1092,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function modify_rule(RuleArn; aws_config::AbstractAWSConfig=global_aws_config())
     return elastic_load_balancing_v2(
-        "ModifyRule", Dict{String,Any}("RuleArn" => RuleArn); aws_config=aws_config
+        "ModifyRule",
+        Dict{String,Any}("RuleArn" => RuleArn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_rule(
@@ -1024,6 +1105,7 @@ function modify_rule(
         "ModifyRule",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("RuleArn" => RuleArn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1075,6 +1157,7 @@ function modify_target_group(
         "ModifyTargetGroup",
         Dict{String,Any}("TargetGroupArn" => TargetGroupArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_target_group(
@@ -1088,6 +1171,7 @@ function modify_target_group(
             mergewith(_merge, Dict{String,Any}("TargetGroupArn" => TargetGroupArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1109,6 +1193,7 @@ function modify_target_group_attributes(
         "ModifyTargetGroupAttributes",
         Dict{String,Any}("Attributes" => Attributes, "TargetGroupArn" => TargetGroupArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_target_group_attributes(
@@ -1129,6 +1214,7 @@ function modify_target_group_attributes(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1157,6 +1243,7 @@ function register_targets(
         "RegisterTargets",
         Dict{String,Any}("TargetGroupArn" => TargetGroupArn, "Targets" => Targets);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function register_targets(
@@ -1175,6 +1262,7 @@ function register_targets(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1198,6 +1286,7 @@ function remove_listener_certificates(
         "RemoveListenerCertificates",
         Dict{String,Any}("Certificates" => Certificates, "ListenerArn" => ListenerArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function remove_listener_certificates(
@@ -1218,6 +1307,7 @@ function remove_listener_certificates(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1241,6 +1331,7 @@ function remove_tags(
         "RemoveTags",
         Dict{String,Any}("ResourceArns" => ResourceArns, "TagKeys" => TagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function remove_tags(
@@ -1259,6 +1350,7 @@ function remove_tags(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1285,6 +1377,7 @@ function set_ip_address_type(
             "IpAddressType" => IpAddressType, "LoadBalancerArn" => LoadBalancerArn
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function set_ip_address_type(
@@ -1305,6 +1398,7 @@ function set_ip_address_type(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1327,6 +1421,7 @@ function set_rule_priorities(
         "SetRulePriorities",
         Dict{String,Any}("RulePriorities" => RulePriorities);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function set_rule_priorities(
@@ -1340,6 +1435,7 @@ function set_rule_priorities(
             mergewith(_merge, Dict{String,Any}("RulePriorities" => RulePriorities), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1365,6 +1461,7 @@ function set_security_groups(
             "LoadBalancerArn" => LoadBalancerArn, "SecurityGroups" => SecurityGroups
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function set_security_groups(
@@ -1385,6 +1482,7 @@ function set_security_groups(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1429,6 +1527,7 @@ function set_subnets(LoadBalancerArn; aws_config::AbstractAWSConfig=global_aws_c
         "SetSubnets",
         Dict{String,Any}("LoadBalancerArn" => LoadBalancerArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function set_subnets(
@@ -1444,5 +1543,6 @@ function set_subnets(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/elastic_transcoder.jl
+++ b/src/services/elastic_transcoder.jl
@@ -19,13 +19,22 @@ getting the job identifier, use UpdatePipelineStatus to temporarily pause the pi
 
 """
 function cancel_job(Id; aws_config::AbstractAWSConfig=global_aws_config())
-    return elastic_transcoder("DELETE", "/2012-09-25/jobs/$(Id)"; aws_config=aws_config)
+    return elastic_transcoder(
+        "DELETE",
+        "/2012-09-25/jobs/$(Id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function cancel_job(
     Id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return elastic_transcoder(
-        "DELETE", "/2012-09-25/jobs/$(Id)", params; aws_config=aws_config
+        "DELETE",
+        "/2012-09-25/jobs/$(Id)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -75,6 +84,7 @@ function create_job(PipelineId; aws_config::AbstractAWSConfig=global_aws_config(
         "/2012-09-25/jobs",
         Dict{String,Any}("PipelineId" => PipelineId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_job(
@@ -89,6 +99,7 @@ function create_job(
             mergewith(_merge, Dict{String,Any}("PipelineId" => PipelineId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -217,6 +228,7 @@ function create_pipeline(
         "/2012-09-25/pipelines",
         Dict{String,Any}("InputBucket" => InputBucket, "Name" => Name, "Role" => Role);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_pipeline(
@@ -239,6 +251,7 @@ function create_pipeline(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -279,6 +292,7 @@ function create_preset(Container, Name; aws_config::AbstractAWSConfig=global_aws
         "/2012-09-25/presets",
         Dict{String,Any}("Container" => Container, "Name" => Name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_preset(
@@ -296,6 +310,7 @@ function create_preset(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -313,14 +328,21 @@ pipeline is currently in use, DeletePipeline returns an error.
 """
 function delete_pipeline(Id; aws_config::AbstractAWSConfig=global_aws_config())
     return elastic_transcoder(
-        "DELETE", "/2012-09-25/pipelines/$(Id)"; aws_config=aws_config
+        "DELETE",
+        "/2012-09-25/pipelines/$(Id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_pipeline(
     Id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return elastic_transcoder(
-        "DELETE", "/2012-09-25/pipelines/$(Id)", params; aws_config=aws_config
+        "DELETE",
+        "/2012-09-25/pipelines/$(Id)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -336,13 +358,22 @@ delete the default presets that are included with Elastic Transcoder.
 
 """
 function delete_preset(Id; aws_config::AbstractAWSConfig=global_aws_config())
-    return elastic_transcoder("DELETE", "/2012-09-25/presets/$(Id)"; aws_config=aws_config)
+    return elastic_transcoder(
+        "DELETE",
+        "/2012-09-25/presets/$(Id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_preset(
     Id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return elastic_transcoder(
-        "DELETE", "/2012-09-25/presets/$(Id)", params; aws_config=aws_config
+        "DELETE",
+        "/2012-09-25/presets/$(Id)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -368,7 +399,10 @@ function list_jobs_by_pipeline(
     PipelineId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return elastic_transcoder(
-        "GET", "/2012-09-25/jobsByPipeline/$(PipelineId)"; aws_config=aws_config
+        "GET",
+        "/2012-09-25/jobsByPipeline/$(PipelineId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_jobs_by_pipeline(
@@ -377,7 +411,11 @@ function list_jobs_by_pipeline(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return elastic_transcoder(
-        "GET", "/2012-09-25/jobsByPipeline/$(PipelineId)", params; aws_config=aws_config
+        "GET",
+        "/2012-09-25/jobsByPipeline/$(PipelineId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -402,14 +440,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function list_jobs_by_status(Status; aws_config::AbstractAWSConfig=global_aws_config())
     return elastic_transcoder(
-        "GET", "/2012-09-25/jobsByStatus/$(Status)"; aws_config=aws_config
+        "GET",
+        "/2012-09-25/jobsByStatus/$(Status)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_jobs_by_status(
     Status, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return elastic_transcoder(
-        "GET", "/2012-09-25/jobsByStatus/$(Status)", params; aws_config=aws_config
+        "GET",
+        "/2012-09-25/jobsByStatus/$(Status)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -428,12 +473,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   pageToken in subsequent GET requests to get each successive page of results.
 """
 function list_pipelines(; aws_config::AbstractAWSConfig=global_aws_config())
-    return elastic_transcoder("GET", "/2012-09-25/pipelines"; aws_config=aws_config)
+    return elastic_transcoder(
+        "GET",
+        "/2012-09-25/pipelines";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_pipelines(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return elastic_transcoder("GET", "/2012-09-25/pipelines", params; aws_config=aws_config)
+    return elastic_transcoder(
+        "GET",
+        "/2012-09-25/pipelines",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -451,12 +507,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   pageToken in subsequent GET requests to get each successive page of results.
 """
 function list_presets(; aws_config::AbstractAWSConfig=global_aws_config())
-    return elastic_transcoder("GET", "/2012-09-25/presets"; aws_config=aws_config)
+    return elastic_transcoder(
+        "GET", "/2012-09-25/presets"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_presets(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return elastic_transcoder("GET", "/2012-09-25/presets", params; aws_config=aws_config)
+    return elastic_transcoder(
+        "GET",
+        "/2012-09-25/presets",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -470,13 +534,22 @@ The ReadJob operation returns detailed information about a job.
 
 """
 function read_job(Id; aws_config::AbstractAWSConfig=global_aws_config())
-    return elastic_transcoder("GET", "/2012-09-25/jobs/$(Id)"; aws_config=aws_config)
+    return elastic_transcoder(
+        "GET",
+        "/2012-09-25/jobs/$(Id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function read_job(
     Id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return elastic_transcoder(
-        "GET", "/2012-09-25/jobs/$(Id)", params; aws_config=aws_config
+        "GET",
+        "/2012-09-25/jobs/$(Id)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -491,13 +564,22 @@ The ReadPipeline operation gets detailed information about a pipeline.
 
 """
 function read_pipeline(Id; aws_config::AbstractAWSConfig=global_aws_config())
-    return elastic_transcoder("GET", "/2012-09-25/pipelines/$(Id)"; aws_config=aws_config)
+    return elastic_transcoder(
+        "GET",
+        "/2012-09-25/pipelines/$(Id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function read_pipeline(
     Id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return elastic_transcoder(
-        "GET", "/2012-09-25/pipelines/$(Id)", params; aws_config=aws_config
+        "GET",
+        "/2012-09-25/pipelines/$(Id)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -512,13 +594,22 @@ The ReadPreset operation gets detailed information about a preset.
 
 """
 function read_preset(Id; aws_config::AbstractAWSConfig=global_aws_config())
-    return elastic_transcoder("GET", "/2012-09-25/presets/$(Id)"; aws_config=aws_config)
+    return elastic_transcoder(
+        "GET",
+        "/2012-09-25/presets/$(Id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function read_preset(
     Id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return elastic_transcoder(
-        "GET", "/2012-09-25/presets/$(Id)", params; aws_config=aws_config
+        "GET",
+        "/2012-09-25/presets/$(Id)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -560,6 +651,7 @@ function test_role(
             "Topics" => Topics,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function test_role(
@@ -586,6 +678,7 @@ function test_role(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -696,13 +789,22 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   S3 bucket.
 """
 function update_pipeline(Id; aws_config::AbstractAWSConfig=global_aws_config())
-    return elastic_transcoder("PUT", "/2012-09-25/pipelines/$(Id)"; aws_config=aws_config)
+    return elastic_transcoder(
+        "PUT",
+        "/2012-09-25/pipelines/$(Id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function update_pipeline(
     Id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return elastic_transcoder(
-        "PUT", "/2012-09-25/pipelines/$(Id)", params; aws_config=aws_config
+        "PUT",
+        "/2012-09-25/pipelines/$(Id)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -739,6 +841,7 @@ function update_pipeline_notifications(
         "/2012-09-25/pipelines/$(Id)/notifications",
         Dict{String,Any}("Notifications" => Notifications);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_pipeline_notifications(
@@ -754,6 +857,7 @@ function update_pipeline_notifications(
             mergewith(_merge, Dict{String,Any}("Notifications" => Notifications), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -782,6 +886,7 @@ function update_pipeline_status(
         "/2012-09-25/pipelines/$(Id)/status",
         Dict{String,Any}("Status" => Status);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_pipeline_status(
@@ -795,5 +900,6 @@ function update_pipeline_status(
         "/2012-09-25/pipelines/$(Id)/status",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Status" => Status), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/elasticache.jl
+++ b/src/services/elasticache.jl
@@ -40,6 +40,7 @@ function add_tags_to_resource(
         "AddTagsToResource",
         Dict{String,Any}("ResourceName" => ResourceName, "Tag" => Tag);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function add_tags_to_resource(
@@ -58,6 +59,7 @@ function add_tags_to_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -93,6 +95,7 @@ function authorize_cache_security_group_ingress(
             "EC2SecurityGroupOwnerId" => EC2SecurityGroupOwnerId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function authorize_cache_security_group_ingress(
@@ -116,6 +119,7 @@ function authorize_cache_security_group_ingress(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -141,6 +145,7 @@ function batch_apply_update_action(
         "BatchApplyUpdateAction",
         Dict{String,Any}("ServiceUpdateName" => ServiceUpdateName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_apply_update_action(
@@ -156,6 +161,7 @@ function batch_apply_update_action(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -181,6 +187,7 @@ function batch_stop_update_action(
         "BatchStopUpdateAction",
         Dict{String,Any}("ServiceUpdateName" => ServiceUpdateName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_stop_update_action(
@@ -196,6 +203,7 @@ function batch_stop_update_action(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -221,6 +229,7 @@ function complete_migration(
         "CompleteMigration",
         Dict{String,Any}("ReplicationGroupId" => ReplicationGroupId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function complete_migration(
@@ -236,6 +245,7 @@ function complete_migration(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -302,6 +312,7 @@ function copy_snapshot(
             "TargetSnapshotName" => TargetSnapshotName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function copy_snapshot(
@@ -323,6 +334,7 @@ function copy_snapshot(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -469,6 +481,7 @@ function create_cache_cluster(
         "CreateCacheCluster",
         Dict{String,Any}("CacheClusterId" => CacheClusterId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_cache_cluster(
@@ -482,6 +495,7 @@ function create_cache_cluster(
             mergewith(_merge, Dict{String,Any}("CacheClusterId" => CacheClusterId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -524,6 +538,7 @@ function create_cache_parameter_group(
             "Description" => Description,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_cache_parameter_group(
@@ -547,6 +562,7 @@ function create_cache_parameter_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -579,6 +595,7 @@ function create_cache_security_group(
             "CacheSecurityGroupName" => CacheSecurityGroupName, "Description" => Description
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_cache_security_group(
@@ -600,6 +617,7 @@ function create_cache_security_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -637,6 +655,7 @@ function create_cache_subnet_group(
             "SubnetIdentifier" => SubnetIdentifier,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_cache_subnet_group(
@@ -660,6 +679,7 @@ function create_cache_subnet_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -702,6 +722,7 @@ function create_global_replication_group(
             "PrimaryReplicationGroupId" => PrimaryReplicationGroupId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_global_replication_group(
@@ -723,6 +744,7 @@ function create_global_replication_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -929,6 +951,7 @@ function create_replication_group(
             "ReplicationGroupId" => ReplicationGroupId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_replication_group(
@@ -950,6 +973,7 @@ function create_replication_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -978,6 +1002,7 @@ function create_snapshot(SnapshotName; aws_config::AbstractAWSConfig=global_aws_
         "CreateSnapshot",
         Dict{String,Any}("SnapshotName" => SnapshotName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_snapshot(
@@ -991,6 +1016,7 @@ function create_snapshot(
             mergewith(_merge, Dict{String,Any}("SnapshotName" => SnapshotName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1031,6 +1057,7 @@ function create_user(
             "UserName" => UserName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_user(
@@ -1056,6 +1083,7 @@ function create_user(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1083,6 +1111,7 @@ function create_user_group(
         "CreateUserGroup",
         Dict{String,Any}("Engine" => Engine, "UserGroupId" => UserGroupId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_user_group(
@@ -1101,6 +1130,7 @@ function create_user_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1144,6 +1174,7 @@ function decrease_node_groups_in_global_replication_group(
             "NodeGroupCount" => NodeGroupCount,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function decrease_node_groups_in_global_replication_group(
@@ -1167,6 +1198,7 @@ function decrease_node_groups_in_global_replication_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1211,6 +1243,7 @@ function decrease_replica_count(
             "ReplicationGroupId" => ReplicationGroupId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function decrease_replica_count(
@@ -1232,6 +1265,7 @@ function decrease_replica_count(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1265,6 +1299,7 @@ function delete_cache_cluster(
         "DeleteCacheCluster",
         Dict{String,Any}("CacheClusterId" => CacheClusterId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_cache_cluster(
@@ -1278,6 +1313,7 @@ function delete_cache_cluster(
             mergewith(_merge, Dict{String,Any}("CacheClusterId" => CacheClusterId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1301,6 +1337,7 @@ function delete_cache_parameter_group(
         "DeleteCacheParameterGroup",
         Dict{String,Any}("CacheParameterGroupName" => CacheParameterGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_cache_parameter_group(
@@ -1318,6 +1355,7 @@ function delete_cache_parameter_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1340,6 +1378,7 @@ function delete_cache_security_group(
         "DeleteCacheSecurityGroup",
         Dict{String,Any}("CacheSecurityGroupName" => CacheSecurityGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_cache_security_group(
@@ -1357,6 +1396,7 @@ function delete_cache_security_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1379,6 +1419,7 @@ function delete_cache_subnet_group(
         "DeleteCacheSubnetGroup",
         Dict{String,Any}("CacheSubnetGroupName" => CacheSubnetGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_cache_subnet_group(
@@ -1396,6 +1437,7 @@ function delete_cache_subnet_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1433,6 +1475,7 @@ function delete_global_replication_group(
             "RetainPrimaryReplicationGroup" => RetainPrimaryReplicationGroup,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_global_replication_group(
@@ -1454,6 +1497,7 @@ function delete_global_replication_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1489,6 +1533,7 @@ function delete_replication_group(
         "DeleteReplicationGroup",
         Dict{String,Any}("ReplicationGroupId" => ReplicationGroupId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_replication_group(
@@ -1504,6 +1549,7 @@ function delete_replication_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1524,6 +1570,7 @@ function delete_snapshot(SnapshotName; aws_config::AbstractAWSConfig=global_aws_
         "DeleteSnapshot",
         Dict{String,Any}("SnapshotName" => SnapshotName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_snapshot(
@@ -1537,6 +1584,7 @@ function delete_snapshot(
             mergewith(_merge, Dict{String,Any}("SnapshotName" => SnapshotName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1554,7 +1602,10 @@ Using Role Based Access Control (RBAC).
 """
 function delete_user(UserId; aws_config::AbstractAWSConfig=global_aws_config())
     return elasticache(
-        "DeleteUser", Dict{String,Any}("UserId" => UserId); aws_config=aws_config
+        "DeleteUser",
+        Dict{String,Any}("UserId" => UserId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_user(
@@ -1564,6 +1615,7 @@ function delete_user(
         "DeleteUser",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("UserId" => UserId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1584,6 +1636,7 @@ function delete_user_group(UserGroupId; aws_config::AbstractAWSConfig=global_aws
         "DeleteUserGroup",
         Dict{String,Any}("UserGroupId" => UserGroupId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_user_group(
@@ -1597,6 +1650,7 @@ function delete_user_group(
             mergewith(_merge, Dict{String,Any}("UserGroupId" => UserGroupId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1635,12 +1689,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   request to retrieve information about the individual cache nodes.
 """
 function describe_cache_clusters(; aws_config::AbstractAWSConfig=global_aws_config())
-    return elasticache("DescribeCacheClusters"; aws_config=aws_config)
+    return elasticache(
+        "DescribeCacheClusters"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_cache_clusters(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return elasticache("DescribeCacheClusters", params; aws_config=aws_config)
+    return elasticache(
+        "DescribeCacheClusters",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1668,12 +1729,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   remaining results can be retrieved. Default: 100 Constraints: minimum 20; maximum 100.
 """
 function describe_cache_engine_versions(; aws_config::AbstractAWSConfig=global_aws_config())
-    return elasticache("DescribeCacheEngineVersions"; aws_config=aws_config)
+    return elasticache(
+        "DescribeCacheEngineVersions";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_cache_engine_versions(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return elasticache("DescribeCacheEngineVersions", params; aws_config=aws_config)
+    return elasticache(
+        "DescribeCacheEngineVersions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1697,12 +1767,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_cache_parameter_groups(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return elasticache("DescribeCacheParameterGroups"; aws_config=aws_config)
+    return elasticache(
+        "DescribeCacheParameterGroups";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_cache_parameter_groups(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return elasticache("DescribeCacheParameterGroups", params; aws_config=aws_config)
+    return elasticache(
+        "DescribeCacheParameterGroups",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1732,6 +1811,7 @@ function describe_cache_parameters(
         "DescribeCacheParameters",
         Dict{String,Any}("CacheParameterGroupName" => CacheParameterGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_cache_parameters(
@@ -1749,6 +1829,7 @@ function describe_cache_parameters(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1771,12 +1852,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   remaining results can be retrieved. Default: 100 Constraints: minimum 20; maximum 100.
 """
 function describe_cache_security_groups(; aws_config::AbstractAWSConfig=global_aws_config())
-    return elasticache("DescribeCacheSecurityGroups"; aws_config=aws_config)
+    return elasticache(
+        "DescribeCacheSecurityGroups";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_cache_security_groups(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return elasticache("DescribeCacheSecurityGroups", params; aws_config=aws_config)
+    return elasticache(
+        "DescribeCacheSecurityGroups",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1798,12 +1888,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   remaining results can be retrieved. Default: 100 Constraints: minimum 20; maximum 100.
 """
 function describe_cache_subnet_groups(; aws_config::AbstractAWSConfig=global_aws_config())
-    return elasticache("DescribeCacheSubnetGroups"; aws_config=aws_config)
+    return elasticache(
+        "DescribeCacheSubnetGroups"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_cache_subnet_groups(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return elasticache("DescribeCacheSubnetGroups", params; aws_config=aws_config)
+    return elasticache(
+        "DescribeCacheSubnetGroups",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1833,6 +1930,7 @@ function describe_engine_default_parameters(
         "DescribeEngineDefaultParameters",
         Dict{String,Any}("CacheParameterGroupFamily" => CacheParameterGroupFamily);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_engine_default_parameters(
@@ -1850,6 +1948,7 @@ function describe_engine_default_parameters(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1882,12 +1981,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   ISO 8601 format.  Example: 2017-03-30T07:03:49.555Z
 """
 function describe_events(; aws_config::AbstractAWSConfig=global_aws_config())
-    return elasticache("DescribeEvents"; aws_config=aws_config)
+    return elasticache(
+        "DescribeEvents"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_events(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return elasticache("DescribeEvents", params; aws_config=aws_config)
+    return elasticache(
+        "DescribeEvents", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1911,12 +2014,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_global_replication_groups(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return elasticache("DescribeGlobalReplicationGroups"; aws_config=aws_config)
+    return elasticache(
+        "DescribeGlobalReplicationGroups";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_global_replication_groups(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return elasticache("DescribeGlobalReplicationGroups", params; aws_config=aws_config)
+    return elasticache(
+        "DescribeGlobalReplicationGroups",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1940,12 +2052,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   all replication groups is returned.
 """
 function describe_replication_groups(; aws_config::AbstractAWSConfig=global_aws_config())
-    return elasticache("DescribeReplicationGroups"; aws_config=aws_config)
+    return elasticache(
+        "DescribeReplicationGroups"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_replication_groups(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return elasticache("DescribeReplicationGroups", params; aws_config=aws_config)
+    return elasticache(
+        "DescribeReplicationGroups",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2008,12 +2127,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   parameter to show only purchased reservations matching the specified offering identifier.
 """
 function describe_reserved_cache_nodes(; aws_config::AbstractAWSConfig=global_aws_config())
-    return elasticache("DescribeReservedCacheNodes"; aws_config=aws_config)
+    return elasticache(
+        "DescribeReservedCacheNodes"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_reserved_cache_nodes(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return elasticache("DescribeReservedCacheNodes", params; aws_config=aws_config)
+    return elasticache(
+        "DescribeReservedCacheNodes",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2075,12 +2201,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_reserved_cache_nodes_offerings(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return elasticache("DescribeReservedCacheNodesOfferings"; aws_config=aws_config)
+    return elasticache(
+        "DescribeReservedCacheNodesOfferings";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_reserved_cache_nodes_offerings(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return elasticache("DescribeReservedCacheNodesOfferings", params; aws_config=aws_config)
+    return elasticache(
+        "DescribeReservedCacheNodesOfferings",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2099,12 +2234,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"ServiceUpdateStatus"`: The status of the service update
 """
 function describe_service_updates(; aws_config::AbstractAWSConfig=global_aws_config())
-    return elasticache("DescribeServiceUpdates"; aws_config=aws_config)
+    return elasticache(
+        "DescribeServiceUpdates"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_service_updates(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return elasticache("DescribeServiceUpdates", params; aws_config=aws_config)
+    return elasticache(
+        "DescribeServiceUpdates",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2137,12 +2279,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   created. If omitted, the output shows both automatically and manually created snapshots.
 """
 function describe_snapshots(; aws_config::AbstractAWSConfig=global_aws_config())
-    return elasticache("DescribeSnapshots"; aws_config=aws_config)
+    return elasticache(
+        "DescribeSnapshots"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_snapshots(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return elasticache("DescribeSnapshots", params; aws_config=aws_config)
+    return elasticache(
+        "DescribeSnapshots", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -2169,12 +2315,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"UpdateActionStatus"`: The status of the update action.
 """
 function describe_update_actions(; aws_config::AbstractAWSConfig=global_aws_config())
-    return elasticache("DescribeUpdateActions"; aws_config=aws_config)
+    return elasticache(
+        "DescribeUpdateActions"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_update_actions(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return elasticache("DescribeUpdateActions", params; aws_config=aws_config)
+    return elasticache(
+        "DescribeUpdateActions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2194,12 +2347,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"UserGroupId"`: The ID of the user group.
 """
 function describe_user_groups(; aws_config::AbstractAWSConfig=global_aws_config())
-    return elasticache("DescribeUserGroups"; aws_config=aws_config)
+    return elasticache(
+        "DescribeUserGroups"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_user_groups(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return elasticache("DescribeUserGroups", params; aws_config=aws_config)
+    return elasticache(
+        "DescribeUserGroups", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -2221,12 +2378,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"UserId"`: The ID of the user.
 """
 function describe_users(; aws_config::AbstractAWSConfig=global_aws_config())
-    return elasticache("DescribeUsers"; aws_config=aws_config)
+    return elasticache(
+        "DescribeUsers"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_users(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return elasticache("DescribeUsers", params; aws_config=aws_config)
+    return elasticache(
+        "DescribeUsers", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -2259,6 +2420,7 @@ function disassociate_global_replication_group(
             "ReplicationGroupRegion" => ReplicationGroupRegion,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disassociate_global_replication_group(
@@ -2282,6 +2444,7 @@ function disassociate_global_replication_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2312,6 +2475,7 @@ function failover_global_replication_group(
             "PrimaryReplicationGroupId" => PrimaryReplicationGroupId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function failover_global_replication_group(
@@ -2335,6 +2499,7 @@ function failover_global_replication_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2369,6 +2534,7 @@ function increase_node_groups_in_global_replication_group(
             "NodeGroupCount" => NodeGroupCount,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function increase_node_groups_in_global_replication_group(
@@ -2392,6 +2558,7 @@ function increase_node_groups_in_global_replication_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2430,6 +2597,7 @@ function increase_replica_count(
             "ReplicationGroupId" => ReplicationGroupId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function increase_replica_count(
@@ -2451,6 +2619,7 @@ function increase_replica_count(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2478,12 +2647,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function list_allowed_node_type_modifications(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return elasticache("ListAllowedNodeTypeModifications"; aws_config=aws_config)
+    return elasticache(
+        "ListAllowedNodeTypeModifications";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_allowed_node_type_modifications(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return elasticache("ListAllowedNodeTypeModifications", params; aws_config=aws_config)
+    return elasticache(
+        "ListAllowedNodeTypeModifications",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2511,6 +2689,7 @@ function list_tags_for_resource(
         "ListTagsForResource",
         Dict{String,Any}("ResourceName" => ResourceName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags_for_resource(
@@ -2524,6 +2703,7 @@ function list_tags_for_resource(
             mergewith(_merge, Dict{String,Any}("ResourceName" => ResourceName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2660,6 +2840,7 @@ function modify_cache_cluster(
         "ModifyCacheCluster",
         Dict{String,Any}("CacheClusterId" => CacheClusterId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_cache_cluster(
@@ -2673,6 +2854,7 @@ function modify_cache_cluster(
             mergewith(_merge, Dict{String,Any}("CacheClusterId" => CacheClusterId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2707,6 +2889,7 @@ function modify_cache_parameter_group(
             "ParameterNameValue" => ParameterNameValue,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_cache_parameter_group(
@@ -2728,6 +2911,7 @@ function modify_cache_parameter_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2754,6 +2938,7 @@ function modify_cache_subnet_group(
         "ModifyCacheSubnetGroup",
         Dict{String,Any}("CacheSubnetGroupName" => CacheSubnetGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_cache_subnet_group(
@@ -2771,6 +2956,7 @@ function modify_cache_subnet_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2810,6 +2996,7 @@ function modify_global_replication_group(
             "GlobalReplicationGroupId" => GlobalReplicationGroupId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_global_replication_group(
@@ -2831,6 +3018,7 @@ function modify_global_replication_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2930,6 +3118,7 @@ function modify_replication_group(
         "ModifyReplicationGroup",
         Dict{String,Any}("ReplicationGroupId" => ReplicationGroupId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_replication_group(
@@ -2945,6 +3134,7 @@ function modify_replication_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2995,6 +3185,7 @@ function modify_replication_group_shard_configuration(
             "ReplicationGroupId" => ReplicationGroupId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_replication_group_shard_configuration(
@@ -3018,6 +3209,7 @@ function modify_replication_group_shard_configuration(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3039,7 +3231,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function modify_user(UserId; aws_config::AbstractAWSConfig=global_aws_config())
     return elasticache(
-        "ModifyUser", Dict{String,Any}("UserId" => UserId); aws_config=aws_config
+        "ModifyUser",
+        Dict{String,Any}("UserId" => UserId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_user(
@@ -3049,6 +3244,7 @@ function modify_user(
         "ModifyUser",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("UserId" => UserId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3071,6 +3267,7 @@ function modify_user_group(UserGroupId; aws_config::AbstractAWSConfig=global_aws
         "ModifyUserGroup",
         Dict{String,Any}("UserGroupId" => UserGroupId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_user_group(
@@ -3084,6 +3281,7 @@ function modify_user_group(
             mergewith(_merge, Dict{String,Any}("UserGroupId" => UserGroupId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3116,6 +3314,7 @@ function purchase_reserved_cache_nodes_offering(
         "PurchaseReservedCacheNodesOffering",
         Dict{String,Any}("ReservedCacheNodesOfferingId" => ReservedCacheNodesOfferingId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function purchase_reserved_cache_nodes_offering(
@@ -3135,6 +3334,7 @@ function purchase_reserved_cache_nodes_offering(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3161,6 +3361,7 @@ function rebalance_slots_in_global_replication_group(
             "GlobalReplicationGroupId" => GlobalReplicationGroupId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function rebalance_slots_in_global_replication_group(
@@ -3182,6 +3383,7 @@ function rebalance_slots_in_global_replication_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3219,6 +3421,7 @@ function reboot_cache_cluster(
         "RebootCacheCluster",
         Dict{String,Any}("CacheClusterId" => CacheClusterId, "CacheNodeId" => CacheNodeId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function reboot_cache_cluster(
@@ -3239,6 +3442,7 @@ function reboot_cache_cluster(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3268,6 +3472,7 @@ function remove_tags_from_resource(
         "RemoveTagsFromResource",
         Dict{String,Any}("ResourceName" => ResourceName, "TagKeys" => TagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function remove_tags_from_resource(
@@ -3286,6 +3491,7 @@ function remove_tags_from_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3317,6 +3523,7 @@ function reset_cache_parameter_group(
         "ResetCacheParameterGroup",
         Dict{String,Any}("CacheParameterGroupName" => CacheParameterGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function reset_cache_parameter_group(
@@ -3334,6 +3541,7 @@ function reset_cache_parameter_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3367,6 +3575,7 @@ function revoke_cache_security_group_ingress(
             "EC2SecurityGroupOwnerId" => EC2SecurityGroupOwnerId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function revoke_cache_security_group_ingress(
@@ -3390,6 +3599,7 @@ function revoke_cache_security_group_ingress(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3417,6 +3627,7 @@ function start_migration(
             "ReplicationGroupId" => ReplicationGroupId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_migration(
@@ -3438,6 +3649,7 @@ function start_migration(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3482,6 +3694,7 @@ function test_failover(
             "NodeGroupId" => NodeGroupId, "ReplicationGroupId" => ReplicationGroupId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function test_failover(
@@ -3502,5 +3715,6 @@ function test_failover(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/elasticsearch_service.jl
+++ b/src/services/elasticsearch_service.jl
@@ -22,6 +22,7 @@ function accept_inbound_cross_cluster_search_connection(
         "PUT",
         "/2015-01-01/es/ccs/inboundConnection/$(ConnectionId)/accept";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function accept_inbound_cross_cluster_search_connection(
@@ -34,6 +35,7 @@ function accept_inbound_cross_cluster_search_connection(
         "/2015-01-01/es/ccs/inboundConnection/$(ConnectionId)/accept",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -56,6 +58,7 @@ function add_tags(ARN, TagList; aws_config::AbstractAWSConfig=global_aws_config(
         "/2015-01-01/tags",
         Dict{String,Any}("ARN" => ARN, "TagList" => TagList);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function add_tags(
@@ -71,6 +74,7 @@ function add_tags(
             mergewith(_merge, Dict{String,Any}("ARN" => ARN, "TagList" => TagList), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -93,6 +97,7 @@ function associate_package(
         "POST",
         "/2015-01-01/packages/associate/$(PackageID)/$(DomainName)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_package(
@@ -106,6 +111,7 @@ function associate_package(
         "/2015-01-01/packages/associate/$(PackageID)/$(DomainName)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -130,6 +136,7 @@ function cancel_elasticsearch_service_software_update(
         "/2015-01-01/es/serviceSoftwareUpdate/cancel",
         Dict{String,Any}("DomainName" => DomainName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function cancel_elasticsearch_service_software_update(
@@ -144,6 +151,7 @@ function cancel_elasticsearch_service_software_update(
             mergewith(_merge, Dict{String,Any}("DomainName" => DomainName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -198,6 +206,7 @@ function create_elasticsearch_domain(
         "/2015-01-01/es/domain",
         Dict{String,Any}("DomainName" => DomainName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_elasticsearch_domain(
@@ -212,6 +221,7 @@ function create_elasticsearch_domain(
             mergewith(_merge, Dict{String,Any}("DomainName" => DomainName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -244,6 +254,7 @@ function create_outbound_cross_cluster_search_connection(
             "SourceDomainInfo" => SourceDomainInfo,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_outbound_cross_cluster_search_connection(
@@ -268,6 +279,7 @@ function create_outbound_cross_cluster_search_connection(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -301,6 +313,7 @@ function create_package(
             "PackageType" => PackageType,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_package(
@@ -325,6 +338,7 @@ function create_package(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -343,7 +357,10 @@ function delete_elasticsearch_domain(
     DomainName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return elasticsearch_service(
-        "DELETE", "/2015-01-01/es/domain/$(DomainName)"; aws_config=aws_config
+        "DELETE",
+        "/2015-01-01/es/domain/$(DomainName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_elasticsearch_domain(
@@ -352,7 +369,11 @@ function delete_elasticsearch_domain(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return elasticsearch_service(
-        "DELETE", "/2015-01-01/es/domain/$(DomainName)", params; aws_config=aws_config
+        "DELETE",
+        "/2015-01-01/es/domain/$(DomainName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -369,13 +390,22 @@ Role in VPC Endpoints for Amazon Elasticsearch Service Domains.
 function delete_elasticsearch_service_role(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return elasticsearch_service("DELETE", "/2015-01-01/es/role"; aws_config=aws_config)
+    return elasticsearch_service(
+        "DELETE",
+        "/2015-01-01/es/role";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_elasticsearch_service_role(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return elasticsearch_service(
-        "DELETE", "/2015-01-01/es/role", params; aws_config=aws_config
+        "DELETE",
+        "/2015-01-01/es/role",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -397,6 +427,7 @@ function delete_inbound_cross_cluster_search_connection(
         "DELETE",
         "/2015-01-01/es/ccs/inboundConnection/$(ConnectionId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_inbound_cross_cluster_search_connection(
@@ -409,6 +440,7 @@ function delete_inbound_cross_cluster_search_connection(
         "/2015-01-01/es/ccs/inboundConnection/$(ConnectionId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -430,6 +462,7 @@ function delete_outbound_cross_cluster_search_connection(
         "DELETE",
         "/2015-01-01/es/ccs/outboundConnection/$(ConnectionId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_outbound_cross_cluster_search_connection(
@@ -442,6 +475,7 @@ function delete_outbound_cross_cluster_search_connection(
         "/2015-01-01/es/ccs/outboundConnection/$(ConnectionId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -458,7 +492,10 @@ Delete the package.
 """
 function delete_package(PackageID; aws_config::AbstractAWSConfig=global_aws_config())
     return elasticsearch_service(
-        "DELETE", "/2015-01-01/packages/$(PackageID)"; aws_config=aws_config
+        "DELETE",
+        "/2015-01-01/packages/$(PackageID)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_package(
@@ -467,7 +504,11 @@ function delete_package(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return elasticsearch_service(
-        "DELETE", "/2015-01-01/packages/$(PackageID)", params; aws_config=aws_config
+        "DELETE",
+        "/2015-01-01/packages/$(PackageID)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -492,7 +533,10 @@ function describe_domain_auto_tunes(
     DomainName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return elasticsearch_service(
-        "GET", "/2015-01-01/es/domain/$(DomainName)/autoTunes"; aws_config=aws_config
+        "GET",
+        "/2015-01-01/es/domain/$(DomainName)/autoTunes";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_domain_auto_tunes(
@@ -505,6 +549,7 @@ function describe_domain_auto_tunes(
         "/2015-01-01/es/domain/$(DomainName)/autoTunes",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -523,7 +568,10 @@ function describe_elasticsearch_domain(
     DomainName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return elasticsearch_service(
-        "GET", "/2015-01-01/es/domain/$(DomainName)"; aws_config=aws_config
+        "GET",
+        "/2015-01-01/es/domain/$(DomainName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_elasticsearch_domain(
@@ -532,7 +580,11 @@ function describe_elasticsearch_domain(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return elasticsearch_service(
-        "GET", "/2015-01-01/es/domain/$(DomainName)", params; aws_config=aws_config
+        "GET",
+        "/2015-01-01/es/domain/$(DomainName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -551,7 +603,10 @@ function describe_elasticsearch_domain_config(
     DomainName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return elasticsearch_service(
-        "GET", "/2015-01-01/es/domain/$(DomainName)/config"; aws_config=aws_config
+        "GET",
+        "/2015-01-01/es/domain/$(DomainName)/config";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_elasticsearch_domain_config(
@@ -560,7 +615,11 @@ function describe_elasticsearch_domain_config(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return elasticsearch_service(
-        "GET", "/2015-01-01/es/domain/$(DomainName)/config", params; aws_config=aws_config
+        "GET",
+        "/2015-01-01/es/domain/$(DomainName)/config",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -583,6 +642,7 @@ function describe_elasticsearch_domains(
         "/2015-01-01/es/domain-info",
         Dict{String,Any}("DomainNames" => DomainNames);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_elasticsearch_domains(
@@ -597,6 +657,7 @@ function describe_elasticsearch_domains(
             mergewith(_merge, Dict{String,Any}("DomainNames" => DomainNames), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -626,6 +687,7 @@ function describe_elasticsearch_instance_type_limits(
         "GET",
         "/2015-01-01/es/instanceTypeLimits/$(ElasticsearchVersion)/$(InstanceType)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_elasticsearch_instance_type_limits(
@@ -639,6 +701,7 @@ function describe_elasticsearch_instance_type_limits(
         "/2015-01-01/es/instanceTypeLimits/$(ElasticsearchVersion)/$(InstanceType)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -663,14 +726,21 @@ function describe_inbound_cross_cluster_search_connections(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
     return elasticsearch_service(
-        "POST", "/2015-01-01/es/ccs/inboundConnection/search"; aws_config=aws_config
+        "POST",
+        "/2015-01-01/es/ccs/inboundConnection/search";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_inbound_cross_cluster_search_connections(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return elasticsearch_service(
-        "POST", "/2015-01-01/es/ccs/inboundConnection/search", params; aws_config=aws_config
+        "POST",
+        "/2015-01-01/es/ccs/inboundConnection/search",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -696,7 +766,10 @@ function describe_outbound_cross_cluster_search_connections(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
     return elasticsearch_service(
-        "POST", "/2015-01-01/es/ccs/outboundConnection/search"; aws_config=aws_config
+        "POST",
+        "/2015-01-01/es/ccs/outboundConnection/search";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_outbound_cross_cluster_search_connections(
@@ -707,6 +780,7 @@ function describe_outbound_cross_cluster_search_connections(
         "/2015-01-01/es/ccs/outboundConnection/search",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -726,14 +800,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function describe_packages(; aws_config::AbstractAWSConfig=global_aws_config())
     return elasticsearch_service(
-        "POST", "/2015-01-01/packages/describe"; aws_config=aws_config
+        "POST",
+        "/2015-01-01/packages/describe";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_packages(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return elasticsearch_service(
-        "POST", "/2015-01-01/packages/describe", params; aws_config=aws_config
+        "POST",
+        "/2015-01-01/packages/describe",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -756,14 +837,21 @@ function describe_reserved_elasticsearch_instance_offerings(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
     return elasticsearch_service(
-        "GET", "/2015-01-01/es/reservedInstanceOfferings"; aws_config=aws_config
+        "GET",
+        "/2015-01-01/es/reservedInstanceOfferings";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_reserved_elasticsearch_instance_offerings(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return elasticsearch_service(
-        "GET", "/2015-01-01/es/reservedInstanceOfferings", params; aws_config=aws_config
+        "GET",
+        "/2015-01-01/es/reservedInstanceOfferings",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -786,14 +874,21 @@ function describe_reserved_elasticsearch_instances(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
     return elasticsearch_service(
-        "GET", "/2015-01-01/es/reservedInstances"; aws_config=aws_config
+        "GET",
+        "/2015-01-01/es/reservedInstances";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_reserved_elasticsearch_instances(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return elasticsearch_service(
-        "GET", "/2015-01-01/es/reservedInstances", params; aws_config=aws_config
+        "GET",
+        "/2015-01-01/es/reservedInstances",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -816,6 +911,7 @@ function dissociate_package(
         "POST",
         "/2015-01-01/packages/dissociate/$(PackageID)/$(DomainName)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function dissociate_package(
@@ -829,6 +925,7 @@ function dissociate_package(
         "/2015-01-01/packages/dissociate/$(PackageID)/$(DomainName)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -847,14 +944,21 @@ function get_compatible_elasticsearch_versions(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
     return elasticsearch_service(
-        "GET", "/2015-01-01/es/compatibleVersions"; aws_config=aws_config
+        "GET",
+        "/2015-01-01/es/compatibleVersions";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_compatible_elasticsearch_versions(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return elasticsearch_service(
-        "GET", "/2015-01-01/es/compatibleVersions", params; aws_config=aws_config
+        "GET",
+        "/2015-01-01/es/compatibleVersions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -878,7 +982,10 @@ function get_package_version_history(
     PackageID; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return elasticsearch_service(
-        "GET", "/2015-01-01/packages/$(PackageID)/history"; aws_config=aws_config
+        "GET",
+        "/2015-01-01/packages/$(PackageID)/history";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_package_version_history(
@@ -887,7 +994,11 @@ function get_package_version_history(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return elasticsearch_service(
-        "GET", "/2015-01-01/packages/$(PackageID)/history", params; aws_config=aws_config
+        "GET",
+        "/2015-01-01/packages/$(PackageID)/history",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -907,7 +1018,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function get_upgrade_history(DomainName; aws_config::AbstractAWSConfig=global_aws_config())
     return elasticsearch_service(
-        "GET", "/2015-01-01/es/upgradeDomain/$(DomainName)/history"; aws_config=aws_config
+        "GET",
+        "/2015-01-01/es/upgradeDomain/$(DomainName)/history";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_upgrade_history(
@@ -920,6 +1034,7 @@ function get_upgrade_history(
         "/2015-01-01/es/upgradeDomain/$(DomainName)/history",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -936,7 +1051,10 @@ performed on the domain.
 """
 function get_upgrade_status(DomainName; aws_config::AbstractAWSConfig=global_aws_config())
     return elasticsearch_service(
-        "GET", "/2015-01-01/es/upgradeDomain/$(DomainName)/status"; aws_config=aws_config
+        "GET",
+        "/2015-01-01/es/upgradeDomain/$(DomainName)/status";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_upgrade_status(
@@ -949,6 +1067,7 @@ function get_upgrade_status(
         "/2015-01-01/es/upgradeDomain/$(DomainName)/status",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -964,12 +1083,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Acceptable values are 'Elasticsearch' and 'OpenSearch'.
 """
 function list_domain_names(; aws_config::AbstractAWSConfig=global_aws_config())
-    return elasticsearch_service("GET", "/2015-01-01/domain"; aws_config=aws_config)
+    return elasticsearch_service(
+        "GET", "/2015-01-01/domain"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_domain_names(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return elasticsearch_service("GET", "/2015-01-01/domain", params; aws_config=aws_config)
+    return elasticsearch_service(
+        "GET",
+        "/2015-01-01/domain",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -991,7 +1118,10 @@ function list_domains_for_package(
     PackageID; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return elasticsearch_service(
-        "GET", "/2015-01-01/packages/$(PackageID)/domains"; aws_config=aws_config
+        "GET",
+        "/2015-01-01/packages/$(PackageID)/domains";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_domains_for_package(
@@ -1000,7 +1130,11 @@ function list_domains_for_package(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return elasticsearch_service(
-        "GET", "/2015-01-01/packages/$(PackageID)/domains", params; aws_config=aws_config
+        "GET",
+        "/2015-01-01/packages/$(PackageID)/domains",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1028,7 +1162,10 @@ function list_elasticsearch_instance_types(
     ElasticsearchVersion; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return elasticsearch_service(
-        "GET", "/2015-01-01/es/instanceTypes/$(ElasticsearchVersion)"; aws_config=aws_config
+        "GET",
+        "/2015-01-01/es/instanceTypes/$(ElasticsearchVersion)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_elasticsearch_instance_types(
@@ -1041,6 +1178,7 @@ function list_elasticsearch_instance_types(
         "/2015-01-01/es/instanceTypes/$(ElasticsearchVersion)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1057,13 +1195,22 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`:
 """
 function list_elasticsearch_versions(; aws_config::AbstractAWSConfig=global_aws_config())
-    return elasticsearch_service("GET", "/2015-01-01/es/versions"; aws_config=aws_config)
+    return elasticsearch_service(
+        "GET",
+        "/2015-01-01/es/versions";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_elasticsearch_versions(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return elasticsearch_service(
-        "GET", "/2015-01-01/es/versions", params; aws_config=aws_config
+        "GET",
+        "/2015-01-01/es/versions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1086,7 +1233,10 @@ function list_packages_for_domain(
     DomainName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return elasticsearch_service(
-        "GET", "/2015-01-01/domain/$(DomainName)/packages"; aws_config=aws_config
+        "GET",
+        "/2015-01-01/domain/$(DomainName)/packages";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_packages_for_domain(
@@ -1095,7 +1245,11 @@ function list_packages_for_domain(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return elasticsearch_service(
-        "GET", "/2015-01-01/domain/$(DomainName)/packages", params; aws_config=aws_config
+        "GET",
+        "/2015-01-01/domain/$(DomainName)/packages",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1112,7 +1266,11 @@ Returns all tags for the given Elasticsearch domain.
 """
 function list_tags(arn; aws_config::AbstractAWSConfig=global_aws_config())
     return elasticsearch_service(
-        "GET", "/2015-01-01/tags/", Dict{String,Any}("arn" => arn); aws_config=aws_config
+        "GET",
+        "/2015-01-01/tags/",
+        Dict{String,Any}("arn" => arn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags(
@@ -1123,6 +1281,7 @@ function list_tags(
         "/2015-01-01/tags/",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("arn" => arn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1155,6 +1314,7 @@ function purchase_reserved_elasticsearch_instance_offering(
                 ReservedElasticsearchInstanceOfferingId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function purchase_reserved_elasticsearch_instance_offering(
@@ -1178,6 +1338,7 @@ function purchase_reserved_elasticsearch_instance_offering(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1199,6 +1360,7 @@ function reject_inbound_cross_cluster_search_connection(
         "PUT",
         "/2015-01-01/es/ccs/inboundConnection/$(ConnectionId)/reject";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function reject_inbound_cross_cluster_search_connection(
@@ -1211,6 +1373,7 @@ function reject_inbound_cross_cluster_search_connection(
         "/2015-01-01/es/ccs/inboundConnection/$(ConnectionId)/reject",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1233,6 +1396,7 @@ function remove_tags(ARN, TagKeys; aws_config::AbstractAWSConfig=global_aws_conf
         "/2015-01-01/tags-removal",
         Dict{String,Any}("ARN" => ARN, "TagKeys" => TagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function remove_tags(
@@ -1248,6 +1412,7 @@ function remove_tags(
             mergewith(_merge, Dict{String,Any}("ARN" => ARN, "TagKeys" => TagKeys), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1270,6 +1435,7 @@ function start_elasticsearch_service_software_update(
         "/2015-01-01/es/serviceSoftwareUpdate/start",
         Dict{String,Any}("DomainName" => DomainName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_elasticsearch_service_software_update(
@@ -1284,6 +1450,7 @@ function start_elasticsearch_service_software_update(
             mergewith(_merge, Dict{String,Any}("DomainName" => DomainName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1326,7 +1493,10 @@ function update_elasticsearch_domain_config(
     DomainName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return elasticsearch_service(
-        "POST", "/2015-01-01/es/domain/$(DomainName)/config"; aws_config=aws_config
+        "POST",
+        "/2015-01-01/es/domain/$(DomainName)/config";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_elasticsearch_domain_config(
@@ -1335,7 +1505,11 @@ function update_elasticsearch_domain_config(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return elasticsearch_service(
-        "POST", "/2015-01-01/es/domain/$(DomainName)/config", params; aws_config=aws_config
+        "POST",
+        "/2015-01-01/es/domain/$(DomainName)/config",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1363,6 +1537,7 @@ function update_package(
         "/2015-01-01/packages/update",
         Dict{String,Any}("PackageID" => PackageID, "PackageSource" => PackageSource);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_package(
@@ -1384,6 +1559,7 @@ function update_package(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1411,6 +1587,7 @@ function upgrade_elasticsearch_domain(
         "/2015-01-01/es/upgradeDomain",
         Dict{String,Any}("DomainName" => DomainName, "TargetVersion" => TargetVersion);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function upgrade_elasticsearch_domain(
@@ -1432,5 +1609,6 @@ function upgrade_elasticsearch_domain(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/emr.jl
+++ b/src/services/emr.jl
@@ -23,6 +23,7 @@ function add_instance_fleet(
         "AddInstanceFleet",
         Dict{String,Any}("ClusterId" => ClusterId, "InstanceFleet" => InstanceFleet);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function add_instance_fleet(
@@ -43,6 +44,7 @@ function add_instance_fleet(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -64,6 +66,7 @@ function add_instance_groups(
         "AddInstanceGroups",
         Dict{String,Any}("InstanceGroups" => InstanceGroups, "JobFlowId" => JobFlowId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function add_instance_groups(
@@ -84,6 +87,7 @@ function add_instance_groups(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -119,6 +123,7 @@ function add_job_flow_steps(
         "AddJobFlowSteps",
         Dict{String,Any}("JobFlowId" => JobFlowId, "Steps" => Steps);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function add_job_flow_steps(
@@ -135,6 +140,7 @@ function add_job_flow_steps(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -159,6 +165,7 @@ function add_tags(ResourceId, Tags; aws_config::AbstractAWSConfig=global_aws_con
         "AddTags",
         Dict{String,Any}("ResourceId" => ResourceId, "Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function add_tags(
@@ -175,6 +182,7 @@ function add_tags(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -205,6 +213,7 @@ function cancel_steps(ClusterId, StepIds; aws_config::AbstractAWSConfig=global_a
         "CancelSteps",
         Dict{String,Any}("ClusterId" => ClusterId, "StepIds" => StepIds);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function cancel_steps(
@@ -223,6 +232,7 @@ function cancel_steps(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -247,6 +257,7 @@ function create_security_configuration(
         "CreateSecurityConfiguration",
         Dict{String,Any}("Name" => Name, "SecurityConfiguration" => SecurityConfiguration);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_security_configuration(
@@ -267,6 +278,7 @@ function create_security_configuration(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -340,6 +352,7 @@ function create_studio(
             "WorkspaceSecurityGroupId" => WorkspaceSecurityGroupId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_studio(
@@ -373,6 +386,7 @@ function create_studio(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -419,6 +433,7 @@ function create_studio_session_mapping(
             "StudioId" => StudioId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_studio_session_mapping(
@@ -442,6 +457,7 @@ function create_studio_session_mapping(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -462,6 +478,7 @@ function delete_security_configuration(
         "DeleteSecurityConfiguration",
         Dict{String,Any}("Name" => Name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_security_configuration(
@@ -471,6 +488,7 @@ function delete_security_configuration(
         "DeleteSecurityConfiguration",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -486,7 +504,10 @@ Removes an Amazon EMR Studio from the Studio metadata store.
 """
 function delete_studio(StudioId; aws_config::AbstractAWSConfig=global_aws_config())
     return emr(
-        "DeleteStudio", Dict{String,Any}("StudioId" => StudioId); aws_config=aws_config
+        "DeleteStudio",
+        Dict{String,Any}("StudioId" => StudioId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_studio(
@@ -500,6 +521,7 @@ function delete_studio(
             mergewith(_merge, Dict{String,Any}("StudioId" => StudioId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -531,6 +553,7 @@ function delete_studio_session_mapping(
         "DeleteStudioSessionMapping",
         Dict{String,Any}("IdentityType" => IdentityType, "StudioId" => StudioId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_studio_session_mapping(
@@ -549,6 +572,7 @@ function delete_studio_session_mapping(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -565,7 +589,10 @@ settings, and so on.
 """
 function describe_cluster(ClusterId; aws_config::AbstractAWSConfig=global_aws_config())
     return emr(
-        "DescribeCluster", Dict{String,Any}("ClusterId" => ClusterId); aws_config=aws_config
+        "DescribeCluster",
+        Dict{String,Any}("ClusterId" => ClusterId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_cluster(
@@ -579,6 +606,7 @@ function describe_cluster(
             mergewith(_merge, Dict{String,Any}("ClusterId" => ClusterId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -605,12 +633,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"JobFlowStates"`: Return only job flows whose state is contained in this list.
 """
 function describe_job_flows(; aws_config::AbstractAWSConfig=global_aws_config())
-    return emr("DescribeJobFlows"; aws_config=aws_config)
+    return emr("DescribeJobFlows"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function describe_job_flows(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return emr("DescribeJobFlows", params; aws_config=aws_config)
+    return emr(
+        "DescribeJobFlows", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -630,6 +660,7 @@ function describe_notebook_execution(
         "DescribeNotebookExecution",
         Dict{String,Any}("NotebookExecutionId" => NotebookExecutionId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_notebook_execution(
@@ -647,6 +678,7 @@ function describe_notebook_execution(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -665,12 +697,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"ReleaseLabel"`: The target release label to be described.
 """
 function describe_release_label(; aws_config::AbstractAWSConfig=global_aws_config())
-    return emr("DescribeReleaseLabel"; aws_config=aws_config)
+    return emr(
+        "DescribeReleaseLabel"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_release_label(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return emr("DescribeReleaseLabel", params; aws_config=aws_config)
+    return emr(
+        "DescribeReleaseLabel",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -690,6 +729,7 @@ function describe_security_configuration(
         "DescribeSecurityConfiguration",
         Dict{String,Any}("Name" => Name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_security_configuration(
@@ -699,6 +739,7 @@ function describe_security_configuration(
         "DescribeSecurityConfiguration",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -718,6 +759,7 @@ function describe_step(ClusterId, StepId; aws_config::AbstractAWSConfig=global_a
         "DescribeStep",
         Dict{String,Any}("ClusterId" => ClusterId, "StepId" => StepId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_step(
@@ -736,6 +778,7 @@ function describe_step(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -752,7 +795,10 @@ URL, and so on.
 """
 function describe_studio(StudioId; aws_config::AbstractAWSConfig=global_aws_config())
     return emr(
-        "DescribeStudio", Dict{String,Any}("StudioId" => StudioId); aws_config=aws_config
+        "DescribeStudio",
+        Dict{String,Any}("StudioId" => StudioId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_studio(
@@ -766,6 +812,7 @@ function describe_studio(
             mergewith(_merge, Dict{String,Any}("StudioId" => StudioId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -787,6 +834,7 @@ function get_auto_termination_policy(
         "GetAutoTerminationPolicy",
         Dict{String,Any}("ClusterId" => ClusterId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_auto_termination_policy(
@@ -800,6 +848,7 @@ function get_auto_termination_policy(
             mergewith(_merge, Dict{String,Any}("ClusterId" => ClusterId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -815,12 +864,21 @@ Amazon EMR in the Amazon EMR Management Guide.
 function get_block_public_access_configuration(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return emr("GetBlockPublicAccessConfiguration"; aws_config=aws_config)
+    return emr(
+        "GetBlockPublicAccessConfiguration";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_block_public_access_configuration(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return emr("GetBlockPublicAccessConfiguration", params; aws_config=aws_config)
+    return emr(
+        "GetBlockPublicAccessConfiguration",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -841,6 +899,7 @@ function get_managed_scaling_policy(
         "GetManagedScalingPolicy",
         Dict{String,Any}("ClusterId" => ClusterId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_managed_scaling_policy(
@@ -854,6 +913,7 @@ function get_managed_scaling_policy(
             mergewith(_merge, Dict{String,Any}("ClusterId" => ClusterId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -883,6 +943,7 @@ function get_studio_session_mapping(
         "GetStudioSessionMapping",
         Dict{String,Any}("IdentityType" => IdentityType, "StudioId" => StudioId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_studio_session_mapping(
@@ -901,6 +962,7 @@ function get_studio_session_mapping(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -924,6 +986,7 @@ function list_bootstrap_actions(
         "ListBootstrapActions",
         Dict{String,Any}("ClusterId" => ClusterId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_bootstrap_actions(
@@ -937,6 +1000,7 @@ function list_bootstrap_actions(
             mergewith(_merge, Dict{String,Any}("ClusterId" => ClusterId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -960,12 +1024,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"Marker"`: The pagination token that indicates the next set of results to retrieve.
 """
 function list_clusters(; aws_config::AbstractAWSConfig=global_aws_config())
-    return emr("ListClusters"; aws_config=aws_config)
+    return emr("ListClusters"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_clusters(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return emr("ListClusters", params; aws_config=aws_config)
+    return emr(
+        "ListClusters", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -988,6 +1054,7 @@ function list_instance_fleets(ClusterId; aws_config::AbstractAWSConfig=global_aw
         "ListInstanceFleets",
         Dict{String,Any}("ClusterId" => ClusterId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_instance_fleets(
@@ -1001,6 +1068,7 @@ function list_instance_fleets(
             mergewith(_merge, Dict{String,Any}("ClusterId" => ClusterId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1022,6 +1090,7 @@ function list_instance_groups(ClusterId; aws_config::AbstractAWSConfig=global_aw
         "ListInstanceGroups",
         Dict{String,Any}("ClusterId" => ClusterId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_instance_groups(
@@ -1035,6 +1104,7 @@ function list_instance_groups(
             mergewith(_merge, Dict{String,Any}("ClusterId" => ClusterId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1062,7 +1132,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function list_instances(ClusterId; aws_config::AbstractAWSConfig=global_aws_config())
     return emr(
-        "ListInstances", Dict{String,Any}("ClusterId" => ClusterId); aws_config=aws_config
+        "ListInstances",
+        Dict{String,Any}("ClusterId" => ClusterId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_instances(
@@ -1076,6 +1149,7 @@ function list_instances(
             mergewith(_merge, Dict{String,Any}("ClusterId" => ClusterId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1110,12 +1184,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   current timestamp.
 """
 function list_notebook_executions(; aws_config::AbstractAWSConfig=global_aws_config())
-    return emr("ListNotebookExecutions"; aws_config=aws_config)
+    return emr(
+        "ListNotebookExecutions"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_notebook_executions(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return emr("ListNotebookExecutions", params; aws_config=aws_config)
+    return emr(
+        "ListNotebookExecutions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1139,12 +1220,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   expired or tampered with.
 """
 function list_release_labels(; aws_config::AbstractAWSConfig=global_aws_config())
-    return emr("ListReleaseLabels"; aws_config=aws_config)
+    return emr("ListReleaseLabels"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_release_labels(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return emr("ListReleaseLabels", params; aws_config=aws_config)
+    return emr(
+        "ListReleaseLabels", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1161,12 +1244,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"Marker"`: The pagination token that indicates the set of results to retrieve.
 """
 function list_security_configurations(; aws_config::AbstractAWSConfig=global_aws_config())
-    return emr("ListSecurityConfigurations"; aws_config=aws_config)
+    return emr(
+        "ListSecurityConfigurations"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_security_configurations(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return emr("ListSecurityConfigurations", params; aws_config=aws_config)
+    return emr(
+        "ListSecurityConfigurations",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1194,7 +1284,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function list_steps(ClusterId; aws_config::AbstractAWSConfig=global_aws_config())
     return emr(
-        "ListSteps", Dict{String,Any}("ClusterId" => ClusterId); aws_config=aws_config
+        "ListSteps",
+        Dict{String,Any}("ClusterId" => ClusterId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_steps(
@@ -1208,6 +1301,7 @@ function list_steps(
             mergewith(_merge, Dict{String,Any}("ClusterId" => ClusterId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1226,12 +1320,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"StudioId"`: The ID of the Amazon EMR Studio.
 """
 function list_studio_session_mappings(; aws_config::AbstractAWSConfig=global_aws_config())
-    return emr("ListStudioSessionMappings"; aws_config=aws_config)
+    return emr(
+        "ListStudioSessionMappings"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_studio_session_mappings(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return emr("ListStudioSessionMappings", params; aws_config=aws_config)
+    return emr(
+        "ListStudioSessionMappings",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1246,12 +1347,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"Marker"`: The pagination token that indicates the set of results to retrieve.
 """
 function list_studios(; aws_config::AbstractAWSConfig=global_aws_config())
-    return emr("ListStudios"; aws_config=aws_config)
+    return emr("ListStudios"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_studios(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return emr("ListStudios", params; aws_config=aws_config)
+    return emr(
+        "ListStudios", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1273,7 +1376,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function modify_cluster(ClusterId; aws_config::AbstractAWSConfig=global_aws_config())
     return emr(
-        "ModifyCluster", Dict{String,Any}("ClusterId" => ClusterId); aws_config=aws_config
+        "ModifyCluster",
+        Dict{String,Any}("ClusterId" => ClusterId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_cluster(
@@ -1287,6 +1393,7 @@ function modify_cluster(
             mergewith(_merge, Dict{String,Any}("ClusterId" => ClusterId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1311,6 +1418,7 @@ function modify_instance_fleet(
         "ModifyInstanceFleet",
         Dict{String,Any}("ClusterId" => ClusterId, "InstanceFleet" => InstanceFleet);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_instance_fleet(
@@ -1331,6 +1439,7 @@ function modify_instance_fleet(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1348,12 +1457,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"InstanceGroups"`: Instance groups to change.
 """
 function modify_instance_groups(; aws_config::AbstractAWSConfig=global_aws_config())
-    return emr("ModifyInstanceGroups"; aws_config=aws_config)
+    return emr(
+        "ModifyInstanceGroups"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function modify_instance_groups(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return emr("ModifyInstanceGroups", params; aws_config=aws_config)
+    return emr(
+        "ModifyInstanceGroups",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1387,6 +1503,7 @@ function put_auto_scaling_policy(
             "InstanceGroupId" => InstanceGroupId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_auto_scaling_policy(
@@ -1410,6 +1527,7 @@ function put_auto_scaling_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1437,6 +1555,7 @@ function put_auto_termination_policy(
         "PutAutoTerminationPolicy",
         Dict{String,Any}("ClusterId" => ClusterId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_auto_termination_policy(
@@ -1450,6 +1569,7 @@ function put_auto_termination_policy(
             mergewith(_merge, Dict{String,Any}("ClusterId" => ClusterId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1486,6 +1606,7 @@ function put_block_public_access_configuration(
             "BlockPublicAccessConfiguration" => BlockPublicAccessConfiguration
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_block_public_access_configuration(
@@ -1505,6 +1626,7 @@ function put_block_public_access_configuration(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1532,6 +1654,7 @@ function put_managed_scaling_policy(
             "ClusterId" => ClusterId, "ManagedScalingPolicy" => ManagedScalingPolicy
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_managed_scaling_policy(
@@ -1552,6 +1675,7 @@ function put_managed_scaling_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1575,6 +1699,7 @@ function remove_auto_scaling_policy(
         "RemoveAutoScalingPolicy",
         Dict{String,Any}("ClusterId" => ClusterId, "InstanceGroupId" => InstanceGroupId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function remove_auto_scaling_policy(
@@ -1595,6 +1720,7 @@ function remove_auto_scaling_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1616,6 +1742,7 @@ function remove_auto_termination_policy(
         "RemoveAutoTerminationPolicy",
         Dict{String,Any}("ClusterId" => ClusterId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function remove_auto_termination_policy(
@@ -1629,6 +1756,7 @@ function remove_auto_termination_policy(
             mergewith(_merge, Dict{String,Any}("ClusterId" => ClusterId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1650,6 +1778,7 @@ function remove_managed_scaling_policy(
         "RemoveManagedScalingPolicy",
         Dict{String,Any}("ClusterId" => ClusterId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function remove_managed_scaling_policy(
@@ -1663,6 +1792,7 @@ function remove_managed_scaling_policy(
             mergewith(_merge, Dict{String,Any}("ClusterId" => ClusterId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1686,6 +1816,7 @@ function remove_tags(ResourceId, TagKeys; aws_config::AbstractAWSConfig=global_a
         "RemoveTags",
         Dict{String,Any}("ResourceId" => ResourceId, "TagKeys" => TagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function remove_tags(
@@ -1704,6 +1835,7 @@ function remove_tags(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1839,6 +1971,7 @@ function run_job_flow(Instances, Name; aws_config::AbstractAWSConfig=global_aws_
         "RunJobFlow",
         Dict{String,Any}("Instances" => Instances, "Name" => Name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function run_job_flow(
@@ -1855,6 +1988,7 @@ function run_job_flow(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1891,6 +2025,7 @@ function set_termination_protection(
             "JobFlowIds" => JobFlowIds, "TerminationProtected" => TerminationProtected
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function set_termination_protection(
@@ -1912,6 +2047,7 @@ function set_termination_protection(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1945,6 +2081,7 @@ function set_visible_to_all_users(
             "JobFlowIds" => JobFlowIds, "VisibleToAllUsers" => VisibleToAllUsers
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function set_visible_to_all_users(
@@ -1965,6 +2102,7 @@ function set_visible_to_all_users(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2016,6 +2154,7 @@ function start_notebook_execution(
             "ServiceRole" => ServiceRole,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_notebook_execution(
@@ -2041,6 +2180,7 @@ function start_notebook_execution(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2061,6 +2201,7 @@ function stop_notebook_execution(
         "StopNotebookExecution",
         Dict{String,Any}("NotebookExecutionId" => NotebookExecutionId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function stop_notebook_execution(
@@ -2078,6 +2219,7 @@ function stop_notebook_execution(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2102,6 +2244,7 @@ function terminate_job_flows(JobFlowIds; aws_config::AbstractAWSConfig=global_aw
         "TerminateJobFlows",
         Dict{String,Any}("JobFlowIds" => JobFlowIds);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function terminate_job_flows(
@@ -2115,6 +2258,7 @@ function terminate_job_flows(
             mergewith(_merge, Dict{String,Any}("JobFlowIds" => JobFlowIds), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2141,7 +2285,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function update_studio(StudioId; aws_config::AbstractAWSConfig=global_aws_config())
     return emr(
-        "UpdateStudio", Dict{String,Any}("StudioId" => StudioId); aws_config=aws_config
+        "UpdateStudio",
+        Dict{String,Any}("StudioId" => StudioId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_studio(
@@ -2155,6 +2302,7 @@ function update_studio(
             mergewith(_merge, Dict{String,Any}("StudioId" => StudioId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2194,6 +2342,7 @@ function update_studio_session_mapping(
             "StudioId" => StudioId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_studio_session_mapping(
@@ -2217,5 +2366,6 @@ function update_studio_session_mapping(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/emr_containers.jl
+++ b/src/services/emr_containers.jl
@@ -24,6 +24,7 @@ function cancel_job_run(
         "DELETE",
         "/virtualclusters/$(virtualClusterId)/jobruns/$(jobRunId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function cancel_job_run(
@@ -37,6 +38,7 @@ function cancel_job_run(
         "/virtualclusters/$(virtualClusterId)/jobruns/$(jobRunId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -85,6 +87,7 @@ function create_managed_endpoint(
             "type" => type,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_managed_endpoint(
@@ -116,6 +119,7 @@ function create_managed_endpoint(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -150,6 +154,7 @@ function create_virtual_cluster(
             "name" => name,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_virtual_cluster(
@@ -174,6 +179,7 @@ function create_virtual_cluster(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -196,6 +202,7 @@ function delete_managed_endpoint(
         "DELETE",
         "/virtualclusters/$(virtualClusterId)/endpoints/$(endpointId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_managed_endpoint(
@@ -209,6 +216,7 @@ function delete_managed_endpoint(
         "/virtualclusters/$(virtualClusterId)/endpoints/$(endpointId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -230,7 +238,10 @@ function delete_virtual_cluster(
     virtualClusterId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return emr_containers(
-        "DELETE", "/virtualclusters/$(virtualClusterId)"; aws_config=aws_config
+        "DELETE",
+        "/virtualclusters/$(virtualClusterId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_virtual_cluster(
@@ -239,7 +250,11 @@ function delete_virtual_cluster(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return emr_containers(
-        "DELETE", "/virtualclusters/$(virtualClusterId)", params; aws_config=aws_config
+        "DELETE",
+        "/virtualclusters/$(virtualClusterId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -262,6 +277,7 @@ function describe_job_run(
         "GET",
         "/virtualclusters/$(virtualClusterId)/jobruns/$(jobRunId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_job_run(
@@ -275,6 +291,7 @@ function describe_job_run(
         "/virtualclusters/$(virtualClusterId)/jobruns/$(jobRunId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -298,6 +315,7 @@ function describe_managed_endpoint(
         "GET",
         "/virtualclusters/$(virtualClusterId)/endpoints/$(endpointId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_managed_endpoint(
@@ -311,6 +329,7 @@ function describe_managed_endpoint(
         "/virtualclusters/$(virtualClusterId)/endpoints/$(endpointId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -332,7 +351,10 @@ function describe_virtual_cluster(
     virtualClusterId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return emr_containers(
-        "GET", "/virtualclusters/$(virtualClusterId)"; aws_config=aws_config
+        "GET",
+        "/virtualclusters/$(virtualClusterId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_virtual_cluster(
@@ -341,7 +363,11 @@ function describe_virtual_cluster(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return emr_containers(
-        "GET", "/virtualclusters/$(virtualClusterId)", params; aws_config=aws_config
+        "GET",
+        "/virtualclusters/$(virtualClusterId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -366,7 +392,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function list_job_runs(virtualClusterId; aws_config::AbstractAWSConfig=global_aws_config())
     return emr_containers(
-        "GET", "/virtualclusters/$(virtualClusterId)/jobruns"; aws_config=aws_config
+        "GET",
+        "/virtualclusters/$(virtualClusterId)/jobruns";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_job_runs(
@@ -375,7 +404,11 @@ function list_job_runs(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return emr_containers(
-        "GET", "/virtualclusters/$(virtualClusterId)/jobruns", params; aws_config=aws_config
+        "GET",
+        "/virtualclusters/$(virtualClusterId)/jobruns",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -403,7 +436,10 @@ function list_managed_endpoints(
     virtualClusterId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return emr_containers(
-        "GET", "/virtualclusters/$(virtualClusterId)/endpoints"; aws_config=aws_config
+        "GET",
+        "/virtualclusters/$(virtualClusterId)/endpoints";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_managed_endpoints(
@@ -416,6 +452,7 @@ function list_managed_endpoints(
         "/virtualclusters/$(virtualClusterId)/endpoints",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -432,14 +469,25 @@ Lists the tags assigned to the resources.
 function list_tags_for_resource(
     resourceArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return emr_containers("GET", "/tags/$(resourceArn)"; aws_config=aws_config)
+    return emr_containers(
+        "GET",
+        "/tags/$(resourceArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_tags_for_resource(
     resourceArn,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return emr_containers("GET", "/tags/$(resourceArn)", params; aws_config=aws_config)
+    return emr_containers(
+        "GET",
+        "/tags/$(resourceArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -464,12 +512,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"states"`: The states of the requested virtual clusters.
 """
 function list_virtual_clusters(; aws_config::AbstractAWSConfig=global_aws_config())
-    return emr_containers("GET", "/virtualclusters"; aws_config=aws_config)
+    return emr_containers(
+        "GET", "/virtualclusters"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_virtual_clusters(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return emr_containers("GET", "/virtualclusters", params; aws_config=aws_config)
+    return emr_containers(
+        "GET",
+        "/virtualclusters",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -510,6 +566,7 @@ function start_job_run(
             "releaseLabel" => releaseLabel,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_job_run(
@@ -537,6 +594,7 @@ function start_job_run(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -564,6 +622,7 @@ function tag_resource(resourceArn, tags; aws_config::AbstractAWSConfig=global_aw
         "/tags/$(resourceArn)",
         Dict{String,Any}("tags" => tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -577,6 +636,7 @@ function tag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tags" => tags), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -599,6 +659,7 @@ function untag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}("tagKeys" => tagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -612,5 +673,6 @@ function untag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tagKeys" => tagKeys), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/eventbridge.jl
+++ b/src/services/eventbridge.jl
@@ -17,7 +17,10 @@ event bus will start receiving events from the event source.
 """
 function activate_event_source(Name; aws_config::AbstractAWSConfig=global_aws_config())
     return eventbridge(
-        "ActivateEventSource", Dict{String,Any}("Name" => Name); aws_config=aws_config
+        "ActivateEventSource",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function activate_event_source(
@@ -27,6 +30,7 @@ function activate_event_source(
         "ActivateEventSource",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -42,7 +46,10 @@ Cancels the specified replay.
 """
 function cancel_replay(ReplayName; aws_config::AbstractAWSConfig=global_aws_config())
     return eventbridge(
-        "CancelReplay", Dict{String,Any}("ReplayName" => ReplayName); aws_config=aws_config
+        "CancelReplay",
+        Dict{String,Any}("ReplayName" => ReplayName);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function cancel_replay(
@@ -56,6 +63,7 @@ function cancel_replay(
             mergewith(_merge, Dict{String,Any}("ReplayName" => ReplayName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -95,6 +103,7 @@ function create_api_destination(
             "Name" => Name,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_api_destination(
@@ -120,6 +129,7 @@ function create_api_destination(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -151,6 +161,7 @@ function create_archive(
         "CreateArchive",
         Dict{String,Any}("ArchiveName" => ArchiveName, "EventSourceArn" => EventSourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_archive(
@@ -171,6 +182,7 @@ function create_archive(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -205,6 +217,7 @@ function create_connection(
             "Name" => Name,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_connection(
@@ -228,6 +241,7 @@ function create_connection(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -253,7 +267,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function create_event_bus(Name; aws_config::AbstractAWSConfig=global_aws_config())
     return eventbridge(
-        "CreateEventBus", Dict{String,Any}("Name" => Name); aws_config=aws_config
+        "CreateEventBus",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_event_bus(
@@ -263,6 +280,7 @@ function create_event_bus(
         "CreateEventBus",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -303,6 +321,7 @@ function create_partner_event_source(
         "CreatePartnerEventSource",
         Dict{String,Any}("Account" => Account, "Name" => Name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_partner_event_source(
@@ -319,6 +338,7 @@ function create_partner_event_source(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -338,7 +358,10 @@ ActivateEventSource.
 """
 function deactivate_event_source(Name; aws_config::AbstractAWSConfig=global_aws_config())
     return eventbridge(
-        "DeactivateEventSource", Dict{String,Any}("Name" => Name); aws_config=aws_config
+        "DeactivateEventSource",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function deactivate_event_source(
@@ -348,6 +371,7 @@ function deactivate_event_source(
         "DeactivateEventSource",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -364,7 +388,10 @@ from the connection so you can reuse it without having to create a new connectio
 """
 function deauthorize_connection(Name; aws_config::AbstractAWSConfig=global_aws_config())
     return eventbridge(
-        "DeauthorizeConnection", Dict{String,Any}("Name" => Name); aws_config=aws_config
+        "DeauthorizeConnection",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function deauthorize_connection(
@@ -374,6 +401,7 @@ function deauthorize_connection(
         "DeauthorizeConnection",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -389,7 +417,10 @@ Deletes the specified API destination.
 """
 function delete_api_destination(Name; aws_config::AbstractAWSConfig=global_aws_config())
     return eventbridge(
-        "DeleteApiDestination", Dict{String,Any}("Name" => Name); aws_config=aws_config
+        "DeleteApiDestination",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_api_destination(
@@ -399,6 +430,7 @@ function delete_api_destination(
         "DeleteApiDestination",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -417,6 +449,7 @@ function delete_archive(ArchiveName; aws_config::AbstractAWSConfig=global_aws_co
         "DeleteArchive",
         Dict{String,Any}("ArchiveName" => ArchiveName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_archive(
@@ -430,6 +463,7 @@ function delete_archive(
             mergewith(_merge, Dict{String,Any}("ArchiveName" => ArchiveName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -445,7 +479,10 @@ Deletes a connection.
 """
 function delete_connection(Name; aws_config::AbstractAWSConfig=global_aws_config())
     return eventbridge(
-        "DeleteConnection", Dict{String,Any}("Name" => Name); aws_config=aws_config
+        "DeleteConnection",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_connection(
@@ -455,6 +492,7 @@ function delete_connection(
         "DeleteConnection",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -471,7 +509,10 @@ event bus need to be deleted. You can't delete your account's default event bus.
 """
 function delete_event_bus(Name; aws_config::AbstractAWSConfig=global_aws_config())
     return eventbridge(
-        "DeleteEventBus", Dict{String,Any}("Name" => Name); aws_config=aws_config
+        "DeleteEventBus",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_event_bus(
@@ -481,6 +522,7 @@ function delete_event_bus(
         "DeleteEventBus",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -506,6 +548,7 @@ function delete_partner_event_source(
         "DeletePartnerEventSource",
         Dict{String,Any}("Account" => Account, "Name" => Name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_partner_event_source(
@@ -522,6 +565,7 @@ function delete_partner_event_source(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -553,7 +597,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function delete_rule(Name; aws_config::AbstractAWSConfig=global_aws_config())
     return eventbridge(
-        "DeleteRule", Dict{String,Any}("Name" => Name); aws_config=aws_config
+        "DeleteRule",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_rule(
@@ -563,6 +610,7 @@ function delete_rule(
         "DeleteRule",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -578,7 +626,10 @@ Retrieves details about an API destination.
 """
 function describe_api_destination(Name; aws_config::AbstractAWSConfig=global_aws_config())
     return eventbridge(
-        "DescribeApiDestination", Dict{String,Any}("Name" => Name); aws_config=aws_config
+        "DescribeApiDestination",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_api_destination(
@@ -588,6 +639,7 @@ function describe_api_destination(
         "DescribeApiDestination",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -606,6 +658,7 @@ function describe_archive(ArchiveName; aws_config::AbstractAWSConfig=global_aws_
         "DescribeArchive",
         Dict{String,Any}("ArchiveName" => ArchiveName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_archive(
@@ -619,6 +672,7 @@ function describe_archive(
             mergewith(_merge, Dict{String,Any}("ArchiveName" => ArchiveName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -634,7 +688,10 @@ Retrieves details about a connection.
 """
 function describe_connection(Name; aws_config::AbstractAWSConfig=global_aws_config())
     return eventbridge(
-        "DescribeConnection", Dict{String,Any}("Name" => Name); aws_config=aws_config
+        "DescribeConnection",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_connection(
@@ -644,6 +701,7 @@ function describe_connection(
         "DescribeConnection",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -664,12 +722,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   default event bus is displayed.
 """
 function describe_event_bus(; aws_config::AbstractAWSConfig=global_aws_config())
-    return eventbridge("DescribeEventBus"; aws_config=aws_config)
+    return eventbridge(
+        "DescribeEventBus"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_event_bus(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return eventbridge("DescribeEventBus", params; aws_config=aws_config)
+    return eventbridge(
+        "DescribeEventBus", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -684,7 +746,10 @@ This operation lists details about a partner event source that is shared with yo
 """
 function describe_event_source(Name; aws_config::AbstractAWSConfig=global_aws_config())
     return eventbridge(
-        "DescribeEventSource", Dict{String,Any}("Name" => Name); aws_config=aws_config
+        "DescribeEventSource",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_event_source(
@@ -694,6 +759,7 @@ function describe_event_source(
         "DescribeEventSource",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -717,6 +783,7 @@ function describe_partner_event_source(
         "DescribePartnerEventSource",
         Dict{String,Any}("Name" => Name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_partner_event_source(
@@ -726,6 +793,7 @@ function describe_partner_event_source(
         "DescribePartnerEventSource",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -751,6 +819,7 @@ function describe_replay(ReplayName; aws_config::AbstractAWSConfig=global_aws_co
         "DescribeReplay",
         Dict{String,Any}("ReplayName" => ReplayName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_replay(
@@ -764,6 +833,7 @@ function describe_replay(
             mergewith(_merge, Dict{String,Any}("ReplayName" => ReplayName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -784,7 +854,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function describe_rule(Name; aws_config::AbstractAWSConfig=global_aws_config())
     return eventbridge(
-        "DescribeRule", Dict{String,Any}("Name" => Name); aws_config=aws_config
+        "DescribeRule",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_rule(
@@ -794,6 +867,7 @@ function describe_rule(
         "DescribeRule",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -815,7 +889,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function disable_rule(Name; aws_config::AbstractAWSConfig=global_aws_config())
     return eventbridge(
-        "DisableRule", Dict{String,Any}("Name" => Name); aws_config=aws_config
+        "DisableRule",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disable_rule(
@@ -825,6 +902,7 @@ function disable_rule(
         "DisableRule",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -846,7 +924,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function enable_rule(Name; aws_config::AbstractAWSConfig=global_aws_config())
     return eventbridge(
-        "EnableRule", Dict{String,Any}("Name" => Name); aws_config=aws_config
+        "EnableRule",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function enable_rule(
@@ -856,6 +937,7 @@ function enable_rule(
         "EnableRule",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -874,12 +956,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`: The token returned by a previous call to retrieve the next set of results.
 """
 function list_api_destinations(; aws_config::AbstractAWSConfig=global_aws_config())
-    return eventbridge("ListApiDestinations"; aws_config=aws_config)
+    return eventbridge(
+        "ListApiDestinations"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_api_destinations(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return eventbridge("ListApiDestinations", params; aws_config=aws_config)
+    return eventbridge(
+        "ListApiDestinations",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -899,12 +988,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"State"`: The state of the archive.
 """
 function list_archives(; aws_config::AbstractAWSConfig=global_aws_config())
-    return eventbridge("ListArchives"; aws_config=aws_config)
+    return eventbridge(
+        "ListArchives"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_archives(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return eventbridge("ListArchives", params; aws_config=aws_config)
+    return eventbridge(
+        "ListArchives", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -922,12 +1015,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`: The token returned by a previous call to retrieve the next set of results.
 """
 function list_connections(; aws_config::AbstractAWSConfig=global_aws_config())
-    return eventbridge("ListConnections"; aws_config=aws_config)
+    return eventbridge(
+        "ListConnections"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_connections(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return eventbridge("ListConnections", params; aws_config=aws_config)
+    return eventbridge(
+        "ListConnections", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -947,12 +1044,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`: The token returned by a previous call to retrieve the next set of results.
 """
 function list_event_buses(; aws_config::AbstractAWSConfig=global_aws_config())
-    return eventbridge("ListEventBuses"; aws_config=aws_config)
+    return eventbridge(
+        "ListEventBuses"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_event_buses(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return eventbridge("ListEventBuses", params; aws_config=aws_config)
+    return eventbridge(
+        "ListEventBuses", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -973,12 +1074,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`: The token returned by a previous call to retrieve the next set of results.
 """
 function list_event_sources(; aws_config::AbstractAWSConfig=global_aws_config())
-    return eventbridge("ListEventSources"; aws_config=aws_config)
+    return eventbridge(
+        "ListEventSources"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_event_sources(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return eventbridge("ListEventSources", params; aws_config=aws_config)
+    return eventbridge(
+        "ListEventSources", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1008,6 +1113,7 @@ function list_partner_event_source_accounts(
         "ListPartnerEventSourceAccounts",
         Dict{String,Any}("EventSourceName" => EventSourceName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_partner_event_source_accounts(
@@ -1023,6 +1129,7 @@ function list_partner_event_source_accounts(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1052,6 +1159,7 @@ function list_partner_event_sources(
         "ListPartnerEventSources",
         Dict{String,Any}("NamePrefix" => NamePrefix);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_partner_event_sources(
@@ -1065,6 +1173,7 @@ function list_partner_event_sources(
             mergewith(_merge, Dict{String,Any}("NamePrefix" => NamePrefix), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1085,12 +1194,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"State"`: The state of the replay.
 """
 function list_replays(; aws_config::AbstractAWSConfig=global_aws_config())
-    return eventbridge("ListReplays"; aws_config=aws_config)
+    return eventbridge(
+        "ListReplays"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_replays(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return eventbridge("ListReplays", params; aws_config=aws_config)
+    return eventbridge(
+        "ListReplays", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1117,6 +1230,7 @@ function list_rule_names_by_target(
         "ListRuleNamesByTarget",
         Dict{String,Any}("TargetArn" => TargetArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_rule_names_by_target(
@@ -1130,6 +1244,7 @@ function list_rule_names_by_target(
             mergewith(_merge, Dict{String,Any}("TargetArn" => TargetArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1150,12 +1265,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`: The token returned by a previous call to retrieve the next set of results.
 """
 function list_rules(; aws_config::AbstractAWSConfig=global_aws_config())
-    return eventbridge("ListRules"; aws_config=aws_config)
+    return eventbridge("ListRules"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_rules(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return eventbridge("ListRules", params; aws_config=aws_config)
+    return eventbridge(
+        "ListRules", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1176,6 +1293,7 @@ function list_tags_for_resource(
         "ListTagsForResource",
         Dict{String,Any}("ResourceARN" => ResourceARN);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags_for_resource(
@@ -1189,6 +1307,7 @@ function list_tags_for_resource(
             mergewith(_merge, Dict{String,Any}("ResourceARN" => ResourceARN), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1210,7 +1329,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function list_targets_by_rule(Rule; aws_config::AbstractAWSConfig=global_aws_config())
     return eventbridge(
-        "ListTargetsByRule", Dict{String,Any}("Rule" => Rule); aws_config=aws_config
+        "ListTargetsByRule",
+        Dict{String,Any}("Rule" => Rule);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_targets_by_rule(
@@ -1220,6 +1342,7 @@ function list_targets_by_rule(
         "ListTargetsByRule",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Rule" => Rule), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1237,7 +1360,10 @@ Sends custom events to Amazon EventBridge so that they can be matched to rules.
 """
 function put_events(Entries; aws_config::AbstractAWSConfig=global_aws_config())
     return eventbridge(
-        "PutEvents", Dict{String,Any}("Entries" => Entries); aws_config=aws_config
+        "PutEvents",
+        Dict{String,Any}("Entries" => Entries);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_events(
@@ -1247,6 +1373,7 @@ function put_events(
         "PutEvents",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Entries" => Entries), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1263,7 +1390,10 @@ Services customers do not use this operation.
 """
 function put_partner_events(Entries; aws_config::AbstractAWSConfig=global_aws_config())
     return eventbridge(
-        "PutPartnerEvents", Dict{String,Any}("Entries" => Entries); aws_config=aws_config
+        "PutPartnerEvents",
+        Dict{String,Any}("Entries" => Entries);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_partner_events(
@@ -1273,6 +1403,7 @@ function put_partner_events(
         "PutPartnerEvents",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Entries" => Entries), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1323,12 +1454,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   specify this StatementId when you run RemovePermission.
 """
 function put_permission(; aws_config::AbstractAWSConfig=global_aws_config())
-    return eventbridge("PutPermission"; aws_config=aws_config)
+    return eventbridge(
+        "PutPermission"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function put_permission(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return eventbridge("PutPermission", params; aws_config=aws_config)
+    return eventbridge(
+        "PutPermission", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1391,7 +1526,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"Tags"`: The list of key-value pairs to associate with the rule.
 """
 function put_rule(Name; aws_config::AbstractAWSConfig=global_aws_config())
-    return eventbridge("PutRule", Dict{String,Any}("Name" => Name); aws_config=aws_config)
+    return eventbridge(
+        "PutRule",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function put_rule(
     Name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -1400,6 +1540,7 @@ function put_rule(
         "PutRule",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1477,6 +1618,7 @@ function put_targets(Rule, Targets; aws_config::AbstractAWSConfig=global_aws_con
         "PutTargets",
         Dict{String,Any}("Rule" => Rule, "Targets" => Targets);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_targets(
@@ -1493,6 +1635,7 @@ function put_targets(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1514,12 +1657,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   to put events to the default event bus.
 """
 function remove_permission(; aws_config::AbstractAWSConfig=global_aws_config())
-    return eventbridge("RemovePermission"; aws_config=aws_config)
+    return eventbridge(
+        "RemovePermission"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function remove_permission(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return eventbridge("RemovePermission", params; aws_config=aws_config)
+    return eventbridge(
+        "RemovePermission", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1551,6 +1698,7 @@ function remove_targets(Ids, Rule; aws_config::AbstractAWSConfig=global_aws_conf
         "RemoveTargets",
         Dict{String,Any}("Ids" => Ids, "Rule" => Rule);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function remove_targets(
@@ -1565,6 +1713,7 @@ function remove_targets(
             mergewith(_merge, Dict{String,Any}("Ids" => Ids, "Rule" => Rule), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1613,6 +1762,7 @@ function start_replay(
             "ReplayName" => ReplayName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_replay(
@@ -1640,6 +1790,7 @@ function start_replay(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1668,6 +1819,7 @@ function tag_resource(ResourceARN, Tags; aws_config::AbstractAWSConfig=global_aw
         "TagResource",
         Dict{String,Any}("ResourceARN" => ResourceARN, "Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -1686,6 +1838,7 @@ function tag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1714,6 +1867,7 @@ function test_event_pattern(
         "TestEventPattern",
         Dict{String,Any}("Event" => Event, "EventPattern" => EventPattern);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function test_event_pattern(
@@ -1732,6 +1886,7 @@ function test_event_pattern(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1754,6 +1909,7 @@ function untag_resource(
         "UntagResource",
         Dict{String,Any}("ResourceARN" => ResourceARN, "TagKeys" => TagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -1772,6 +1928,7 @@ function untag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1795,7 +1952,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function update_api_destination(Name; aws_config::AbstractAWSConfig=global_aws_config())
     return eventbridge(
-        "UpdateApiDestination", Dict{String,Any}("Name" => Name); aws_config=aws_config
+        "UpdateApiDestination",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_api_destination(
@@ -1805,6 +1965,7 @@ function update_api_destination(
         "UpdateApiDestination",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1828,6 +1989,7 @@ function update_archive(ArchiveName; aws_config::AbstractAWSConfig=global_aws_co
         "UpdateArchive",
         Dict{String,Any}("ArchiveName" => ArchiveName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_archive(
@@ -1841,6 +2003,7 @@ function update_archive(
             mergewith(_merge, Dict{String,Any}("ArchiveName" => ArchiveName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1861,7 +2024,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function update_connection(Name; aws_config::AbstractAWSConfig=global_aws_config())
     return eventbridge(
-        "UpdateConnection", Dict{String,Any}("Name" => Name); aws_config=aws_config
+        "UpdateConnection",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_connection(
@@ -1871,5 +2037,6 @@ function update_connection(
         "UpdateConnection",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/finspace.jl
+++ b/src/services/finspace.jl
@@ -25,7 +25,11 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function create_environment(name; aws_config::AbstractAWSConfig=global_aws_config())
     return finspace(
-        "POST", "/environment", Dict{String,Any}("name" => name); aws_config=aws_config
+        "POST",
+        "/environment",
+        Dict{String,Any}("name" => name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_environment(
@@ -36,6 +40,7 @@ function create_environment(
         "/environment",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("name" => name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -52,7 +57,12 @@ Delete an FinSpace environment.
 function delete_environment(
     environmentId; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return finspace("DELETE", "/environment/$(environmentId)"; aws_config=aws_config)
+    return finspace(
+        "DELETE",
+        "/environment/$(environmentId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_environment(
     environmentId,
@@ -60,7 +70,11 @@ function delete_environment(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return finspace(
-        "DELETE", "/environment/$(environmentId)", params; aws_config=aws_config
+        "DELETE",
+        "/environment/$(environmentId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -75,14 +89,25 @@ Returns the FinSpace environment object.
 
 """
 function get_environment(environmentId; aws_config::AbstractAWSConfig=global_aws_config())
-    return finspace("GET", "/environment/$(environmentId)"; aws_config=aws_config)
+    return finspace(
+        "GET",
+        "/environment/$(environmentId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_environment(
     environmentId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return finspace("GET", "/environment/$(environmentId)", params; aws_config=aws_config)
+    return finspace(
+        "GET",
+        "/environment/$(environmentId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -99,12 +124,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   value from the response object of the previous page call.
 """
 function list_environments(; aws_config::AbstractAWSConfig=global_aws_config())
-    return finspace("GET", "/environment"; aws_config=aws_config)
+    return finspace(
+        "GET", "/environment"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_environments(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return finspace("GET", "/environment", params; aws_config=aws_config)
+    return finspace(
+        "GET",
+        "/environment",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -120,14 +153,25 @@ A list of all tags for a resource.
 function list_tags_for_resource(
     resourceArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return finspace("GET", "/tags/$(resourceArn)"; aws_config=aws_config)
+    return finspace(
+        "GET",
+        "/tags/$(resourceArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_tags_for_resource(
     resourceArn,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return finspace("GET", "/tags/$(resourceArn)", params; aws_config=aws_config)
+    return finspace(
+        "GET",
+        "/tags/$(resourceArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -147,6 +191,7 @@ function tag_resource(resourceArn, tags; aws_config::AbstractAWSConfig=global_aw
         "/tags/$(resourceArn)",
         Dict{String,Any}("tags" => tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -160,6 +205,7 @@ function tag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tags" => tags), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -183,6 +229,7 @@ function untag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}("tagKeys" => tagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -196,6 +243,7 @@ function untag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tagKeys" => tagKeys), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -220,12 +268,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function update_environment(
     environmentId; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return finspace("PUT", "/environment/$(environmentId)"; aws_config=aws_config)
+    return finspace(
+        "PUT",
+        "/environment/$(environmentId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function update_environment(
     environmentId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return finspace("PUT", "/environment/$(environmentId)", params; aws_config=aws_config)
+    return finspace(
+        "PUT",
+        "/environment/$(environmentId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end

--- a/src/services/finspace_data.jl
+++ b/src/services/finspace_data.jl
@@ -43,6 +43,7 @@ function create_changeset(
             "sourceType" => sourceType,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_changeset(
@@ -68,6 +69,7 @@ function create_changeset(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -92,6 +94,7 @@ function get_programmatic_access_credentials(
         "/credentials/programmatic",
         Dict{String,Any}("environmentId" => environmentId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_programmatic_access_credentials(
@@ -106,6 +109,7 @@ function get_programmatic_access_credentials(
             mergewith(_merge, Dict{String,Any}("environmentId" => environmentId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -125,10 +129,18 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   creation operation.
 """
 function get_working_location(; aws_config::AbstractAWSConfig=global_aws_config())
-    return finspace_data("POST", "/workingLocationV1"; aws_config=aws_config)
+    return finspace_data(
+        "POST", "/workingLocationV1"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_working_location(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return finspace_data("POST", "/workingLocationV1", params; aws_config=aws_config)
+    return finspace_data(
+        "POST",
+        "/workingLocationV1",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end

--- a/src/services/firehose.jl
+++ b/src/services/firehose.jl
@@ -94,6 +94,7 @@ function create_delivery_stream(
         "CreateDeliveryStream",
         Dict{String,Any}("DeliveryStreamName" => DeliveryStreamName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_delivery_stream(
@@ -109,6 +110,7 @@ function create_delivery_stream(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -145,6 +147,7 @@ function delete_delivery_stream(
         "DeleteDeliveryStream",
         Dict{String,Any}("DeliveryStreamName" => DeliveryStreamName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_delivery_stream(
@@ -160,6 +163,7 @@ function delete_delivery_stream(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -192,6 +196,7 @@ function describe_delivery_stream(
         "DescribeDeliveryStream",
         Dict{String,Any}("DeliveryStreamName" => DeliveryStreamName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_delivery_stream(
@@ -207,6 +212,7 @@ function describe_delivery_stream(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -235,12 +241,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"Limit"`: The maximum number of delivery streams to list. The default value is 10.
 """
 function list_delivery_streams(; aws_config::AbstractAWSConfig=global_aws_config())
-    return firehose("ListDeliveryStreams"; aws_config=aws_config)
+    return firehose(
+        "ListDeliveryStreams"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_delivery_streams(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return firehose("ListDeliveryStreams", params; aws_config=aws_config)
+    return firehose(
+        "ListDeliveryStreams",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -269,6 +282,7 @@ function list_tags_for_delivery_stream(
         "ListTagsForDeliveryStream",
         Dict{String,Any}("DeliveryStreamName" => DeliveryStreamName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags_for_delivery_stream(
@@ -284,6 +298,7 @@ function list_tags_for_delivery_stream(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -327,6 +342,7 @@ function put_record(
         "PutRecord",
         Dict{String,Any}("DeliveryStreamName" => DeliveryStreamName, "Record" => Record);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_record(
@@ -347,6 +363,7 @@ function put_record(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -407,6 +424,7 @@ function put_record_batch(
         "PutRecordBatch",
         Dict{String,Any}("DeliveryStreamName" => DeliveryStreamName, "Records" => Records);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_record_batch(
@@ -427,6 +445,7 @@ function put_record_batch(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -479,6 +498,7 @@ function start_delivery_stream_encryption(
         "StartDeliveryStreamEncryption",
         Dict{String,Any}("DeliveryStreamName" => DeliveryStreamName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_delivery_stream_encryption(
@@ -494,6 +514,7 @@ function start_delivery_stream_encryption(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -530,6 +551,7 @@ function stop_delivery_stream_encryption(
         "StopDeliveryStreamEncryption",
         Dict{String,Any}("DeliveryStreamName" => DeliveryStreamName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function stop_delivery_stream_encryption(
@@ -545,6 +567,7 @@ function stop_delivery_stream_encryption(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -573,6 +596,7 @@ function tag_delivery_stream(
         "TagDeliveryStream",
         Dict{String,Any}("DeliveryStreamName" => DeliveryStreamName, "Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_delivery_stream(
@@ -593,6 +617,7 @@ function tag_delivery_stream(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -618,6 +643,7 @@ function untag_delivery_stream(
         "UntagDeliveryStream",
         Dict{String,Any}("DeliveryStreamName" => DeliveryStreamName, "TagKeys" => TagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_delivery_stream(
@@ -638,6 +664,7 @@ function untag_delivery_stream(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -701,6 +728,7 @@ function update_destination(
             "DestinationId" => DestinationId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_destination(
@@ -724,5 +752,6 @@ function update_destination(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/fis.jl
+++ b/src/services/fis.jl
@@ -51,6 +51,7 @@ function create_experiment_template(
             "stopConditions" => stopConditions,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_experiment_template(
@@ -79,6 +80,7 @@ function create_experiment_template(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -93,12 +95,23 @@ Deletes the specified experiment template.
 
 """
 function delete_experiment_template(id; aws_config::AbstractAWSConfig=global_aws_config())
-    return fis("DELETE", "/experimentTemplates/$(id)"; aws_config=aws_config)
+    return fis(
+        "DELETE",
+        "/experimentTemplates/$(id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_experiment_template(
     id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return fis("DELETE", "/experimentTemplates/$(id)", params; aws_config=aws_config)
+    return fis(
+        "DELETE",
+        "/experimentTemplates/$(id)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -112,12 +125,20 @@ Gets information about the specified AWS FIS action.
 
 """
 function get_action(id; aws_config::AbstractAWSConfig=global_aws_config())
-    return fis("GET", "/actions/$(id)"; aws_config=aws_config)
+    return fis(
+        "GET", "/actions/$(id)"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_action(
     id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return fis("GET", "/actions/$(id)", params; aws_config=aws_config)
+    return fis(
+        "GET",
+        "/actions/$(id)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -131,12 +152,20 @@ Gets information about the specified experiment.
 
 """
 function get_experiment(id; aws_config::AbstractAWSConfig=global_aws_config())
-    return fis("GET", "/experiments/$(id)"; aws_config=aws_config)
+    return fis(
+        "GET", "/experiments/$(id)"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_experiment(
     id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return fis("GET", "/experiments/$(id)", params; aws_config=aws_config)
+    return fis(
+        "GET",
+        "/experiments/$(id)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -150,12 +179,23 @@ Gets information about the specified experiment template.
 
 """
 function get_experiment_template(id; aws_config::AbstractAWSConfig=global_aws_config())
-    return fis("GET", "/experimentTemplates/$(id)"; aws_config=aws_config)
+    return fis(
+        "GET",
+        "/experimentTemplates/$(id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_experiment_template(
     id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return fis("GET", "/experimentTemplates/$(id)", params; aws_config=aws_config)
+    return fis(
+        "GET",
+        "/experimentTemplates/$(id)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -171,12 +211,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: The token for the next page of results.
 """
 function list_actions(; aws_config::AbstractAWSConfig=global_aws_config())
-    return fis("GET", "/actions"; aws_config=aws_config)
+    return fis("GET", "/actions"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_actions(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return fis("GET", "/actions", params; aws_config=aws_config)
+    return fis(
+        "GET", "/actions", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -192,12 +234,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: The token for the next page of results.
 """
 function list_experiment_templates(; aws_config::AbstractAWSConfig=global_aws_config())
-    return fis("GET", "/experimentTemplates"; aws_config=aws_config)
+    return fis(
+        "GET",
+        "/experimentTemplates";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_experiment_templates(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return fis("GET", "/experimentTemplates", params; aws_config=aws_config)
+    return fis(
+        "GET",
+        "/experimentTemplates",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -213,12 +266,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: The token for the next page of results.
 """
 function list_experiments(; aws_config::AbstractAWSConfig=global_aws_config())
-    return fis("GET", "/experiments"; aws_config=aws_config)
+    return fis(
+        "GET", "/experiments"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_experiments(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return fis("GET", "/experiments", params; aws_config=aws_config)
+    return fis(
+        "GET",
+        "/experiments",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -234,14 +295,25 @@ Lists the tags for the specified resource.
 function list_tags_for_resource(
     resourceArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return fis("GET", "/tags/$(resourceArn)"; aws_config=aws_config)
+    return fis(
+        "GET",
+        "/tags/$(resourceArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_tags_for_resource(
     resourceArn,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return fis("GET", "/tags/$(resourceArn)", params; aws_config=aws_config)
+    return fis(
+        "GET",
+        "/tags/$(resourceArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -269,6 +341,7 @@ function start_experiment(
             "clientToken" => clientToken, "experimentTemplateId" => experimentTemplateId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_experiment(
@@ -291,6 +364,7 @@ function start_experiment(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -305,12 +379,23 @@ Stops the specified experiment.
 
 """
 function stop_experiment(id; aws_config::AbstractAWSConfig=global_aws_config())
-    return fis("DELETE", "/experiments/$(id)"; aws_config=aws_config)
+    return fis(
+        "DELETE",
+        "/experiments/$(id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function stop_experiment(
     id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return fis("DELETE", "/experiments/$(id)", params; aws_config=aws_config)
+    return fis(
+        "DELETE",
+        "/experiments/$(id)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -330,6 +415,7 @@ function tag_resource(resourceArn, tags; aws_config::AbstractAWSConfig=global_aw
         "/tags/$(resourceArn)",
         Dict{String,Any}("tags" => tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -343,6 +429,7 @@ function tag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tags" => tags), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -360,14 +447,25 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"tagKeys"`: The tag keys to remove.
 """
 function untag_resource(resourceArn; aws_config::AbstractAWSConfig=global_aws_config())
-    return fis("DELETE", "/tags/$(resourceArn)"; aws_config=aws_config)
+    return fis(
+        "DELETE",
+        "/tags/$(resourceArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function untag_resource(
     resourceArn,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return fis("DELETE", "/tags/$(resourceArn)", params; aws_config=aws_config)
+    return fis(
+        "DELETE",
+        "/tags/$(resourceArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -389,10 +487,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"targets"`: The targets for the experiment.
 """
 function update_experiment_template(id; aws_config::AbstractAWSConfig=global_aws_config())
-    return fis("PATCH", "/experimentTemplates/$(id)"; aws_config=aws_config)
+    return fis(
+        "PATCH",
+        "/experimentTemplates/$(id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function update_experiment_template(
     id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return fis("PATCH", "/experimentTemplates/$(id)", params; aws_config=aws_config)
+    return fis(
+        "PATCH",
+        "/experimentTemplates/$(id)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end

--- a/src/services/fms.jl
+++ b/src/services/fms.jl
@@ -28,6 +28,7 @@ function associate_admin_account(
         "AssociateAdminAccount",
         Dict{String,Any}("AdminAccount" => AdminAccount);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_admin_account(
@@ -41,6 +42,7 @@ function associate_admin_account(
             mergewith(_merge, Dict{String,Any}("AdminAccount" => AdminAccount), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -57,7 +59,10 @@ Permanently deletes an Firewall Manager applications list.
 """
 function delete_apps_list(ListId; aws_config::AbstractAWSConfig=global_aws_config())
     return fms(
-        "DeleteAppsList", Dict{String,Any}("ListId" => ListId); aws_config=aws_config
+        "DeleteAppsList",
+        Dict{String,Any}("ListId" => ListId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_apps_list(
@@ -67,6 +72,7 @@ function delete_apps_list(
         "DeleteAppsList",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("ListId" => ListId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -79,12 +85,19 @@ Notification Service (SNS) topic that is used to record Firewall Manager SNS log
 
 """
 function delete_notification_channel(; aws_config::AbstractAWSConfig=global_aws_config())
-    return fms("DeleteNotificationChannel"; aws_config=aws_config)
+    return fms(
+        "DeleteNotificationChannel"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function delete_notification_channel(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return fms("DeleteNotificationChannel", params; aws_config=aws_config)
+    return fms(
+        "DeleteNotificationChannel",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -115,7 +128,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function delete_policy(PolicyId; aws_config::AbstractAWSConfig=global_aws_config())
     return fms(
-        "DeletePolicy", Dict{String,Any}("PolicyId" => PolicyId); aws_config=aws_config
+        "DeletePolicy",
+        Dict{String,Any}("PolicyId" => PolicyId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_policy(
@@ -129,6 +145,7 @@ function delete_policy(
             mergewith(_merge, Dict{String,Any}("PolicyId" => PolicyId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -145,7 +162,10 @@ Permanently deletes an Firewall Manager protocols list.
 """
 function delete_protocols_list(ListId; aws_config::AbstractAWSConfig=global_aws_config())
     return fms(
-        "DeleteProtocolsList", Dict{String,Any}("ListId" => ListId); aws_config=aws_config
+        "DeleteProtocolsList",
+        Dict{String,Any}("ListId" => ListId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_protocols_list(
@@ -155,6 +175,7 @@ function delete_protocols_list(
         "DeleteProtocolsList",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("ListId" => ListId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -168,12 +189,19 @@ AssociateAdminAccount request.
 
 """
 function disassociate_admin_account(; aws_config::AbstractAWSConfig=global_aws_config())
-    return fms("DisassociateAdminAccount"; aws_config=aws_config)
+    return fms(
+        "DisassociateAdminAccount"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function disassociate_admin_account(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return fms("DisassociateAdminAccount", params; aws_config=aws_config)
+    return fms(
+        "DisassociateAdminAccount",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -185,12 +213,14 @@ Manager administrator.
 
 """
 function get_admin_account(; aws_config::AbstractAWSConfig=global_aws_config())
-    return fms("GetAdminAccount"; aws_config=aws_config)
+    return fms("GetAdminAccount"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function get_admin_account(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return fms("GetAdminAccount", params; aws_config=aws_config)
+    return fms(
+        "GetAdminAccount", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -208,7 +238,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Firewall Manager.
 """
 function get_apps_list(ListId; aws_config::AbstractAWSConfig=global_aws_config())
-    return fms("GetAppsList", Dict{String,Any}("ListId" => ListId); aws_config=aws_config)
+    return fms(
+        "GetAppsList",
+        Dict{String,Any}("ListId" => ListId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_apps_list(
     ListId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -217,6 +252,7 @@ function get_apps_list(
         "GetAppsList",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("ListId" => ListId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -251,6 +287,7 @@ function get_compliance_detail(
         "GetComplianceDetail",
         Dict{String,Any}("MemberAccount" => MemberAccount, "PolicyId" => PolicyId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_compliance_detail(
@@ -269,6 +306,7 @@ function get_compliance_detail(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -281,12 +319,19 @@ Firewall Manager SNS logs.
 
 """
 function get_notification_channel(; aws_config::AbstractAWSConfig=global_aws_config())
-    return fms("GetNotificationChannel"; aws_config=aws_config)
+    return fms(
+        "GetNotificationChannel"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_notification_channel(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return fms("GetNotificationChannel", params; aws_config=aws_config)
+    return fms(
+        "GetNotificationChannel",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -300,7 +345,12 @@ Returns information about the specified Firewall Manager policy.
 
 """
 function get_policy(PolicyId; aws_config::AbstractAWSConfig=global_aws_config())
-    return fms("GetPolicy", Dict{String,Any}("PolicyId" => PolicyId); aws_config=aws_config)
+    return fms(
+        "GetPolicy",
+        Dict{String,Any}("PolicyId" => PolicyId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_policy(
     PolicyId,
@@ -313,6 +363,7 @@ function get_policy(
             mergewith(_merge, Dict{String,Any}("PolicyId" => PolicyId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -350,6 +401,7 @@ function get_protection_status(PolicyId; aws_config::AbstractAWSConfig=global_aw
         "GetProtectionStatus",
         Dict{String,Any}("PolicyId" => PolicyId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_protection_status(
@@ -363,6 +415,7 @@ function get_protection_status(
             mergewith(_merge, Dict{String,Any}("PolicyId" => PolicyId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -382,7 +435,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function get_protocols_list(ListId; aws_config::AbstractAWSConfig=global_aws_config())
     return fms(
-        "GetProtocolsList", Dict{String,Any}("ListId" => ListId); aws_config=aws_config
+        "GetProtocolsList",
+        Dict{String,Any}("ListId" => ListId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_protocols_list(
@@ -392,6 +448,7 @@ function get_protocols_list(
         "GetProtocolsList",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("ListId" => ListId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -429,6 +486,7 @@ function get_violation_details(
             "ResourceType" => ResourceType,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_violation_details(
@@ -454,6 +512,7 @@ function get_violation_details(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -480,7 +539,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function list_apps_lists(MaxResults; aws_config::AbstractAWSConfig=global_aws_config())
     return fms(
-        "ListAppsLists", Dict{String,Any}("MaxResults" => MaxResults); aws_config=aws_config
+        "ListAppsLists",
+        Dict{String,Any}("MaxResults" => MaxResults);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_apps_lists(
@@ -494,6 +556,7 @@ function list_apps_lists(
             mergewith(_merge, Dict{String,Any}("MaxResults" => MaxResults), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -525,6 +588,7 @@ function list_compliance_status(PolicyId; aws_config::AbstractAWSConfig=global_a
         "ListComplianceStatus",
         Dict{String,Any}("PolicyId" => PolicyId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_compliance_status(
@@ -538,6 +602,7 @@ function list_compliance_status(
             mergewith(_merge, Dict{String,Any}("PolicyId" => PolicyId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -562,12 +627,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   response to get information about another batch of member account IDs.
 """
 function list_member_accounts(; aws_config::AbstractAWSConfig=global_aws_config())
-    return fms("ListMemberAccounts"; aws_config=aws_config)
+    return fms("ListMemberAccounts"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_member_accounts(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return fms("ListMemberAccounts", params; aws_config=aws_config)
+    return fms(
+        "ListMemberAccounts", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -590,12 +657,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   PolicySummary objects.
 """
 function list_policies(; aws_config::AbstractAWSConfig=global_aws_config())
-    return fms("ListPolicies"; aws_config=aws_config)
+    return fms("ListPolicies"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_policies(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return fms("ListPolicies", params; aws_config=aws_config)
+    return fms(
+        "ListPolicies", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -624,6 +693,7 @@ function list_protocols_lists(MaxResults; aws_config::AbstractAWSConfig=global_a
         "ListProtocolsLists",
         Dict{String,Any}("MaxResults" => MaxResults);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_protocols_lists(
@@ -637,6 +707,7 @@ function list_protocols_lists(
             mergewith(_merge, Dict{String,Any}("MaxResults" => MaxResults), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -659,6 +730,7 @@ function list_tags_for_resource(
         "ListTagsForResource",
         Dict{String,Any}("ResourceArn" => ResourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags_for_resource(
@@ -672,6 +744,7 @@ function list_tags_for_resource(
             mergewith(_merge, Dict{String,Any}("ResourceArn" => ResourceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -690,7 +763,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function put_apps_list(AppsList; aws_config::AbstractAWSConfig=global_aws_config())
     return fms(
-        "PutAppsList", Dict{String,Any}("AppsList" => AppsList); aws_config=aws_config
+        "PutAppsList",
+        Dict{String,Any}("AppsList" => AppsList);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_apps_list(
@@ -704,6 +780,7 @@ function put_apps_list(
             mergewith(_merge, Dict{String,Any}("AppsList" => AppsList), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -731,6 +808,7 @@ function put_notification_channel(
         "PutNotificationChannel",
         Dict{String,Any}("SnsRoleName" => SnsRoleName, "SnsTopicArn" => SnsTopicArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_notification_channel(
@@ -751,6 +829,7 @@ function put_notification_channel(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -780,7 +859,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"TagList"`: The tags to add to the Amazon Web Services resource.
 """
 function put_policy(Policy; aws_config::AbstractAWSConfig=global_aws_config())
-    return fms("PutPolicy", Dict{String,Any}("Policy" => Policy); aws_config=aws_config)
+    return fms(
+        "PutPolicy",
+        Dict{String,Any}("Policy" => Policy);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function put_policy(
     Policy, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -789,6 +873,7 @@ function put_policy(
         "PutPolicy",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Policy" => Policy), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -812,6 +897,7 @@ function put_protocols_list(
         "PutProtocolsList",
         Dict{String,Any}("ProtocolsList" => ProtocolsList);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_protocols_list(
@@ -825,6 +911,7 @@ function put_protocols_list(
             mergewith(_merge, Dict{String,Any}("ProtocolsList" => ProtocolsList), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -848,6 +935,7 @@ function tag_resource(
         "TagResource",
         Dict{String,Any}("ResourceArn" => ResourceArn, "TagList" => TagList);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -866,6 +954,7 @@ function tag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -889,6 +978,7 @@ function untag_resource(
         "UntagResource",
         Dict{String,Any}("ResourceArn" => ResourceArn, "TagKeys" => TagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -907,5 +997,6 @@ function untag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/forecast.jl
+++ b/src/services/forecast.jl
@@ -78,6 +78,7 @@ function create_dataset(
             "Schema" => Schema,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_dataset(
@@ -103,6 +104,7 @@ function create_dataset(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -156,6 +158,7 @@ function create_dataset_group(
         "CreateDatasetGroup",
         Dict{String,Any}("DatasetGroupName" => DatasetGroupName, "Domain" => Domain);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_dataset_group(
@@ -176,6 +179,7 @@ function create_dataset_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -261,6 +265,7 @@ function create_dataset_import_job(
             "DatasetImportJobName" => DatasetImportJobName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_dataset_import_job(
@@ -284,6 +289,7 @@ function create_dataset_import_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -337,6 +343,7 @@ function create_forecast(
         "CreateForecast",
         Dict{String,Any}("ForecastName" => ForecastName, "PredictorArn" => PredictorArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_forecast(
@@ -357,6 +364,7 @@ function create_forecast(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -416,6 +424,7 @@ function create_forecast_export_job(
             "ForecastExportJobName" => ForecastExportJobName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_forecast_export_job(
@@ -439,6 +448,7 @@ function create_forecast_export_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -560,6 +570,7 @@ function create_predictor(
             "PredictorName" => PredictorName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_predictor(
@@ -585,6 +596,7 @@ function create_predictor(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -638,6 +650,7 @@ function create_predictor_backtest_export_job(
             "PredictorBacktestExportJobName" => PredictorBacktestExportJobName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_predictor_backtest_export_job(
@@ -661,6 +674,7 @@ function create_predictor_backtest_export_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -680,7 +694,10 @@ operation, omitting the deleted dataset's ARN.
 """
 function delete_dataset(DatasetArn; aws_config::AbstractAWSConfig=global_aws_config())
     return forecast(
-        "DeleteDataset", Dict{String,Any}("DatasetArn" => DatasetArn); aws_config=aws_config
+        "DeleteDataset",
+        Dict{String,Any}("DatasetArn" => DatasetArn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_dataset(
@@ -694,6 +711,7 @@ function delete_dataset(
             mergewith(_merge, Dict{String,Any}("DatasetArn" => DatasetArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -717,6 +735,7 @@ function delete_dataset_group(
         "DeleteDatasetGroup",
         Dict{String,Any}("DatasetGroupArn" => DatasetGroupArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_dataset_group(
@@ -732,6 +751,7 @@ function delete_dataset_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -755,6 +775,7 @@ function delete_dataset_import_job(
         "DeleteDatasetImportJob",
         Dict{String,Any}("DatasetImportJobArn" => DatasetImportJobArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_dataset_import_job(
@@ -772,6 +793,7 @@ function delete_dataset_import_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -793,6 +815,7 @@ function delete_forecast(ForecastArn; aws_config::AbstractAWSConfig=global_aws_c
         "DeleteForecast",
         Dict{String,Any}("ForecastArn" => ForecastArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_forecast(
@@ -806,6 +829,7 @@ function delete_forecast(
             mergewith(_merge, Dict{String,Any}("ForecastArn" => ForecastArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -829,6 +853,7 @@ function delete_forecast_export_job(
         "DeleteForecastExportJob",
         Dict{String,Any}("ForecastExportJobArn" => ForecastExportJobArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_forecast_export_job(
@@ -846,6 +871,7 @@ function delete_forecast_export_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -866,6 +892,7 @@ function delete_predictor(PredictorArn; aws_config::AbstractAWSConfig=global_aws
         "DeletePredictor",
         Dict{String,Any}("PredictorArn" => PredictorArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_predictor(
@@ -879,6 +906,7 @@ function delete_predictor(
             mergewith(_merge, Dict{String,Any}("PredictorArn" => PredictorArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -900,6 +928,7 @@ function delete_predictor_backtest_export_job(
         "DeletePredictorBacktestExportJob",
         Dict{String,Any}("PredictorBacktestExportJobArn" => PredictorBacktestExportJobArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_predictor_backtest_export_job(
@@ -919,6 +948,7 @@ function delete_predictor_backtest_export_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -948,6 +978,7 @@ function delete_resource_tree(
         "DeleteResourceTree",
         Dict{String,Any}("ResourceArn" => ResourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_resource_tree(
@@ -961,6 +992,7 @@ function delete_resource_tree(
             mergewith(_merge, Dict{String,Any}("ResourceArn" => ResourceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -981,6 +1013,7 @@ function describe_dataset(DatasetArn; aws_config::AbstractAWSConfig=global_aws_c
         "DescribeDataset",
         Dict{String,Any}("DatasetArn" => DatasetArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_dataset(
@@ -994,6 +1027,7 @@ function describe_dataset(
             mergewith(_merge, Dict{String,Any}("DatasetArn" => DatasetArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1017,6 +1051,7 @@ function describe_dataset_group(
         "DescribeDatasetGroup",
         Dict{String,Any}("DatasetGroupArn" => DatasetGroupArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_dataset_group(
@@ -1032,6 +1067,7 @@ function describe_dataset_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1056,6 +1092,7 @@ function describe_dataset_import_job(
         "DescribeDatasetImportJob",
         Dict{String,Any}("DatasetImportJobArn" => DatasetImportJobArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_dataset_import_job(
@@ -1073,6 +1110,7 @@ function describe_dataset_import_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1095,6 +1133,7 @@ function describe_forecast(ForecastArn; aws_config::AbstractAWSConfig=global_aws
         "DescribeForecast",
         Dict{String,Any}("ForecastArn" => ForecastArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_forecast(
@@ -1108,6 +1147,7 @@ function describe_forecast(
             mergewith(_merge, Dict{String,Any}("ForecastArn" => ForecastArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1132,6 +1172,7 @@ function describe_forecast_export_job(
         "DescribeForecastExportJob",
         Dict{String,Any}("ForecastExportJobArn" => ForecastExportJobArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_forecast_export_job(
@@ -1149,6 +1190,7 @@ function describe_forecast_export_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1173,6 +1215,7 @@ function describe_predictor(PredictorArn; aws_config::AbstractAWSConfig=global_a
         "DescribePredictor",
         Dict{String,Any}("PredictorArn" => PredictorArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_predictor(
@@ -1186,6 +1229,7 @@ function describe_predictor(
             mergewith(_merge, Dict{String,Any}("PredictorArn" => PredictorArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1211,6 +1255,7 @@ function describe_predictor_backtest_export_job(
         "DescribePredictorBacktestExportJob",
         Dict{String,Any}("PredictorBacktestExportJobArn" => PredictorBacktestExportJobArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_predictor_backtest_export_job(
@@ -1230,6 +1275,7 @@ function describe_predictor_backtest_export_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1261,6 +1307,7 @@ function get_accuracy_metrics(
         "GetAccuracyMetrics",
         Dict{String,Any}("PredictorArn" => PredictorArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_accuracy_metrics(
@@ -1274,6 +1321,7 @@ function get_accuracy_metrics(
             mergewith(_merge, Dict{String,Any}("PredictorArn" => PredictorArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1294,12 +1342,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   expire after 24 hours.
 """
 function list_dataset_groups(; aws_config::AbstractAWSConfig=global_aws_config())
-    return forecast("ListDatasetGroups"; aws_config=aws_config)
+    return forecast(
+        "ListDatasetGroups"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_dataset_groups(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return forecast("ListDatasetGroups", params; aws_config=aws_config)
+    return forecast(
+        "ListDatasetGroups", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1330,12 +1382,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   expire after 24 hours.
 """
 function list_dataset_import_jobs(; aws_config::AbstractAWSConfig=global_aws_config())
-    return forecast("ListDatasetImportJobs"; aws_config=aws_config)
+    return forecast(
+        "ListDatasetImportJobs"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_dataset_import_jobs(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return forecast("ListDatasetImportJobs", params; aws_config=aws_config)
+    return forecast(
+        "ListDatasetImportJobs",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1354,12 +1413,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   expire after 24 hours.
 """
 function list_datasets(; aws_config::AbstractAWSConfig=global_aws_config())
-    return forecast("ListDatasets"; aws_config=aws_config)
+    return forecast("ListDatasets"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_datasets(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return forecast("ListDatasets", params; aws_config=aws_config)
+    return forecast(
+        "ListDatasets", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1391,12 +1452,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   expire after 24 hours.
 """
 function list_forecast_export_jobs(; aws_config::AbstractAWSConfig=global_aws_config())
-    return forecast("ListForecastExportJobs"; aws_config=aws_config)
+    return forecast(
+        "ListForecastExportJobs"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_forecast_export_jobs(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return forecast("ListForecastExportJobs", params; aws_config=aws_config)
+    return forecast(
+        "ListForecastExportJobs",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1426,12 +1494,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   expire after 24 hours.
 """
 function list_forecasts(; aws_config::AbstractAWSConfig=global_aws_config())
-    return forecast("ListForecasts"; aws_config=aws_config)
+    return forecast("ListForecasts"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_forecasts(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return forecast("ListForecasts", params; aws_config=aws_config)
+    return forecast(
+        "ListForecasts", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1462,12 +1532,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function list_predictor_backtest_export_jobs(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return forecast("ListPredictorBacktestExportJobs"; aws_config=aws_config)
+    return forecast(
+        "ListPredictorBacktestExportJobs";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_predictor_backtest_export_jobs(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return forecast("ListPredictorBacktestExportJobs", params; aws_config=aws_config)
+    return forecast(
+        "ListPredictorBacktestExportJobs",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1497,12 +1576,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   expire after 24 hours.
 """
 function list_predictors(; aws_config::AbstractAWSConfig=global_aws_config())
-    return forecast("ListPredictors"; aws_config=aws_config)
+    return forecast(
+        "ListPredictors"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_predictors(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return forecast("ListPredictors", params; aws_config=aws_config)
+    return forecast(
+        "ListPredictors", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1524,6 +1607,7 @@ function list_tags_for_resource(
         "ListTagsForResource",
         Dict{String,Any}("ResourceArn" => ResourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags_for_resource(
@@ -1537,6 +1621,7 @@ function list_tags_for_resource(
             mergewith(_merge, Dict{String,Any}("ResourceArn" => ResourceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1561,6 +1646,7 @@ function stop_resource(ResourceArn; aws_config::AbstractAWSConfig=global_aws_con
         "StopResource",
         Dict{String,Any}("ResourceArn" => ResourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function stop_resource(
@@ -1574,6 +1660,7 @@ function stop_resource(
             mergewith(_merge, Dict{String,Any}("ResourceArn" => ResourceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1609,6 +1696,7 @@ function tag_resource(ResourceArn, Tags; aws_config::AbstractAWSConfig=global_aw
         "TagResource",
         Dict{String,Any}("ResourceArn" => ResourceArn, "Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -1627,6 +1715,7 @@ function tag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1650,6 +1739,7 @@ function untag_resource(
         "UntagResource",
         Dict{String,Any}("ResourceArn" => ResourceArn, "TagKeys" => TagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -1668,6 +1758,7 @@ function untag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1694,6 +1785,7 @@ function update_dataset_group(
             "DatasetArns" => DatasetArns, "DatasetGroupArn" => DatasetGroupArn
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_dataset_group(
@@ -1714,5 +1806,6 @@ function update_dataset_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/forecastquery.jl
+++ b/src/services/forecastquery.jl
@@ -40,6 +40,7 @@ function query_forecast(
         "QueryForecast",
         Dict{String,Any}("Filters" => Filters, "ForecastArn" => ForecastArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function query_forecast(
@@ -58,5 +59,6 @@ function query_forecast(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/frauddetector.jl
+++ b/src/services/frauddetector.jl
@@ -24,6 +24,7 @@ function batch_create_variable(
         "BatchCreateVariable",
         Dict{String,Any}("variableEntries" => variableEntries);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_create_variable(
@@ -39,6 +40,7 @@ function batch_create_variable(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -54,7 +56,10 @@ Gets a batch of variables.
 """
 function batch_get_variable(names; aws_config::AbstractAWSConfig=global_aws_config())
     return frauddetector(
-        "BatchGetVariable", Dict{String,Any}("names" => names); aws_config=aws_config
+        "BatchGetVariable",
+        Dict{String,Any}("names" => names);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_get_variable(
@@ -64,6 +69,7 @@ function batch_get_variable(
         "BatchGetVariable",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("names" => names), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -84,6 +90,7 @@ function cancel_batch_prediction_job(
         "CancelBatchPredictionJob",
         Dict{String,Any}("jobId" => jobId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function cancel_batch_prediction_job(
@@ -93,6 +100,7 @@ function cancel_batch_prediction_job(
         "CancelBatchPredictionJob",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("jobId" => jobId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -135,6 +143,7 @@ function create_batch_prediction_job(
             "outputPath" => outputPath,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_batch_prediction_job(
@@ -164,6 +173,7 @@ function create_batch_prediction_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -199,6 +209,7 @@ function create_detector_version(
         "CreateDetectorVersion",
         Dict{String,Any}("detectorId" => detectorId, "rules" => rules);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_detector_version(
@@ -217,6 +228,7 @@ function create_detector_version(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -245,6 +257,7 @@ function create_model(
             "eventTypeName" => eventTypeName, "modelId" => modelId, "modelType" => modelType
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_model(
@@ -268,6 +281,7 @@ function create_model(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -305,6 +319,7 @@ function create_model_version(
             "trainingDataSource" => trainingDataSource,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_model_version(
@@ -330,6 +345,7 @@ function create_model_version(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -369,6 +385,7 @@ function create_rule(
             "ruleId" => ruleId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_rule(
@@ -396,6 +413,7 @@ function create_rule(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -439,6 +457,7 @@ function create_variable(
             "name" => name,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_variable(
@@ -464,6 +483,7 @@ function create_variable(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -484,6 +504,7 @@ function delete_batch_prediction_job(
         "DeleteBatchPredictionJob",
         Dict{String,Any}("jobId" => jobId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_batch_prediction_job(
@@ -493,6 +514,7 @@ function delete_batch_prediction_job(
         "DeleteBatchPredictionJob",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("jobId" => jobId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -514,6 +536,7 @@ function delete_detector(detectorId; aws_config::AbstractAWSConfig=global_aws_co
         "DeleteDetector",
         Dict{String,Any}("detectorId" => detectorId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_detector(
@@ -527,6 +550,7 @@ function delete_detector(
             mergewith(_merge, Dict{String,Any}("detectorId" => detectorId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -552,6 +576,7 @@ function delete_detector_version(
             "detectorId" => detectorId, "detectorVersionId" => detectorVersionId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_detector_version(
@@ -572,6 +597,7 @@ function delete_detector_version(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -589,7 +615,10 @@ and the data is no longer stored in Amazon Fraud Detector.
 """
 function delete_entity_type(name; aws_config::AbstractAWSConfig=global_aws_config())
     return frauddetector(
-        "DeleteEntityType", Dict{String,Any}("name" => name); aws_config=aws_config
+        "DeleteEntityType",
+        Dict{String,Any}("name" => name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_entity_type(
@@ -599,6 +628,7 @@ function delete_entity_type(
         "DeleteEntityType",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("name" => name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -621,6 +651,7 @@ function delete_event(
         "DeleteEvent",
         Dict{String,Any}("eventId" => eventId, "eventTypeName" => eventTypeName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_event(
@@ -639,6 +670,7 @@ function delete_event(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -656,7 +688,10 @@ entity type and the data is no longer stored in Amazon Fraud Detector.
 """
 function delete_event_type(name; aws_config::AbstractAWSConfig=global_aws_config())
     return frauddetector(
-        "DeleteEventType", Dict{String,Any}("name" => name); aws_config=aws_config
+        "DeleteEventType",
+        Dict{String,Any}("name" => name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_event_type(
@@ -666,6 +701,7 @@ function delete_event_type(
         "DeleteEventType",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("name" => name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -688,6 +724,7 @@ function delete_external_model(
         "DeleteExternalModel",
         Dict{String,Any}("modelEndpoint" => modelEndpoint);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_external_model(
@@ -701,6 +738,7 @@ function delete_external_model(
             mergewith(_merge, Dict{String,Any}("modelEndpoint" => modelEndpoint), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -719,7 +757,10 @@ that label and the data is no longer stored in Amazon Fraud Detector.
 """
 function delete_label(name; aws_config::AbstractAWSConfig=global_aws_config())
     return frauddetector(
-        "DeleteLabel", Dict{String,Any}("name" => name); aws_config=aws_config
+        "DeleteLabel",
+        Dict{String,Any}("name" => name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_label(
@@ -729,6 +770,7 @@ function delete_label(
         "DeleteLabel",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("name" => name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -751,6 +793,7 @@ function delete_model(modelId, modelType; aws_config::AbstractAWSConfig=global_a
         "DeleteModel",
         Dict{String,Any}("modelId" => modelId, "modelType" => modelType);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_model(
@@ -769,6 +812,7 @@ function delete_model(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -801,6 +845,7 @@ function delete_model_version(
             "modelVersionNumber" => modelVersionNumber,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_model_version(
@@ -824,6 +869,7 @@ function delete_model_version(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -841,7 +887,10 @@ no longer stored in Amazon Fraud Detector.
 """
 function delete_outcome(name; aws_config::AbstractAWSConfig=global_aws_config())
     return frauddetector(
-        "DeleteOutcome", Dict{String,Any}("name" => name); aws_config=aws_config
+        "DeleteOutcome",
+        Dict{String,Any}("name" => name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_outcome(
@@ -851,6 +900,7 @@ function delete_outcome(
         "DeleteOutcome",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("name" => name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -868,7 +918,10 @@ the data is no longer stored in Amazon Fraud Detector.
 """
 function delete_rule(rule; aws_config::AbstractAWSConfig=global_aws_config())
     return frauddetector(
-        "DeleteRule", Dict{String,Any}("rule" => rule); aws_config=aws_config
+        "DeleteRule",
+        Dict{String,Any}("rule" => rule);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_rule(
@@ -878,6 +931,7 @@ function delete_rule(
         "DeleteRule",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("rule" => rule), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -897,7 +951,10 @@ that variable and the data is no longer stored in Amazon Fraud Detector.
 """
 function delete_variable(name; aws_config::AbstractAWSConfig=global_aws_config())
     return frauddetector(
-        "DeleteVariable", Dict{String,Any}("name" => name); aws_config=aws_config
+        "DeleteVariable",
+        Dict{String,Any}("name" => name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_variable(
@@ -907,6 +964,7 @@ function delete_variable(
         "DeleteVariable",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("name" => name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -929,6 +987,7 @@ function describe_detector(detectorId; aws_config::AbstractAWSConfig=global_aws_
         "DescribeDetector",
         Dict{String,Any}("detectorId" => detectorId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_detector(
@@ -942,6 +1001,7 @@ function describe_detector(
             mergewith(_merge, Dict{String,Any}("detectorId" => detectorId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -961,12 +1021,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: The next token from the previous results.
 """
 function describe_model_versions(; aws_config::AbstractAWSConfig=global_aws_config())
-    return frauddetector("DescribeModelVersions"; aws_config=aws_config)
+    return frauddetector(
+        "DescribeModelVersions"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_model_versions(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return frauddetector("DescribeModelVersions", params; aws_config=aws_config)
+    return frauddetector(
+        "DescribeModelVersions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -986,12 +1053,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: The next token from the previous request.
 """
 function get_batch_prediction_jobs(; aws_config::AbstractAWSConfig=global_aws_config())
-    return frauddetector("GetBatchPredictionJobs"; aws_config=aws_config)
+    return frauddetector(
+        "GetBatchPredictionJobs"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_batch_prediction_jobs(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return frauddetector("GetBatchPredictionJobs", params; aws_config=aws_config)
+    return frauddetector(
+        "GetBatchPredictionJobs",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1014,6 +1088,7 @@ function get_detector_version(
             "detectorId" => detectorId, "detectorVersionId" => detectorVersionId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_detector_version(
@@ -1034,6 +1109,7 @@ function get_detector_version(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1054,12 +1130,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: The next token for the subsequent request.
 """
 function get_detectors(; aws_config::AbstractAWSConfig=global_aws_config())
-    return frauddetector("GetDetectors"; aws_config=aws_config)
+    return frauddetector(
+        "GetDetectors"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_detectors(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return frauddetector("GetDetectors", params; aws_config=aws_config)
+    return frauddetector(
+        "GetDetectors", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1079,12 +1159,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: The next token for the subsequent request.
 """
 function get_entity_types(; aws_config::AbstractAWSConfig=global_aws_config())
-    return frauddetector("GetEntityTypes"; aws_config=aws_config)
+    return frauddetector(
+        "GetEntityTypes"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_entity_types(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return frauddetector("GetEntityTypes", params; aws_config=aws_config)
+    return frauddetector(
+        "GetEntityTypes", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1143,6 +1227,7 @@ function get_event_prediction(
             "eventVariables" => eventVariables,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_event_prediction(
@@ -1172,6 +1257,7 @@ function get_event_prediction(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1192,12 +1278,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: The next token for the subsequent request.
 """
 function get_event_types(; aws_config::AbstractAWSConfig=global_aws_config())
-    return frauddetector("GetEventTypes"; aws_config=aws_config)
+    return frauddetector(
+        "GetEventTypes"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_event_types(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return frauddetector("GetEventTypes", params; aws_config=aws_config)
+    return frauddetector(
+        "GetEventTypes", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1218,12 +1308,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: The next page token for the request.
 """
 function get_external_models(; aws_config::AbstractAWSConfig=global_aws_config())
-    return frauddetector("GetExternalModels"; aws_config=aws_config)
+    return frauddetector(
+        "GetExternalModels"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_external_models(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return frauddetector("GetExternalModels", params; aws_config=aws_config)
+    return frauddetector(
+        "GetExternalModels", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1235,12 +1329,19 @@ been specified to be used to encrypt content in Amazon Fraud Detector.
 
 """
 function get_kmsencryption_key(; aws_config::AbstractAWSConfig=global_aws_config())
-    return frauddetector("GetKMSEncryptionKey"; aws_config=aws_config)
+    return frauddetector(
+        "GetKMSEncryptionKey"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_kmsencryption_key(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return frauddetector("GetKMSEncryptionKey", params; aws_config=aws_config)
+    return frauddetector(
+        "GetKMSEncryptionKey",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1260,12 +1361,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: The next token for the subsequent request.
 """
 function get_labels(; aws_config::AbstractAWSConfig=global_aws_config())
-    return frauddetector("GetLabels"; aws_config=aws_config)
+    return frauddetector(
+        "GetLabels"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_labels(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return frauddetector("GetLabels", params; aws_config=aws_config)
+    return frauddetector(
+        "GetLabels", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1294,6 +1399,7 @@ function get_model_version(
             "modelVersionNumber" => modelVersionNumber,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_model_version(
@@ -1317,6 +1423,7 @@ function get_model_version(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1341,12 +1448,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: The next token for the subsequent request.
 """
 function get_models(; aws_config::AbstractAWSConfig=global_aws_config())
-    return frauddetector("GetModels"; aws_config=aws_config)
+    return frauddetector(
+        "GetModels"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_models(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return frauddetector("GetModels", params; aws_config=aws_config)
+    return frauddetector(
+        "GetModels", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1366,12 +1477,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: The next page token for the request.
 """
 function get_outcomes(; aws_config::AbstractAWSConfig=global_aws_config())
-    return frauddetector("GetOutcomes"; aws_config=aws_config)
+    return frauddetector(
+        "GetOutcomes"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_outcomes(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return frauddetector("GetOutcomes", params; aws_config=aws_config)
+    return frauddetector(
+        "GetOutcomes", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1398,7 +1513,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function get_rules(detectorId; aws_config::AbstractAWSConfig=global_aws_config())
     return frauddetector(
-        "GetRules", Dict{String,Any}("detectorId" => detectorId); aws_config=aws_config
+        "GetRules",
+        Dict{String,Any}("detectorId" => detectorId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_rules(
@@ -1412,6 +1530,7 @@ function get_rules(
             mergewith(_merge, Dict{String,Any}("detectorId" => detectorId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1432,12 +1551,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: The next page token of the get variable request.
 """
 function get_variables(; aws_config::AbstractAWSConfig=global_aws_config())
-    return frauddetector("GetVariables"; aws_config=aws_config)
+    return frauddetector(
+        "GetVariables"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_variables(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return frauddetector("GetVariables", params; aws_config=aws_config)
+    return frauddetector(
+        "GetVariables", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1463,6 +1586,7 @@ function list_tags_for_resource(
         "ListTagsForResource",
         Dict{String,Any}("resourceARN" => resourceARN);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags_for_resource(
@@ -1476,6 +1600,7 @@ function list_tags_for_resource(
             mergewith(_merge, Dict{String,Any}("resourceARN" => resourceARN), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1501,6 +1626,7 @@ function put_detector(
         "PutDetector",
         Dict{String,Any}("detectorId" => detectorId, "eventTypeName" => eventTypeName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_detector(
@@ -1521,6 +1647,7 @@ function put_detector(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1543,7 +1670,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function put_entity_type(name; aws_config::AbstractAWSConfig=global_aws_config())
     return frauddetector(
-        "PutEntityType", Dict{String,Any}("name" => name); aws_config=aws_config
+        "PutEntityType",
+        Dict{String,Any}("name" => name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_entity_type(
@@ -1553,6 +1683,7 @@ function put_entity_type(
         "PutEntityType",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("name" => name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1588,6 +1719,7 @@ function put_event_type(
             "entityTypes" => entityTypes, "eventVariables" => eventVariables, "name" => name
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_event_type(
@@ -1611,6 +1743,7 @@ function put_event_type(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1654,6 +1787,7 @@ function put_external_model(
             "outputConfiguration" => outputConfiguration,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_external_model(
@@ -1683,6 +1817,7 @@ function put_external_model(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1704,6 +1839,7 @@ function put_kmsencryption_key(
         "PutKMSEncryptionKey",
         Dict{String,Any}("kmsEncryptionKeyArn" => kmsEncryptionKeyArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_kmsencryption_key(
@@ -1721,6 +1857,7 @@ function put_kmsencryption_key(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1742,7 +1879,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function put_label(name; aws_config::AbstractAWSConfig=global_aws_config())
     return frauddetector(
-        "PutLabel", Dict{String,Any}("name" => name); aws_config=aws_config
+        "PutLabel",
+        Dict{String,Any}("name" => name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_label(
@@ -1752,6 +1892,7 @@ function put_label(
         "PutLabel",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("name" => name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1771,7 +1912,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function put_outcome(name; aws_config::AbstractAWSConfig=global_aws_config())
     return frauddetector(
-        "PutOutcome", Dict{String,Any}("name" => name); aws_config=aws_config
+        "PutOutcome",
+        Dict{String,Any}("name" => name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_outcome(
@@ -1781,6 +1925,7 @@ function put_outcome(
         "PutOutcome",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("name" => name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1800,6 +1945,7 @@ function tag_resource(resourceARN, tags; aws_config::AbstractAWSConfig=global_aw
         "TagResource",
         Dict{String,Any}("resourceARN" => resourceARN, "tags" => tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -1818,6 +1964,7 @@ function tag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1839,6 +1986,7 @@ function untag_resource(
         "UntagResource",
         Dict{String,Any}("resourceARN" => resourceARN, "tagKeys" => tagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -1857,6 +2005,7 @@ function untag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1902,6 +2051,7 @@ function update_detector_version(
             "rules" => rules,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_detector_version(
@@ -1927,6 +2077,7 @@ function update_detector_version(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1957,6 +2108,7 @@ function update_detector_version_metadata(
             "detectorVersionId" => detectorVersionId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_detector_version_metadata(
@@ -1980,6 +2132,7 @@ function update_detector_version_metadata(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2008,6 +2161,7 @@ function update_detector_version_status(
             "status" => status,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_detector_version_status(
@@ -2031,6 +2185,7 @@ function update_detector_version_status(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2053,6 +2208,7 @@ function update_model(modelId, modelType; aws_config::AbstractAWSConfig=global_a
         "UpdateModel",
         Dict{String,Any}("modelId" => modelId, "modelType" => modelType);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_model(
@@ -2071,6 +2227,7 @@ function update_model(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2107,6 +2264,7 @@ function update_model_version(
             "modelType" => modelType,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_model_version(
@@ -2130,6 +2288,7 @@ function update_model_version(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2163,6 +2322,7 @@ function update_model_version_status(
             "status" => status,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_model_version_status(
@@ -2188,6 +2348,7 @@ function update_model_version_status(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2209,6 +2370,7 @@ function update_rule_metadata(
         "UpdateRuleMetadata",
         Dict{String,Any}("description" => description, "rule" => rule);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_rule_metadata(
@@ -2227,6 +2389,7 @@ function update_rule_metadata(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2260,6 +2423,7 @@ function update_rule_version(
             "rule" => rule,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_rule_version(
@@ -2285,6 +2449,7 @@ function update_rule_version(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2305,7 +2470,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function update_variable(name; aws_config::AbstractAWSConfig=global_aws_config())
     return frauddetector(
-        "UpdateVariable", Dict{String,Any}("name" => name); aws_config=aws_config
+        "UpdateVariable",
+        Dict{String,Any}("name" => name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_variable(
@@ -2315,5 +2483,6 @@ function update_variable(
         "UpdateVariable",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("name" => name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/fsx.jl
+++ b/src/services/fsx.jl
@@ -45,6 +45,7 @@ function associate_file_system_aliases(
             "ClientRequestToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_file_system_aliases(
@@ -67,6 +68,7 @@ function associate_file_system_aliases(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -91,6 +93,7 @@ function cancel_data_repository_task(
         "CancelDataRepositoryTask",
         Dict{String,Any}("TaskId" => TaskId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function cancel_data_repository_task(
@@ -100,6 +103,7 @@ function cancel_data_repository_task(
         "CancelDataRepositoryTask",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("TaskId" => TaskId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -151,6 +155,7 @@ function copy_backup(SourceBackupId; aws_config::AbstractAWSConfig=global_aws_co
             "SourceBackupId" => SourceBackupId, "ClientRequestToken" => string(uuid4())
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function copy_backup(
@@ -171,6 +176,7 @@ function copy_backup(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -218,6 +224,7 @@ function create_backup(; aws_config::AbstractAWSConfig=global_aws_config())
         "CreateBackup",
         Dict{String,Any}("ClientRequestToken" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_backup(
@@ -231,6 +238,7 @@ function create_backup(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -278,6 +286,7 @@ function create_data_repository_task(
             "ClientRequestToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_data_repository_task(
@@ -302,6 +311,7 @@ function create_data_repository_task(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -389,6 +399,7 @@ function create_file_system(
             "ClientRequestToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_file_system(
@@ -413,6 +424,7 @@ function create_file_system(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -484,6 +496,7 @@ function create_file_system_from_backup(
             "ClientRequestToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_file_system_from_backup(
@@ -506,6 +519,7 @@ function create_file_system_from_backup(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -549,6 +563,7 @@ function create_storage_virtual_machine(
             "ClientRequestToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_storage_virtual_machine(
@@ -571,6 +586,7 @@ function create_storage_virtual_machine(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -600,6 +616,7 @@ function create_volume(Name, VolumeType; aws_config::AbstractAWSConfig=global_aw
             "ClientRequestToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_volume(
@@ -622,6 +639,7 @@ function create_volume(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -651,6 +669,7 @@ function create_volume_from_backup(
             "BackupId" => BackupId, "Name" => Name, "ClientRequestToken" => string(uuid4())
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_volume_from_backup(
@@ -673,6 +692,7 @@ function create_volume_from_backup(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -699,6 +719,7 @@ function delete_backup(BackupId; aws_config::AbstractAWSConfig=global_aws_config
         "DeleteBackup",
         Dict{String,Any}("BackupId" => BackupId, "ClientRequestToken" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_backup(
@@ -718,6 +739,7 @@ function delete_backup(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -757,6 +779,7 @@ function delete_file_system(FileSystemId; aws_config::AbstractAWSConfig=global_a
             "FileSystemId" => FileSystemId, "ClientRequestToken" => string(uuid4())
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_file_system(
@@ -776,6 +799,7 @@ function delete_file_system(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -803,6 +827,7 @@ function delete_storage_virtual_machine(
             "ClientRequestToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_storage_virtual_machine(
@@ -823,6 +848,7 @@ function delete_storage_virtual_machine(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -849,6 +875,7 @@ function delete_volume(VolumeId; aws_config::AbstractAWSConfig=global_aws_config
         "DeleteVolume",
         Dict{String,Any}("VolumeId" => VolumeId, "ClientRequestToken" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_volume(
@@ -868,6 +895,7 @@ function delete_volume(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -905,12 +933,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   left off.
 """
 function describe_backups(; aws_config::AbstractAWSConfig=global_aws_config())
-    return fsx("DescribeBackups"; aws_config=aws_config)
+    return fsx("DescribeBackups"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function describe_backups(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return fsx("DescribeBackups", params; aws_config=aws_config)
+    return fsx(
+        "DescribeBackups", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -938,12 +968,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"TaskIds"`: (Optional) IDs of the tasks whose descriptions you want to retrieve (String).
 """
 function describe_data_repository_tasks(; aws_config::AbstractAWSConfig=global_aws_config())
-    return fsx("DescribeDataRepositoryTasks"; aws_config=aws_config)
+    return fsx(
+        "DescribeDataRepositoryTasks";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_data_repository_tasks(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return fsx("DescribeDataRepositoryTasks", params; aws_config=aws_config)
+    return fsx(
+        "DescribeDataRepositoryTasks",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -979,6 +1018,7 @@ function describe_file_system_aliases(
             "FileSystemId" => FileSystemId, "ClientRequestToken" => string(uuid4())
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_file_system_aliases(
@@ -998,6 +1038,7 @@ function describe_file_system_aliases(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1034,12 +1075,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   returning call left off.
 """
 function describe_file_systems(; aws_config::AbstractAWSConfig=global_aws_config())
-    return fsx("DescribeFileSystems"; aws_config=aws_config)
+    return fsx(
+        "DescribeFileSystems"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_file_systems(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return fsx("DescribeFileSystems", params; aws_config=aws_config)
+    return fsx(
+        "DescribeFileSystems",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1058,12 +1106,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_storage_virtual_machines(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return fsx("DescribeStorageVirtualMachines"; aws_config=aws_config)
+    return fsx(
+        "DescribeStorageVirtualMachines";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_storage_virtual_machines(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return fsx("DescribeStorageVirtualMachines", params; aws_config=aws_config)
+    return fsx(
+        "DescribeStorageVirtualMachines",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1080,12 +1137,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"VolumeIds"`: IDs of the volumes whose descriptions you want to retrieve.
 """
 function describe_volumes(; aws_config::AbstractAWSConfig=global_aws_config())
-    return fsx("DescribeVolumes"; aws_config=aws_config)
+    return fsx("DescribeVolumes"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function describe_volumes(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return fsx("DescribeVolumes", params; aws_config=aws_config)
+    return fsx(
+        "DescribeVolumes", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1120,6 +1179,7 @@ function disassociate_file_system_aliases(
             "ClientRequestToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disassociate_file_system_aliases(
@@ -1142,6 +1202,7 @@ function disassociate_file_system_aliases(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1182,6 +1243,7 @@ function list_tags_for_resource(
         "ListTagsForResource",
         Dict{String,Any}("ResourceARN" => ResourceARN);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags_for_resource(
@@ -1195,6 +1257,7 @@ function list_tags_for_resource(
             mergewith(_merge, Dict{String,Any}("ResourceARN" => ResourceARN), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1216,6 +1279,7 @@ function tag_resource(ResourceARN, Tags; aws_config::AbstractAWSConfig=global_aw
         "TagResource",
         Dict{String,Any}("ResourceARN" => ResourceARN, "Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -1234,6 +1298,7 @@ function tag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1256,6 +1321,7 @@ function untag_resource(
         "UntagResource",
         Dict{String,Any}("ResourceARN" => ResourceARN, "TagKeys" => TagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -1274,6 +1340,7 @@ function untag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1329,6 +1396,7 @@ function update_file_system(FileSystemId; aws_config::AbstractAWSConfig=global_a
             "FileSystemId" => FileSystemId, "ClientRequestToken" => string(uuid4())
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_file_system(
@@ -1348,6 +1416,7 @@ function update_file_system(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1378,6 +1447,7 @@ function update_storage_virtual_machine(
             "ClientRequestToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_storage_virtual_machine(
@@ -1398,6 +1468,7 @@ function update_storage_virtual_machine(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1421,6 +1492,7 @@ function update_volume(VolumeId; aws_config::AbstractAWSConfig=global_aws_config
         "UpdateVolume",
         Dict{String,Any}("VolumeId" => VolumeId, "ClientRequestToken" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_volume(
@@ -1440,5 +1512,6 @@ function update_volume(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/gamelift.jl
+++ b/src/services/gamelift.jl
@@ -46,6 +46,7 @@ function accept_match(
             "TicketId" => TicketId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function accept_match(
@@ -69,6 +70,7 @@ function accept_match(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -121,6 +123,7 @@ function claim_game_server(
         "ClaimGameServer",
         Dict{String,Any}("GameServerGroupName" => GameServerGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function claim_game_server(
@@ -138,6 +141,7 @@ function claim_game_server(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -183,6 +187,7 @@ function create_alias(
         "CreateAlias",
         Dict{String,Any}("Name" => Name, "RoutingStrategy" => RoutingStrategy);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_alias(
@@ -201,6 +206,7 @@ function create_alias(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -254,12 +260,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   strings do not need to be unique. You can use UpdateBuild to change this value later.
 """
 function create_build(; aws_config::AbstractAWSConfig=global_aws_config())
-    return gamelift("CreateBuild"; aws_config=aws_config)
+    return gamelift("CreateBuild"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function create_build(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return gamelift("CreateBuild", params; aws_config=aws_config)
+    return gamelift(
+        "CreateBuild", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -387,6 +395,7 @@ function create_fleet(
         "CreateFleet",
         Dict{String,Any}("EC2InstanceType" => EC2InstanceType, "Name" => Name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_fleet(
@@ -405,6 +414,7 @@ function create_fleet(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -445,6 +455,7 @@ function create_fleet_locations(
         "CreateFleetLocations",
         Dict{String,Any}("FleetId" => FleetId, "Locations" => Locations);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_fleet_locations(
@@ -463,6 +474,7 @@ function create_fleet_locations(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -590,6 +602,7 @@ function create_game_server_group(
             "RoleArn" => RoleArn,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_game_server_group(
@@ -619,6 +632,7 @@ function create_game_server_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -698,6 +712,7 @@ function create_game_session(
         "CreateGameSession",
         Dict{String,Any}("MaximumPlayerSessionCount" => MaximumPlayerSessionCount);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_game_session(
@@ -715,6 +730,7 @@ function create_game_session(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -784,7 +800,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function create_game_session_queue(Name; aws_config::AbstractAWSConfig=global_aws_config())
     return gamelift(
-        "CreateGameSessionQueue", Dict{String,Any}("Name" => Name); aws_config=aws_config
+        "CreateGameSessionQueue",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_game_session_queue(
@@ -794,6 +813,7 @@ function create_game_session_queue(
         "CreateGameSessionQueue",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -901,6 +921,7 @@ function create_matchmaking_configuration(
             "RuleSetName" => RuleSetName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_matchmaking_configuration(
@@ -926,6 +947,7 @@ function create_matchmaking_configuration(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -970,6 +992,7 @@ function create_matchmaking_rule_set(
         "CreateMatchmakingRuleSet",
         Dict{String,Any}("Name" => Name, "RuleSetBody" => RuleSetBody);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_matchmaking_rule_set(
@@ -988,6 +1011,7 @@ function create_matchmaking_rule_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1023,6 +1047,7 @@ function create_player_session(
         "CreatePlayerSession",
         Dict{String,Any}("GameSessionId" => GameSessionId, "PlayerId" => PlayerId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_player_session(
@@ -1041,6 +1066,7 @@ function create_player_session(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1079,6 +1105,7 @@ function create_player_sessions(
         "CreatePlayerSessions",
         Dict{String,Any}("GameSessionId" => GameSessionId, "PlayerIds" => PlayerIds);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_player_sessions(
@@ -1099,6 +1126,7 @@ function create_player_sessions(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1151,12 +1179,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   object. For example: --zip-file fileb://myRealtimeScript.zip.
 """
 function create_script(; aws_config::AbstractAWSConfig=global_aws_config())
-    return gamelift("CreateScript"; aws_config=aws_config)
+    return gamelift("CreateScript"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function create_script(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return gamelift("CreateScript", params; aws_config=aws_config)
+    return gamelift(
+        "CreateScript", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1205,6 +1235,7 @@ function create_vpc_peering_authorization(
             "GameLiftAwsAccountId" => GameLiftAwsAccountId, "PeerVpcId" => PeerVpcId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_vpc_peering_authorization(
@@ -1225,6 +1256,7 @@ function create_vpc_peering_authorization(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1279,6 +1311,7 @@ function create_vpc_peering_connection(
             "PeerVpcId" => PeerVpcId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_vpc_peering_connection(
@@ -1302,6 +1335,7 @@ function create_vpc_peering_connection(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1321,7 +1355,10 @@ DescribeAlias | UpdateAlias | DeleteAlias | ResolveAlias | All APIs by task
 """
 function delete_alias(AliasId; aws_config::AbstractAWSConfig=global_aws_config())
     return gamelift(
-        "DeleteAlias", Dict{String,Any}("AliasId" => AliasId); aws_config=aws_config
+        "DeleteAlias",
+        Dict{String,Any}("AliasId" => AliasId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_alias(
@@ -1331,6 +1368,7 @@ function delete_alias(
         "DeleteAlias",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("AliasId" => AliasId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1351,7 +1389,10 @@ CreateBuild | ListBuilds | DescribeBuild | UpdateBuild | DeleteBuild | All APIs 
 """
 function delete_build(BuildId; aws_config::AbstractAWSConfig=global_aws_config())
     return gamelift(
-        "DeleteBuild", Dict{String,Any}("BuildId" => BuildId); aws_config=aws_config
+        "DeleteBuild",
+        Dict{String,Any}("BuildId" => BuildId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_build(
@@ -1361,6 +1402,7 @@ function delete_build(
         "DeleteBuild",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("BuildId" => BuildId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1389,7 +1431,10 @@ task
 """
 function delete_fleet(FleetId; aws_config::AbstractAWSConfig=global_aws_config())
     return gamelift(
-        "DeleteFleet", Dict{String,Any}("FleetId" => FleetId); aws_config=aws_config
+        "DeleteFleet",
+        Dict{String,Any}("FleetId" => FleetId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_fleet(
@@ -1399,6 +1444,7 @@ function delete_fleet(
         "DeleteFleet",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("FleetId" => FleetId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1431,6 +1477,7 @@ function delete_fleet_locations(
         "DeleteFleetLocations",
         Dict{String,Any}("FleetId" => FleetId, "Locations" => Locations);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_fleet_locations(
@@ -1449,6 +1496,7 @@ function delete_fleet_locations(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1494,6 +1542,7 @@ function delete_game_server_group(
         "DeleteGameServerGroup",
         Dict{String,Any}("GameServerGroupName" => GameServerGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_game_server_group(
@@ -1511,6 +1560,7 @@ function delete_game_server_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1531,7 +1581,10 @@ DeleteGameSessionQueue | All APIs by task
 """
 function delete_game_session_queue(Name; aws_config::AbstractAWSConfig=global_aws_config())
     return gamelift(
-        "DeleteGameSessionQueue", Dict{String,Any}("Name" => Name); aws_config=aws_config
+        "DeleteGameSessionQueue",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_game_session_queue(
@@ -1541,6 +1594,7 @@ function delete_game_session_queue(
         "DeleteGameSessionQueue",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1567,6 +1621,7 @@ function delete_matchmaking_configuration(
         "DeleteMatchmakingConfiguration",
         Dict{String,Any}("Name" => Name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_matchmaking_configuration(
@@ -1576,6 +1631,7 @@ function delete_matchmaking_configuration(
         "DeleteMatchmakingConfiguration",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1601,7 +1657,10 @@ function delete_matchmaking_rule_set(
     Name; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return gamelift(
-        "DeleteMatchmakingRuleSet", Dict{String,Any}("Name" => Name); aws_config=aws_config
+        "DeleteMatchmakingRuleSet",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_matchmaking_rule_set(
@@ -1611,6 +1670,7 @@ function delete_matchmaking_rule_set(
         "DeleteMatchmakingRuleSet",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1640,6 +1700,7 @@ function delete_scaling_policy(
         "DeleteScalingPolicy",
         Dict{String,Any}("FleetId" => FleetId, "Name" => Name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_scaling_policy(
@@ -1656,6 +1717,7 @@ function delete_scaling_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1679,7 +1741,10 @@ UpdateScript | DeleteScript | All APIs by task
 """
 function delete_script(ScriptId; aws_config::AbstractAWSConfig=global_aws_config())
     return gamelift(
-        "DeleteScript", Dict{String,Any}("ScriptId" => ScriptId); aws_config=aws_config
+        "DeleteScript",
+        Dict{String,Any}("ScriptId" => ScriptId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_script(
@@ -1693,6 +1758,7 @@ function delete_script(
             mergewith(_merge, Dict{String,Any}("ScriptId" => ScriptId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1725,6 +1791,7 @@ function delete_vpc_peering_authorization(
             "GameLiftAwsAccountId" => GameLiftAwsAccountId, "PeerVpcId" => PeerVpcId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_vpc_peering_authorization(
@@ -1745,6 +1812,7 @@ function delete_vpc_peering_authorization(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1780,6 +1848,7 @@ function delete_vpc_peering_connection(
             "FleetId" => FleetId, "VpcPeeringConnectionId" => VpcPeeringConnectionId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_vpc_peering_connection(
@@ -1800,6 +1869,7 @@ function delete_vpc_peering_connection(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1831,6 +1901,7 @@ function deregister_game_server(
             "GameServerGroupName" => GameServerGroupName, "GameServerId" => GameServerId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function deregister_game_server(
@@ -1852,6 +1923,7 @@ function deregister_game_server(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1872,7 +1944,10 @@ APIs by task
 """
 function describe_alias(AliasId; aws_config::AbstractAWSConfig=global_aws_config())
     return gamelift(
-        "DescribeAlias", Dict{String,Any}("AliasId" => AliasId); aws_config=aws_config
+        "DescribeAlias",
+        Dict{String,Any}("AliasId" => AliasId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_alias(
@@ -1882,6 +1957,7 @@ function describe_alias(
         "DescribeAlias",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("AliasId" => AliasId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1901,7 +1977,10 @@ UpdateBuild | DeleteBuild | All APIs by task
 """
 function describe_build(BuildId; aws_config::AbstractAWSConfig=global_aws_config())
     return gamelift(
-        "DescribeBuild", Dict{String,Any}("BuildId" => BuildId); aws_config=aws_config
+        "DescribeBuild",
+        Dict{String,Any}("BuildId" => BuildId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_build(
@@ -1911,6 +1990,7 @@ function describe_build(
         "DescribeBuild",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("BuildId" => BuildId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1959,12 +2039,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   of an AWS Region code such as us-west-2.
 """
 function describe_ec2_instance_limits(; aws_config::AbstractAWSConfig=global_aws_config())
-    return gamelift("DescribeEC2InstanceLimits"; aws_config=aws_config)
+    return gamelift(
+        "DescribeEC2InstanceLimits"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_ec2_instance_limits(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return gamelift("DescribeEC2InstanceLimits", params; aws_config=aws_config)
+    return gamelift(
+        "DescribeEC2InstanceLimits",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1999,12 +2086,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   request specifies one or a list of fleet IDs.
 """
 function describe_fleet_attributes(; aws_config::AbstractAWSConfig=global_aws_config())
-    return gamelift("DescribeFleetAttributes"; aws_config=aws_config)
+    return gamelift(
+        "DescribeFleetAttributes"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_fleet_attributes(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return gamelift("DescribeFleetAttributes", params; aws_config=aws_config)
+    return gamelift(
+        "DescribeFleetAttributes",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2044,12 +2138,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   request specifies one or a list of fleet IDs.
 """
 function describe_fleet_capacity(; aws_config::AbstractAWSConfig=global_aws_config())
-    return gamelift("DescribeFleetCapacity"; aws_config=aws_config)
+    return gamelift(
+        "DescribeFleetCapacity"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_fleet_capacity(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return gamelift("DescribeFleetCapacity", params; aws_config=aws_config)
+    return gamelift(
+        "DescribeFleetCapacity",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2088,7 +2189,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function describe_fleet_events(FleetId; aws_config::AbstractAWSConfig=global_aws_config())
     return gamelift(
-        "DescribeFleetEvents", Dict{String,Any}("FleetId" => FleetId); aws_config=aws_config
+        "DescribeFleetEvents",
+        Dict{String,Any}("FleetId" => FleetId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_fleet_events(
@@ -2098,6 +2202,7 @@ function describe_fleet_events(
         "DescribeFleetEvents",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("FleetId" => FleetId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2141,6 +2246,7 @@ function describe_fleet_location_attributes(
         "DescribeFleetLocationAttributes",
         Dict{String,Any}("FleetId" => FleetId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_fleet_location_attributes(
@@ -2150,6 +2256,7 @@ function describe_fleet_location_attributes(
         "DescribeFleetLocationAttributes",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("FleetId" => FleetId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2183,6 +2290,7 @@ function describe_fleet_location_capacity(
         "DescribeFleetLocationCapacity",
         Dict{String,Any}("FleetId" => FleetId, "Location" => Location);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_fleet_location_capacity(
@@ -2201,6 +2309,7 @@ function describe_fleet_location_capacity(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2233,6 +2342,7 @@ function describe_fleet_location_utilization(
         "DescribeFleetLocationUtilization",
         Dict{String,Any}("FleetId" => FleetId, "Location" => Location);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_fleet_location_utilization(
@@ -2251,6 +2361,7 @@ function describe_fleet_location_utilization(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2289,6 +2400,7 @@ function describe_fleet_port_settings(
         "DescribeFleetPortSettings",
         Dict{String,Any}("FleetId" => FleetId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_fleet_port_settings(
@@ -2298,6 +2410,7 @@ function describe_fleet_port_settings(
         "DescribeFleetPortSettings",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("FleetId" => FleetId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2338,12 +2451,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   request specifies one or a list of fleet IDs.
 """
 function describe_fleet_utilization(; aws_config::AbstractAWSConfig=global_aws_config())
-    return gamelift("DescribeFleetUtilization"; aws_config=aws_config)
+    return gamelift(
+        "DescribeFleetUtilization"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_fleet_utilization(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return gamelift("DescribeFleetUtilization", params; aws_config=aws_config)
+    return gamelift(
+        "DescribeFleetUtilization",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2374,6 +2494,7 @@ function describe_game_server(
             "GameServerGroupName" => GameServerGroupName, "GameServerId" => GameServerId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_game_server(
@@ -2395,6 +2516,7 @@ function describe_game_server(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2425,6 +2547,7 @@ function describe_game_server_group(
         "DescribeGameServerGroup",
         Dict{String,Any}("GameServerGroupName" => GameServerGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_game_server_group(
@@ -2442,6 +2565,7 @@ function describe_game_server_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2488,6 +2612,7 @@ function describe_game_server_instances(
         "DescribeGameServerInstances",
         Dict{String,Any}("GameServerGroupName" => GameServerGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_game_server_instances(
@@ -2505,6 +2630,7 @@ function describe_game_server_instances(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2551,12 +2677,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   transitory).
 """
 function describe_game_session_details(; aws_config::AbstractAWSConfig=global_aws_config())
-    return gamelift("DescribeGameSessionDetails"; aws_config=aws_config)
+    return gamelift(
+        "DescribeGameSessionDetails"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_game_session_details(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return gamelift("DescribeGameSessionDetails", params; aws_config=aws_config)
+    return gamelift(
+        "DescribeGameSessionDetails",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2581,6 +2714,7 @@ function describe_game_session_placement(
         "DescribeGameSessionPlacement",
         Dict{String,Any}("PlacementId" => PlacementId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_game_session_placement(
@@ -2594,6 +2728,7 @@ function describe_game_session_placement(
             mergewith(_merge, Dict{String,Any}("PlacementId" => PlacementId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2620,12 +2755,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   beginning of the result set, do not specify a value.
 """
 function describe_game_session_queues(; aws_config::AbstractAWSConfig=global_aws_config())
-    return gamelift("DescribeGameSessionQueues"; aws_config=aws_config)
+    return gamelift(
+        "DescribeGameSessionQueues"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_game_session_queues(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return gamelift("DescribeGameSessionQueues", params; aws_config=aws_config)
+    return gamelift(
+        "DescribeGameSessionQueues",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2671,12 +2813,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   transitory and used for only very brief periods of time.
 """
 function describe_game_sessions(; aws_config::AbstractAWSConfig=global_aws_config())
-    return gamelift("DescribeGameSessions"; aws_config=aws_config)
+    return gamelift(
+        "DescribeGameSessions"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_game_sessions(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return gamelift("DescribeGameSessions", params; aws_config=aws_config)
+    return gamelift(
+        "DescribeGameSessions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2712,7 +2861,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function describe_instances(FleetId; aws_config::AbstractAWSConfig=global_aws_config())
     return gamelift(
-        "DescribeInstances", Dict{String,Any}("FleetId" => FleetId); aws_config=aws_config
+        "DescribeInstances",
+        Dict{String,Any}("FleetId" => FleetId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_instances(
@@ -2722,6 +2874,7 @@ function describe_instances(
         "DescribeInstances",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("FleetId" => FleetId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2752,6 +2905,7 @@ function describe_matchmaking(TicketIds; aws_config::AbstractAWSConfig=global_aw
         "DescribeMatchmaking",
         Dict{String,Any}("TicketIds" => TicketIds);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_matchmaking(
@@ -2765,6 +2919,7 @@ function describe_matchmaking(
             mergewith(_merge, Dict{String,Any}("TicketIds" => TicketIds), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2801,12 +2956,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_matchmaking_configurations(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return gamelift("DescribeMatchmakingConfigurations"; aws_config=aws_config)
+    return gamelift(
+        "DescribeMatchmakingConfigurations";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_matchmaking_configurations(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return gamelift("DescribeMatchmakingConfigurations", params; aws_config=aws_config)
+    return gamelift(
+        "DescribeMatchmakingConfigurations",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2834,12 +2998,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   beginning of the result set, do not specify a value.
 """
 function describe_matchmaking_rule_sets(; aws_config::AbstractAWSConfig=global_aws_config())
-    return gamelift("DescribeMatchmakingRuleSets"; aws_config=aws_config)
+    return gamelift(
+        "DescribeMatchmakingRuleSets";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_matchmaking_rule_sets(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return gamelift("DescribeMatchmakingRuleSets", params; aws_config=aws_config)
+    return gamelift(
+        "DescribeMatchmakingRuleSets",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2879,12 +3052,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   validated within the timeout limit (60 seconds).
 """
 function describe_player_sessions(; aws_config::AbstractAWSConfig=global_aws_config())
-    return gamelift("DescribePlayerSessions"; aws_config=aws_config)
+    return gamelift(
+        "DescribePlayerSessions"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_player_sessions(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return gamelift("DescribePlayerSessions", params; aws_config=aws_config)
+    return gamelift(
+        "DescribePlayerSessions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2914,6 +3094,7 @@ function describe_runtime_configuration(
         "DescribeRuntimeConfiguration",
         Dict{String,Any}("FleetId" => FleetId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_runtime_configuration(
@@ -2923,6 +3104,7 @@ function describe_runtime_configuration(
         "DescribeRuntimeConfiguration",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("FleetId" => FleetId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2968,6 +3150,7 @@ function describe_scaling_policies(
         "DescribeScalingPolicies",
         Dict{String,Any}("FleetId" => FleetId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_scaling_policies(
@@ -2977,6 +3160,7 @@ function describe_scaling_policies(
         "DescribeScalingPolicies",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("FleetId" => FleetId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2996,7 +3180,10 @@ DescribeScript | UpdateScript | DeleteScript | All APIs by task
 """
 function describe_script(ScriptId; aws_config::AbstractAWSConfig=global_aws_config())
     return gamelift(
-        "DescribeScript", Dict{String,Any}("ScriptId" => ScriptId); aws_config=aws_config
+        "DescribeScript",
+        Dict{String,Any}("ScriptId" => ScriptId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_script(
@@ -3010,6 +3197,7 @@ function describe_script(
             mergewith(_merge, Dict{String,Any}("ScriptId" => ScriptId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3028,12 +3216,21 @@ DeleteVpcPeeringAuthorization | CreateVpcPeeringConnection | DescribeVpcPeeringC
 function describe_vpc_peering_authorizations(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return gamelift("DescribeVpcPeeringAuthorizations"; aws_config=aws_config)
+    return gamelift(
+        "DescribeVpcPeeringAuthorizations";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_vpc_peering_authorizations(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return gamelift("DescribeVpcPeeringAuthorizations", params; aws_config=aws_config)
+    return gamelift(
+        "DescribeVpcPeeringAuthorizations",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -3058,12 +3255,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_vpc_peering_connections(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return gamelift("DescribeVpcPeeringConnections"; aws_config=aws_config)
+    return gamelift(
+        "DescribeVpcPeeringConnections";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_vpc_peering_connections(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return gamelift("DescribeVpcPeeringConnections", params; aws_config=aws_config)
+    return gamelift(
+        "DescribeVpcPeeringConnections",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -3089,6 +3295,7 @@ function get_game_session_log_url(
         "GetGameSessionLogUrl",
         Dict{String,Any}("GameSessionId" => GameSessionId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_game_session_log_url(
@@ -3102,6 +3309,7 @@ function get_game_session_log_url(
             mergewith(_merge, Dict{String,Any}("GameSessionId" => GameSessionId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3140,6 +3348,7 @@ function get_instance_access(
         "GetInstanceAccess",
         Dict{String,Any}("FleetId" => FleetId, "InstanceId" => InstanceId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_instance_access(
@@ -3158,6 +3367,7 @@ function get_instance_access(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3189,12 +3399,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   message embedded.
 """
 function list_aliases(; aws_config::AbstractAWSConfig=global_aws_config())
-    return gamelift("ListAliases"; aws_config=aws_config)
+    return gamelift("ListAliases"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_aliases(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return gamelift("ListAliases", params; aws_config=aws_config)
+    return gamelift(
+        "ListAliases", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -3224,12 +3436,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   create new fleets for this build.
 """
 function list_builds(; aws_config::AbstractAWSConfig=global_aws_config())
-    return gamelift("ListBuilds"; aws_config=aws_config)
+    return gamelift("ListBuilds"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_builds(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return gamelift("ListBuilds", params; aws_config=aws_config)
+    return gamelift(
+        "ListBuilds", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -3268,12 +3482,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   value.
 """
 function list_fleets(; aws_config::AbstractAWSConfig=global_aws_config())
-    return gamelift("ListFleets"; aws_config=aws_config)
+    return gamelift("ListFleets"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_fleets(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return gamelift("ListFleets", params; aws_config=aws_config)
+    return gamelift(
+        "ListFleets", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -3297,12 +3513,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   beginning of the result set, do not specify a value.
 """
 function list_game_server_groups(; aws_config::AbstractAWSConfig=global_aws_config())
-    return gamelift("ListGameServerGroups"; aws_config=aws_config)
+    return gamelift(
+        "ListGameServerGroups"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_game_server_groups(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return gamelift("ListGameServerGroups", params; aws_config=aws_config)
+    return gamelift(
+        "ListGameServerGroups",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -3339,6 +3562,7 @@ function list_game_servers(
         "ListGameServers",
         Dict{String,Any}("GameServerGroupName" => GameServerGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_game_servers(
@@ -3356,6 +3580,7 @@ function list_game_servers(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3376,12 +3601,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   beginning of the result set, do not specify a value.
 """
 function list_scripts(; aws_config::AbstractAWSConfig=global_aws_config())
-    return gamelift("ListScripts"; aws_config=aws_config)
+    return gamelift("ListScripts"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_scripts(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return gamelift("ListScripts", params; aws_config=aws_config)
+    return gamelift(
+        "ListScripts", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -3410,6 +3637,7 @@ function list_tags_for_resource(
         "ListTagsForResource",
         Dict{String,Any}("ResourceARN" => ResourceARN);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags_for_resource(
@@ -3423,6 +3651,7 @@ function list_tags_for_resource(
             mergewith(_merge, Dict{String,Any}("ResourceARN" => ResourceARN), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3534,6 +3763,7 @@ function put_scaling_policy(
         "PutScalingPolicy",
         Dict{String,Any}("FleetId" => FleetId, "MetricName" => MetricName, "Name" => Name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_scaling_policy(
@@ -3555,6 +3785,7 @@ function put_scaling_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3610,6 +3841,7 @@ function register_game_server(
             "InstanceId" => InstanceId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function register_game_server(
@@ -3633,6 +3865,7 @@ function register_game_server(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3660,6 +3893,7 @@ function request_upload_credentials(
         "RequestUploadCredentials",
         Dict{String,Any}("BuildId" => BuildId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function request_upload_credentials(
@@ -3669,6 +3903,7 @@ function request_upload_credentials(
         "RequestUploadCredentials",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("BuildId" => BuildId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3687,7 +3922,10 @@ APIs by task
 """
 function resolve_alias(AliasId; aws_config::AbstractAWSConfig=global_aws_config())
     return gamelift(
-        "ResolveAlias", Dict{String,Any}("AliasId" => AliasId); aws_config=aws_config
+        "ResolveAlias",
+        Dict{String,Any}("AliasId" => AliasId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function resolve_alias(
@@ -3697,6 +3935,7 @@ function resolve_alias(
         "ResolveAlias",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("AliasId" => AliasId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3732,6 +3971,7 @@ function resume_game_server_group(
             "GameServerGroupName" => GameServerGroupName, "ResumeActions" => ResumeActions
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function resume_game_server_group(
@@ -3753,6 +3993,7 @@ function resume_game_server_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3843,12 +4084,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   value for the sort operand are returned at the end of the list.
 """
 function search_game_sessions(; aws_config::AbstractAWSConfig=global_aws_config())
-    return gamelift("SearchGameSessions"; aws_config=aws_config)
+    return gamelift(
+        "SearchGameSessions"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function search_game_sessions(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return gamelift("SearchGameSessions", params; aws_config=aws_config)
+    return gamelift(
+        "SearchGameSessions", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -3887,6 +4132,7 @@ function start_fleet_actions(
         "StartFleetActions",
         Dict{String,Any}("Actions" => Actions, "FleetId" => FleetId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_fleet_actions(
@@ -3903,6 +4149,7 @@ function start_fleet_actions(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3979,6 +4226,7 @@ function start_game_session_placement(
             "PlacementId" => PlacementId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_game_session_placement(
@@ -4002,6 +4250,7 @@ function start_game_session_placement(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4062,6 +4311,7 @@ function start_match_backfill(
         "StartMatchBackfill",
         Dict{String,Any}("ConfigurationName" => ConfigurationName, "Players" => Players);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_match_backfill(
@@ -4082,6 +4332,7 @@ function start_match_backfill(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4128,6 +4379,7 @@ function start_matchmaking(
         "StartMatchmaking",
         Dict{String,Any}("ConfigurationName" => ConfigurationName, "Players" => Players);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_matchmaking(
@@ -4148,6 +4400,7 @@ function start_matchmaking(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4189,6 +4442,7 @@ function stop_fleet_actions(
         "StopFleetActions",
         Dict{String,Any}("Actions" => Actions, "FleetId" => FleetId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function stop_fleet_actions(
@@ -4205,6 +4459,7 @@ function stop_fleet_actions(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4229,6 +4484,7 @@ function stop_game_session_placement(
         "StopGameSessionPlacement",
         Dict{String,Any}("PlacementId" => PlacementId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function stop_game_session_placement(
@@ -4242,6 +4498,7 @@ function stop_game_session_placement(
             mergewith(_merge, Dict{String,Any}("PlacementId" => PlacementId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4266,7 +4523,10 @@ StopMatchmaking | AcceptMatch | StartMatchBackfill | All APIs by task
 """
 function stop_matchmaking(TicketId; aws_config::AbstractAWSConfig=global_aws_config())
     return gamelift(
-        "StopMatchmaking", Dict{String,Any}("TicketId" => TicketId); aws_config=aws_config
+        "StopMatchmaking",
+        Dict{String,Any}("TicketId" => TicketId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function stop_matchmaking(
@@ -4280,6 +4540,7 @@ function stop_matchmaking(
             mergewith(_merge, Dict{String,Any}("TicketId" => TicketId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4319,6 +4580,7 @@ function suspend_game_server_group(
             "GameServerGroupName" => GameServerGroupName, "SuspendActions" => SuspendActions
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function suspend_game_server_group(
@@ -4340,6 +4602,7 @@ function suspend_game_server_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4373,6 +4636,7 @@ function tag_resource(ResourceARN, Tags; aws_config::AbstractAWSConfig=global_aw
         "TagResource",
         Dict{String,Any}("ResourceARN" => ResourceARN, "Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -4391,6 +4655,7 @@ function tag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4425,6 +4690,7 @@ function untag_resource(
         "UntagResource",
         Dict{String,Any}("ResourceARN" => ResourceARN, "TagKeys" => TagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -4443,6 +4709,7 @@ function untag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4470,7 +4737,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function update_alias(AliasId; aws_config::AbstractAWSConfig=global_aws_config())
     return gamelift(
-        "UpdateAlias", Dict{String,Any}("AliasId" => AliasId); aws_config=aws_config
+        "UpdateAlias",
+        Dict{String,Any}("AliasId" => AliasId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_alias(
@@ -4480,6 +4750,7 @@ function update_alias(
         "UpdateAlias",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("AliasId" => AliasId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4506,7 +4777,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function update_build(BuildId; aws_config::AbstractAWSConfig=global_aws_config())
     return gamelift(
-        "UpdateBuild", Dict{String,Any}("BuildId" => BuildId); aws_config=aws_config
+        "UpdateBuild",
+        Dict{String,Any}("BuildId" => BuildId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_build(
@@ -4516,6 +4790,7 @@ function update_build(
         "UpdateBuild",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("BuildId" => BuildId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4557,6 +4832,7 @@ function update_fleet_attributes(FleetId; aws_config::AbstractAWSConfig=global_a
         "UpdateFleetAttributes",
         Dict{String,Any}("FleetId" => FleetId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_fleet_attributes(
@@ -4566,6 +4842,7 @@ function update_fleet_attributes(
         "UpdateFleetAttributes",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("FleetId" => FleetId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4616,7 +4893,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function update_fleet_capacity(FleetId; aws_config::AbstractAWSConfig=global_aws_config())
     return gamelift(
-        "UpdateFleetCapacity", Dict{String,Any}("FleetId" => FleetId); aws_config=aws_config
+        "UpdateFleetCapacity",
+        Dict{String,Any}("FleetId" => FleetId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_fleet_capacity(
@@ -4626,6 +4906,7 @@ function update_fleet_capacity(
         "UpdateFleetCapacity",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("FleetId" => FleetId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4665,6 +4946,7 @@ function update_fleet_port_settings(
         "UpdateFleetPortSettings",
         Dict{String,Any}("FleetId" => FleetId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_fleet_port_settings(
@@ -4674,6 +4956,7 @@ function update_fleet_port_settings(
         "UpdateFleetPortSettings",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("FleetId" => FleetId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4723,6 +5006,7 @@ function update_game_server(
             "GameServerGroupName" => GameServerGroupName, "GameServerId" => GameServerId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_game_server(
@@ -4744,6 +5028,7 @@ function update_game_server(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4807,6 +5092,7 @@ function update_game_server_group(
         "UpdateGameServerGroup",
         Dict{String,Any}("GameServerGroupName" => GameServerGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_game_server_group(
@@ -4824,6 +5110,7 @@ function update_game_server_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4861,6 +5148,7 @@ function update_game_session(
         "UpdateGameSession",
         Dict{String,Any}("GameSessionId" => GameSessionId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_game_session(
@@ -4874,6 +5162,7 @@ function update_game_session(
             mergewith(_merge, Dict{String,Any}("GameSessionId" => GameSessionId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4923,7 +5212,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function update_game_session_queue(Name; aws_config::AbstractAWSConfig=global_aws_config())
     return gamelift(
-        "UpdateGameSessionQueue", Dict{String,Any}("Name" => Name); aws_config=aws_config
+        "UpdateGameSessionQueue",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_game_session_queue(
@@ -4933,6 +5225,7 @@ function update_game_session_queue(
         "UpdateGameSessionQueue",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5010,6 +5303,7 @@ function update_matchmaking_configuration(
         "UpdateMatchmakingConfiguration",
         Dict{String,Any}("Name" => Name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_matchmaking_configuration(
@@ -5019,6 +5313,7 @@ function update_matchmaking_configuration(
         "UpdateMatchmakingConfiguration",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5059,6 +5354,7 @@ function update_runtime_configuration(
             "FleetId" => FleetId, "RuntimeConfiguration" => RuntimeConfiguration
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_runtime_configuration(
@@ -5079,6 +5375,7 @@ function update_runtime_configuration(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5122,7 +5419,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function update_script(ScriptId; aws_config::AbstractAWSConfig=global_aws_config())
     return gamelift(
-        "UpdateScript", Dict{String,Any}("ScriptId" => ScriptId); aws_config=aws_config
+        "UpdateScript",
+        Dict{String,Any}("ScriptId" => ScriptId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_script(
@@ -5136,6 +5436,7 @@ function update_script(
             mergewith(_merge, Dict{String,Any}("ScriptId" => ScriptId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5163,6 +5464,7 @@ function validate_matchmaking_rule_set(
         "ValidateMatchmakingRuleSet",
         Dict{String,Any}("RuleSetBody" => RuleSetBody);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function validate_matchmaking_rule_set(
@@ -5176,5 +5478,6 @@ function validate_matchmaking_rule_set(
             mergewith(_merge, Dict{String,Any}("RuleSetBody" => RuleSetBody), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/glacier.jl
+++ b/src/services/glacier.jl
@@ -37,6 +37,7 @@ function abort_multipart_upload(
         "DELETE",
         "/$(accountId)/vaults/$(vaultName)/multipart-uploads/$(uploadId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function abort_multipart_upload(
@@ -51,6 +52,7 @@ function abort_multipart_upload(
         "/$(accountId)/vaults/$(vaultName)/multipart-uploads/$(uploadId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -83,7 +85,10 @@ function abort_vault_lock(
     accountId, vaultName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return glacier(
-        "DELETE", "/$(accountId)/vaults/$(vaultName)/lock-policy"; aws_config=aws_config
+        "DELETE",
+        "/$(accountId)/vaults/$(vaultName)/lock-policy";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function abort_vault_lock(
@@ -97,6 +102,7 @@ function abort_vault_lock(
         "/$(accountId)/vaults/$(vaultName)/lock-policy",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -129,6 +135,7 @@ function add_tags_to_vault(
         "POST",
         "/$(accountId)/vaults/$(vaultName)/tags?operation=add";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function add_tags_to_vault(
@@ -142,6 +149,7 @@ function add_tags_to_vault(
         "/$(accountId)/vaults/$(vaultName)/tags?operation=add",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -203,6 +211,7 @@ function complete_multipart_upload(
         "POST",
         "/$(accountId)/vaults/$(vaultName)/multipart-uploads/$(uploadId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function complete_multipart_upload(
@@ -217,6 +226,7 @@ function complete_multipart_upload(
         "/$(accountId)/vaults/$(vaultName)/multipart-uploads/$(uploadId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -252,6 +262,7 @@ function complete_vault_lock(
         "POST",
         "/$(accountId)/vaults/$(vaultName)/lock-policy/$(lockId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function complete_vault_lock(
@@ -266,6 +277,7 @@ function complete_vault_lock(
         "/$(accountId)/vaults/$(vaultName)/lock-policy/$(lockId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -297,7 +309,12 @@ Glacier and Create Vault  in the Amazon Glacier Developer Guide.
 function create_vault(
     accountId, vaultName; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return glacier("PUT", "/$(accountId)/vaults/$(vaultName)"; aws_config=aws_config)
+    return glacier(
+        "PUT",
+        "/$(accountId)/vaults/$(vaultName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function create_vault(
     accountId,
@@ -306,7 +323,11 @@ function create_vault(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return glacier(
-        "PUT", "/$(accountId)/vaults/$(vaultName)", params; aws_config=aws_config
+        "PUT",
+        "/$(accountId)/vaults/$(vaultName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -345,6 +366,7 @@ function delete_archive(
         "DELETE",
         "/$(accountId)/vaults/$(vaultName)/archives/$(archiveId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_archive(
@@ -359,6 +381,7 @@ function delete_archive(
         "/$(accountId)/vaults/$(vaultName)/archives/$(archiveId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -391,7 +414,12 @@ Glacier and Delete Vault  in the Amazon S3 Glacier Developer Guide.
 function delete_vault(
     accountId, vaultName; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return glacier("DELETE", "/$(accountId)/vaults/$(vaultName)"; aws_config=aws_config)
+    return glacier(
+        "DELETE",
+        "/$(accountId)/vaults/$(vaultName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_vault(
     accountId,
@@ -400,7 +428,11 @@ function delete_vault(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return glacier(
-        "DELETE", "/$(accountId)/vaults/$(vaultName)", params; aws_config=aws_config
+        "DELETE",
+        "/$(accountId)/vaults/$(vaultName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -428,7 +460,10 @@ function delete_vault_access_policy(
     accountId, vaultName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return glacier(
-        "DELETE", "/$(accountId)/vaults/$(vaultName)/access-policy"; aws_config=aws_config
+        "DELETE",
+        "/$(accountId)/vaults/$(vaultName)/access-policy";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_vault_access_policy(
@@ -442,6 +477,7 @@ function delete_vault_access_policy(
         "/$(accountId)/vaults/$(vaultName)/access-policy",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -475,6 +511,7 @@ function delete_vault_notifications(
         "DELETE",
         "/$(accountId)/vaults/$(vaultName)/notification-configuration";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_vault_notifications(
@@ -488,6 +525,7 @@ function delete_vault_notifications(
         "/$(accountId)/vaults/$(vaultName)/notification-configuration",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -522,7 +560,10 @@ function describe_job(
     accountId, jobId, vaultName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return glacier(
-        "GET", "/$(accountId)/vaults/$(vaultName)/jobs/$(jobId)"; aws_config=aws_config
+        "GET",
+        "/$(accountId)/vaults/$(vaultName)/jobs/$(jobId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_job(
@@ -537,6 +578,7 @@ function describe_job(
         "/$(accountId)/vaults/$(vaultName)/jobs/$(jobId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -570,7 +612,12 @@ Glacier Developer Guide.
 function describe_vault(
     accountId, vaultName; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return glacier("GET", "/$(accountId)/vaults/$(vaultName)"; aws_config=aws_config)
+    return glacier(
+        "GET",
+        "/$(accountId)/vaults/$(vaultName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_vault(
     accountId,
@@ -579,7 +626,11 @@ function describe_vault(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return glacier(
-        "GET", "/$(accountId)/vaults/$(vaultName)", params; aws_config=aws_config
+        "GET",
+        "/$(accountId)/vaults/$(vaultName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -602,7 +653,12 @@ Amazon Glacier Data Retrieval Policies.
 function get_data_retrieval_policy(
     accountId; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return glacier("GET", "/$(accountId)/policies/data-retrieval"; aws_config=aws_config)
+    return glacier(
+        "GET",
+        "/$(accountId)/policies/data-retrieval";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_data_retrieval_policy(
     accountId,
@@ -610,7 +666,11 @@ function get_data_retrieval_policy(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return glacier(
-        "GET", "/$(accountId)/policies/data-retrieval", params; aws_config=aws_config
+        "GET",
+        "/$(accountId)/policies/data-retrieval",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -682,6 +742,7 @@ function get_job_output(
         "GET",
         "/$(accountId)/vaults/$(vaultName)/jobs/$(jobId)/output";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_job_output(
@@ -696,6 +757,7 @@ function get_job_output(
         "/$(accountId)/vaults/$(vaultName)/jobs/$(jobId)/output",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -721,7 +783,10 @@ function get_vault_access_policy(
     accountId, vaultName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return glacier(
-        "GET", "/$(accountId)/vaults/$(vaultName)/access-policy"; aws_config=aws_config
+        "GET",
+        "/$(accountId)/vaults/$(vaultName)/access-policy";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_vault_access_policy(
@@ -735,6 +800,7 @@ function get_vault_access_policy(
         "/$(accountId)/vaults/$(vaultName)/access-policy",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -765,7 +831,10 @@ function get_vault_lock(
     accountId, vaultName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return glacier(
-        "GET", "/$(accountId)/vaults/$(vaultName)/lock-policy"; aws_config=aws_config
+        "GET",
+        "/$(accountId)/vaults/$(vaultName)/lock-policy";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_vault_lock(
@@ -779,6 +848,7 @@ function get_vault_lock(
         "/$(accountId)/vaults/$(vaultName)/lock-policy",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -813,6 +883,7 @@ function get_vault_notifications(
         "GET",
         "/$(accountId)/vaults/$(vaultName)/notification-configuration";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_vault_notifications(
@@ -826,6 +897,7 @@ function get_vault_notifications(
         "/$(accountId)/vaults/$(vaultName)/notification-configuration",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -851,7 +923,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function initiate_job(
     accountId, vaultName; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return glacier("POST", "/$(accountId)/vaults/$(vaultName)/jobs"; aws_config=aws_config)
+    return glacier(
+        "POST",
+        "/$(accountId)/vaults/$(vaultName)/jobs";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function initiate_job(
     accountId,
@@ -860,7 +937,11 @@ function initiate_job(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return glacier(
-        "POST", "/$(accountId)/vaults/$(vaultName)/jobs", params; aws_config=aws_config
+        "POST",
+        "/$(accountId)/vaults/$(vaultName)/jobs",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -910,7 +991,10 @@ function initiate_multipart_upload(
     accountId, vaultName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return glacier(
-        "POST", "/$(accountId)/vaults/$(vaultName)/multipart-uploads"; aws_config=aws_config
+        "POST",
+        "/$(accountId)/vaults/$(vaultName)/multipart-uploads";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function initiate_multipart_upload(
@@ -924,6 +1008,7 @@ function initiate_multipart_upload(
         "/$(accountId)/vaults/$(vaultName)/multipart-uploads",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -965,7 +1050,10 @@ function initiate_vault_lock(
     accountId, vaultName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return glacier(
-        "POST", "/$(accountId)/vaults/$(vaultName)/lock-policy"; aws_config=aws_config
+        "POST",
+        "/$(accountId)/vaults/$(vaultName)/lock-policy";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function initiate_vault_lock(
@@ -979,6 +1067,7 @@ function initiate_vault_lock(
         "/$(accountId)/vaults/$(vaultName)/lock-policy",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1032,7 +1121,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   InProgress, Succeeded, or Failed.
 """
 function list_jobs(accountId, vaultName; aws_config::AbstractAWSConfig=global_aws_config())
-    return glacier("GET", "/$(accountId)/vaults/$(vaultName)/jobs"; aws_config=aws_config)
+    return glacier(
+        "GET",
+        "/$(accountId)/vaults/$(vaultName)/jobs";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_jobs(
     accountId,
@@ -1041,7 +1135,11 @@ function list_jobs(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return glacier(
-        "GET", "/$(accountId)/vaults/$(vaultName)/jobs", params; aws_config=aws_config
+        "GET",
+        "/$(accountId)/vaults/$(vaultName)/jobs",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1089,7 +1187,10 @@ function list_multipart_uploads(
     accountId, vaultName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return glacier(
-        "GET", "/$(accountId)/vaults/$(vaultName)/multipart-uploads"; aws_config=aws_config
+        "GET",
+        "/$(accountId)/vaults/$(vaultName)/multipart-uploads";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_multipart_uploads(
@@ -1103,6 +1204,7 @@ function list_multipart_uploads(
         "/$(accountId)/vaults/$(vaultName)/multipart-uploads",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1152,6 +1254,7 @@ function list_parts(
         "GET",
         "/$(accountId)/vaults/$(vaultName)/multipart-uploads/$(uploadId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_parts(
@@ -1166,6 +1269,7 @@ function list_parts(
         "/$(accountId)/vaults/$(vaultName)/multipart-uploads/$(uploadId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1185,7 +1289,12 @@ This operation lists the provisioned capacity units for the specified AWS accoun
 function list_provisioned_capacity(
     accountId; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return glacier("GET", "/$(accountId)/provisioned-capacity"; aws_config=aws_config)
+    return glacier(
+        "GET",
+        "/$(accountId)/provisioned-capacity";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_provisioned_capacity(
     accountId,
@@ -1193,7 +1302,11 @@ function list_provisioned_capacity(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return glacier(
-        "GET", "/$(accountId)/provisioned-capacity", params; aws_config=aws_config
+        "GET",
+        "/$(accountId)/provisioned-capacity",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1216,7 +1329,12 @@ Resources.
 function list_tags_for_vault(
     accountId, vaultName; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return glacier("GET", "/$(accountId)/vaults/$(vaultName)/tags"; aws_config=aws_config)
+    return glacier(
+        "GET",
+        "/$(accountId)/vaults/$(vaultName)/tags";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_tags_for_vault(
     accountId,
@@ -1225,7 +1343,11 @@ function list_tags_for_vault(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return glacier(
-        "GET", "/$(accountId)/vaults/$(vaultName)/tags", params; aws_config=aws_config
+        "GET",
+        "/$(accountId)/vaults/$(vaultName)/tags",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1263,14 +1385,25 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   the listing of vaults should begin.
 """
 function list_vaults(accountId; aws_config::AbstractAWSConfig=global_aws_config())
-    return glacier("GET", "/$(accountId)/vaults"; aws_config=aws_config)
+    return glacier(
+        "GET",
+        "/$(accountId)/vaults";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_vaults(
     accountId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return glacier("GET", "/$(accountId)/vaults", params; aws_config=aws_config)
+    return glacier(
+        "GET",
+        "/$(accountId)/vaults",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1289,7 +1422,12 @@ This operation purchases a provisioned capacity unit for an AWS account.
 function purchase_provisioned_capacity(
     accountId; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return glacier("POST", "/$(accountId)/provisioned-capacity"; aws_config=aws_config)
+    return glacier(
+        "POST",
+        "/$(accountId)/provisioned-capacity";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function purchase_provisioned_capacity(
     accountId,
@@ -1297,7 +1435,11 @@ function purchase_provisioned_capacity(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return glacier(
-        "POST", "/$(accountId)/provisioned-capacity", params; aws_config=aws_config
+        "POST",
+        "/$(accountId)/provisioned-capacity",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1328,6 +1470,7 @@ function remove_tags_from_vault(
         "POST",
         "/$(accountId)/vaults/$(vaultName)/tags?operation=remove";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function remove_tags_from_vault(
@@ -1341,6 +1484,7 @@ function remove_tags_from_vault(
         "/$(accountId)/vaults/$(vaultName)/tags?operation=remove",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1368,7 +1512,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function set_data_retrieval_policy(
     accountId; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return glacier("PUT", "/$(accountId)/policies/data-retrieval"; aws_config=aws_config)
+    return glacier(
+        "PUT",
+        "/$(accountId)/policies/data-retrieval";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function set_data_retrieval_policy(
     accountId,
@@ -1376,7 +1525,11 @@ function set_data_retrieval_policy(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return glacier(
-        "PUT", "/$(accountId)/policies/data-retrieval", params; aws_config=aws_config
+        "PUT",
+        "/$(accountId)/policies/data-retrieval",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1406,7 +1559,10 @@ function set_vault_access_policy(
     accountId, vaultName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return glacier(
-        "PUT", "/$(accountId)/vaults/$(vaultName)/access-policy"; aws_config=aws_config
+        "PUT",
+        "/$(accountId)/vaults/$(vaultName)/access-policy";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function set_vault_access_policy(
@@ -1420,6 +1576,7 @@ function set_vault_access_policy(
         "/$(accountId)/vaults/$(vaultName)/access-policy",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1466,6 +1623,7 @@ function set_vault_notifications(
         "PUT",
         "/$(accountId)/vaults/$(vaultName)/notification-configuration";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function set_vault_notifications(
@@ -1479,6 +1637,7 @@ function set_vault_notifications(
         "/$(accountId)/vaults/$(vaultName)/notification-configuration",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1527,7 +1686,10 @@ function upload_archive(
     accountId, vaultName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return glacier(
-        "POST", "/$(accountId)/vaults/$(vaultName)/archives"; aws_config=aws_config
+        "POST",
+        "/$(accountId)/vaults/$(vaultName)/archives";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function upload_archive(
@@ -1537,7 +1699,11 @@ function upload_archive(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return glacier(
-        "POST", "/$(accountId)/vaults/$(vaultName)/archives", params; aws_config=aws_config
+        "POST",
+        "/$(accountId)/vaults/$(vaultName)/archives",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1596,6 +1762,7 @@ function upload_multipart_part(
         "PUT",
         "/$(accountId)/vaults/$(vaultName)/multipart-uploads/$(uploadId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function upload_multipart_part(
@@ -1610,5 +1777,6 @@ function upload_multipart_part(
         "/$(accountId)/vaults/$(vaultName)/multipart-uploads/$(uploadId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/global_accelerator.jl
+++ b/src/services/global_accelerator.jl
@@ -38,6 +38,7 @@ function add_custom_routing_endpoints(
             "EndpointGroupArn" => EndpointGroupArn,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function add_custom_routing_endpoints(
@@ -59,6 +60,7 @@ function add_custom_routing_endpoints(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -79,7 +81,10 @@ Bring Your Own IP Addresses (BYOIP) in the AWS Global Accelerator Developer Guid
 """
 function advertise_byoip_cidr(Cidr; aws_config::AbstractAWSConfig=global_aws_config())
     return global_accelerator(
-        "AdvertiseByoipCidr", Dict{String,Any}("Cidr" => Cidr); aws_config=aws_config
+        "AdvertiseByoipCidr",
+        Dict{String,Any}("Cidr" => Cidr);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function advertise_byoip_cidr(
@@ -89,6 +94,7 @@ function advertise_byoip_cidr(
         "AdvertiseByoipCidr",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Cidr" => Cidr), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -135,6 +141,7 @@ function allow_custom_routing_traffic(
             "EndpointGroupArn" => EndpointGroupArn, "EndpointId" => EndpointId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function allow_custom_routing_traffic(
@@ -155,6 +162,7 @@ function allow_custom_routing_traffic(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -201,6 +209,7 @@ function create_accelerator(
         "CreateAccelerator",
         Dict{String,Any}("IdempotencyToken" => IdempotencyToken, "Name" => Name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_accelerator(
@@ -219,6 +228,7 @@ function create_accelerator(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -268,6 +278,7 @@ function create_custom_routing_accelerator(
         "CreateCustomRoutingAccelerator",
         Dict{String,Any}("IdempotencyToken" => IdempotencyToken, "Name" => Name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_custom_routing_accelerator(
@@ -286,6 +297,7 @@ function create_custom_routing_accelerator(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -323,6 +335,7 @@ function create_custom_routing_endpoint_group(
             "ListenerArn" => ListenerArn,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_custom_routing_endpoint_group(
@@ -348,6 +361,7 @@ function create_custom_routing_endpoint_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -383,6 +397,7 @@ function create_custom_routing_listener(
             "PortRanges" => PortRanges,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_custom_routing_listener(
@@ -406,6 +421,7 @@ function create_custom_routing_listener(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -465,6 +481,7 @@ function create_endpoint_group(
             "ListenerArn" => ListenerArn,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_endpoint_group(
@@ -488,6 +505,7 @@ function create_endpoint_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -540,6 +558,7 @@ function create_listener(
             "Protocol" => Protocol,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_listener(
@@ -565,6 +584,7 @@ function create_listener(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -597,6 +617,7 @@ function delete_accelerator(
         "DeleteAccelerator",
         Dict{String,Any}("AcceleratorArn" => AcceleratorArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_accelerator(
@@ -610,6 +631,7 @@ function delete_accelerator(
             mergewith(_merge, Dict{String,Any}("AcceleratorArn" => AcceleratorArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -642,6 +664,7 @@ function delete_custom_routing_accelerator(
         "DeleteCustomRoutingAccelerator",
         Dict{String,Any}("AcceleratorArn" => AcceleratorArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_custom_routing_accelerator(
@@ -655,6 +678,7 @@ function delete_custom_routing_accelerator(
             mergewith(_merge, Dict{String,Any}("AcceleratorArn" => AcceleratorArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -675,6 +699,7 @@ function delete_custom_routing_endpoint_group(
         "DeleteCustomRoutingEndpointGroup",
         Dict{String,Any}("EndpointGroupArn" => EndpointGroupArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_custom_routing_endpoint_group(
@@ -690,6 +715,7 @@ function delete_custom_routing_endpoint_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -710,6 +736,7 @@ function delete_custom_routing_listener(
         "DeleteCustomRoutingListener",
         Dict{String,Any}("ListenerArn" => ListenerArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_custom_routing_listener(
@@ -723,6 +750,7 @@ function delete_custom_routing_listener(
             mergewith(_merge, Dict{String,Any}("ListenerArn" => ListenerArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -743,6 +771,7 @@ function delete_endpoint_group(
         "DeleteEndpointGroup",
         Dict{String,Any}("EndpointGroupArn" => EndpointGroupArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_endpoint_group(
@@ -758,6 +787,7 @@ function delete_endpoint_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -776,6 +806,7 @@ function delete_listener(ListenerArn; aws_config::AbstractAWSConfig=global_aws_c
         "DeleteListener",
         Dict{String,Any}("ListenerArn" => ListenerArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_listener(
@@ -789,6 +820,7 @@ function delete_listener(
             mergewith(_merge, Dict{String,Any}("ListenerArn" => ListenerArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -835,6 +867,7 @@ function deny_custom_routing_traffic(
             "EndpointGroupArn" => EndpointGroupArn, "EndpointId" => EndpointId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function deny_custom_routing_traffic(
@@ -855,6 +888,7 @@ function deny_custom_routing_traffic(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -876,7 +910,10 @@ allocated from its address range.  For more information, see Bring Your Own IP A
 """
 function deprovision_byoip_cidr(Cidr; aws_config::AbstractAWSConfig=global_aws_config())
     return global_accelerator(
-        "DeprovisionByoipCidr", Dict{String,Any}("Cidr" => Cidr); aws_config=aws_config
+        "DeprovisionByoipCidr",
+        Dict{String,Any}("Cidr" => Cidr);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function deprovision_byoip_cidr(
@@ -886,6 +923,7 @@ function deprovision_byoip_cidr(
         "DeprovisionByoipCidr",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Cidr" => Cidr), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -906,6 +944,7 @@ function describe_accelerator(
         "DescribeAccelerator",
         Dict{String,Any}("AcceleratorArn" => AcceleratorArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_accelerator(
@@ -919,6 +958,7 @@ function describe_accelerator(
             mergewith(_merge, Dict{String,Any}("AcceleratorArn" => AcceleratorArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -940,6 +980,7 @@ function describe_accelerator_attributes(
         "DescribeAcceleratorAttributes",
         Dict{String,Any}("AcceleratorArn" => AcceleratorArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_accelerator_attributes(
@@ -953,6 +994,7 @@ function describe_accelerator_attributes(
             mergewith(_merge, Dict{String,Any}("AcceleratorArn" => AcceleratorArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -973,6 +1015,7 @@ function describe_custom_routing_accelerator(
         "DescribeCustomRoutingAccelerator",
         Dict{String,Any}("AcceleratorArn" => AcceleratorArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_custom_routing_accelerator(
@@ -986,6 +1029,7 @@ function describe_custom_routing_accelerator(
             mergewith(_merge, Dict{String,Any}("AcceleratorArn" => AcceleratorArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1007,6 +1051,7 @@ function describe_custom_routing_accelerator_attributes(
         "DescribeCustomRoutingAcceleratorAttributes",
         Dict{String,Any}("AcceleratorArn" => AcceleratorArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_custom_routing_accelerator_attributes(
@@ -1020,6 +1065,7 @@ function describe_custom_routing_accelerator_attributes(
             mergewith(_merge, Dict{String,Any}("AcceleratorArn" => AcceleratorArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1040,6 +1086,7 @@ function describe_custom_routing_endpoint_group(
         "DescribeCustomRoutingEndpointGroup",
         Dict{String,Any}("EndpointGroupArn" => EndpointGroupArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_custom_routing_endpoint_group(
@@ -1055,6 +1102,7 @@ function describe_custom_routing_endpoint_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1075,6 +1123,7 @@ function describe_custom_routing_listener(
         "DescribeCustomRoutingListener",
         Dict{String,Any}("ListenerArn" => ListenerArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_custom_routing_listener(
@@ -1088,6 +1137,7 @@ function describe_custom_routing_listener(
             mergewith(_merge, Dict{String,Any}("ListenerArn" => ListenerArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1108,6 +1158,7 @@ function describe_endpoint_group(
         "DescribeEndpointGroup",
         Dict{String,Any}("EndpointGroupArn" => EndpointGroupArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_endpoint_group(
@@ -1123,6 +1174,7 @@ function describe_endpoint_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1141,6 +1193,7 @@ function describe_listener(ListenerArn; aws_config::AbstractAWSConfig=global_aws
         "DescribeListener",
         Dict{String,Any}("ListenerArn" => ListenerArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_listener(
@@ -1154,6 +1207,7 @@ function describe_listener(
             mergewith(_merge, Dict{String,Any}("ListenerArn" => ListenerArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1171,12 +1225,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   previous call.
 """
 function list_accelerators(; aws_config::AbstractAWSConfig=global_aws_config())
-    return global_accelerator("ListAccelerators"; aws_config=aws_config)
+    return global_accelerator(
+        "ListAccelerators"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_accelerators(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return global_accelerator("ListAccelerators", params; aws_config=aws_config)
+    return global_accelerator(
+        "ListAccelerators", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1193,12 +1251,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`: The token for the next page of results.
 """
 function list_byoip_cidrs(; aws_config::AbstractAWSConfig=global_aws_config())
-    return global_accelerator("ListByoipCidrs"; aws_config=aws_config)
+    return global_accelerator(
+        "ListByoipCidrs"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_byoip_cidrs(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return global_accelerator("ListByoipCidrs", params; aws_config=aws_config)
+    return global_accelerator(
+        "ListByoipCidrs", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1217,13 +1279,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function list_custom_routing_accelerators(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return global_accelerator("ListCustomRoutingAccelerators"; aws_config=aws_config)
+    return global_accelerator(
+        "ListCustomRoutingAccelerators";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_custom_routing_accelerators(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return global_accelerator(
-        "ListCustomRoutingAccelerators", params; aws_config=aws_config
+        "ListCustomRoutingAccelerators",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1252,6 +1321,7 @@ function list_custom_routing_endpoint_groups(
         "ListCustomRoutingEndpointGroups",
         Dict{String,Any}("ListenerArn" => ListenerArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_custom_routing_endpoint_groups(
@@ -1265,6 +1335,7 @@ function list_custom_routing_endpoint_groups(
             mergewith(_merge, Dict{String,Any}("ListenerArn" => ListenerArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1292,6 +1363,7 @@ function list_custom_routing_listeners(
         "ListCustomRoutingListeners",
         Dict{String,Any}("AcceleratorArn" => AcceleratorArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_custom_routing_listeners(
@@ -1305,6 +1377,7 @@ function list_custom_routing_listeners(
             mergewith(_merge, Dict{String,Any}("AcceleratorArn" => AcceleratorArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1344,6 +1417,7 @@ function list_custom_routing_port_mappings(
         "ListCustomRoutingPortMappings",
         Dict{String,Any}("AcceleratorArn" => AcceleratorArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_custom_routing_port_mappings(
@@ -1357,6 +1431,7 @@ function list_custom_routing_port_mappings(
             mergewith(_merge, Dict{String,Any}("AcceleratorArn" => AcceleratorArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1391,6 +1466,7 @@ function list_custom_routing_port_mappings_by_destination(
             "DestinationAddress" => DestinationAddress, "EndpointId" => EndpointId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_custom_routing_port_mappings_by_destination(
@@ -1411,6 +1487,7 @@ function list_custom_routing_port_mappings_by_destination(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1437,6 +1514,7 @@ function list_endpoint_groups(
         "ListEndpointGroups",
         Dict{String,Any}("ListenerArn" => ListenerArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_endpoint_groups(
@@ -1450,6 +1528,7 @@ function list_endpoint_groups(
             mergewith(_merge, Dict{String,Any}("ListenerArn" => ListenerArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1475,6 +1554,7 @@ function list_listeners(AcceleratorArn; aws_config::AbstractAWSConfig=global_aws
         "ListListeners",
         Dict{String,Any}("AcceleratorArn" => AcceleratorArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_listeners(
@@ -1488,6 +1568,7 @@ function list_listeners(
             mergewith(_merge, Dict{String,Any}("AcceleratorArn" => AcceleratorArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1510,6 +1591,7 @@ function list_tags_for_resource(
         "ListTagsForResource",
         Dict{String,Any}("ResourceArn" => ResourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags_for_resource(
@@ -1523,6 +1605,7 @@ function list_tags_for_resource(
             mergewith(_merge, Dict{String,Any}("ResourceArn" => ResourceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1552,6 +1635,7 @@ function provision_byoip_cidr(
             "Cidr" => Cidr, "CidrAuthorizationContext" => CidrAuthorizationContext
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function provision_byoip_cidr(
@@ -1572,6 +1656,7 @@ function provision_byoip_cidr(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1597,6 +1682,7 @@ function remove_custom_routing_endpoints(
             "EndpointGroupArn" => EndpointGroupArn, "EndpointIds" => EndpointIds
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function remove_custom_routing_endpoints(
@@ -1617,6 +1703,7 @@ function remove_custom_routing_endpoints(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1639,6 +1726,7 @@ function tag_resource(ResourceArn, Tags; aws_config::AbstractAWSConfig=global_aw
         "TagResource",
         Dict{String,Any}("ResourceArn" => ResourceArn, "Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -1657,6 +1745,7 @@ function tag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1682,6 +1771,7 @@ function untag_resource(
         "UntagResource",
         Dict{String,Any}("ResourceArn" => ResourceArn, "TagKeys" => TagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -1700,6 +1790,7 @@ function untag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1731,6 +1822,7 @@ function update_accelerator(
         "UpdateAccelerator",
         Dict{String,Any}("AcceleratorArn" => AcceleratorArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_accelerator(
@@ -1744,6 +1836,7 @@ function update_accelerator(
             mergewith(_merge, Dict{String,Any}("AcceleratorArn" => AcceleratorArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1778,6 +1871,7 @@ function update_accelerator_attributes(
         "UpdateAcceleratorAttributes",
         Dict{String,Any}("AcceleratorArn" => AcceleratorArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_accelerator_attributes(
@@ -1791,6 +1885,7 @@ function update_accelerator_attributes(
             mergewith(_merge, Dict{String,Any}("AcceleratorArn" => AcceleratorArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1820,6 +1915,7 @@ function update_custom_routing_accelerator(
         "UpdateCustomRoutingAccelerator",
         Dict{String,Any}("AcceleratorArn" => AcceleratorArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_custom_routing_accelerator(
@@ -1833,6 +1929,7 @@ function update_custom_routing_accelerator(
             mergewith(_merge, Dict{String,Any}("AcceleratorArn" => AcceleratorArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1867,6 +1964,7 @@ function update_custom_routing_accelerator_attributes(
         "UpdateCustomRoutingAcceleratorAttributes",
         Dict{String,Any}("AcceleratorArn" => AcceleratorArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_custom_routing_accelerator_attributes(
@@ -1880,6 +1978,7 @@ function update_custom_routing_accelerator_attributes(
             mergewith(_merge, Dict{String,Any}("AcceleratorArn" => AcceleratorArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1904,6 +2003,7 @@ function update_custom_routing_listener(
         "UpdateCustomRoutingListener",
         Dict{String,Any}("ListenerArn" => ListenerArn, "PortRanges" => PortRanges);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_custom_routing_listener(
@@ -1922,6 +2022,7 @@ function update_custom_routing_listener(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1970,6 +2071,7 @@ function update_endpoint_group(
         "UpdateEndpointGroup",
         Dict{String,Any}("EndpointGroupArn" => EndpointGroupArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_endpoint_group(
@@ -1985,6 +2087,7 @@ function update_endpoint_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2022,6 +2125,7 @@ function update_listener(ListenerArn; aws_config::AbstractAWSConfig=global_aws_c
         "UpdateListener",
         Dict{String,Any}("ListenerArn" => ListenerArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_listener(
@@ -2035,6 +2139,7 @@ function update_listener(
             mergewith(_merge, Dict{String,Any}("ListenerArn" => ListenerArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2054,7 +2159,10 @@ Addresses (BYOIP) in the AWS Global Accelerator Developer Guide.
 """
 function withdraw_byoip_cidr(Cidr; aws_config::AbstractAWSConfig=global_aws_config())
     return global_accelerator(
-        "WithdrawByoipCidr", Dict{String,Any}("Cidr" => Cidr); aws_config=aws_config
+        "WithdrawByoipCidr",
+        Dict{String,Any}("Cidr" => Cidr);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function withdraw_byoip_cidr(
@@ -2064,5 +2172,6 @@ function withdraw_byoip_cidr(
         "WithdrawByoipCidr",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Cidr" => Cidr), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/glue.jl
+++ b/src/services/glue.jl
@@ -36,6 +36,7 @@ function batch_create_partition(
             "TableName" => TableName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_create_partition(
@@ -59,6 +60,7 @@ function batch_create_partition(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -83,6 +85,7 @@ function batch_delete_connection(
         "BatchDeleteConnection",
         Dict{String,Any}("ConnectionNameList" => ConnectionNameList);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_delete_connection(
@@ -98,6 +101,7 @@ function batch_delete_connection(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -132,6 +136,7 @@ function batch_delete_partition(
             "TableName" => TableName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_delete_partition(
@@ -155,6 +160,7 @@ function batch_delete_partition(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -188,6 +194,7 @@ function batch_delete_table(
             "DatabaseName" => DatabaseName, "TablesToDelete" => TablesToDelete
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_delete_table(
@@ -208,6 +215,7 @@ function batch_delete_table(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -241,6 +249,7 @@ function batch_delete_table_version(
             "VersionIds" => VersionIds,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_delete_table_version(
@@ -264,6 +273,7 @@ function batch_delete_table_version(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -284,7 +294,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function batch_get_blueprints(Names; aws_config::AbstractAWSConfig=global_aws_config())
     return glue(
-        "BatchGetBlueprints", Dict{String,Any}("Names" => Names); aws_config=aws_config
+        "BatchGetBlueprints",
+        Dict{String,Any}("Names" => Names);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_get_blueprints(
@@ -294,6 +307,7 @@ function batch_get_blueprints(
         "BatchGetBlueprints",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Names" => Names), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -316,6 +330,7 @@ function batch_get_crawlers(CrawlerNames; aws_config::AbstractAWSConfig=global_a
         "BatchGetCrawlers",
         Dict{String,Any}("CrawlerNames" => CrawlerNames);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_get_crawlers(
@@ -329,6 +344,7 @@ function batch_get_crawlers(
             mergewith(_merge, Dict{String,Any}("CrawlerNames" => CrawlerNames), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -353,6 +369,7 @@ function batch_get_dev_endpoints(
         "BatchGetDevEndpoints",
         Dict{String,Any}("DevEndpointNames" => DevEndpointNames);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_get_dev_endpoints(
@@ -368,6 +385,7 @@ function batch_get_dev_endpoints(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -387,7 +405,10 @@ conditions that uses tags.
 """
 function batch_get_jobs(JobNames; aws_config::AbstractAWSConfig=global_aws_config())
     return glue(
-        "BatchGetJobs", Dict{String,Any}("JobNames" => JobNames); aws_config=aws_config
+        "BatchGetJobs",
+        Dict{String,Any}("JobNames" => JobNames);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_get_jobs(
@@ -401,6 +422,7 @@ function batch_get_jobs(
             mergewith(_merge, Dict{String,Any}("JobNames" => JobNames), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -434,6 +456,7 @@ function batch_get_partition(
             "TableName" => TableName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_get_partition(
@@ -457,6 +480,7 @@ function batch_get_partition(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -479,6 +503,7 @@ function batch_get_triggers(TriggerNames; aws_config::AbstractAWSConfig=global_a
         "BatchGetTriggers",
         Dict{String,Any}("TriggerNames" => TriggerNames);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_get_triggers(
@@ -492,6 +517,7 @@ function batch_get_triggers(
             mergewith(_merge, Dict{String,Any}("TriggerNames" => TriggerNames), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -515,7 +541,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function batch_get_workflows(Names; aws_config::AbstractAWSConfig=global_aws_config())
     return glue(
-        "BatchGetWorkflows", Dict{String,Any}("Names" => Names); aws_config=aws_config
+        "BatchGetWorkflows",
+        Dict{String,Any}("Names" => Names);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_get_workflows(
@@ -525,6 +554,7 @@ function batch_get_workflows(
         "BatchGetWorkflows",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Names" => Names), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -546,6 +576,7 @@ function batch_stop_job_run(
         "BatchStopJobRun",
         Dict{String,Any}("JobName" => JobName, "JobRunIds" => JobRunIds);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_stop_job_run(
@@ -564,6 +595,7 @@ function batch_stop_job_run(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -593,6 +625,7 @@ function batch_update_partition(
             "DatabaseName" => DatabaseName, "Entries" => Entries, "TableName" => TableName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_update_partition(
@@ -616,6 +649,7 @@ function batch_update_partition(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -640,6 +674,7 @@ function cancel_mltask_run(
         "CancelMLTaskRun",
         Dict{String,Any}("TaskRunId" => TaskRunId, "TransformId" => TransformId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function cancel_mltask_run(
@@ -658,6 +693,7 @@ function cancel_mltask_run(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -684,6 +720,7 @@ function check_schema_version_validity(
             "DataFormat" => DataFormat, "SchemaDefinition" => SchemaDefinition
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function check_schema_version_validity(
@@ -704,6 +741,7 @@ function check_schema_version_validity(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -729,6 +767,7 @@ function create_blueprint(
         "CreateBlueprint",
         Dict{String,Any}("BlueprintLocation" => BlueprintLocation, "Name" => Name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_blueprint(
@@ -747,6 +786,7 @@ function create_blueprint(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -765,12 +805,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"XMLClassifier"`: An XMLClassifier object specifying the classifier to create.
 """
 function create_classifier(; aws_config::AbstractAWSConfig=global_aws_config())
-    return glue("CreateClassifier"; aws_config=aws_config)
+    return glue("CreateClassifier"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function create_classifier(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return glue("CreateClassifier", params; aws_config=aws_config)
+    return glue(
+        "CreateClassifier", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -794,6 +836,7 @@ function create_connection(
         "CreateConnection",
         Dict{String,Any}("ConnectionInput" => ConnectionInput);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_connection(
@@ -809,6 +852,7 @@ function create_connection(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -858,6 +902,7 @@ function create_crawler(
         "CreateCrawler",
         Dict{String,Any}("Name" => Name, "Role" => Role, "Targets" => Targets);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_crawler(
@@ -877,6 +922,7 @@ function create_crawler(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -899,6 +945,7 @@ function create_database(DatabaseInput; aws_config::AbstractAWSConfig=global_aws
         "CreateDatabase",
         Dict{String,Any}("DatabaseInput" => DatabaseInput);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_database(
@@ -912,6 +959,7 @@ function create_database(
             mergewith(_merge, Dict{String,Any}("DatabaseInput" => DatabaseInput), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -983,6 +1031,7 @@ function create_dev_endpoint(
         "CreateDevEndpoint",
         Dict{String,Any}("EndpointName" => EndpointName, "RoleArn" => RoleArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_dev_endpoint(
@@ -1001,6 +1050,7 @@ function create_dev_endpoint(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1079,6 +1129,7 @@ function create_job(Command, Name, Role; aws_config::AbstractAWSConfig=global_aw
         "CreateJob",
         Dict{String,Any}("Command" => Command, "Name" => Name, "Role" => Role);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_job(
@@ -1098,6 +1149,7 @@ function create_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1187,6 +1239,7 @@ function create_mltransform(
             "Role" => Role,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_mltransform(
@@ -1212,6 +1265,7 @@ function create_mltransform(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1246,6 +1300,7 @@ function create_partition(
             "TableName" => TableName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_partition(
@@ -1269,6 +1324,7 @@ function create_partition(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1303,6 +1359,7 @@ function create_partition_index(
             "TableName" => TableName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_partition_index(
@@ -1326,6 +1383,7 @@ function create_partition_index(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1351,6 +1409,7 @@ function create_registry(RegistryName; aws_config::AbstractAWSConfig=global_aws_
         "CreateRegistry",
         Dict{String,Any}("RegistryName" => RegistryName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_registry(
@@ -1364,6 +1423,7 @@ function create_registry(
             mergewith(_merge, Dict{String,Any}("RegistryName" => RegistryName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1431,6 +1491,7 @@ function create_schema(
         "CreateSchema",
         Dict{String,Any}("DataFormat" => DataFormat, "SchemaName" => SchemaName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_schema(
@@ -1449,6 +1510,7 @@ function create_schema(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1465,12 +1527,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"Language"`: The programming language of the resulting code from the DAG.
 """
 function create_script(; aws_config::AbstractAWSConfig=global_aws_config())
-    return glue("CreateScript"; aws_config=aws_config)
+    return glue("CreateScript"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function create_script(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return glue("CreateScript", params; aws_config=aws_config)
+    return glue(
+        "CreateScript", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1497,6 +1561,7 @@ function create_security_configuration(
             "EncryptionConfiguration" => EncryptionConfiguration, "Name" => Name
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_security_configuration(
@@ -1517,6 +1582,7 @@ function create_security_configuration(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1546,6 +1612,7 @@ function create_table(
         "CreateTable",
         Dict{String,Any}("DatabaseName" => DatabaseName, "TableInput" => TableInput);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_table(
@@ -1566,6 +1633,7 @@ function create_table(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1604,6 +1672,7 @@ function create_trigger(
         "CreateTrigger",
         Dict{String,Any}("Actions" => Actions, "Name" => Name, "Type" => Type);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_trigger(
@@ -1623,6 +1692,7 @@ function create_trigger(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1649,6 +1719,7 @@ function create_user_defined_function(
         "CreateUserDefinedFunction",
         Dict{String,Any}("DatabaseName" => DatabaseName, "FunctionInput" => FunctionInput);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_user_defined_function(
@@ -1669,6 +1740,7 @@ function create_user_defined_function(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1693,7 +1765,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"Tags"`: The tags to be used with this workflow.
 """
 function create_workflow(Name; aws_config::AbstractAWSConfig=global_aws_config())
-    return glue("CreateWorkflow", Dict{String,Any}("Name" => Name); aws_config=aws_config)
+    return glue(
+        "CreateWorkflow",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function create_workflow(
     Name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -1702,6 +1779,7 @@ function create_workflow(
         "CreateWorkflow",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1716,7 +1794,12 @@ Deletes an existing blueprint.
 
 """
 function delete_blueprint(Name; aws_config::AbstractAWSConfig=global_aws_config())
-    return glue("DeleteBlueprint", Dict{String,Any}("Name" => Name); aws_config=aws_config)
+    return glue(
+        "DeleteBlueprint",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_blueprint(
     Name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -1725,6 +1808,7 @@ function delete_blueprint(
         "DeleteBlueprint",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1739,7 +1823,12 @@ Removes a classifier from the Data Catalog.
 
 """
 function delete_classifier(Name; aws_config::AbstractAWSConfig=global_aws_config())
-    return glue("DeleteClassifier", Dict{String,Any}("Name" => Name); aws_config=aws_config)
+    return glue(
+        "DeleteClassifier",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_classifier(
     Name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -1748,6 +1837,7 @@ function delete_classifier(
         "DeleteClassifier",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1785,6 +1875,7 @@ function delete_column_statistics_for_partition(
             "TableName" => TableName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_column_statistics_for_partition(
@@ -1810,6 +1901,7 @@ function delete_column_statistics_for_partition(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1841,6 +1933,7 @@ function delete_column_statistics_for_table(
             "TableName" => TableName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_column_statistics_for_table(
@@ -1864,6 +1957,7 @@ function delete_column_statistics_for_table(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1888,6 +1982,7 @@ function delete_connection(
         "DeleteConnection",
         Dict{String,Any}("ConnectionName" => ConnectionName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_connection(
@@ -1901,6 +1996,7 @@ function delete_connection(
             mergewith(_merge, Dict{String,Any}("ConnectionName" => ConnectionName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1915,7 +2011,12 @@ Removes a specified crawler from the Glue Data Catalog, unless the crawler state
 
 """
 function delete_crawler(Name; aws_config::AbstractAWSConfig=global_aws_config())
-    return glue("DeleteCrawler", Dict{String,Any}("Name" => Name); aws_config=aws_config)
+    return glue(
+        "DeleteCrawler",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_crawler(
     Name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -1924,6 +2025,7 @@ function delete_crawler(
         "DeleteCrawler",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1950,7 +2052,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   provided, the Amazon Web Services account ID is used by default.
 """
 function delete_database(Name; aws_config::AbstractAWSConfig=global_aws_config())
-    return glue("DeleteDatabase", Dict{String,Any}("Name" => Name); aws_config=aws_config)
+    return glue(
+        "DeleteDatabase",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_database(
     Name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -1959,6 +2066,7 @@ function delete_database(
         "DeleteDatabase",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1979,6 +2087,7 @@ function delete_dev_endpoint(
         "DeleteDevEndpoint",
         Dict{String,Any}("EndpointName" => EndpointName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_dev_endpoint(
@@ -1992,6 +2101,7 @@ function delete_dev_endpoint(
             mergewith(_merge, Dict{String,Any}("EndpointName" => EndpointName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2007,7 +2117,12 @@ thrown.
 
 """
 function delete_job(JobName; aws_config::AbstractAWSConfig=global_aws_config())
-    return glue("DeleteJob", Dict{String,Any}("JobName" => JobName); aws_config=aws_config)
+    return glue(
+        "DeleteJob",
+        Dict{String,Any}("JobName" => JobName);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_job(
     JobName, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -2016,6 +2131,7 @@ function delete_job(
         "DeleteJob",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("JobName" => JobName), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2039,6 +2155,7 @@ function delete_mltransform(TransformId; aws_config::AbstractAWSConfig=global_aw
         "DeleteMLTransform",
         Dict{String,Any}("TransformId" => TransformId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_mltransform(
@@ -2052,6 +2169,7 @@ function delete_mltransform(
             mergewith(_merge, Dict{String,Any}("TransformId" => TransformId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2085,6 +2203,7 @@ function delete_partition(
             "TableName" => TableName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_partition(
@@ -2108,6 +2227,7 @@ function delete_partition(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2139,6 +2259,7 @@ function delete_partition_index(
             "TableName" => TableName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_partition_index(
@@ -2162,6 +2283,7 @@ function delete_partition_index(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2184,6 +2306,7 @@ function delete_registry(RegistryId; aws_config::AbstractAWSConfig=global_aws_co
         "DeleteRegistry",
         Dict{String,Any}("RegistryId" => RegistryId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_registry(
@@ -2197,6 +2320,7 @@ function delete_registry(
             mergewith(_merge, Dict{String,Any}("RegistryId" => RegistryId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2212,12 +2336,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"ResourceArn"`: The ARN of the Glue resource for the resource policy to be deleted.
 """
 function delete_resource_policy(; aws_config::AbstractAWSConfig=global_aws_config())
-    return glue("DeleteResourcePolicy"; aws_config=aws_config)
+    return glue(
+        "DeleteResourcePolicy"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function delete_resource_policy(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return glue("DeleteResourcePolicy", params; aws_config=aws_config)
+    return glue(
+        "DeleteResourcePolicy",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2236,7 +2367,10 @@ GetSchemaByDefinition, and RegisterSchemaVersion APIs.
 """
 function delete_schema(SchemaId; aws_config::AbstractAWSConfig=global_aws_config())
     return glue(
-        "DeleteSchema", Dict{String,Any}("SchemaId" => SchemaId); aws_config=aws_config
+        "DeleteSchema",
+        Dict{String,Any}("SchemaId" => SchemaId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_schema(
@@ -2250,6 +2384,7 @@ function delete_schema(
             mergewith(_merge, Dict{String,Any}("SchemaId" => SchemaId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2284,6 +2419,7 @@ function delete_schema_versions(
         "DeleteSchemaVersions",
         Dict{String,Any}("SchemaId" => SchemaId, "Versions" => Versions);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_schema_versions(
@@ -2302,6 +2438,7 @@ function delete_schema_versions(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2322,6 +2459,7 @@ function delete_security_configuration(
         "DeleteSecurityConfiguration",
         Dict{String,Any}("Name" => Name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_security_configuration(
@@ -2331,6 +2469,7 @@ function delete_security_configuration(
         "DeleteSecurityConfiguration",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2361,6 +2500,7 @@ function delete_table(DatabaseName, Name; aws_config::AbstractAWSConfig=global_a
         "DeleteTable",
         Dict{String,Any}("DatabaseName" => DatabaseName, "Name" => Name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_table(
@@ -2379,6 +2519,7 @@ function delete_table(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2412,6 +2553,7 @@ function delete_table_version(
             "VersionId" => VersionId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_table_version(
@@ -2435,6 +2577,7 @@ function delete_table_version(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2449,7 +2592,12 @@ Deletes a specified trigger. If the trigger is not found, no exception is thrown
 
 """
 function delete_trigger(Name; aws_config::AbstractAWSConfig=global_aws_config())
-    return glue("DeleteTrigger", Dict{String,Any}("Name" => Name); aws_config=aws_config)
+    return glue(
+        "DeleteTrigger",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_trigger(
     Name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -2458,6 +2606,7 @@ function delete_trigger(
         "DeleteTrigger",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2483,6 +2632,7 @@ function delete_user_defined_function(
         "DeleteUserDefinedFunction",
         Dict{String,Any}("DatabaseName" => DatabaseName, "FunctionName" => FunctionName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_user_defined_function(
@@ -2503,6 +2653,7 @@ function delete_user_defined_function(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2517,7 +2668,12 @@ Deletes a workflow.
 
 """
 function delete_workflow(Name; aws_config::AbstractAWSConfig=global_aws_config())
-    return glue("DeleteWorkflow", Dict{String,Any}("Name" => Name); aws_config=aws_config)
+    return glue(
+        "DeleteWorkflow",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_workflow(
     Name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -2526,6 +2682,7 @@ function delete_workflow(
         "DeleteWorkflow",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2544,7 +2701,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"IncludeParameterSpec"`: Specifies whether or not to include the parameter specification.
 """
 function get_blueprint(Name; aws_config::AbstractAWSConfig=global_aws_config())
-    return glue("GetBlueprint", Dict{String,Any}("Name" => Name); aws_config=aws_config)
+    return glue(
+        "GetBlueprint",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_blueprint(
     Name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -2553,6 +2715,7 @@ function get_blueprint(
         "GetBlueprint",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2574,6 +2737,7 @@ function get_blueprint_run(
         "GetBlueprintRun",
         Dict{String,Any}("BlueprintName" => BlueprintName, "RunId" => RunId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_blueprint_run(
@@ -2592,6 +2756,7 @@ function get_blueprint_run(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2616,6 +2781,7 @@ function get_blueprint_runs(
         "GetBlueprintRuns",
         Dict{String,Any}("BlueprintName" => BlueprintName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_blueprint_runs(
@@ -2629,6 +2795,7 @@ function get_blueprint_runs(
             mergewith(_merge, Dict{String,Any}("BlueprintName" => BlueprintName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2644,12 +2811,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Services account ID.
 """
 function get_catalog_import_status(; aws_config::AbstractAWSConfig=global_aws_config())
-    return glue("GetCatalogImportStatus"; aws_config=aws_config)
+    return glue(
+        "GetCatalogImportStatus"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_catalog_import_status(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return glue("GetCatalogImportStatus", params; aws_config=aws_config)
+    return glue(
+        "GetCatalogImportStatus",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2663,7 +2837,12 @@ Retrieve a classifier by name.
 
 """
 function get_classifier(Name; aws_config::AbstractAWSConfig=global_aws_config())
-    return glue("GetClassifier", Dict{String,Any}("Name" => Name); aws_config=aws_config)
+    return glue(
+        "GetClassifier",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_classifier(
     Name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -2672,6 +2851,7 @@ function get_classifier(
         "GetClassifier",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2687,12 +2867,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`: An optional continuation token.
 """
 function get_classifiers(; aws_config::AbstractAWSConfig=global_aws_config())
-    return glue("GetClassifiers"; aws_config=aws_config)
+    return glue("GetClassifiers"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function get_classifiers(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return glue("GetClassifiers", params; aws_config=aws_config)
+    return glue(
+        "GetClassifiers", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -2729,6 +2911,7 @@ function get_column_statistics_for_partition(
             "TableName" => TableName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_column_statistics_for_partition(
@@ -2754,6 +2937,7 @@ function get_column_statistics_for_partition(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2785,6 +2969,7 @@ function get_column_statistics_for_table(
             "TableName" => TableName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_column_statistics_for_table(
@@ -2808,6 +2993,7 @@ function get_column_statistics_for_table(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2831,7 +3017,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   of the connection properties.
 """
 function get_connection(Name; aws_config::AbstractAWSConfig=global_aws_config())
-    return glue("GetConnection", Dict{String,Any}("Name" => Name); aws_config=aws_config)
+    return glue(
+        "GetConnection",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_connection(
     Name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -2840,6 +3031,7 @@ function get_connection(
         "GetConnection",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2863,12 +3055,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`: A continuation token, if this is a continuation call.
 """
 function get_connections(; aws_config::AbstractAWSConfig=global_aws_config())
-    return glue("GetConnections"; aws_config=aws_config)
+    return glue("GetConnections"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function get_connections(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return glue("GetConnections", params; aws_config=aws_config)
+    return glue(
+        "GetConnections", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -2882,7 +3076,12 @@ Retrieves metadata for a specified crawler.
 
 """
 function get_crawler(Name; aws_config::AbstractAWSConfig=global_aws_config())
-    return glue("GetCrawler", Dict{String,Any}("Name" => Name); aws_config=aws_config)
+    return glue(
+        "GetCrawler",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_crawler(
     Name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -2891,6 +3090,7 @@ function get_crawler(
         "GetCrawler",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2907,12 +3107,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`: A continuation token, if this is a continuation call.
 """
 function get_crawler_metrics(; aws_config::AbstractAWSConfig=global_aws_config())
-    return glue("GetCrawlerMetrics"; aws_config=aws_config)
+    return glue("GetCrawlerMetrics"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function get_crawler_metrics(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return glue("GetCrawlerMetrics", params; aws_config=aws_config)
+    return glue(
+        "GetCrawlerMetrics", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -2927,12 +3129,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`: A continuation token, if this is a continuation request.
 """
 function get_crawlers(; aws_config::AbstractAWSConfig=global_aws_config())
-    return glue("GetCrawlers"; aws_config=aws_config)
+    return glue("GetCrawlers"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function get_crawlers(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return glue("GetCrawlers", params; aws_config=aws_config)
+    return glue(
+        "GetCrawlers", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -2949,12 +3153,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function get_data_catalog_encryption_settings(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return glue("GetDataCatalogEncryptionSettings"; aws_config=aws_config)
+    return glue(
+        "GetDataCatalogEncryptionSettings";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_data_catalog_encryption_settings(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return glue("GetDataCatalogEncryptionSettings", params; aws_config=aws_config)
+    return glue(
+        "GetDataCatalogEncryptionSettings",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2973,7 +3186,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   provided, the Amazon Web Services account ID is used by default.
 """
 function get_database(Name; aws_config::AbstractAWSConfig=global_aws_config())
-    return glue("GetDatabase", Dict{String,Any}("Name" => Name); aws_config=aws_config)
+    return glue(
+        "GetDatabase",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_database(
     Name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -2982,6 +3200,7 @@ function get_database(
         "GetDatabase",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3003,12 +3222,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   with your account, as well as the databases in yor local account.
 """
 function get_databases(; aws_config::AbstractAWSConfig=global_aws_config())
-    return glue("GetDatabases"; aws_config=aws_config)
+    return glue("GetDatabases"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function get_databases(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return glue("GetDatabases", params; aws_config=aws_config)
+    return glue(
+        "GetDatabases", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -3022,12 +3243,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"PythonScript"`: The Python script to transform.
 """
 function get_dataflow_graph(; aws_config::AbstractAWSConfig=global_aws_config())
-    return glue("GetDataflowGraph"; aws_config=aws_config)
+    return glue("GetDataflowGraph"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function get_dataflow_graph(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return glue("GetDataflowGraph", params; aws_config=aws_config)
+    return glue(
+        "GetDataflowGraph", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -3048,6 +3271,7 @@ function get_dev_endpoint(EndpointName; aws_config::AbstractAWSConfig=global_aws
         "GetDevEndpoint",
         Dict{String,Any}("EndpointName" => EndpointName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_dev_endpoint(
@@ -3061,6 +3285,7 @@ function get_dev_endpoint(
             mergewith(_merge, Dict{String,Any}("EndpointName" => EndpointName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3079,12 +3304,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`: A continuation token, if this is a continuation call.
 """
 function get_dev_endpoints(; aws_config::AbstractAWSConfig=global_aws_config())
-    return glue("GetDevEndpoints"; aws_config=aws_config)
+    return glue("GetDevEndpoints"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function get_dev_endpoints(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return glue("GetDevEndpoints", params; aws_config=aws_config)
+    return glue(
+        "GetDevEndpoints", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -3098,7 +3325,12 @@ Retrieves an existing job definition.
 
 """
 function get_job(JobName; aws_config::AbstractAWSConfig=global_aws_config())
-    return glue("GetJob", Dict{String,Any}("JobName" => JobName); aws_config=aws_config)
+    return glue(
+        "GetJob",
+        Dict{String,Any}("JobName" => JobName);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_job(
     JobName, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -3107,6 +3339,7 @@ function get_job(
         "GetJob",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("JobName" => JobName), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3125,7 +3358,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function get_job_bookmark(JobName; aws_config::AbstractAWSConfig=global_aws_config())
     return glue(
-        "GetJobBookmark", Dict{String,Any}("JobName" => JobName); aws_config=aws_config
+        "GetJobBookmark",
+        Dict{String,Any}("JobName" => JobName);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_job_bookmark(
@@ -3135,6 +3371,7 @@ function get_job_bookmark(
         "GetJobBookmark",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("JobName" => JobName), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3157,6 +3394,7 @@ function get_job_run(JobName, RunId; aws_config::AbstractAWSConfig=global_aws_co
         "GetJobRun",
         Dict{String,Any}("JobName" => JobName, "RunId" => RunId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_job_run(
@@ -3173,6 +3411,7 @@ function get_job_run(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3191,7 +3430,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`: A continuation token, if this is a continuation call.
 """
 function get_job_runs(JobName; aws_config::AbstractAWSConfig=global_aws_config())
-    return glue("GetJobRuns", Dict{String,Any}("JobName" => JobName); aws_config=aws_config)
+    return glue(
+        "GetJobRuns",
+        Dict{String,Any}("JobName" => JobName);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_job_runs(
     JobName, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -3200,6 +3444,7 @@ function get_job_runs(
         "GetJobRuns",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("JobName" => JobName), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3215,12 +3460,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`: A continuation token, if this is a continuation call.
 """
 function get_jobs(; aws_config::AbstractAWSConfig=global_aws_config())
-    return glue("GetJobs"; aws_config=aws_config)
+    return glue("GetJobs"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function get_jobs(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return glue("GetJobs", params; aws_config=aws_config)
+    return glue("GetJobs", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 
 """
@@ -3238,7 +3483,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"Sinks"`: A list of target tables.
 """
 function get_mapping(Source; aws_config::AbstractAWSConfig=global_aws_config())
-    return glue("GetMapping", Dict{String,Any}("Source" => Source); aws_config=aws_config)
+    return glue(
+        "GetMapping",
+        Dict{String,Any}("Source" => Source);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_mapping(
     Source, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -3247,6 +3497,7 @@ function get_mapping(
         "GetMapping",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Source" => Source), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3271,6 +3522,7 @@ function get_mltask_run(
         "GetMLTaskRun",
         Dict{String,Any}("TaskRunId" => TaskRunId, "TransformId" => TransformId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_mltask_run(
@@ -3289,6 +3541,7 @@ function get_mltask_run(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3318,6 +3571,7 @@ function get_mltask_runs(TransformId; aws_config::AbstractAWSConfig=global_aws_c
         "GetMLTaskRuns",
         Dict{String,Any}("TransformId" => TransformId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_mltask_runs(
@@ -3331,6 +3585,7 @@ function get_mltask_runs(
             mergewith(_merge, Dict{String,Any}("TransformId" => TransformId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3354,6 +3609,7 @@ function get_mltransform(TransformId; aws_config::AbstractAWSConfig=global_aws_c
         "GetMLTransform",
         Dict{String,Any}("TransformId" => TransformId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_mltransform(
@@ -3367,6 +3623,7 @@ function get_mltransform(
             mergewith(_merge, Dict{String,Any}("TransformId" => TransformId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3388,12 +3645,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"Sort"`: The sorting criteria.
 """
 function get_mltransforms(; aws_config::AbstractAWSConfig=global_aws_config())
-    return glue("GetMLTransforms"; aws_config=aws_config)
+    return glue("GetMLTransforms"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function get_mltransforms(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return glue("GetMLTransforms", params; aws_config=aws_config)
+    return glue(
+        "GetMLTransforms", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -3426,6 +3685,7 @@ function get_partition(
             "TableName" => TableName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_partition(
@@ -3449,6 +3709,7 @@ function get_partition(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3476,6 +3737,7 @@ function get_partition_indexes(
         "GetPartitionIndexes",
         Dict{String,Any}("DatabaseName" => DatabaseName, "TableName" => TableName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_partition_indexes(
@@ -3494,6 +3756,7 @@ function get_partition_indexes(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3545,6 +3808,7 @@ function get_partitions(
         "GetPartitions",
         Dict{String,Any}("DatabaseName" => DatabaseName, "TableName" => TableName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_partitions(
@@ -3563,6 +3827,7 @@ function get_partitions(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3592,6 +3857,7 @@ function get_plan(Mapping, Source; aws_config::AbstractAWSConfig=global_aws_conf
         "GetPlan",
         Dict{String,Any}("Mapping" => Mapping, "Source" => Source);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_plan(
@@ -3608,6 +3874,7 @@ function get_plan(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3624,7 +3891,10 @@ Describes the specified registry in detail.
 """
 function get_registry(RegistryId; aws_config::AbstractAWSConfig=global_aws_config())
     return glue(
-        "GetRegistry", Dict{String,Any}("RegistryId" => RegistryId); aws_config=aws_config
+        "GetRegistry",
+        Dict{String,Any}("RegistryId" => RegistryId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_registry(
@@ -3638,6 +3908,7 @@ function get_registry(
             mergewith(_merge, Dict{String,Any}("RegistryId" => RegistryId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3656,12 +3927,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`: A continuation token, if this is a continuation request.
 """
 function get_resource_policies(; aws_config::AbstractAWSConfig=global_aws_config())
-    return glue("GetResourcePolicies"; aws_config=aws_config)
+    return glue(
+        "GetResourcePolicies"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_resource_policies(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return glue("GetResourcePolicies", params; aws_config=aws_config)
+    return glue(
+        "GetResourcePolicies",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -3678,12 +3956,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   ARNs.
 """
 function get_resource_policy(; aws_config::AbstractAWSConfig=global_aws_config())
-    return glue("GetResourcePolicy"; aws_config=aws_config)
+    return glue("GetResourcePolicy"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function get_resource_policy(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return glue("GetResourcePolicy", params; aws_config=aws_config)
+    return glue(
+        "GetResourcePolicy", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -3701,7 +3981,10 @@ Describes the specified schema in detail.
 """
 function get_schema(SchemaId; aws_config::AbstractAWSConfig=global_aws_config())
     return glue(
-        "GetSchema", Dict{String,Any}("SchemaId" => SchemaId); aws_config=aws_config
+        "GetSchema",
+        Dict{String,Any}("SchemaId" => SchemaId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_schema(
@@ -3715,6 +3998,7 @@ function get_schema(
             mergewith(_merge, Dict{String,Any}("SchemaId" => SchemaId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3743,6 +4027,7 @@ function get_schema_by_definition(
         "GetSchemaByDefinition",
         Dict{String,Any}("SchemaDefinition" => SchemaDefinition, "SchemaId" => SchemaId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_schema_by_definition(
@@ -3763,6 +4048,7 @@ function get_schema_by_definition(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3785,12 +4071,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"SchemaVersionNumber"`: The version number of the schema.
 """
 function get_schema_version(; aws_config::AbstractAWSConfig=global_aws_config())
-    return glue("GetSchemaVersion"; aws_config=aws_config)
+    return glue("GetSchemaVersion"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function get_schema_version(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return glue("GetSchemaVersion", params; aws_config=aws_config)
+    return glue(
+        "GetSchemaVersion", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -3827,6 +4115,7 @@ function get_schema_versions_diff(
             "SecondSchemaVersionNumber" => SecondSchemaVersionNumber,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_schema_versions_diff(
@@ -3852,6 +4141,7 @@ function get_schema_versions_diff(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3867,7 +4157,10 @@ Retrieves a specified security configuration.
 """
 function get_security_configuration(Name; aws_config::AbstractAWSConfig=global_aws_config())
     return glue(
-        "GetSecurityConfiguration", Dict{String,Any}("Name" => Name); aws_config=aws_config
+        "GetSecurityConfiguration",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_security_configuration(
@@ -3877,6 +4170,7 @@ function get_security_configuration(
         "GetSecurityConfiguration",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3892,12 +4186,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`: A continuation token, if this is a continuation call.
 """
 function get_security_configurations(; aws_config::AbstractAWSConfig=global_aws_config())
-    return glue("GetSecurityConfigurations"; aws_config=aws_config)
+    return glue(
+        "GetSecurityConfigurations"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_security_configurations(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return glue("GetSecurityConfigurations", params; aws_config=aws_config)
+    return glue(
+        "GetSecurityConfigurations",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -3922,6 +4223,7 @@ function get_table(DatabaseName, Name; aws_config::AbstractAWSConfig=global_aws_
         "GetTable",
         Dict{String,Any}("DatabaseName" => DatabaseName, "Name" => Name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_table(
@@ -3940,6 +4242,7 @@ function get_table(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3969,6 +4272,7 @@ function get_table_version(
         "GetTableVersion",
         Dict{String,Any}("DatabaseName" => DatabaseName, "TableName" => TableName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_table_version(
@@ -3987,6 +4291,7 @@ function get_table_version(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4016,6 +4321,7 @@ function get_table_versions(
         "GetTableVersions",
         Dict{String,Any}("DatabaseName" => DatabaseName, "TableName" => TableName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_table_versions(
@@ -4034,6 +4340,7 @@ function get_table_versions(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4058,7 +4365,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function get_tables(DatabaseName; aws_config::AbstractAWSConfig=global_aws_config())
     return glue(
-        "GetTables", Dict{String,Any}("DatabaseName" => DatabaseName); aws_config=aws_config
+        "GetTables",
+        Dict{String,Any}("DatabaseName" => DatabaseName);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_tables(
@@ -4072,6 +4382,7 @@ function get_tables(
             mergewith(_merge, Dict{String,Any}("DatabaseName" => DatabaseName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4087,7 +4398,10 @@ Retrieves a list of tags associated with a resource.
 """
 function get_tags(ResourceArn; aws_config::AbstractAWSConfig=global_aws_config())
     return glue(
-        "GetTags", Dict{String,Any}("ResourceArn" => ResourceArn); aws_config=aws_config
+        "GetTags",
+        Dict{String,Any}("ResourceArn" => ResourceArn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_tags(
@@ -4101,6 +4415,7 @@ function get_tags(
             mergewith(_merge, Dict{String,Any}("ResourceArn" => ResourceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4115,7 +4430,12 @@ Retrieves the definition of a trigger.
 
 """
 function get_trigger(Name; aws_config::AbstractAWSConfig=global_aws_config())
-    return glue("GetTrigger", Dict{String,Any}("Name" => Name); aws_config=aws_config)
+    return glue(
+        "GetTrigger",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_trigger(
     Name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -4124,6 +4444,7 @@ function get_trigger(
         "GetTrigger",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4141,12 +4462,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`: A continuation token, if this is a continuation call.
 """
 function get_triggers(; aws_config::AbstractAWSConfig=global_aws_config())
-    return glue("GetTriggers"; aws_config=aws_config)
+    return glue("GetTriggers"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function get_triggers(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return glue("GetTriggers", params; aws_config=aws_config)
+    return glue(
+        "GetTriggers", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -4171,6 +4494,7 @@ function get_user_defined_function(
         "GetUserDefinedFunction",
         Dict{String,Any}("DatabaseName" => DatabaseName, "FunctionName" => FunctionName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_user_defined_function(
@@ -4191,6 +4515,7 @@ function get_user_defined_function(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4220,6 +4545,7 @@ function get_user_defined_functions(
         "GetUserDefinedFunctions",
         Dict{String,Any}("Pattern" => Pattern);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_user_defined_functions(
@@ -4229,6 +4555,7 @@ function get_user_defined_functions(
         "GetUserDefinedFunctions",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Pattern" => Pattern), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4247,7 +4574,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   resource metadata.
 """
 function get_workflow(Name; aws_config::AbstractAWSConfig=global_aws_config())
-    return glue("GetWorkflow", Dict{String,Any}("Name" => Name); aws_config=aws_config)
+    return glue(
+        "GetWorkflow",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_workflow(
     Name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -4256,6 +4588,7 @@ function get_workflow(
         "GetWorkflow",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4278,6 +4611,7 @@ function get_workflow_run(Name, RunId; aws_config::AbstractAWSConfig=global_aws_
         "GetWorkflowRun",
         Dict{String,Any}("Name" => Name, "RunId" => RunId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_workflow_run(
@@ -4292,6 +4626,7 @@ function get_workflow_run(
             mergewith(_merge, Dict{String,Any}("Name" => Name, "RunId" => RunId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4313,6 +4648,7 @@ function get_workflow_run_properties(
         "GetWorkflowRunProperties",
         Dict{String,Any}("Name" => Name, "RunId" => RunId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_workflow_run_properties(
@@ -4327,6 +4663,7 @@ function get_workflow_run_properties(
             mergewith(_merge, Dict{String,Any}("Name" => Name, "RunId" => RunId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4346,7 +4683,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`: The maximum size of the response.
 """
 function get_workflow_runs(Name; aws_config::AbstractAWSConfig=global_aws_config())
-    return glue("GetWorkflowRuns", Dict{String,Any}("Name" => Name); aws_config=aws_config)
+    return glue(
+        "GetWorkflowRuns",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_workflow_runs(
     Name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -4355,6 +4697,7 @@ function get_workflow_runs(
         "GetWorkflowRuns",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4370,12 +4713,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Services account ID.
 """
 function import_catalog_to_glue(; aws_config::AbstractAWSConfig=global_aws_config())
-    return glue("ImportCatalogToGlue"; aws_config=aws_config)
+    return glue(
+        "ImportCatalogToGlue"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function import_catalog_to_glue(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return glue("ImportCatalogToGlue", params; aws_config=aws_config)
+    return glue(
+        "ImportCatalogToGlue",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -4391,12 +4741,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"Tags"`: Filters the list by an Amazon Web Services resource tag.
 """
 function list_blueprints(; aws_config::AbstractAWSConfig=global_aws_config())
-    return glue("ListBlueprints"; aws_config=aws_config)
+    return glue("ListBlueprints"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_blueprints(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return glue("ListBlueprints", params; aws_config=aws_config)
+    return glue(
+        "ListBlueprints", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -4416,12 +4768,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"Tags"`: Specifies to return only these tagged resources.
 """
 function list_crawlers(; aws_config::AbstractAWSConfig=global_aws_config())
-    return glue("ListCrawlers"; aws_config=aws_config)
+    return glue("ListCrawlers"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_crawlers(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return glue("ListCrawlers", params; aws_config=aws_config)
+    return glue(
+        "ListCrawlers", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -4441,12 +4795,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"Tags"`: Specifies to return only these tagged resources.
 """
 function list_dev_endpoints(; aws_config::AbstractAWSConfig=global_aws_config())
-    return glue("ListDevEndpoints"; aws_config=aws_config)
+    return glue("ListDevEndpoints"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_dev_endpoints(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return glue("ListDevEndpoints", params; aws_config=aws_config)
+    return glue(
+        "ListDevEndpoints", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -4466,12 +4822,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"Tags"`: Specifies to return only these tagged resources.
 """
 function list_jobs(; aws_config::AbstractAWSConfig=global_aws_config())
-    return glue("ListJobs"; aws_config=aws_config)
+    return glue("ListJobs"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_jobs(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return glue("ListJobs", params; aws_config=aws_config)
+    return glue("ListJobs", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 
 """
@@ -4493,12 +4849,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"Tags"`: Specifies to return only these tagged resources.
 """
 function list_mltransforms(; aws_config::AbstractAWSConfig=global_aws_config())
-    return glue("ListMLTransforms"; aws_config=aws_config)
+    return glue("ListMLTransforms"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_mltransforms(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return glue("ListMLTransforms", params; aws_config=aws_config)
+    return glue(
+        "ListMLTransforms", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -4516,12 +4874,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`: A continuation token, if this is a continuation call.
 """
 function list_registries(; aws_config::AbstractAWSConfig=global_aws_config())
-    return glue("ListRegistries"; aws_config=aws_config)
+    return glue("ListRegistries"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_registries(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return glue("ListRegistries", params; aws_config=aws_config)
+    return glue(
+        "ListRegistries", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -4549,6 +4909,7 @@ function list_schema_versions(SchemaId; aws_config::AbstractAWSConfig=global_aws
         "ListSchemaVersions",
         Dict{String,Any}("SchemaId" => SchemaId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_schema_versions(
@@ -4562,6 +4923,7 @@ function list_schema_versions(
             mergewith(_merge, Dict{String,Any}("SchemaId" => SchemaId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4583,12 +4945,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Resource Name (ARN).
 """
 function list_schemas(; aws_config::AbstractAWSConfig=global_aws_config())
-    return glue("ListSchemas"; aws_config=aws_config)
+    return glue("ListSchemas"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_schemas(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return glue("ListSchemas", params; aws_config=aws_config)
+    return glue(
+        "ListSchemas", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -4610,12 +4974,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"Tags"`: Specifies to return only these tagged resources.
 """
 function list_triggers(; aws_config::AbstractAWSConfig=global_aws_config())
-    return glue("ListTriggers"; aws_config=aws_config)
+    return glue("ListTriggers"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_triggers(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return glue("ListTriggers", params; aws_config=aws_config)
+    return glue(
+        "ListTriggers", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -4630,12 +4996,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`: A continuation token, if this is a continuation request.
 """
 function list_workflows(; aws_config::AbstractAWSConfig=global_aws_config())
-    return glue("ListWorkflows"; aws_config=aws_config)
+    return glue("ListWorkflows"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_workflows(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return glue("ListWorkflows", params; aws_config=aws_config)
+    return glue(
+        "ListWorkflows", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -4660,6 +5028,7 @@ function put_data_catalog_encryption_settings(
         "PutDataCatalogEncryptionSettings",
         Dict{String,Any}("DataCatalogEncryptionSettings" => DataCatalogEncryptionSettings);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_data_catalog_encryption_settings(
@@ -4679,6 +5048,7 @@ function put_data_catalog_encryption_settings(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4713,6 +5083,7 @@ function put_resource_policy(
         "PutResourcePolicy",
         Dict{String,Any}("PolicyInJson" => PolicyInJson);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_resource_policy(
@@ -4726,6 +5097,7 @@ function put_resource_policy(
             mergewith(_merge, Dict{String,Any}("PolicyInJson" => PolicyInJson), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4752,6 +5124,7 @@ function put_schema_version_metadata(
         "PutSchemaVersionMetadata",
         Dict{String,Any}("MetadataKeyValue" => MetadataKeyValue);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_schema_version_metadata(
@@ -4767,6 +5140,7 @@ function put_schema_version_metadata(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4793,6 +5167,7 @@ function put_workflow_run_properties(
             "Name" => Name, "RunId" => RunId, "RunProperties" => RunProperties
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_workflow_run_properties(
@@ -4814,6 +5189,7 @@ function put_workflow_run_properties(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4836,12 +5212,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"SchemaVersionNumber"`: The version number of the schema.
 """
 function query_schema_version_metadata(; aws_config::AbstractAWSConfig=global_aws_config())
-    return glue("QuerySchemaVersionMetadata"; aws_config=aws_config)
+    return glue(
+        "QuerySchemaVersionMetadata"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function query_schema_version_metadata(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return glue("QuerySchemaVersionMetadata", params; aws_config=aws_config)
+    return glue(
+        "QuerySchemaVersionMetadata",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -4874,6 +5257,7 @@ function register_schema_version(
         "RegisterSchemaVersion",
         Dict{String,Any}("SchemaDefinition" => SchemaDefinition, "SchemaId" => SchemaId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function register_schema_version(
@@ -4894,6 +5278,7 @@ function register_schema_version(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4921,6 +5306,7 @@ function remove_schema_version_metadata(
         "RemoveSchemaVersionMetadata",
         Dict{String,Any}("MetadataKeyValue" => MetadataKeyValue);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function remove_schema_version_metadata(
@@ -4936,6 +5322,7 @@ function remove_schema_version_metadata(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4954,7 +5341,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function reset_job_bookmark(JobName; aws_config::AbstractAWSConfig=global_aws_config())
     return glue(
-        "ResetJobBookmark", Dict{String,Any}("JobName" => JobName); aws_config=aws_config
+        "ResetJobBookmark",
+        Dict{String,Any}("JobName" => JobName);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function reset_job_bookmark(
@@ -4964,6 +5354,7 @@ function reset_job_bookmark(
         "ResetJobBookmark",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("JobName" => JobName), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4989,6 +5380,7 @@ function resume_workflow_run(
         "ResumeWorkflowRun",
         Dict{String,Any}("Name" => Name, "NodeIds" => NodeIds, "RunId" => RunId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function resume_workflow_run(
@@ -5008,6 +5400,7 @@ function resume_workflow_run(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5048,12 +5441,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   ascending or descending order.
 """
 function search_tables(; aws_config::AbstractAWSConfig=global_aws_config())
-    return glue("SearchTables"; aws_config=aws_config)
+    return glue("SearchTables"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function search_tables(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return glue("SearchTables", params; aws_config=aws_config)
+    return glue(
+        "SearchTables", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -5077,6 +5472,7 @@ function start_blueprint_run(
         "StartBlueprintRun",
         Dict{String,Any}("BlueprintName" => BlueprintName, "RoleArn" => RoleArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_blueprint_run(
@@ -5095,6 +5491,7 @@ function start_blueprint_run(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5110,7 +5507,12 @@ is already running, returns a CrawlerRunningException.
 
 """
 function start_crawler(Name; aws_config::AbstractAWSConfig=global_aws_config())
-    return glue("StartCrawler", Dict{String,Any}("Name" => Name); aws_config=aws_config)
+    return glue(
+        "StartCrawler",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function start_crawler(
     Name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -5119,6 +5521,7 @@ function start_crawler(
         "StartCrawler",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5140,6 +5543,7 @@ function start_crawler_schedule(
         "StartCrawlerSchedule",
         Dict{String,Any}("CrawlerName" => CrawlerName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_crawler_schedule(
@@ -5153,6 +5557,7 @@ function start_crawler_schedule(
             mergewith(_merge, Dict{String,Any}("CrawlerName" => CrawlerName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5181,6 +5586,7 @@ function start_export_labels_task_run(
         "StartExportLabelsTaskRun",
         Dict{String,Any}("OutputS3Path" => OutputS3Path, "TransformId" => TransformId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_export_labels_task_run(
@@ -5201,6 +5607,7 @@ function start_export_labels_task_run(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5245,6 +5652,7 @@ function start_import_labels_task_run(
         "StartImportLabelsTaskRun",
         Dict{String,Any}("InputS3Path" => InputS3Path, "TransformId" => TransformId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_import_labels_task_run(
@@ -5265,6 +5673,7 @@ function start_import_labels_task_run(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5320,7 +5729,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function start_job_run(JobName; aws_config::AbstractAWSConfig=global_aws_config())
     return glue(
-        "StartJobRun", Dict{String,Any}("JobName" => JobName); aws_config=aws_config
+        "StartJobRun",
+        Dict{String,Any}("JobName" => JobName);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_job_run(
@@ -5330,6 +5742,7 @@ function start_job_run(
         "StartJobRun",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("JobName" => JobName), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5354,6 +5767,7 @@ function start_mlevaluation_task_run(
         "StartMLEvaluationTaskRun",
         Dict{String,Any}("TransformId" => TransformId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_mlevaluation_task_run(
@@ -5367,6 +5781,7 @@ function start_mlevaluation_task_run(
             mergewith(_merge, Dict{String,Any}("TransformId" => TransformId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5397,6 +5812,7 @@ function start_mllabeling_set_generation_task_run(
         "StartMLLabelingSetGenerationTaskRun",
         Dict{String,Any}("OutputS3Path" => OutputS3Path, "TransformId" => TransformId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_mllabeling_set_generation_task_run(
@@ -5417,6 +5833,7 @@ function start_mllabeling_set_generation_task_run(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5432,7 +5849,12 @@ of trigger are started.
 
 """
 function start_trigger(Name; aws_config::AbstractAWSConfig=global_aws_config())
-    return glue("StartTrigger", Dict{String,Any}("Name" => Name); aws_config=aws_config)
+    return glue(
+        "StartTrigger",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function start_trigger(
     Name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -5441,6 +5863,7 @@ function start_trigger(
         "StartTrigger",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5455,7 +5878,12 @@ Starts a new run of the specified workflow.
 
 """
 function start_workflow_run(Name; aws_config::AbstractAWSConfig=global_aws_config())
-    return glue("StartWorkflowRun", Dict{String,Any}("Name" => Name); aws_config=aws_config)
+    return glue(
+        "StartWorkflowRun",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function start_workflow_run(
     Name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -5464,6 +5892,7 @@ function start_workflow_run(
         "StartWorkflowRun",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5478,7 +5907,12 @@ If the specified crawler is running, stops the crawl.
 
 """
 function stop_crawler(Name; aws_config::AbstractAWSConfig=global_aws_config())
-    return glue("StopCrawler", Dict{String,Any}("Name" => Name); aws_config=aws_config)
+    return glue(
+        "StopCrawler",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function stop_crawler(
     Name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -5487,6 +5921,7 @@ function stop_crawler(
         "StopCrawler",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5508,6 +5943,7 @@ function stop_crawler_schedule(
         "StopCrawlerSchedule",
         Dict{String,Any}("CrawlerName" => CrawlerName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function stop_crawler_schedule(
@@ -5521,6 +5957,7 @@ function stop_crawler_schedule(
             mergewith(_merge, Dict{String,Any}("CrawlerName" => CrawlerName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5535,7 +5972,12 @@ Stops a specified trigger.
 
 """
 function stop_trigger(Name; aws_config::AbstractAWSConfig=global_aws_config())
-    return glue("StopTrigger", Dict{String,Any}("Name" => Name); aws_config=aws_config)
+    return glue(
+        "StopTrigger",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function stop_trigger(
     Name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -5544,6 +5986,7 @@ function stop_trigger(
         "StopTrigger",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5563,6 +6006,7 @@ function stop_workflow_run(Name, RunId; aws_config::AbstractAWSConfig=global_aws
         "StopWorkflowRun",
         Dict{String,Any}("Name" => Name, "RunId" => RunId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function stop_workflow_run(
@@ -5577,6 +6021,7 @@ function stop_workflow_run(
             mergewith(_merge, Dict{String,Any}("Name" => Name, "RunId" => RunId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5601,6 +6046,7 @@ function tag_resource(
         "TagResource",
         Dict{String,Any}("ResourceArn" => ResourceArn, "TagsToAdd" => TagsToAdd);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -5619,6 +6065,7 @@ function tag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5641,6 +6088,7 @@ function untag_resource(
         "UntagResource",
         Dict{String,Any}("ResourceArn" => ResourceArn, "TagsToRemove" => TagsToRemove);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -5661,6 +6109,7 @@ function untag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5685,6 +6134,7 @@ function update_blueprint(
         "UpdateBlueprint",
         Dict{String,Any}("BlueprintLocation" => BlueprintLocation, "Name" => Name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_blueprint(
@@ -5703,6 +6153,7 @@ function update_blueprint(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5721,12 +6172,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"XMLClassifier"`: An XMLClassifier object with updated fields.
 """
 function update_classifier(; aws_config::AbstractAWSConfig=global_aws_config())
-    return glue("UpdateClassifier"; aws_config=aws_config)
+    return glue("UpdateClassifier"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function update_classifier(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return glue("UpdateClassifier", params; aws_config=aws_config)
+    return glue(
+        "UpdateClassifier", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -5763,6 +6216,7 @@ function update_column_statistics_for_partition(
             "TableName" => TableName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_column_statistics_for_partition(
@@ -5788,6 +6242,7 @@ function update_column_statistics_for_partition(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5822,6 +6277,7 @@ function update_column_statistics_for_table(
             "TableName" => TableName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_column_statistics_for_table(
@@ -5845,6 +6301,7 @@ function update_column_statistics_for_table(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5870,6 +6327,7 @@ function update_connection(
         "UpdateConnection",
         Dict{String,Any}("ConnectionInput" => ConnectionInput, "Name" => Name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_connection(
@@ -5888,6 +6346,7 @@ function update_connection(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5927,7 +6386,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"Targets"`: A list of targets to crawl.
 """
 function update_crawler(Name; aws_config::AbstractAWSConfig=global_aws_config())
-    return glue("UpdateCrawler", Dict{String,Any}("Name" => Name); aws_config=aws_config)
+    return glue(
+        "UpdateCrawler",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function update_crawler(
     Name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -5936,6 +6400,7 @@ function update_crawler(
         "UpdateCrawler",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5961,6 +6426,7 @@ function update_crawler_schedule(
         "UpdateCrawlerSchedule",
         Dict{String,Any}("CrawlerName" => CrawlerName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_crawler_schedule(
@@ -5974,6 +6440,7 @@ function update_crawler_schedule(
             mergewith(_merge, Dict{String,Any}("CrawlerName" => CrawlerName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6001,6 +6468,7 @@ function update_database(
         "UpdateDatabase",
         Dict{String,Any}("DatabaseInput" => DatabaseInput, "Name" => Name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_database(
@@ -6019,6 +6487,7 @@ function update_database(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6054,6 +6523,7 @@ function update_dev_endpoint(
         "UpdateDevEndpoint",
         Dict{String,Any}("EndpointName" => EndpointName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_dev_endpoint(
@@ -6067,6 +6537,7 @@ function update_dev_endpoint(
             mergewith(_merge, Dict{String,Any}("EndpointName" => EndpointName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6086,6 +6557,7 @@ function update_job(JobName, JobUpdate; aws_config::AbstractAWSConfig=global_aws
         "UpdateJob",
         Dict{String,Any}("JobName" => JobName, "JobUpdate" => JobUpdate);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_job(
@@ -6104,6 +6576,7 @@ function update_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6157,6 +6630,7 @@ function update_mltransform(TransformId; aws_config::AbstractAWSConfig=global_aw
         "UpdateMLTransform",
         Dict{String,Any}("TransformId" => TransformId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_mltransform(
@@ -6170,6 +6644,7 @@ function update_mltransform(
             mergewith(_merge, Dict{String,Any}("TransformId" => TransformId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6208,6 +6683,7 @@ function update_partition(
             "TableName" => TableName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_partition(
@@ -6233,6 +6709,7 @@ function update_partition(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6258,6 +6735,7 @@ function update_registry(
         "UpdateRegistry",
         Dict{String,Any}("Description" => Description, "RegistryId" => RegistryId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_registry(
@@ -6276,6 +6754,7 @@ function update_registry(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6306,7 +6785,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function update_schema(SchemaId; aws_config::AbstractAWSConfig=global_aws_config())
     return glue(
-        "UpdateSchema", Dict{String,Any}("SchemaId" => SchemaId); aws_config=aws_config
+        "UpdateSchema",
+        Dict{String,Any}("SchemaId" => SchemaId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_schema(
@@ -6320,6 +6802,7 @@ function update_schema(
             mergewith(_merge, Dict{String,Any}("SchemaId" => SchemaId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6349,6 +6832,7 @@ function update_table(
         "UpdateTable",
         Dict{String,Any}("DatabaseName" => DatabaseName, "TableInput" => TableInput);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_table(
@@ -6369,6 +6853,7 @@ function update_table(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6390,6 +6875,7 @@ function update_trigger(
         "UpdateTrigger",
         Dict{String,Any}("Name" => Name, "TriggerUpdate" => TriggerUpdate);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_trigger(
@@ -6408,6 +6894,7 @@ function update_trigger(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6442,6 +6929,7 @@ function update_user_defined_function(
             "FunctionName" => FunctionName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_user_defined_function(
@@ -6465,6 +6953,7 @@ function update_user_defined_function(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6488,7 +6977,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   no limit to the number of concurrent workflow runs.
 """
 function update_workflow(Name; aws_config::AbstractAWSConfig=global_aws_config())
-    return glue("UpdateWorkflow", Dict{String,Any}("Name" => Name); aws_config=aws_config)
+    return glue(
+        "UpdateWorkflow",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function update_workflow(
     Name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -6497,5 +6991,6 @@ function update_workflow(
         "UpdateWorkflow",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/greengrass.jl
+++ b/src/services/greengrass.jl
@@ -26,6 +26,7 @@ function associate_role_to_group(
         "/greengrass/groups/$(GroupId)/role",
         Dict{String,Any}("RoleArn" => RoleArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_role_to_group(
@@ -39,6 +40,7 @@ function associate_role_to_group(
         "/greengrass/groups/$(GroupId)/role",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("RoleArn" => RoleArn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -63,6 +65,7 @@ function associate_service_role_to_account(
         "/greengrass/servicerole",
         Dict{String,Any}("RoleArn" => RoleArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_service_role_to_account(
@@ -73,6 +76,7 @@ function associate_service_role_to_account(
         "/greengrass/servicerole",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("RoleArn" => RoleArn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -91,13 +95,22 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"tags"`: Tag(s) to add to the new resource.
 """
 function create_connector_definition(; aws_config::AbstractAWSConfig=global_aws_config())
-    return greengrass("POST", "/greengrass/definition/connectors"; aws_config=aws_config)
+    return greengrass(
+        "POST",
+        "/greengrass/definition/connectors";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function create_connector_definition(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return greengrass(
-        "POST", "/greengrass/definition/connectors", params; aws_config=aws_config
+        "POST",
+        "/greengrass/definition/connectors",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -123,6 +136,7 @@ function create_connector_definition_version(
         "POST",
         "/greengrass/definition/connectors/$(ConnectorDefinitionId)/versions";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_connector_definition_version(
@@ -135,6 +149,7 @@ function create_connector_definition_version(
         "/greengrass/definition/connectors/$(ConnectorDefinitionId)/versions",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -154,12 +169,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"tags"`: Tag(s) to add to the new resource.
 """
 function create_core_definition(; aws_config::AbstractAWSConfig=global_aws_config())
-    return greengrass("POST", "/greengrass/definition/cores"; aws_config=aws_config)
+    return greengrass(
+        "POST",
+        "/greengrass/definition/cores";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function create_core_definition(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return greengrass("POST", "/greengrass/definition/cores", params; aws_config=aws_config)
+    return greengrass(
+        "POST",
+        "/greengrass/definition/cores",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -184,6 +210,7 @@ function create_core_definition_version(
         "POST",
         "/greengrass/definition/cores/$(CoreDefinitionId)/versions";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_core_definition_version(
@@ -196,6 +223,7 @@ function create_core_definition_version(
         "/greengrass/definition/cores/$(CoreDefinitionId)/versions",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -225,6 +253,7 @@ function create_deployment(
         "/greengrass/groups/$(GroupId)/deployments",
         Dict{String,Any}("DeploymentType" => DeploymentType);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_deployment(
@@ -240,6 +269,7 @@ function create_deployment(
             mergewith(_merge, Dict{String,Any}("DeploymentType" => DeploymentType), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -258,13 +288,22 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"tags"`: Tag(s) to add to the new resource.
 """
 function create_device_definition(; aws_config::AbstractAWSConfig=global_aws_config())
-    return greengrass("POST", "/greengrass/definition/devices"; aws_config=aws_config)
+    return greengrass(
+        "POST",
+        "/greengrass/definition/devices";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function create_device_definition(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return greengrass(
-        "POST", "/greengrass/definition/devices", params; aws_config=aws_config
+        "POST",
+        "/greengrass/definition/devices",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -289,6 +328,7 @@ function create_device_definition_version(
         "POST",
         "/greengrass/definition/devices/$(DeviceDefinitionId)/versions";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_device_definition_version(
@@ -301,6 +341,7 @@ function create_device_definition_version(
         "/greengrass/definition/devices/$(DeviceDefinitionId)/versions",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -321,13 +362,22 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"tags"`: Tag(s) to add to the new resource.
 """
 function create_function_definition(; aws_config::AbstractAWSConfig=global_aws_config())
-    return greengrass("POST", "/greengrass/definition/functions"; aws_config=aws_config)
+    return greengrass(
+        "POST",
+        "/greengrass/definition/functions";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function create_function_definition(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return greengrass(
-        "POST", "/greengrass/definition/functions", params; aws_config=aws_config
+        "POST",
+        "/greengrass/definition/functions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -354,6 +404,7 @@ function create_function_definition_version(
         "POST",
         "/greengrass/definition/functions/$(FunctionDefinitionId)/versions";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_function_definition_version(
@@ -366,6 +417,7 @@ function create_function_definition_version(
         "/greengrass/definition/functions/$(FunctionDefinitionId)/versions",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -393,6 +445,7 @@ function create_group(Name; aws_config::AbstractAWSConfig=global_aws_config())
         "/greengrass/groups",
         Dict{String,Any}("Name" => Name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_group(
@@ -403,6 +456,7 @@ function create_group(
         "/greengrass/groups",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -426,6 +480,7 @@ function create_group_certificate_authority(
         "POST",
         "/greengrass/groups/$(GroupId)/certificateauthorities";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_group_certificate_authority(
@@ -436,6 +491,7 @@ function create_group_certificate_authority(
         "/greengrass/groups/$(GroupId)/certificateauthorities",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -465,14 +521,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function create_group_version(GroupId; aws_config::AbstractAWSConfig=global_aws_config())
     return greengrass(
-        "POST", "/greengrass/groups/$(GroupId)/versions"; aws_config=aws_config
+        "POST",
+        "/greengrass/groups/$(GroupId)/versions";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_group_version(
     GroupId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return greengrass(
-        "POST", "/greengrass/groups/$(GroupId)/versions", params; aws_config=aws_config
+        "POST",
+        "/greengrass/groups/$(GroupId)/versions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -491,13 +554,22 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"tags"`: Tag(s) to add to the new resource.
 """
 function create_logger_definition(; aws_config::AbstractAWSConfig=global_aws_config())
-    return greengrass("POST", "/greengrass/definition/loggers"; aws_config=aws_config)
+    return greengrass(
+        "POST",
+        "/greengrass/definition/loggers";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function create_logger_definition(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return greengrass(
-        "POST", "/greengrass/definition/loggers", params; aws_config=aws_config
+        "POST",
+        "/greengrass/definition/loggers",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -522,6 +594,7 @@ function create_logger_definition_version(
         "POST",
         "/greengrass/definition/loggers/$(LoggerDefinitionId)/versions";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_logger_definition_version(
@@ -534,6 +607,7 @@ function create_logger_definition_version(
         "/greengrass/definition/loggers/$(LoggerDefinitionId)/versions",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -553,13 +627,22 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"tags"`: Tag(s) to add to the new resource.
 """
 function create_resource_definition(; aws_config::AbstractAWSConfig=global_aws_config())
-    return greengrass("POST", "/greengrass/definition/resources"; aws_config=aws_config)
+    return greengrass(
+        "POST",
+        "/greengrass/definition/resources";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function create_resource_definition(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return greengrass(
-        "POST", "/greengrass/definition/resources", params; aws_config=aws_config
+        "POST",
+        "/greengrass/definition/resources",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -584,6 +667,7 @@ function create_resource_definition_version(
         "POST",
         "/greengrass/definition/resources/$(ResourceDefinitionId)/versions";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_resource_definition_version(
@@ -596,6 +680,7 @@ function create_resource_definition_version(
         "/greengrass/definition/resources/$(ResourceDefinitionId)/versions",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -639,6 +724,7 @@ function create_software_update_job(
             "UpdateTargetsOperatingSystem" => UpdateTargetsOperatingSystem,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_software_update_job(
@@ -667,6 +753,7 @@ function create_software_update_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -685,13 +772,22 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"tags"`: Tag(s) to add to the new resource.
 """
 function create_subscription_definition(; aws_config::AbstractAWSConfig=global_aws_config())
-    return greengrass("POST", "/greengrass/definition/subscriptions"; aws_config=aws_config)
+    return greengrass(
+        "POST",
+        "/greengrass/definition/subscriptions";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function create_subscription_definition(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return greengrass(
-        "POST", "/greengrass/definition/subscriptions", params; aws_config=aws_config
+        "POST",
+        "/greengrass/definition/subscriptions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -716,6 +812,7 @@ function create_subscription_definition_version(
         "POST",
         "/greengrass/definition/subscriptions/$(SubscriptionDefinitionId)/versions";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_subscription_definition_version(
@@ -728,6 +825,7 @@ function create_subscription_definition_version(
         "/greengrass/definition/subscriptions/$(SubscriptionDefinitionId)/versions",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -748,6 +846,7 @@ function delete_connector_definition(
         "DELETE",
         "/greengrass/definition/connectors/$(ConnectorDefinitionId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_connector_definition(
@@ -760,6 +859,7 @@ function delete_connector_definition(
         "/greengrass/definition/connectors/$(ConnectorDefinitionId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -777,7 +877,10 @@ function delete_core_definition(
     CoreDefinitionId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return greengrass(
-        "DELETE", "/greengrass/definition/cores/$(CoreDefinitionId)"; aws_config=aws_config
+        "DELETE",
+        "/greengrass/definition/cores/$(CoreDefinitionId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_core_definition(
@@ -790,6 +893,7 @@ function delete_core_definition(
         "/greengrass/definition/cores/$(CoreDefinitionId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -810,6 +914,7 @@ function delete_device_definition(
         "DELETE",
         "/greengrass/definition/devices/$(DeviceDefinitionId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_device_definition(
@@ -822,6 +927,7 @@ function delete_device_definition(
         "/greengrass/definition/devices/$(DeviceDefinitionId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -842,6 +948,7 @@ function delete_function_definition(
         "DELETE",
         "/greengrass/definition/functions/$(FunctionDefinitionId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_function_definition(
@@ -854,6 +961,7 @@ function delete_function_definition(
         "/greengrass/definition/functions/$(FunctionDefinitionId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -868,13 +976,22 @@ Deletes a group.
 
 """
 function delete_group(GroupId; aws_config::AbstractAWSConfig=global_aws_config())
-    return greengrass("DELETE", "/greengrass/groups/$(GroupId)"; aws_config=aws_config)
+    return greengrass(
+        "DELETE",
+        "/greengrass/groups/$(GroupId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_group(
     GroupId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return greengrass(
-        "DELETE", "/greengrass/groups/$(GroupId)", params; aws_config=aws_config
+        "DELETE",
+        "/greengrass/groups/$(GroupId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -895,6 +1012,7 @@ function delete_logger_definition(
         "DELETE",
         "/greengrass/definition/loggers/$(LoggerDefinitionId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_logger_definition(
@@ -907,6 +1025,7 @@ function delete_logger_definition(
         "/greengrass/definition/loggers/$(LoggerDefinitionId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -927,6 +1046,7 @@ function delete_resource_definition(
         "DELETE",
         "/greengrass/definition/resources/$(ResourceDefinitionId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_resource_definition(
@@ -939,6 +1059,7 @@ function delete_resource_definition(
         "/greengrass/definition/resources/$(ResourceDefinitionId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -959,6 +1080,7 @@ function delete_subscription_definition(
         "DELETE",
         "/greengrass/definition/subscriptions/$(SubscriptionDefinitionId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_subscription_definition(
@@ -971,6 +1093,7 @@ function delete_subscription_definition(
         "/greengrass/definition/subscriptions/$(SubscriptionDefinitionId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -987,13 +1110,22 @@ Disassociates the role from a group.
 function disassociate_role_from_group(
     GroupId; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return greengrass("DELETE", "/greengrass/groups/$(GroupId)/role"; aws_config=aws_config)
+    return greengrass(
+        "DELETE",
+        "/greengrass/groups/$(GroupId)/role";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function disassociate_role_from_group(
     GroupId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return greengrass(
-        "DELETE", "/greengrass/groups/$(GroupId)/role", params; aws_config=aws_config
+        "DELETE",
+        "/greengrass/groups/$(GroupId)/role",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1008,12 +1140,23 @@ not work.
 function disassociate_service_role_from_account(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return greengrass("DELETE", "/greengrass/servicerole"; aws_config=aws_config)
+    return greengrass(
+        "DELETE",
+        "/greengrass/servicerole";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function disassociate_service_role_from_account(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return greengrass("DELETE", "/greengrass/servicerole", params; aws_config=aws_config)
+    return greengrass(
+        "DELETE",
+        "/greengrass/servicerole",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1027,13 +1170,22 @@ Retrieves the role associated with a particular group.
 
 """
 function get_associated_role(GroupId; aws_config::AbstractAWSConfig=global_aws_config())
-    return greengrass("GET", "/greengrass/groups/$(GroupId)/role"; aws_config=aws_config)
+    return greengrass(
+        "GET",
+        "/greengrass/groups/$(GroupId)/role";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_associated_role(
     GroupId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return greengrass(
-        "GET", "/greengrass/groups/$(GroupId)/role", params; aws_config=aws_config
+        "GET",
+        "/greengrass/groups/$(GroupId)/role",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1054,6 +1206,7 @@ function get_bulk_deployment_status(
         "GET",
         "/greengrass/bulk/deployments/$(BulkDeploymentId)/status";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_bulk_deployment_status(
@@ -1066,6 +1219,7 @@ function get_bulk_deployment_status(
         "/greengrass/bulk/deployments/$(BulkDeploymentId)/status",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1081,7 +1235,10 @@ Retrieves the connectivity information for a core.
 """
 function get_connectivity_info(ThingName; aws_config::AbstractAWSConfig=global_aws_config())
     return greengrass(
-        "GET", "/greengrass/things/$(ThingName)/connectivityInfo"; aws_config=aws_config
+        "GET",
+        "/greengrass/things/$(ThingName)/connectivityInfo";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_connectivity_info(
@@ -1094,6 +1251,7 @@ function get_connectivity_info(
         "/greengrass/things/$(ThingName)/connectivityInfo",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1114,6 +1272,7 @@ function get_connector_definition(
         "GET",
         "/greengrass/definition/connectors/$(ConnectorDefinitionId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_connector_definition(
@@ -1126,6 +1285,7 @@ function get_connector_definition(
         "/greengrass/definition/connectors/$(ConnectorDefinitionId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1159,6 +1319,7 @@ function get_connector_definition_version(
         "GET",
         "/greengrass/definition/connectors/$(ConnectorDefinitionId)/versions/$(ConnectorDefinitionVersionId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_connector_definition_version(
@@ -1172,6 +1333,7 @@ function get_connector_definition_version(
         "/greengrass/definition/connectors/$(ConnectorDefinitionId)/versions/$(ConnectorDefinitionVersionId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1189,7 +1351,10 @@ function get_core_definition(
     CoreDefinitionId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return greengrass(
-        "GET", "/greengrass/definition/cores/$(CoreDefinitionId)"; aws_config=aws_config
+        "GET",
+        "/greengrass/definition/cores/$(CoreDefinitionId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_core_definition(
@@ -1202,6 +1367,7 @@ function get_core_definition(
         "/greengrass/definition/cores/$(CoreDefinitionId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1229,6 +1395,7 @@ function get_core_definition_version(
         "GET",
         "/greengrass/definition/cores/$(CoreDefinitionId)/versions/$(CoreDefinitionVersionId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_core_definition_version(
@@ -1242,6 +1409,7 @@ function get_core_definition_version(
         "/greengrass/definition/cores/$(CoreDefinitionId)/versions/$(CoreDefinitionVersionId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1263,6 +1431,7 @@ function get_deployment_status(
         "GET",
         "/greengrass/groups/$(GroupId)/deployments/$(DeploymentId)/status";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_deployment_status(
@@ -1276,6 +1445,7 @@ function get_deployment_status(
         "/greengrass/groups/$(GroupId)/deployments/$(DeploymentId)/status",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1293,7 +1463,10 @@ function get_device_definition(
     DeviceDefinitionId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return greengrass(
-        "GET", "/greengrass/definition/devices/$(DeviceDefinitionId)"; aws_config=aws_config
+        "GET",
+        "/greengrass/definition/devices/$(DeviceDefinitionId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_device_definition(
@@ -1306,6 +1479,7 @@ function get_device_definition(
         "/greengrass/definition/devices/$(DeviceDefinitionId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1337,6 +1511,7 @@ function get_device_definition_version(
         "GET",
         "/greengrass/definition/devices/$(DeviceDefinitionId)/versions/$(DeviceDefinitionVersionId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_device_definition_version(
@@ -1350,6 +1525,7 @@ function get_device_definition_version(
         "/greengrass/definition/devices/$(DeviceDefinitionId)/versions/$(DeviceDefinitionVersionId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1371,6 +1547,7 @@ function get_function_definition(
         "GET",
         "/greengrass/definition/functions/$(FunctionDefinitionId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_function_definition(
@@ -1383,6 +1560,7 @@ function get_function_definition(
         "/greengrass/definition/functions/$(FunctionDefinitionId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1415,6 +1593,7 @@ function get_function_definition_version(
         "GET",
         "/greengrass/definition/functions/$(FunctionDefinitionId)/versions/$(FunctionDefinitionVersionId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_function_definition_version(
@@ -1428,6 +1607,7 @@ function get_function_definition_version(
         "/greengrass/definition/functions/$(FunctionDefinitionId)/versions/$(FunctionDefinitionVersionId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1442,12 +1622,23 @@ Retrieves information about a group.
 
 """
 function get_group(GroupId; aws_config::AbstractAWSConfig=global_aws_config())
-    return greengrass("GET", "/greengrass/groups/$(GroupId)"; aws_config=aws_config)
+    return greengrass(
+        "GET",
+        "/greengrass/groups/$(GroupId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_group(
     GroupId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return greengrass("GET", "/greengrass/groups/$(GroupId)", params; aws_config=aws_config)
+    return greengrass(
+        "GET",
+        "/greengrass/groups/$(GroupId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1468,6 +1659,7 @@ function get_group_certificate_authority(
         "GET",
         "/greengrass/groups/$(GroupId)/certificateauthorities/$(CertificateAuthorityId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_group_certificate_authority(
@@ -1481,6 +1673,7 @@ function get_group_certificate_authority(
         "/greengrass/groups/$(GroupId)/certificateauthorities/$(CertificateAuthorityId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1501,6 +1694,7 @@ function get_group_certificate_configuration(
         "GET",
         "/greengrass/groups/$(GroupId)/certificateauthorities/configuration/expiry";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_group_certificate_configuration(
@@ -1511,6 +1705,7 @@ function get_group_certificate_configuration(
         "/greengrass/groups/$(GroupId)/certificateauthorities/configuration/expiry",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1536,6 +1731,7 @@ function get_group_version(
         "GET",
         "/greengrass/groups/$(GroupId)/versions/$(GroupVersionId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_group_version(
@@ -1549,6 +1745,7 @@ function get_group_version(
         "/greengrass/groups/$(GroupId)/versions/$(GroupVersionId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1566,7 +1763,10 @@ function get_logger_definition(
     LoggerDefinitionId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return greengrass(
-        "GET", "/greengrass/definition/loggers/$(LoggerDefinitionId)"; aws_config=aws_config
+        "GET",
+        "/greengrass/definition/loggers/$(LoggerDefinitionId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_logger_definition(
@@ -1579,6 +1779,7 @@ function get_logger_definition(
         "/greengrass/definition/loggers/$(LoggerDefinitionId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1610,6 +1811,7 @@ function get_logger_definition_version(
         "GET",
         "/greengrass/definition/loggers/$(LoggerDefinitionId)/versions/$(LoggerDefinitionVersionId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_logger_definition_version(
@@ -1623,6 +1825,7 @@ function get_logger_definition_version(
         "/greengrass/definition/loggers/$(LoggerDefinitionId)/versions/$(LoggerDefinitionVersionId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1644,6 +1847,7 @@ function get_resource_definition(
         "GET",
         "/greengrass/definition/resources/$(ResourceDefinitionId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_resource_definition(
@@ -1656,6 +1860,7 @@ function get_resource_definition(
         "/greengrass/definition/resources/$(ResourceDefinitionId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1684,6 +1889,7 @@ function get_resource_definition_version(
         "GET",
         "/greengrass/definition/resources/$(ResourceDefinitionId)/versions/$(ResourceDefinitionVersionId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_resource_definition_version(
@@ -1697,6 +1903,7 @@ function get_resource_definition_version(
         "/greengrass/definition/resources/$(ResourceDefinitionId)/versions/$(ResourceDefinitionVersionId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1708,12 +1915,23 @@ Retrieves the service role that is attached to your account.
 
 """
 function get_service_role_for_account(; aws_config::AbstractAWSConfig=global_aws_config())
-    return greengrass("GET", "/greengrass/servicerole"; aws_config=aws_config)
+    return greengrass(
+        "GET",
+        "/greengrass/servicerole";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_service_role_for_account(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return greengrass("GET", "/greengrass/servicerole", params; aws_config=aws_config)
+    return greengrass(
+        "GET",
+        "/greengrass/servicerole",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1733,6 +1951,7 @@ function get_subscription_definition(
         "GET",
         "/greengrass/definition/subscriptions/$(SubscriptionDefinitionId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_subscription_definition(
@@ -1745,6 +1964,7 @@ function get_subscription_definition(
         "/greengrass/definition/subscriptions/$(SubscriptionDefinitionId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1776,6 +1996,7 @@ function get_subscription_definition_version(
         "GET",
         "/greengrass/definition/subscriptions/$(SubscriptionDefinitionId)/versions/$(SubscriptionDefinitionVersionId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_subscription_definition_version(
@@ -1789,6 +2010,7 @@ function get_subscription_definition_version(
         "/greengrass/definition/subscriptions/$(SubscriptionDefinitionId)/versions/$(SubscriptionDefinitionVersionId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1806,7 +2028,10 @@ function get_thing_runtime_configuration(
     ThingName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return greengrass(
-        "GET", "/greengrass/things/$(ThingName)/runtimeconfig"; aws_config=aws_config
+        "GET",
+        "/greengrass/things/$(ThingName)/runtimeconfig";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_thing_runtime_configuration(
@@ -1819,6 +2044,7 @@ function get_thing_runtime_configuration(
         "/greengrass/things/$(ThingName)/runtimeconfig",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1845,6 +2071,7 @@ function list_bulk_deployment_detailed_reports(
         "GET",
         "/greengrass/bulk/deployments/$(BulkDeploymentId)/detailed-reports";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_bulk_deployment_detailed_reports(
@@ -1857,6 +2084,7 @@ function list_bulk_deployment_detailed_reports(
         "/greengrass/bulk/deployments/$(BulkDeploymentId)/detailed-reports",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1873,12 +2101,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   additional results.
 """
 function list_bulk_deployments(; aws_config::AbstractAWSConfig=global_aws_config())
-    return greengrass("GET", "/greengrass/bulk/deployments"; aws_config=aws_config)
+    return greengrass(
+        "GET",
+        "/greengrass/bulk/deployments";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_bulk_deployments(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return greengrass("GET", "/greengrass/bulk/deployments", params; aws_config=aws_config)
+    return greengrass(
+        "GET",
+        "/greengrass/bulk/deployments",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1905,6 +2144,7 @@ function list_connector_definition_versions(
         "GET",
         "/greengrass/definition/connectors/$(ConnectorDefinitionId)/versions";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_connector_definition_versions(
@@ -1917,6 +2157,7 @@ function list_connector_definition_versions(
         "/greengrass/definition/connectors/$(ConnectorDefinitionId)/versions",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1933,13 +2174,22 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   additional results.
 """
 function list_connector_definitions(; aws_config::AbstractAWSConfig=global_aws_config())
-    return greengrass("GET", "/greengrass/definition/connectors"; aws_config=aws_config)
+    return greengrass(
+        "GET",
+        "/greengrass/definition/connectors";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_connector_definitions(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return greengrass(
-        "GET", "/greengrass/definition/connectors", params; aws_config=aws_config
+        "GET",
+        "/greengrass/definition/connectors",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1965,6 +2215,7 @@ function list_core_definition_versions(
         "GET",
         "/greengrass/definition/cores/$(CoreDefinitionId)/versions";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_core_definition_versions(
@@ -1977,6 +2228,7 @@ function list_core_definition_versions(
         "/greengrass/definition/cores/$(CoreDefinitionId)/versions",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1993,12 +2245,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   additional results.
 """
 function list_core_definitions(; aws_config::AbstractAWSConfig=global_aws_config())
-    return greengrass("GET", "/greengrass/definition/cores"; aws_config=aws_config)
+    return greengrass(
+        "GET",
+        "/greengrass/definition/cores";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_core_definitions(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return greengrass("GET", "/greengrass/definition/cores", params; aws_config=aws_config)
+    return greengrass(
+        "GET",
+        "/greengrass/definition/cores",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2018,14 +2281,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function list_deployments(GroupId; aws_config::AbstractAWSConfig=global_aws_config())
     return greengrass(
-        "GET", "/greengrass/groups/$(GroupId)/deployments"; aws_config=aws_config
+        "GET",
+        "/greengrass/groups/$(GroupId)/deployments";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_deployments(
     GroupId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return greengrass(
-        "GET", "/greengrass/groups/$(GroupId)/deployments", params; aws_config=aws_config
+        "GET",
+        "/greengrass/groups/$(GroupId)/deployments",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2051,6 +2321,7 @@ function list_device_definition_versions(
         "GET",
         "/greengrass/definition/devices/$(DeviceDefinitionId)/versions";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_device_definition_versions(
@@ -2063,6 +2334,7 @@ function list_device_definition_versions(
         "/greengrass/definition/devices/$(DeviceDefinitionId)/versions",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2079,13 +2351,22 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   additional results.
 """
 function list_device_definitions(; aws_config::AbstractAWSConfig=global_aws_config())
-    return greengrass("GET", "/greengrass/definition/devices"; aws_config=aws_config)
+    return greengrass(
+        "GET",
+        "/greengrass/definition/devices";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_device_definitions(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return greengrass(
-        "GET", "/greengrass/definition/devices", params; aws_config=aws_config
+        "GET",
+        "/greengrass/definition/devices",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2111,6 +2392,7 @@ function list_function_definition_versions(
         "GET",
         "/greengrass/definition/functions/$(FunctionDefinitionId)/versions";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_function_definition_versions(
@@ -2123,6 +2405,7 @@ function list_function_definition_versions(
         "/greengrass/definition/functions/$(FunctionDefinitionId)/versions",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2139,13 +2422,22 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   additional results.
 """
 function list_function_definitions(; aws_config::AbstractAWSConfig=global_aws_config())
-    return greengrass("GET", "/greengrass/definition/functions"; aws_config=aws_config)
+    return greengrass(
+        "GET",
+        "/greengrass/definition/functions";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_function_definitions(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return greengrass(
-        "GET", "/greengrass/definition/functions", params; aws_config=aws_config
+        "GET",
+        "/greengrass/definition/functions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2163,7 +2455,10 @@ function list_group_certificate_authorities(
     GroupId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return greengrass(
-        "GET", "/greengrass/groups/$(GroupId)/certificateauthorities"; aws_config=aws_config
+        "GET",
+        "/greengrass/groups/$(GroupId)/certificateauthorities";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_group_certificate_authorities(
@@ -2174,6 +2469,7 @@ function list_group_certificate_authorities(
         "/greengrass/groups/$(GroupId)/certificateauthorities",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2194,14 +2490,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function list_group_versions(GroupId; aws_config::AbstractAWSConfig=global_aws_config())
     return greengrass(
-        "GET", "/greengrass/groups/$(GroupId)/versions"; aws_config=aws_config
+        "GET",
+        "/greengrass/groups/$(GroupId)/versions";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_group_versions(
     GroupId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return greengrass(
-        "GET", "/greengrass/groups/$(GroupId)/versions", params; aws_config=aws_config
+        "GET",
+        "/greengrass/groups/$(GroupId)/versions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2218,12 +2521,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   additional results.
 """
 function list_groups(; aws_config::AbstractAWSConfig=global_aws_config())
-    return greengrass("GET", "/greengrass/groups"; aws_config=aws_config)
+    return greengrass(
+        "GET", "/greengrass/groups"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_groups(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return greengrass("GET", "/greengrass/groups", params; aws_config=aws_config)
+    return greengrass(
+        "GET",
+        "/greengrass/groups",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2248,6 +2559,7 @@ function list_logger_definition_versions(
         "GET",
         "/greengrass/definition/loggers/$(LoggerDefinitionId)/versions";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_logger_definition_versions(
@@ -2260,6 +2572,7 @@ function list_logger_definition_versions(
         "/greengrass/definition/loggers/$(LoggerDefinitionId)/versions",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2276,13 +2589,22 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   additional results.
 """
 function list_logger_definitions(; aws_config::AbstractAWSConfig=global_aws_config())
-    return greengrass("GET", "/greengrass/definition/loggers"; aws_config=aws_config)
+    return greengrass(
+        "GET",
+        "/greengrass/definition/loggers";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_logger_definitions(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return greengrass(
-        "GET", "/greengrass/definition/loggers", params; aws_config=aws_config
+        "GET",
+        "/greengrass/definition/loggers",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2308,6 +2630,7 @@ function list_resource_definition_versions(
         "GET",
         "/greengrass/definition/resources/$(ResourceDefinitionId)/versions";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_resource_definition_versions(
@@ -2320,6 +2643,7 @@ function list_resource_definition_versions(
         "/greengrass/definition/resources/$(ResourceDefinitionId)/versions",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2336,13 +2660,22 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   additional results.
 """
 function list_resource_definitions(; aws_config::AbstractAWSConfig=global_aws_config())
-    return greengrass("GET", "/greengrass/definition/resources"; aws_config=aws_config)
+    return greengrass(
+        "GET",
+        "/greengrass/definition/resources";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_resource_definitions(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return greengrass(
-        "GET", "/greengrass/definition/resources", params; aws_config=aws_config
+        "GET",
+        "/greengrass/definition/resources",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2368,6 +2701,7 @@ function list_subscription_definition_versions(
         "GET",
         "/greengrass/definition/subscriptions/$(SubscriptionDefinitionId)/versions";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_subscription_definition_versions(
@@ -2380,6 +2714,7 @@ function list_subscription_definition_versions(
         "/greengrass/definition/subscriptions/$(SubscriptionDefinitionId)/versions",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2396,13 +2731,22 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   additional results.
 """
 function list_subscription_definitions(; aws_config::AbstractAWSConfig=global_aws_config())
-    return greengrass("GET", "/greengrass/definition/subscriptions"; aws_config=aws_config)
+    return greengrass(
+        "GET",
+        "/greengrass/definition/subscriptions";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_subscription_definitions(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return greengrass(
-        "GET", "/greengrass/definition/subscriptions", params; aws_config=aws_config
+        "GET",
+        "/greengrass/definition/subscriptions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2419,14 +2763,25 @@ Retrieves a list of resource tags for a resource arn.
 function list_tags_for_resource(
     resource_arn; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return greengrass("GET", "/tags/$(resource-arn)"; aws_config=aws_config)
+    return greengrass(
+        "GET",
+        "/tags/$(resource-arn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_tags_for_resource(
     resource_arn,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return greengrass("GET", "/tags/$(resource-arn)", params; aws_config=aws_config)
+    return greengrass(
+        "GET",
+        "/tags/$(resource-arn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2445,7 +2800,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function reset_deployments(GroupId; aws_config::AbstractAWSConfig=global_aws_config())
     return greengrass(
-        "POST", "/greengrass/groups/$(GroupId)/deployments/$reset"; aws_config=aws_config
+        "POST",
+        "/greengrass/groups/$(GroupId)/deployments/$reset";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function reset_deployments(
@@ -2456,6 +2814,7 @@ function reset_deployments(
         "/greengrass/groups/$(GroupId)/deployments/$reset",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2495,6 +2854,7 @@ function start_bulk_deployment(
             "ExecutionRoleArn" => ExecutionRoleArn, "InputFileUri" => InputFileUri
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_bulk_deployment(
@@ -2516,6 +2876,7 @@ function start_bulk_deployment(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2539,6 +2900,7 @@ function stop_bulk_deployment(
         "PUT",
         "/greengrass/bulk/deployments/$(BulkDeploymentId)/$stop";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function stop_bulk_deployment(
@@ -2551,6 +2913,7 @@ function stop_bulk_deployment(
         "/greengrass/bulk/deployments/$(BulkDeploymentId)/$stop",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2570,14 +2933,25 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"tags"`:
 """
 function tag_resource(resource_arn; aws_config::AbstractAWSConfig=global_aws_config())
-    return greengrass("POST", "/tags/$(resource-arn)"; aws_config=aws_config)
+    return greengrass(
+        "POST",
+        "/tags/$(resource-arn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function tag_resource(
     resource_arn,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return greengrass("POST", "/tags/$(resource-arn)", params; aws_config=aws_config)
+    return greengrass(
+        "POST",
+        "/tags/$(resource-arn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2599,6 +2973,7 @@ function untag_resource(
         "/tags/$(resource-arn)",
         Dict{String,Any}("tagKeys" => tagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -2612,6 +2987,7 @@ function untag_resource(
         "/tags/$(resource-arn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tagKeys" => tagKeys), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2634,7 +3010,10 @@ function update_connectivity_info(
     ThingName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return greengrass(
-        "PUT", "/greengrass/things/$(ThingName)/connectivityInfo"; aws_config=aws_config
+        "PUT",
+        "/greengrass/things/$(ThingName)/connectivityInfo";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_connectivity_info(
@@ -2647,6 +3026,7 @@ function update_connectivity_info(
         "/greengrass/things/$(ThingName)/connectivityInfo",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2670,6 +3050,7 @@ function update_connector_definition(
         "PUT",
         "/greengrass/definition/connectors/$(ConnectorDefinitionId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_connector_definition(
@@ -2682,6 +3063,7 @@ function update_connector_definition(
         "/greengrass/definition/connectors/$(ConnectorDefinitionId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2702,7 +3084,10 @@ function update_core_definition(
     CoreDefinitionId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return greengrass(
-        "PUT", "/greengrass/definition/cores/$(CoreDefinitionId)"; aws_config=aws_config
+        "PUT",
+        "/greengrass/definition/cores/$(CoreDefinitionId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_core_definition(
@@ -2715,6 +3100,7 @@ function update_core_definition(
         "/greengrass/definition/cores/$(CoreDefinitionId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2735,7 +3121,10 @@ function update_device_definition(
     DeviceDefinitionId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return greengrass(
-        "PUT", "/greengrass/definition/devices/$(DeviceDefinitionId)"; aws_config=aws_config
+        "PUT",
+        "/greengrass/definition/devices/$(DeviceDefinitionId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_device_definition(
@@ -2748,6 +3137,7 @@ function update_device_definition(
         "/greengrass/definition/devices/$(DeviceDefinitionId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2771,6 +3161,7 @@ function update_function_definition(
         "PUT",
         "/greengrass/definition/functions/$(FunctionDefinitionId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_function_definition(
@@ -2783,6 +3174,7 @@ function update_function_definition(
         "/greengrass/definition/functions/$(FunctionDefinitionId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2800,12 +3192,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"Name"`: The name of the definition.
 """
 function update_group(GroupId; aws_config::AbstractAWSConfig=global_aws_config())
-    return greengrass("PUT", "/greengrass/groups/$(GroupId)"; aws_config=aws_config)
+    return greengrass(
+        "PUT",
+        "/greengrass/groups/$(GroupId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function update_group(
     GroupId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return greengrass("PUT", "/greengrass/groups/$(GroupId)", params; aws_config=aws_config)
+    return greengrass(
+        "PUT",
+        "/greengrass/groups/$(GroupId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2829,6 +3232,7 @@ function update_group_certificate_configuration(
         "PUT",
         "/greengrass/groups/$(GroupId)/certificateauthorities/configuration/expiry";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_group_certificate_configuration(
@@ -2839,6 +3243,7 @@ function update_group_certificate_configuration(
         "/greengrass/groups/$(GroupId)/certificateauthorities/configuration/expiry",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2859,7 +3264,10 @@ function update_logger_definition(
     LoggerDefinitionId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return greengrass(
-        "PUT", "/greengrass/definition/loggers/$(LoggerDefinitionId)"; aws_config=aws_config
+        "PUT",
+        "/greengrass/definition/loggers/$(LoggerDefinitionId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_logger_definition(
@@ -2872,6 +3280,7 @@ function update_logger_definition(
         "/greengrass/definition/loggers/$(LoggerDefinitionId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2895,6 +3304,7 @@ function update_resource_definition(
         "PUT",
         "/greengrass/definition/resources/$(ResourceDefinitionId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_resource_definition(
@@ -2907,6 +3317,7 @@ function update_resource_definition(
         "/greengrass/definition/resources/$(ResourceDefinitionId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2930,6 +3341,7 @@ function update_subscription_definition(
         "PUT",
         "/greengrass/definition/subscriptions/$(SubscriptionDefinitionId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_subscription_definition(
@@ -2942,6 +3354,7 @@ function update_subscription_definition(
         "/greengrass/definition/subscriptions/$(SubscriptionDefinitionId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2962,7 +3375,10 @@ function update_thing_runtime_configuration(
     ThingName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return greengrass(
-        "PUT", "/greengrass/things/$(ThingName)/runtimeconfig"; aws_config=aws_config
+        "PUT",
+        "/greengrass/things/$(ThingName)/runtimeconfig";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_thing_runtime_configuration(
@@ -2975,5 +3391,6 @@ function update_thing_runtime_configuration(
         "/greengrass/things/$(ThingName)/runtimeconfig",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/greengrassv2.jl
+++ b/src/services/greengrassv2.jl
@@ -33,6 +33,7 @@ function batch_associate_client_device_with_core_device(
         "POST",
         "/greengrass/v2/coreDevices/$(coreDeviceThingName)/associateClientDevices";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_associate_client_device_with_core_device(
@@ -45,6 +46,7 @@ function batch_associate_client_device_with_core_device(
         "/greengrass/v2/coreDevices/$(coreDeviceThingName)/associateClientDevices",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -71,6 +73,7 @@ function batch_disassociate_client_device_from_core_device(
         "POST",
         "/greengrass/v2/coreDevices/$(coreDeviceThingName)/disassociateClientDevices";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_disassociate_client_device_from_core_device(
@@ -83,6 +86,7 @@ function batch_disassociate_client_device_from_core_device(
         "/greengrass/v2/coreDevices/$(coreDeviceThingName)/disassociateClientDevices",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -100,7 +104,10 @@ anything for that device.
 """
 function cancel_deployment(deploymentId; aws_config::AbstractAWSConfig=global_aws_config())
     return greengrassv2(
-        "POST", "/greengrass/v2/deployments/$(deploymentId)/cancel"; aws_config=aws_config
+        "POST",
+        "/greengrass/v2/deployments/$(deploymentId)/cancel";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function cancel_deployment(
@@ -113,6 +120,7 @@ function cancel_deployment(
         "/greengrass/v2/deployments/$(deploymentId)/cancel",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -159,6 +167,7 @@ function create_component_version(; aws_config::AbstractAWSConfig=global_aws_con
         "/greengrass/v2/createComponentVersion",
         Dict{String,Any}("clientToken" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_component_version(
@@ -171,6 +180,7 @@ function create_component_version(
             mergewith(_merge, Dict{String,Any}("clientToken" => string(uuid4())), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -218,6 +228,7 @@ function create_deployment(targetArn; aws_config::AbstractAWSConfig=global_aws_c
         "/greengrass/v2/deployments",
         Dict{String,Any}("targetArn" => targetArn, "clientToken" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_deployment(
@@ -238,6 +249,7 @@ function create_deployment(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -255,13 +267,22 @@ the component from the deployment or update the deployment to use a valid versio
 
 """
 function delete_component(arn; aws_config::AbstractAWSConfig=global_aws_config())
-    return greengrassv2("DELETE", "/greengrass/v2/components/$(arn)"; aws_config=aws_config)
+    return greengrassv2(
+        "DELETE",
+        "/greengrass/v2/components/$(arn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_component(
     arn, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return greengrassv2(
-        "DELETE", "/greengrass/v2/components/$(arn)", params; aws_config=aws_config
+        "DELETE",
+        "/greengrass/v2/components/$(arn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -282,7 +303,10 @@ function delete_core_device(
     coreDeviceThingName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return greengrassv2(
-        "DELETE", "/greengrass/v2/coreDevices/$(coreDeviceThingName)"; aws_config=aws_config
+        "DELETE",
+        "/greengrass/v2/coreDevices/$(coreDeviceThingName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_core_device(
@@ -295,6 +319,7 @@ function delete_core_device(
         "/greengrass/v2/coreDevices/$(coreDeviceThingName)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -310,14 +335,21 @@ Retrieves metadata for a version of a component.
 """
 function describe_component(arn; aws_config::AbstractAWSConfig=global_aws_config())
     return greengrassv2(
-        "GET", "/greengrass/v2/components/$(arn)/metadata"; aws_config=aws_config
+        "GET",
+        "/greengrass/v2/components/$(arn)/metadata";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_component(
     arn, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return greengrassv2(
-        "GET", "/greengrass/v2/components/$(arn)/metadata", params; aws_config=aws_config
+        "GET",
+        "/greengrass/v2/components/$(arn)/metadata",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -336,13 +368,22 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"recipeOutputFormat"`: The format of the recipe.
 """
 function get_component(arn; aws_config::AbstractAWSConfig=global_aws_config())
-    return greengrassv2("GET", "/greengrass/v2/components/$(arn)"; aws_config=aws_config)
+    return greengrassv2(
+        "GET",
+        "/greengrass/v2/components/$(arn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_component(
     arn, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return greengrassv2(
-        "GET", "/greengrass/v2/components/$(arn)", params; aws_config=aws_config
+        "GET",
+        "/greengrass/v2/components/$(arn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -368,6 +409,7 @@ function get_component_version_artifact(
         "GET",
         "/greengrass/v2/components/$(arn)/artifacts/$(artifactName)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_component_version_artifact(
@@ -381,6 +423,7 @@ function get_component_version_artifact(
         "/greengrass/v2/components/$(arn)/artifacts/$(artifactName)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -399,7 +442,10 @@ function get_core_device(
     coreDeviceThingName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return greengrassv2(
-        "GET", "/greengrass/v2/coreDevices/$(coreDeviceThingName)"; aws_config=aws_config
+        "GET",
+        "/greengrass/v2/coreDevices/$(coreDeviceThingName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_core_device(
@@ -412,6 +458,7 @@ function get_core_device(
         "/greengrass/v2/coreDevices/$(coreDeviceThingName)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -427,7 +474,10 @@ Gets a deployment. Deployments define the components that run on Greengrass core
 """
 function get_deployment(deploymentId; aws_config::AbstractAWSConfig=global_aws_config())
     return greengrassv2(
-        "GET", "/greengrass/v2/deployments/$(deploymentId)"; aws_config=aws_config
+        "GET",
+        "/greengrass/v2/deployments/$(deploymentId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_deployment(
@@ -436,7 +486,11 @@ function get_deployment(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return greengrassv2(
-        "GET", "/greengrass/v2/deployments/$(deploymentId)", params; aws_config=aws_config
+        "GET",
+        "/greengrass/v2/deployments/$(deploymentId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -462,6 +516,7 @@ function list_client_devices_associated_with_core_device(
         "GET",
         "/greengrass/v2/coreDevices/$(coreDeviceThingName)/associatedClientDevices";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_client_devices_associated_with_core_device(
@@ -474,6 +529,7 @@ function list_client_devices_associated_with_core_device(
         "/greengrass/v2/coreDevices/$(coreDeviceThingName)/associatedClientDevices",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -494,14 +550,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function list_component_versions(arn; aws_config::AbstractAWSConfig=global_aws_config())
     return greengrassv2(
-        "GET", "/greengrass/v2/components/$(arn)/versions"; aws_config=aws_config
+        "GET",
+        "/greengrass/v2/components/$(arn)/versions";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_component_versions(
     arn, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return greengrassv2(
-        "GET", "/greengrass/v2/components/$(arn)/versions", params; aws_config=aws_config
+        "GET",
+        "/greengrass/v2/components/$(arn)/versions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -519,12 +582,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"scope"`: The scope of the components to list. Default: PRIVATE
 """
 function list_components(; aws_config::AbstractAWSConfig=global_aws_config())
-    return greengrassv2("GET", "/greengrass/v2/components"; aws_config=aws_config)
+    return greengrassv2(
+        "GET",
+        "/greengrass/v2/components";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_components(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return greengrassv2("GET", "/greengrass/v2/components", params; aws_config=aws_config)
+    return greengrassv2(
+        "GET",
+        "/greengrass/v2/components",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -546,12 +620,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   parameter, the list includes only core devices that are members of this thing group.
 """
 function list_core_devices(; aws_config::AbstractAWSConfig=global_aws_config())
-    return greengrassv2("GET", "/greengrass/v2/coreDevices"; aws_config=aws_config)
+    return greengrassv2(
+        "GET",
+        "/greengrass/v2/coreDevices";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_core_devices(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return greengrassv2("GET", "/greengrass/v2/coreDevices", params; aws_config=aws_config)
+    return greengrassv2(
+        "GET",
+        "/greengrass/v2/coreDevices",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -570,12 +655,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"targetArn"`: The ARN of the target IoT thing or thing group.
 """
 function list_deployments(; aws_config::AbstractAWSConfig=global_aws_config())
-    return greengrassv2("GET", "/greengrass/v2/deployments"; aws_config=aws_config)
+    return greengrassv2(
+        "GET",
+        "/greengrass/v2/deployments";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_deployments(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return greengrassv2("GET", "/greengrass/v2/deployments", params; aws_config=aws_config)
+    return greengrassv2(
+        "GET",
+        "/greengrass/v2/deployments",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -601,6 +697,7 @@ function list_effective_deployments(
         "GET",
         "/greengrass/v2/coreDevices/$(coreDeviceThingName)/effectiveDeployments";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_effective_deployments(
@@ -613,6 +710,7 @@ function list_effective_deployments(
         "/greengrass/v2/coreDevices/$(coreDeviceThingName)/effectiveDeployments",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -638,6 +736,7 @@ function list_installed_components(
         "GET",
         "/greengrass/v2/coreDevices/$(coreDeviceThingName)/installedComponents";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_installed_components(
@@ -650,6 +749,7 @@ function list_installed_components(
         "/greengrass/v2/coreDevices/$(coreDeviceThingName)/installedComponents",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -666,14 +766,25 @@ Retrieves the list of tags for an IoT Greengrass resource.
 function list_tags_for_resource(
     resourceArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return greengrassv2("GET", "/tags/$(resourceArn)"; aws_config=aws_config)
+    return greengrassv2(
+        "GET",
+        "/tags/$(resourceArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_tags_for_resource(
     resourceArn,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return greengrassv2("GET", "/tags/$(resourceArn)", params; aws_config=aws_config)
+    return greengrassv2(
+        "GET",
+        "/tags/$(resourceArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -708,6 +819,7 @@ function resolve_component_candidates(
             "componentCandidates" => componentCandidates, "platform" => platform
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function resolve_component_candidates(
@@ -729,6 +841,7 @@ function resolve_component_candidates(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -751,6 +864,7 @@ function tag_resource(resourceArn, tags; aws_config::AbstractAWSConfig=global_aw
         "/tags/$(resourceArn)",
         Dict{String,Any}("tags" => tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -764,6 +878,7 @@ function tag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tags" => tags), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -786,6 +901,7 @@ function untag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}("tagKeys" => tagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -799,5 +915,6 @@ function untag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tagKeys" => tagKeys), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/groundstation.jl
+++ b/src/services/groundstation.jl
@@ -15,14 +15,25 @@ Cancels a contact with a specified contact ID.
 
 """
 function cancel_contact(contactId; aws_config::AbstractAWSConfig=global_aws_config())
-    return groundstation("DELETE", "/contact/$(contactId)"; aws_config=aws_config)
+    return groundstation(
+        "DELETE",
+        "/contact/$(contactId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function cancel_contact(
     contactId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return groundstation("DELETE", "/contact/$(contactId)", params; aws_config=aws_config)
+    return groundstation(
+        "DELETE",
+        "/contact/$(contactId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -46,6 +57,7 @@ function create_config(configData, name; aws_config::AbstractAWSConfig=global_aw
         "/config",
         Dict{String,Any}("configData" => configData, "name" => name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_config(
@@ -63,6 +75,7 @@ function create_config(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -90,6 +103,7 @@ function create_dataflow_endpoint_group(
         "/dataflowEndpointGroup",
         Dict{String,Any}("endpointDetails" => endpointDetails);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_dataflow_endpoint_group(
@@ -106,6 +120,7 @@ function create_dataflow_endpoint_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -150,6 +165,7 @@ function create_mission_profile(
             "trackingConfigArn" => trackingConfigArn,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_mission_profile(
@@ -177,6 +193,7 @@ function create_mission_profile(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -195,7 +212,10 @@ function delete_config(
     configId, configType; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return groundstation(
-        "DELETE", "/config/$(configType)/$(configId)"; aws_config=aws_config
+        "DELETE",
+        "/config/$(configType)/$(configId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_config(
@@ -205,7 +225,11 @@ function delete_config(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return groundstation(
-        "DELETE", "/config/$(configType)/$(configId)", params; aws_config=aws_config
+        "DELETE",
+        "/config/$(configType)/$(configId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -223,7 +247,10 @@ function delete_dataflow_endpoint_group(
     dataflowEndpointGroupId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return groundstation(
-        "DELETE", "/dataflowEndpointGroup/$(dataflowEndpointGroupId)"; aws_config=aws_config
+        "DELETE",
+        "/dataflowEndpointGroup/$(dataflowEndpointGroupId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_dataflow_endpoint_group(
@@ -236,6 +263,7 @@ function delete_dataflow_endpoint_group(
         "/dataflowEndpointGroup/$(dataflowEndpointGroupId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -253,7 +281,10 @@ function delete_mission_profile(
     missionProfileId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return groundstation(
-        "DELETE", "/missionprofile/$(missionProfileId)"; aws_config=aws_config
+        "DELETE",
+        "/missionprofile/$(missionProfileId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_mission_profile(
@@ -262,7 +293,11 @@ function delete_mission_profile(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return groundstation(
-        "DELETE", "/missionprofile/$(missionProfileId)", params; aws_config=aws_config
+        "DELETE",
+        "/missionprofile/$(missionProfileId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -277,14 +312,25 @@ Describes an existing contact.
 
 """
 function describe_contact(contactId; aws_config::AbstractAWSConfig=global_aws_config())
-    return groundstation("GET", "/contact/$(contactId)"; aws_config=aws_config)
+    return groundstation(
+        "GET",
+        "/contact/$(contactId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_contact(
     contactId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return groundstation("GET", "/contact/$(contactId)", params; aws_config=aws_config)
+    return groundstation(
+        "GET",
+        "/contact/$(contactId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -299,7 +345,12 @@ Returns Config information. Only one Config response can be returned.
 
 """
 function get_config(configId, configType; aws_config::AbstractAWSConfig=global_aws_config())
-    return groundstation("GET", "/config/$(configType)/$(configId)"; aws_config=aws_config)
+    return groundstation(
+        "GET",
+        "/config/$(configType)/$(configId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_config(
     configId,
@@ -308,7 +359,11 @@ function get_config(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return groundstation(
-        "GET", "/config/$(configType)/$(configId)", params; aws_config=aws_config
+        "GET",
+        "/config/$(configType)/$(configId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -326,7 +381,10 @@ function get_dataflow_endpoint_group(
     dataflowEndpointGroupId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return groundstation(
-        "GET", "/dataflowEndpointGroup/$(dataflowEndpointGroupId)"; aws_config=aws_config
+        "GET",
+        "/dataflowEndpointGroup/$(dataflowEndpointGroupId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_dataflow_endpoint_group(
@@ -339,6 +397,7 @@ function get_dataflow_endpoint_group(
         "/dataflowEndpointGroup/$(dataflowEndpointGroupId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -359,6 +418,7 @@ function get_minute_usage(month, year; aws_config::AbstractAWSConfig=global_aws_
         "/minute-usage",
         Dict{String,Any}("month" => month, "year" => year);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_minute_usage(
@@ -374,6 +434,7 @@ function get_minute_usage(
             mergewith(_merge, Dict{String,Any}("month" => month, "year" => year), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -391,7 +452,10 @@ function get_mission_profile(
     missionProfileId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return groundstation(
-        "GET", "/missionprofile/$(missionProfileId)"; aws_config=aws_config
+        "GET",
+        "/missionprofile/$(missionProfileId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_mission_profile(
@@ -400,7 +464,11 @@ function get_mission_profile(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return groundstation(
-        "GET", "/missionprofile/$(missionProfileId)", params; aws_config=aws_config
+        "GET",
+        "/missionprofile/$(missionProfileId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -415,14 +483,25 @@ Returns a satellite.
 
 """
 function get_satellite(satelliteId; aws_config::AbstractAWSConfig=global_aws_config())
-    return groundstation("GET", "/satellite/$(satelliteId)"; aws_config=aws_config)
+    return groundstation(
+        "GET",
+        "/satellite/$(satelliteId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_satellite(
     satelliteId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return groundstation("GET", "/satellite/$(satelliteId)", params; aws_config=aws_config)
+    return groundstation(
+        "GET",
+        "/satellite/$(satelliteId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -438,12 +517,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   get the next page of results.
 """
 function list_configs(; aws_config::AbstractAWSConfig=global_aws_config())
-    return groundstation("GET", "/config"; aws_config=aws_config)
+    return groundstation(
+        "GET", "/config"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_configs(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return groundstation("GET", "/config", params; aws_config=aws_config)
+    return groundstation(
+        "GET", "/config", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -477,6 +560,7 @@ function list_contacts(
             "endTime" => endTime, "startTime" => startTime, "statusList" => statusList
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_contacts(
@@ -501,6 +585,7 @@ function list_contacts(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -517,12 +602,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   ListDataflowEndpointGroups call. Used to get the next page of results.
 """
 function list_dataflow_endpoint_groups(; aws_config::AbstractAWSConfig=global_aws_config())
-    return groundstation("GET", "/dataflowEndpointGroup"; aws_config=aws_config)
+    return groundstation(
+        "GET",
+        "/dataflowEndpointGroup";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_dataflow_endpoint_groups(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return groundstation("GET", "/dataflowEndpointGroup", params; aws_config=aws_config)
+    return groundstation(
+        "GET",
+        "/dataflowEndpointGroup",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -539,12 +635,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"satelliteId"`: Satellite ID to retrieve on-boarded ground stations.
 """
 function list_ground_stations(; aws_config::AbstractAWSConfig=global_aws_config())
-    return groundstation("GET", "/groundstation"; aws_config=aws_config)
+    return groundstation(
+        "GET", "/groundstation"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_ground_stations(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return groundstation("GET", "/groundstation", params; aws_config=aws_config)
+    return groundstation(
+        "GET",
+        "/groundstation",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -560,12 +664,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Used to get the next page of results.
 """
 function list_mission_profiles(; aws_config::AbstractAWSConfig=global_aws_config())
-    return groundstation("GET", "/missionprofile"; aws_config=aws_config)
+    return groundstation(
+        "GET", "/missionprofile"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_mission_profiles(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return groundstation("GET", "/missionprofile", params; aws_config=aws_config)
+    return groundstation(
+        "GET",
+        "/missionprofile",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -581,12 +693,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   satellites.
 """
 function list_satellites(; aws_config::AbstractAWSConfig=global_aws_config())
-    return groundstation("GET", "/satellite"; aws_config=aws_config)
+    return groundstation(
+        "GET", "/satellite"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_satellites(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return groundstation("GET", "/satellite", params; aws_config=aws_config)
+    return groundstation(
+        "GET", "/satellite", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -602,14 +718,25 @@ Returns a list of tags for a specified resource.
 function list_tags_for_resource(
     resourceArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return groundstation("GET", "/tags/$(resourceArn)"; aws_config=aws_config)
+    return groundstation(
+        "GET",
+        "/tags/$(resourceArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_tags_for_resource(
     resourceArn,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return groundstation("GET", "/tags/$(resourceArn)", params; aws_config=aws_config)
+    return groundstation(
+        "GET",
+        "/tags/$(resourceArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -648,6 +775,7 @@ function reserve_contact(
             "startTime" => startTime,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function reserve_contact(
@@ -676,6 +804,7 @@ function reserve_contact(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -696,6 +825,7 @@ function tag_resource(resourceArn, tags; aws_config::AbstractAWSConfig=global_aw
         "/tags/$(resourceArn)",
         Dict{String,Any}("tags" => tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -709,6 +839,7 @@ function tag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tags" => tags), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -731,6 +862,7 @@ function untag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}("tagKeys" => tagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -744,6 +876,7 @@ function untag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tagKeys" => tagKeys), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -773,6 +906,7 @@ function update_config(
         "/config/$(configType)/$(configId)",
         Dict{String,Any}("configData" => configData, "name" => name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_config(
@@ -792,6 +926,7 @@ function update_config(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -823,7 +958,10 @@ function update_mission_profile(
     missionProfileId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return groundstation(
-        "PUT", "/missionprofile/$(missionProfileId)"; aws_config=aws_config
+        "PUT",
+        "/missionprofile/$(missionProfileId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_mission_profile(
@@ -832,6 +970,10 @@ function update_mission_profile(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return groundstation(
-        "PUT", "/missionprofile/$(missionProfileId)", params; aws_config=aws_config
+        "PUT",
+        "/missionprofile/$(missionProfileId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/guardduty.jl
+++ b/src/services/guardduty.jl
@@ -26,6 +26,7 @@ function accept_invitation(
         "/detector/$(detectorId)/master",
         Dict{String,Any}("invitationId" => invitationId, "masterId" => masterId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function accept_invitation(
@@ -46,6 +47,7 @@ function accept_invitation(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -71,6 +73,7 @@ function archive_findings(
         "/detector/$(detectorId)/findings/archive",
         Dict{String,Any}("findingIds" => findingIds);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function archive_findings(
@@ -86,6 +89,7 @@ function archive_findings(
             mergewith(_merge, Dict{String,Any}("findingIds" => findingIds), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -115,6 +119,7 @@ function create_detector(enable; aws_config::AbstractAWSConfig=global_aws_config
         "/detector",
         Dict{String,Any}("enable" => enable, "clientToken" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_detector(
@@ -131,6 +136,7 @@ function create_detector(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -210,6 +216,7 @@ function create_filter(
             "clientToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_filter(
@@ -234,6 +241,7 @@ function create_filter(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -281,6 +289,7 @@ function create_ipset(
             "clientToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_ipset(
@@ -309,6 +318,7 @@ function create_ipset(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -340,6 +350,7 @@ function create_members(
         "/detector/$(detectorId)/member",
         Dict{String,Any}("accountDetails" => accountDetails);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_members(
@@ -355,6 +366,7 @@ function create_members(
             mergewith(_merge, Dict{String,Any}("accountDetails" => accountDetails), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -392,6 +404,7 @@ function create_publishing_destination(
             "clientToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_publishing_destination(
@@ -416,6 +429,7 @@ function create_publishing_destination(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -438,7 +452,10 @@ function create_sample_findings(
     detectorId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return guardduty(
-        "POST", "/detector/$(detectorId)/findings/create"; aws_config=aws_config
+        "POST",
+        "/detector/$(detectorId)/findings/create";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_sample_findings(
@@ -447,7 +464,11 @@ function create_sample_findings(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return guardduty(
-        "POST", "/detector/$(detectorId)/findings/create", params; aws_config=aws_config
+        "POST",
+        "/detector/$(detectorId)/findings/create",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -494,6 +515,7 @@ function create_threat_intel_set(
             "clientToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_threat_intel_set(
@@ -522,6 +544,7 @@ function create_threat_intel_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -543,6 +566,7 @@ function decline_invitations(accountIds; aws_config::AbstractAWSConfig=global_aw
         "/invitation/decline",
         Dict{String,Any}("accountIds" => accountIds);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function decline_invitations(
@@ -557,6 +581,7 @@ function decline_invitations(
             mergewith(_merge, Dict{String,Any}("accountIds" => accountIds), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -571,14 +596,25 @@ Deletes an Amazon GuardDuty detector that is specified by the detector ID.
 
 """
 function delete_detector(detectorId; aws_config::AbstractAWSConfig=global_aws_config())
-    return guardduty("DELETE", "/detector/$(detectorId)"; aws_config=aws_config)
+    return guardduty(
+        "DELETE",
+        "/detector/$(detectorId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_detector(
     detectorId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return guardduty("DELETE", "/detector/$(detectorId)", params; aws_config=aws_config)
+    return guardduty(
+        "DELETE",
+        "/detector/$(detectorId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -596,7 +632,10 @@ function delete_filter(
     detectorId, filterName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return guardduty(
-        "DELETE", "/detector/$(detectorId)/filter/$(filterName)"; aws_config=aws_config
+        "DELETE",
+        "/detector/$(detectorId)/filter/$(filterName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_filter(
@@ -610,6 +649,7 @@ function delete_filter(
         "/detector/$(detectorId)/filter/$(filterName)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -631,6 +671,7 @@ function delete_invitations(accountIds; aws_config::AbstractAWSConfig=global_aws
         "/invitation/delete",
         Dict{String,Any}("accountIds" => accountIds);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_invitations(
@@ -645,6 +686,7 @@ function delete_invitations(
             mergewith(_merge, Dict{String,Any}("accountIds" => accountIds), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -664,7 +706,10 @@ function delete_ipset(
     detectorId, ipSetId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return guardduty(
-        "DELETE", "/detector/$(detectorId)/ipset/$(ipSetId)"; aws_config=aws_config
+        "DELETE",
+        "/detector/$(detectorId)/ipset/$(ipSetId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_ipset(
@@ -674,7 +719,11 @@ function delete_ipset(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return guardduty(
-        "DELETE", "/detector/$(detectorId)/ipset/$(ipSetId)", params; aws_config=aws_config
+        "DELETE",
+        "/detector/$(detectorId)/ipset/$(ipSetId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -700,6 +749,7 @@ function delete_members(
         "/detector/$(detectorId)/member/delete",
         Dict{String,Any}("accountIds" => accountIds);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_members(
@@ -715,6 +765,7 @@ function delete_members(
             mergewith(_merge, Dict{String,Any}("accountIds" => accountIds), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -737,6 +788,7 @@ function delete_publishing_destination(
         "DELETE",
         "/detector/$(detectorId)/publishingDestination/$(destinationId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_publishing_destination(
@@ -750,6 +802,7 @@ function delete_publishing_destination(
         "/detector/$(detectorId)/publishingDestination/$(destinationId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -771,6 +824,7 @@ function delete_threat_intel_set(
         "DELETE",
         "/detector/$(detectorId)/threatintelset/$(threatIntelSetId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_threat_intel_set(
@@ -784,6 +838,7 @@ function delete_threat_intel_set(
         "/detector/$(detectorId)/threatintelset/$(threatIntelSetId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -801,14 +856,25 @@ Returns information about the account selected as the delegated administrator fo
 function describe_organization_configuration(
     detectorId; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return guardduty("GET", "/detector/$(detectorId)/admin"; aws_config=aws_config)
+    return guardduty(
+        "GET",
+        "/detector/$(detectorId)/admin";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_organization_configuration(
     detectorId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return guardduty("GET", "/detector/$(detectorId)/admin", params; aws_config=aws_config)
+    return guardduty(
+        "GET",
+        "/detector/$(detectorId)/admin",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -831,6 +897,7 @@ function describe_publishing_destination(
         "GET",
         "/detector/$(detectorId)/publishingDestination/$(destinationId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_publishing_destination(
@@ -844,6 +911,7 @@ function describe_publishing_destination(
         "/detector/$(detectorId)/publishingDestination/$(destinationId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -866,6 +934,7 @@ function disable_organization_admin_account(
         "/admin/disable",
         Dict{String,Any}("adminAccountId" => adminAccountId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disable_organization_admin_account(
@@ -880,6 +949,7 @@ function disable_organization_admin_account(
             mergewith(_merge, Dict{String,Any}("adminAccountId" => adminAccountId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -897,7 +967,10 @@ function disassociate_from_master_account(
     detectorId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return guardduty(
-        "POST", "/detector/$(detectorId)/master/disassociate"; aws_config=aws_config
+        "POST",
+        "/detector/$(detectorId)/master/disassociate";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disassociate_from_master_account(
@@ -906,7 +979,11 @@ function disassociate_from_master_account(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return guardduty(
-        "POST", "/detector/$(detectorId)/master/disassociate", params; aws_config=aws_config
+        "POST",
+        "/detector/$(detectorId)/master/disassociate",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -932,6 +1009,7 @@ function disassociate_members(
         "/detector/$(detectorId)/member/disassociate",
         Dict{String,Any}("accountIds" => accountIds);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disassociate_members(
@@ -947,6 +1025,7 @@ function disassociate_members(
             mergewith(_merge, Dict{String,Any}("accountIds" => accountIds), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -969,6 +1048,7 @@ function enable_organization_admin_account(
         "/admin/enable",
         Dict{String,Any}("adminAccountId" => adminAccountId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function enable_organization_admin_account(
@@ -983,6 +1063,7 @@ function enable_organization_admin_account(
             mergewith(_merge, Dict{String,Any}("adminAccountId" => adminAccountId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -997,14 +1078,25 @@ Retrieves an Amazon GuardDuty detector specified by the detectorId.
 
 """
 function get_detector(detectorId; aws_config::AbstractAWSConfig=global_aws_config())
-    return guardduty("GET", "/detector/$(detectorId)"; aws_config=aws_config)
+    return guardduty(
+        "GET",
+        "/detector/$(detectorId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_detector(
     detectorId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return guardduty("GET", "/detector/$(detectorId)", params; aws_config=aws_config)
+    return guardduty(
+        "GET",
+        "/detector/$(detectorId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1022,7 +1114,10 @@ function get_filter(
     detectorId, filterName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return guardduty(
-        "GET", "/detector/$(detectorId)/filter/$(filterName)"; aws_config=aws_config
+        "GET",
+        "/detector/$(detectorId)/filter/$(filterName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_filter(
@@ -1032,7 +1127,11 @@ function get_filter(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return guardduty(
-        "GET", "/detector/$(detectorId)/filter/$(filterName)", params; aws_config=aws_config
+        "GET",
+        "/detector/$(detectorId)/filter/$(filterName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1059,6 +1158,7 @@ function get_findings(
         "/detector/$(detectorId)/findings/get",
         Dict{String,Any}("findingIds" => findingIds);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_findings(
@@ -1074,6 +1174,7 @@ function get_findings(
             mergewith(_merge, Dict{String,Any}("findingIds" => findingIds), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1100,6 +1201,7 @@ function get_findings_statistics(
         "/detector/$(detectorId)/findings/statistics",
         Dict{String,Any}("findingStatisticTypes" => findingStatisticTypes);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_findings_statistics(
@@ -1119,6 +1221,7 @@ function get_findings_statistics(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1131,12 +1234,20 @@ member account except the currently accepted invitation.
 
 """
 function get_invitations_count(; aws_config::AbstractAWSConfig=global_aws_config())
-    return guardduty("GET", "/invitation/count"; aws_config=aws_config)
+    return guardduty(
+        "GET", "/invitation/count"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_invitations_count(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return guardduty("GET", "/invitation/count", params; aws_config=aws_config)
+    return guardduty(
+        "GET",
+        "/invitation/count",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1152,7 +1263,10 @@ Retrieves the IPSet specified by the ipSetId.
 """
 function get_ipset(detectorId, ipSetId; aws_config::AbstractAWSConfig=global_aws_config())
     return guardduty(
-        "GET", "/detector/$(detectorId)/ipset/$(ipSetId)"; aws_config=aws_config
+        "GET",
+        "/detector/$(detectorId)/ipset/$(ipSetId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_ipset(
@@ -1162,7 +1276,11 @@ function get_ipset(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return guardduty(
-        "GET", "/detector/$(detectorId)/ipset/$(ipSetId)", params; aws_config=aws_config
+        "GET",
+        "/detector/$(detectorId)/ipset/$(ipSetId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1178,14 +1296,25 @@ GuardDuty member account.
 
 """
 function get_master_account(detectorId; aws_config::AbstractAWSConfig=global_aws_config())
-    return guardduty("GET", "/detector/$(detectorId)/master"; aws_config=aws_config)
+    return guardduty(
+        "GET",
+        "/detector/$(detectorId)/master";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_master_account(
     detectorId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return guardduty("GET", "/detector/$(detectorId)/master", params; aws_config=aws_config)
+    return guardduty(
+        "GET",
+        "/detector/$(detectorId)/master",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1207,6 +1336,7 @@ function get_member_detectors(
         "/detector/$(detectorId)/member/detector/get",
         Dict{String,Any}("accountIds" => accountIds);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_member_detectors(
@@ -1222,6 +1352,7 @@ function get_member_detectors(
             mergewith(_merge, Dict{String,Any}("accountIds" => accountIds), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1247,6 +1378,7 @@ function get_members(
         "/detector/$(detectorId)/member/get",
         Dict{String,Any}("accountIds" => accountIds);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_members(
@@ -1262,6 +1394,7 @@ function get_members(
             mergewith(_merge, Dict{String,Any}("accountIds" => accountIds), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1283,6 +1416,7 @@ function get_threat_intel_set(
         "GET",
         "/detector/$(detectorId)/threatintelset/$(threatIntelSetId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_threat_intel_set(
@@ -1296,6 +1430,7 @@ function get_threat_intel_set(
         "/detector/$(detectorId)/threatintelset/$(threatIntelSetId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1338,6 +1473,7 @@ function get_usage_statistics(
             "usageCriteria" => usageCriteria, "usageStatisticsType" => usageStatisticsType
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_usage_statistics(
@@ -1361,6 +1497,7 @@ function get_usage_statistics(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1393,6 +1530,7 @@ function invite_members(
         "/detector/$(detectorId)/member/invite",
         Dict{String,Any}("accountIds" => accountIds);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function invite_members(
@@ -1408,6 +1546,7 @@ function invite_members(
             mergewith(_merge, Dict{String,Any}("accountIds" => accountIds), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1427,12 +1566,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   response to continue listing data.
 """
 function list_detectors(; aws_config::AbstractAWSConfig=global_aws_config())
-    return guardduty("GET", "/detector"; aws_config=aws_config)
+    return guardduty(
+        "GET", "/detector"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_detectors(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return guardduty("GET", "/detector", params; aws_config=aws_config)
+    return guardduty(
+        "GET", "/detector", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1454,14 +1597,25 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   response to continue listing data.
 """
 function list_filters(detectorId; aws_config::AbstractAWSConfig=global_aws_config())
-    return guardduty("GET", "/detector/$(detectorId)/filter"; aws_config=aws_config)
+    return guardduty(
+        "GET",
+        "/detector/$(detectorId)/filter";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_filters(
     detectorId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return guardduty("GET", "/detector/$(detectorId)/filter", params; aws_config=aws_config)
+    return guardduty(
+        "GET",
+        "/detector/$(detectorId)/filter",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1522,7 +1676,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"sortCriteria"`: Represents the criteria used for sorting findings.
 """
 function list_findings(detectorId; aws_config::AbstractAWSConfig=global_aws_config())
-    return guardduty("POST", "/detector/$(detectorId)/findings"; aws_config=aws_config)
+    return guardduty(
+        "POST",
+        "/detector/$(detectorId)/findings";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_findings(
     detectorId,
@@ -1530,7 +1689,11 @@ function list_findings(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return guardduty(
-        "POST", "/detector/$(detectorId)/findings", params; aws_config=aws_config
+        "POST",
+        "/detector/$(detectorId)/findings",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1550,12 +1713,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   response to continue listing data.
 """
 function list_invitations(; aws_config::AbstractAWSConfig=global_aws_config())
-    return guardduty("GET", "/invitation"; aws_config=aws_config)
+    return guardduty(
+        "GET", "/invitation"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_invitations(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return guardduty("GET", "/invitation", params; aws_config=aws_config)
+    return guardduty(
+        "GET", "/invitation", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1579,14 +1746,25 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   response to continue listing data.
 """
 function list_ipsets(detectorId; aws_config::AbstractAWSConfig=global_aws_config())
-    return guardduty("GET", "/detector/$(detectorId)/ipset"; aws_config=aws_config)
+    return guardduty(
+        "GET",
+        "/detector/$(detectorId)/ipset";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_ipsets(
     detectorId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return guardduty("GET", "/detector/$(detectorId)/ipset", params; aws_config=aws_config)
+    return guardduty(
+        "GET",
+        "/detector/$(detectorId)/ipset",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1610,14 +1788,25 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   members (including members who haven't been invited yet or have been disassociated).
 """
 function list_members(detectorId; aws_config::AbstractAWSConfig=global_aws_config())
-    return guardduty("GET", "/detector/$(detectorId)/member"; aws_config=aws_config)
+    return guardduty(
+        "GET",
+        "/detector/$(detectorId)/member";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_members(
     detectorId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return guardduty("GET", "/detector/$(detectorId)/member", params; aws_config=aws_config)
+    return guardduty(
+        "GET",
+        "/detector/$(detectorId)/member",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1637,12 +1826,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function list_organization_admin_accounts(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return guardduty("GET", "/admin"; aws_config=aws_config)
+    return guardduty(
+        "GET", "/admin"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_organization_admin_accounts(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return guardduty("GET", "/admin", params; aws_config=aws_config)
+    return guardduty(
+        "GET", "/admin", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1666,7 +1859,10 @@ function list_publishing_destinations(
     detectorId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return guardduty(
-        "GET", "/detector/$(detectorId)/publishingDestination"; aws_config=aws_config
+        "GET",
+        "/detector/$(detectorId)/publishingDestination";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_publishing_destinations(
@@ -1679,6 +1875,7 @@ function list_publishing_destinations(
         "/detector/$(detectorId)/publishingDestination",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1697,14 +1894,25 @@ operation returns all assigned tags for a given resource.
 function list_tags_for_resource(
     resourceArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return guardduty("GET", "/tags/$(resourceArn)"; aws_config=aws_config)
+    return guardduty(
+        "GET",
+        "/tags/$(resourceArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_tags_for_resource(
     resourceArn,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return guardduty("GET", "/tags/$(resourceArn)", params; aws_config=aws_config)
+    return guardduty(
+        "GET",
+        "/tags/$(resourceArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1730,7 +1938,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function list_threat_intel_sets(
     detectorId; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return guardduty("GET", "/detector/$(detectorId)/threatintelset"; aws_config=aws_config)
+    return guardduty(
+        "GET",
+        "/detector/$(detectorId)/threatintelset";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_threat_intel_sets(
     detectorId,
@@ -1738,7 +1951,11 @@ function list_threat_intel_sets(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return guardduty(
-        "GET", "/detector/$(detectorId)/threatintelset", params; aws_config=aws_config
+        "GET",
+        "/detector/$(detectorId)/threatintelset",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1764,6 +1981,7 @@ function start_monitoring_members(
         "/detector/$(detectorId)/member/start",
         Dict{String,Any}("accountIds" => accountIds);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_monitoring_members(
@@ -1779,6 +1997,7 @@ function start_monitoring_members(
             mergewith(_merge, Dict{String,Any}("accountIds" => accountIds), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1803,6 +2022,7 @@ function stop_monitoring_members(
         "/detector/$(detectorId)/member/stop",
         Dict{String,Any}("accountIds" => accountIds);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function stop_monitoring_members(
@@ -1818,6 +2038,7 @@ function stop_monitoring_members(
             mergewith(_merge, Dict{String,Any}("accountIds" => accountIds), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1839,6 +2060,7 @@ function tag_resource(resourceArn, tags; aws_config::AbstractAWSConfig=global_aw
         "/tags/$(resourceArn)",
         Dict{String,Any}("tags" => tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -1852,6 +2074,7 @@ function tag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tags" => tags), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1874,6 +2097,7 @@ function unarchive_findings(
         "/detector/$(detectorId)/findings/unarchive",
         Dict{String,Any}("findingIds" => findingIds);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function unarchive_findings(
@@ -1889,6 +2113,7 @@ function unarchive_findings(
             mergewith(_merge, Dict{String,Any}("findingIds" => findingIds), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1911,6 +2136,7 @@ function untag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}("tagKeys" => tagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -1924,6 +2150,7 @@ function untag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tagKeys" => tagKeys), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1944,14 +2171,25 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   exported, such as to CloudWatch Events.
 """
 function update_detector(detectorId; aws_config::AbstractAWSConfig=global_aws_config())
-    return guardduty("POST", "/detector/$(detectorId)"; aws_config=aws_config)
+    return guardduty(
+        "POST",
+        "/detector/$(detectorId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function update_detector(
     detectorId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return guardduty("POST", "/detector/$(detectorId)", params; aws_config=aws_config)
+    return guardduty(
+        "POST",
+        "/detector/$(detectorId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1979,7 +2217,10 @@ function update_filter(
     detectorId, filterName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return guardduty(
-        "POST", "/detector/$(detectorId)/filter/$(filterName)"; aws_config=aws_config
+        "POST",
+        "/detector/$(detectorId)/filter/$(filterName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_filter(
@@ -1993,6 +2234,7 @@ function update_filter(
         "/detector/$(detectorId)/filter/$(filterName)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2019,6 +2261,7 @@ function update_findings_feedback(
         "/detector/$(detectorId)/findings/feedback",
         Dict{String,Any}("feedback" => feedback, "findingIds" => findingIds);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_findings_feedback(
@@ -2039,6 +2282,7 @@ function update_findings_feedback(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2064,7 +2308,10 @@ function update_ipset(
     detectorId, ipSetId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return guardduty(
-        "POST", "/detector/$(detectorId)/ipset/$(ipSetId)"; aws_config=aws_config
+        "POST",
+        "/detector/$(detectorId)/ipset/$(ipSetId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_ipset(
@@ -2074,7 +2321,11 @@ function update_ipset(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return guardduty(
-        "POST", "/detector/$(detectorId)/ipset/$(ipSetId)", params; aws_config=aws_config
+        "POST",
+        "/detector/$(detectorId)/ipset/$(ipSetId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2100,6 +2351,7 @@ function update_member_detectors(
         "/detector/$(detectorId)/member/detector/update",
         Dict{String,Any}("accountIds" => accountIds);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_member_detectors(
@@ -2115,6 +2367,7 @@ function update_member_detectors(
             mergewith(_merge, Dict{String,Any}("accountIds" => accountIds), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2141,6 +2394,7 @@ function update_organization_configuration(
         "/detector/$(detectorId)/admin",
         Dict{String,Any}("autoEnable" => autoEnable);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_organization_configuration(
@@ -2156,6 +2410,7 @@ function update_organization_configuration(
             mergewith(_merge, Dict{String,Any}("autoEnable" => autoEnable), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2182,6 +2437,7 @@ function update_publishing_destination(
         "POST",
         "/detector/$(detectorId)/publishingDestination/$(destinationId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_publishing_destination(
@@ -2195,6 +2451,7 @@ function update_publishing_destination(
         "/detector/$(detectorId)/publishingDestination/$(destinationId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2224,6 +2481,7 @@ function update_threat_intel_set(
         "POST",
         "/detector/$(detectorId)/threatintelset/$(threatIntelSetId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_threat_intel_set(
@@ -2237,5 +2495,6 @@ function update_threat_intel_set(
         "/detector/$(detectorId)/threatintelset/$(threatIntelSetId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/health.jl
+++ b/src/services/health.jl
@@ -38,6 +38,7 @@ function describe_affected_accounts_for_organization(
         "DescribeAffectedAccountsForOrganization",
         Dict{String,Any}("eventArn" => eventArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_affected_accounts_for_organization(
@@ -51,6 +52,7 @@ function describe_affected_accounts_for_organization(
             mergewith(_merge, Dict{String,Any}("eventArn" => eventArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -90,6 +92,7 @@ function describe_affected_entities(
         "DescribeAffectedEntities",
         Dict{String,Any}("filter" => filter);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_affected_entities(
@@ -99,6 +102,7 @@ function describe_affected_entities(
         "DescribeAffectedEntities",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("filter" => filter), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -142,6 +146,7 @@ function describe_affected_entities_for_organization(
         "DescribeAffectedEntitiesForOrganization",
         Dict{String,Any}("organizationEntityFilters" => organizationEntityFilters);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_affected_entities_for_organization(
@@ -159,6 +164,7 @@ function describe_affected_entities_for_organization(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -178,12 +184,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   \"
 """
 function describe_entity_aggregates(; aws_config::AbstractAWSConfig=global_aws_config())
-    return health("DescribeEntityAggregates"; aws_config=aws_config)
+    return health(
+        "DescribeEntityAggregates"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_entity_aggregates(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return health("DescribeEntityAggregates", params; aws_config=aws_config)
+    return health(
+        "DescribeEntityAggregates",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -215,6 +228,7 @@ function describe_event_aggregates(
         "DescribeEventAggregates",
         Dict{String,Any}("aggregateField" => aggregateField);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_event_aggregates(
@@ -228,6 +242,7 @@ function describe_event_aggregates(
             mergewith(_merge, Dict{String,Any}("aggregateField" => aggregateField), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -263,6 +278,7 @@ function describe_event_details(
         "DescribeEventDetails",
         Dict{String,Any}("eventArns" => eventArns);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_event_details(
@@ -276,6 +292,7 @@ function describe_event_details(
             mergewith(_merge, Dict{String,Any}("eventArns" => eventArns), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -322,6 +339,7 @@ function describe_event_details_for_organization(
             "organizationEventDetailFilters" => organizationEventDetailFilters
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_event_details_for_organization(
@@ -341,6 +359,7 @@ function describe_event_details_for_organization(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -368,12 +387,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   results have been returned, the response does not contain a pagination token value.
 """
 function describe_event_types(; aws_config::AbstractAWSConfig=global_aws_config())
-    return health("DescribeEventTypes"; aws_config=aws_config)
+    return health(
+        "DescribeEventTypes"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_event_types(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return health("DescribeEventTypes", params; aws_config=aws_config)
+    return health(
+        "DescribeEventTypes", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -407,12 +430,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   results have been returned, the response does not contain a pagination token value.
 """
 function describe_events(; aws_config::AbstractAWSConfig=global_aws_config())
-    return health("DescribeEvents"; aws_config=aws_config)
+    return health("DescribeEvents"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function describe_events(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return health("DescribeEvents", params; aws_config=aws_config)
+    return health(
+        "DescribeEvents", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -448,12 +473,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_events_for_organization(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return health("DescribeEventsForOrganization"; aws_config=aws_config)
+    return health(
+        "DescribeEventsForOrganization";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_events_for_organization(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return health("DescribeEventsForOrganization", params; aws_config=aws_config)
+    return health(
+        "DescribeEventsForOrganization",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -469,13 +503,20 @@ account.
 function describe_health_service_status_for_organization(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return health("DescribeHealthServiceStatusForOrganization"; aws_config=aws_config)
+    return health(
+        "DescribeHealthServiceStatusForOrganization";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_health_service_status_for_organization(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return health(
-        "DescribeHealthServiceStatusForOrganization", params; aws_config=aws_config
+        "DescribeHealthServiceStatusForOrganization",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -500,13 +541,20 @@ continues to aggregate health events for your AWS account.
 function disable_health_service_access_for_organization(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return health("DisableHealthServiceAccessForOrganization"; aws_config=aws_config)
+    return health(
+        "DisableHealthServiceAccessForOrganization";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function disable_health_service_access_for_organization(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return health(
-        "DisableHealthServiceAccessForOrganization", params; aws_config=aws_config
+        "DisableHealthServiceAccessForOrganization",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -531,10 +579,19 @@ AWS Health User Guide.
 function enable_health_service_access_for_organization(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return health("EnableHealthServiceAccessForOrganization"; aws_config=aws_config)
+    return health(
+        "EnableHealthServiceAccessForOrganization";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function enable_health_service_access_for_organization(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return health("EnableHealthServiceAccessForOrganization", params; aws_config=aws_config)
+    return health(
+        "EnableHealthServiceAccessForOrganization",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end

--- a/src/services/healthlake.jl
+++ b/src/services/healthlake.jl
@@ -34,6 +34,7 @@ function create_fhirdatastore(
             "DatastoreTypeVersion" => DatastoreTypeVersion, "ClientToken" => string(uuid4())
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_fhirdatastore(
@@ -54,6 +55,7 @@ function create_fhirdatastore(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -68,12 +70,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"DatastoreId"`:  The AWS-generated ID for the Data Store to be deleted.
 """
 function delete_fhirdatastore(; aws_config::AbstractAWSConfig=global_aws_config())
-    return healthlake("DeleteFHIRDatastore"; aws_config=aws_config)
+    return healthlake(
+        "DeleteFHIRDatastore"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function delete_fhirdatastore(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return healthlake("DeleteFHIRDatastore", params; aws_config=aws_config)
+    return healthlake(
+        "DeleteFHIRDatastore",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -90,12 +99,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   ‘CreateFHIRDatastore’ output.
 """
 function describe_fhirdatastore(; aws_config::AbstractAWSConfig=global_aws_config())
-    return healthlake("DescribeFHIRDatastore"; aws_config=aws_config)
+    return healthlake(
+        "DescribeFHIRDatastore"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_fhirdatastore(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return healthlake("DescribeFHIRDatastore", params; aws_config=aws_config)
+    return healthlake(
+        "DescribeFHIRDatastore",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -118,6 +134,7 @@ function describe_fhirexport_job(
         "DescribeFHIRExportJob",
         Dict{String,Any}("DatastoreId" => DatastoreId, "JobId" => JobId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_fhirexport_job(
@@ -136,6 +153,7 @@ function describe_fhirexport_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -158,6 +176,7 @@ function describe_fhirimport_job(
         "DescribeFHIRImportJob",
         Dict{String,Any}("DatastoreId" => DatastoreId, "JobId" => JobId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_fhirimport_job(
@@ -176,6 +195,7 @@ function describe_fhirimport_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -194,12 +214,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`: Fetches the next page of Data Stores when results are paginated.
 """
 function list_fhirdatastores(; aws_config::AbstractAWSConfig=global_aws_config())
-    return healthlake("ListFHIRDatastores"; aws_config=aws_config)
+    return healthlake(
+        "ListFHIRDatastores"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_fhirdatastores(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return healthlake("ListFHIRDatastores", params; aws_config=aws_config)
+    return healthlake(
+        "ListFHIRDatastores", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -234,6 +258,7 @@ function list_fhirexport_jobs(
         "ListFHIRExportJobs",
         Dict{String,Any}("DatastoreId" => DatastoreId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_fhirexport_jobs(
@@ -247,6 +272,7 @@ function list_fhirexport_jobs(
             mergewith(_merge, Dict{String,Any}("DatastoreId" => DatastoreId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -282,6 +308,7 @@ function list_fhirimport_jobs(
         "ListFHIRImportJobs",
         Dict{String,Any}("DatastoreId" => DatastoreId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_fhirimport_jobs(
@@ -295,6 +322,7 @@ function list_fhirimport_jobs(
             mergewith(_merge, Dict{String,Any}("DatastoreId" => DatastoreId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -316,6 +344,7 @@ function list_tags_for_resource(
         "ListTagsForResource",
         Dict{String,Any}("ResourceARN" => ResourceARN);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags_for_resource(
@@ -329,6 +358,7 @@ function list_tags_for_resource(
             mergewith(_merge, Dict{String,Any}("ResourceARN" => ResourceARN), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -366,6 +396,7 @@ function start_fhirexport_job(
             "OutputDataConfig" => OutputDataConfig,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_fhirexport_job(
@@ -391,6 +422,7 @@ function start_fhirexport_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -431,6 +463,7 @@ function start_fhirimport_job(
             "JobOutputDataConfig" => JobOutputDataConfig,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_fhirimport_job(
@@ -458,6 +491,7 @@ function start_fhirimport_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -478,6 +512,7 @@ function tag_resource(ResourceARN, Tags; aws_config::AbstractAWSConfig=global_aw
         "TagResource",
         Dict{String,Any}("ResourceARN" => ResourceARN, "Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -496,6 +531,7 @@ function tag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -518,6 +554,7 @@ function untag_resource(
         "UntagResource",
         Dict{String,Any}("ResourceARN" => ResourceARN, "TagKeys" => TagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -536,5 +573,6 @@ function untag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/honeycode.jl
+++ b/src/services/honeycode.jl
@@ -45,6 +45,7 @@ function batch_create_table_rows(
         "/workbooks/$(workbookId)/tables/$(tableId)/rows/batchcreate",
         Dict{String,Any}("rowsToCreate" => rowsToCreate);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_create_table_rows(
@@ -61,6 +62,7 @@ function batch_create_table_rows(
             mergewith(_merge, Dict{String,Any}("rowsToCreate" => rowsToCreate), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -98,6 +100,7 @@ function batch_delete_table_rows(
         "/workbooks/$(workbookId)/tables/$(tableId)/rows/batchdelete",
         Dict{String,Any}("rowIds" => rowIds);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_delete_table_rows(
@@ -112,6 +115,7 @@ function batch_delete_table_rows(
         "/workbooks/$(workbookId)/tables/$(tableId)/rows/batchdelete",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("rowIds" => rowIds), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -155,6 +159,7 @@ function batch_update_table_rows(
         "/workbooks/$(workbookId)/tables/$(tableId)/rows/batchupdate",
         Dict{String,Any}("rowsToUpdate" => rowsToUpdate);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_update_table_rows(
@@ -171,6 +176,7 @@ function batch_update_table_rows(
             mergewith(_merge, Dict{String,Any}("rowsToUpdate" => rowsToUpdate), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -219,6 +225,7 @@ function batch_upsert_table_rows(
         "/workbooks/$(workbookId)/tables/$(tableId)/rows/batchupsert",
         Dict{String,Any}("rowsToUpsert" => rowsToUpsert);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_upsert_table_rows(
@@ -235,6 +242,7 @@ function batch_upsert_table_rows(
             mergewith(_merge, Dict{String,Any}("rowsToUpsert" => rowsToUpsert), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -261,6 +269,7 @@ function describe_table_data_import_job(
         "GET",
         "/workbooks/$(workbookId)/tables/$(tableId)/import/$(jobId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_table_data_import_job(
@@ -275,6 +284,7 @@ function describe_table_data_import_job(
         "/workbooks/$(workbookId)/tables/$(tableId)/import/$(jobId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -314,6 +324,7 @@ function get_screen_data(
             "appId" => appId, "screenId" => screenId, "workbookId" => workbookId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_screen_data(
@@ -336,6 +347,7 @@ function get_screen_data(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -381,6 +393,7 @@ function invoke_screen_automation(
         "POST",
         "/workbooks/$(workbookId)/apps/$(appId)/screens/$(screenId)/automations/$(automationId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function invoke_screen_automation(
@@ -396,6 +409,7 @@ function invoke_screen_automation(
         "/workbooks/$(workbookId)/apps/$(appId)/screens/$(screenId)/automations/$(automationId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -423,7 +437,10 @@ function list_table_columns(
     tableId, workbookId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return honeycode(
-        "GET", "/workbooks/$(workbookId)/tables/$(tableId)/columns"; aws_config=aws_config
+        "GET",
+        "/workbooks/$(workbookId)/tables/$(tableId)/columns";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_table_columns(
@@ -437,6 +454,7 @@ function list_table_columns(
         "/workbooks/$(workbookId)/tables/$(tableId)/columns",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -471,6 +489,7 @@ function list_table_rows(
         "POST",
         "/workbooks/$(workbookId)/tables/$(tableId)/rows/list";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_table_rows(
@@ -484,6 +503,7 @@ function list_table_rows(
         "/workbooks/$(workbookId)/tables/$(tableId)/rows/list",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -505,7 +525,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   that was returned more than an hour back, the API will throw ValidationException.
 """
 function list_tables(workbookId; aws_config::AbstractAWSConfig=global_aws_config())
-    return honeycode("GET", "/workbooks/$(workbookId)/tables"; aws_config=aws_config)
+    return honeycode(
+        "GET",
+        "/workbooks/$(workbookId)/tables";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_tables(
     workbookId,
@@ -513,7 +538,11 @@ function list_tables(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return honeycode(
-        "GET", "/workbooks/$(workbookId)/tables", params; aws_config=aws_config
+        "GET",
+        "/workbooks/$(workbookId)/tables",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -547,6 +576,7 @@ function query_table_rows(
         "/workbooks/$(workbookId)/tables/$(tableId)/rows/query",
         Dict{String,Any}("filterFormula" => filterFormula);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function query_table_rows(
@@ -563,6 +593,7 @@ function query_table_rows(
             mergewith(_merge, Dict{String,Any}("filterFormula" => filterFormula), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -613,6 +644,7 @@ function start_table_data_import_job(
             "importOptions" => importOptions,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_table_data_import_job(
@@ -641,5 +673,6 @@ function start_table_data_import_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/iam.jl
+++ b/src/services/iam.jl
@@ -30,6 +30,7 @@ function add_client_idto_open_idconnect_provider(
             "ClientID" => ClientID, "OpenIDConnectProviderArn" => OpenIDConnectProviderArn
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function add_client_idto_open_idconnect_provider(
@@ -51,6 +52,7 @@ function add_client_idto_open_idconnect_provider(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -87,6 +89,7 @@ function add_role_to_instance_profile(
             "InstanceProfileName" => InstanceProfileName, "RoleName" => RoleName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function add_role_to_instance_profile(
@@ -107,6 +110,7 @@ function add_role_to_instance_profile(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -132,6 +136,7 @@ function add_user_to_group(
         "AddUserToGroup",
         Dict{String,Any}("GroupName" => GroupName, "UserName" => UserName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function add_user_to_group(
@@ -150,6 +155,7 @@ function add_user_to_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -180,6 +186,7 @@ function attach_group_policy(
         "AttachGroupPolicy",
         Dict{String,Any}("GroupName" => GroupName, "PolicyArn" => PolicyArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function attach_group_policy(
@@ -198,6 +205,7 @@ function attach_group_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -232,6 +240,7 @@ function attach_role_policy(
         "AttachRolePolicy",
         Dict{String,Any}("PolicyArn" => PolicyArn, "RoleName" => RoleName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function attach_role_policy(
@@ -250,6 +259,7 @@ function attach_role_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -280,6 +290,7 @@ function attach_user_policy(
         "AttachUserPolicy",
         Dict{String,Any}("PolicyArn" => PolicyArn, "UserName" => UserName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function attach_user_policy(
@@ -298,6 +309,7 @@ function attach_user_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -332,6 +344,7 @@ function change_password(
         "ChangePassword",
         Dict{String,Any}("NewPassword" => NewPassword, "OldPassword" => OldPassword);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function change_password(
@@ -352,6 +365,7 @@ function change_password(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -380,12 +394,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   characters: _+=,.@-
 """
 function create_access_key(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iam("CreateAccessKey"; aws_config=aws_config)
+    return iam("CreateAccessKey"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function create_access_key(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iam("CreateAccessKey", params; aws_config=aws_config)
+    return iam(
+        "CreateAccessKey", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -409,6 +425,7 @@ function create_account_alias(
         "CreateAccountAlias",
         Dict{String,Any}("AccountAlias" => AccountAlias);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_account_alias(
@@ -422,6 +439,7 @@ function create_account_alias(
             mergewith(_merge, Dict{String,Any}("AccountAlias" => AccountAlias), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -450,7 +468,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function create_group(GroupName; aws_config::AbstractAWSConfig=global_aws_config())
     return iam(
-        "CreateGroup", Dict{String,Any}("GroupName" => GroupName); aws_config=aws_config
+        "CreateGroup",
+        Dict{String,Any}("GroupName" => GroupName);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_group(
@@ -464,6 +485,7 @@ function create_group(
             mergewith(_merge, Dict{String,Any}("GroupName" => GroupName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -504,6 +526,7 @@ function create_instance_profile(
         "CreateInstanceProfile",
         Dict{String,Any}("InstanceProfileName" => InstanceProfileName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_instance_profile(
@@ -521,6 +544,7 @@ function create_instance_profile(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -560,6 +584,7 @@ function create_login_profile(
         "CreateLoginProfile",
         Dict{String,Any}("Password" => Password, "UserName" => UserName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_login_profile(
@@ -578,6 +603,7 @@ function create_login_profile(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -653,6 +679,7 @@ function create_open_idconnect_provider(
         "CreateOpenIDConnectProvider",
         Dict{String,Any}("ThumbprintList" => ThumbprintList, "Url" => Url);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_open_idconnect_provider(
@@ -671,6 +698,7 @@ function create_open_idconnect_provider(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -729,6 +757,7 @@ function create_policy(
         "CreatePolicy",
         Dict{String,Any}("PolicyDocument" => PolicyDocument, "PolicyName" => PolicyName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_policy(
@@ -749,6 +778,7 @@ function create_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -796,6 +826,7 @@ function create_policy_version(
         "CreatePolicyVersion",
         Dict{String,Any}("PolicyArn" => PolicyArn, "PolicyDocument" => PolicyDocument);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_policy_version(
@@ -816,6 +847,7 @@ function create_policy_version(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -880,6 +912,7 @@ function create_role(
             "AssumeRolePolicyDocument" => AssumeRolePolicyDocument, "RoleName" => RoleName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_role(
@@ -901,6 +934,7 @@ function create_role(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -948,6 +982,7 @@ function create_samlprovider(
         "CreateSAMLProvider",
         Dict{String,Any}("Name" => Name, "SAMLMetadataDocument" => SAMLMetadataDocument);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_samlprovider(
@@ -968,6 +1003,7 @@ function create_samlprovider(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1010,6 +1046,7 @@ function create_service_linked_role(
         "CreateServiceLinkedRole",
         Dict{String,Any}("AWSServiceName" => AWSServiceName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_service_linked_role(
@@ -1023,6 +1060,7 @@ function create_service_linked_role(
             mergewith(_merge, Dict{String,Any}("AWSServiceName" => AWSServiceName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1058,6 +1096,7 @@ function create_service_specific_credential(
         "CreateServiceSpecificCredential",
         Dict{String,Any}("ServiceName" => ServiceName, "UserName" => UserName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_service_specific_credential(
@@ -1076,6 +1115,7 @@ function create_service_specific_credential(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1110,7 +1150,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function create_user(UserName; aws_config::AbstractAWSConfig=global_aws_config())
     return iam(
-        "CreateUser", Dict{String,Any}("UserName" => UserName); aws_config=aws_config
+        "CreateUser",
+        Dict{String,Any}("UserName" => UserName);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_user(
@@ -1124,6 +1167,7 @@ function create_user(
             mergewith(_merge, Dict{String,Any}("UserName" => UserName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1169,6 +1213,7 @@ function create_virtual_mfadevice(
         "CreateVirtualMFADevice",
         Dict{String,Any}("VirtualMFADeviceName" => VirtualMFADeviceName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_virtual_mfadevice(
@@ -1186,6 +1231,7 @@ function create_virtual_mfadevice(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1216,6 +1262,7 @@ function deactivate_mfadevice(
         "DeactivateMFADevice",
         Dict{String,Any}("SerialNumber" => SerialNumber, "UserName" => UserName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function deactivate_mfadevice(
@@ -1234,6 +1281,7 @@ function deactivate_mfadevice(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1265,6 +1313,7 @@ function delete_access_key(AccessKeyId; aws_config::AbstractAWSConfig=global_aws
         "DeleteAccessKey",
         Dict{String,Any}("AccessKeyId" => AccessKeyId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_access_key(
@@ -1278,6 +1327,7 @@ function delete_access_key(
             mergewith(_merge, Dict{String,Any}("AccessKeyId" => AccessKeyId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1302,6 +1352,7 @@ function delete_account_alias(
         "DeleteAccountAlias",
         Dict{String,Any}("AccountAlias" => AccountAlias);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_account_alias(
@@ -1315,6 +1366,7 @@ function delete_account_alias(
             mergewith(_merge, Dict{String,Any}("AccountAlias" => AccountAlias), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1326,12 +1378,21 @@ Deletes the password policy for the Amazon Web Services account. There are no pa
 
 """
 function delete_account_password_policy(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iam("DeleteAccountPasswordPolicy"; aws_config=aws_config)
+    return iam(
+        "DeleteAccountPasswordPolicy";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_account_password_policy(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iam("DeleteAccountPasswordPolicy", params; aws_config=aws_config)
+    return iam(
+        "DeleteAccountPasswordPolicy",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1349,7 +1410,10 @@ policies.
 """
 function delete_group(GroupName; aws_config::AbstractAWSConfig=global_aws_config())
     return iam(
-        "DeleteGroup", Dict{String,Any}("GroupName" => GroupName); aws_config=aws_config
+        "DeleteGroup",
+        Dict{String,Any}("GroupName" => GroupName);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_group(
@@ -1363,6 +1427,7 @@ function delete_group(
             mergewith(_merge, Dict{String,Any}("GroupName" => GroupName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1393,6 +1458,7 @@ function delete_group_policy(
         "DeleteGroupPolicy",
         Dict{String,Any}("GroupName" => GroupName, "PolicyName" => PolicyName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_group_policy(
@@ -1411,6 +1477,7 @@ function delete_group_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1438,6 +1505,7 @@ function delete_instance_profile(
         "DeleteInstanceProfile",
         Dict{String,Any}("InstanceProfileName" => InstanceProfileName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_instance_profile(
@@ -1455,6 +1523,7 @@ function delete_instance_profile(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1484,6 +1553,7 @@ function delete_login_profile(UserName; aws_config::AbstractAWSConfig=global_aws
         "DeleteLoginProfile",
         Dict{String,Any}("UserName" => UserName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_login_profile(
@@ -1497,6 +1567,7 @@ function delete_login_profile(
             mergewith(_merge, Dict{String,Any}("UserName" => UserName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1523,6 +1594,7 @@ function delete_open_idconnect_provider(
         "DeleteOpenIDConnectProvider",
         Dict{String,Any}("OpenIDConnectProviderArn" => OpenIDConnectProviderArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_open_idconnect_provider(
@@ -1540,6 +1612,7 @@ function delete_open_idconnect_provider(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1568,7 +1641,10 @@ policies, see Managed policies and inline policies in the IAM User Guide.
 """
 function delete_policy(PolicyArn; aws_config::AbstractAWSConfig=global_aws_config())
     return iam(
-        "DeletePolicy", Dict{String,Any}("PolicyArn" => PolicyArn); aws_config=aws_config
+        "DeletePolicy",
+        Dict{String,Any}("PolicyArn" => PolicyArn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_policy(
@@ -1582,6 +1658,7 @@ function delete_policy(
             mergewith(_merge, Dict{String,Any}("PolicyArn" => PolicyArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1613,6 +1690,7 @@ function delete_policy_version(
         "DeletePolicyVersion",
         Dict{String,Any}("PolicyArn" => PolicyArn, "VersionId" => VersionId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_policy_version(
@@ -1631,6 +1709,7 @@ function delete_policy_version(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1652,7 +1731,10 @@ the instance.
 """
 function delete_role(RoleName; aws_config::AbstractAWSConfig=global_aws_config())
     return iam(
-        "DeleteRole", Dict{String,Any}("RoleName" => RoleName); aws_config=aws_config
+        "DeleteRole",
+        Dict{String,Any}("RoleName" => RoleName);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_role(
@@ -1666,6 +1748,7 @@ function delete_role(
             mergewith(_merge, Dict{String,Any}("RoleName" => RoleName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1689,6 +1772,7 @@ function delete_role_permissions_boundary(
         "DeleteRolePermissionsBoundary",
         Dict{String,Any}("RoleName" => RoleName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_role_permissions_boundary(
@@ -1702,6 +1786,7 @@ function delete_role_permissions_boundary(
             mergewith(_merge, Dict{String,Any}("RoleName" => RoleName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1732,6 +1817,7 @@ function delete_role_policy(
         "DeleteRolePolicy",
         Dict{String,Any}("PolicyName" => PolicyName, "RoleName" => RoleName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_role_policy(
@@ -1750,6 +1836,7 @@ function delete_role_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1773,6 +1860,7 @@ function delete_samlprovider(
         "DeleteSAMLProvider",
         Dict{String,Any}("SAMLProviderArn" => SAMLProviderArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_samlprovider(
@@ -1788,6 +1876,7 @@ function delete_samlprovider(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1820,6 +1909,7 @@ function delete_server_certificate(
         "DeleteServerCertificate",
         Dict{String,Any}("ServerCertificateName" => ServerCertificateName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_server_certificate(
@@ -1837,6 +1927,7 @@ function delete_server_certificate(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1870,6 +1961,7 @@ function delete_service_linked_role(
         "DeleteServiceLinkedRole",
         Dict{String,Any}("RoleName" => RoleName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_service_linked_role(
@@ -1883,6 +1975,7 @@ function delete_service_linked_role(
             mergewith(_merge, Dict{String,Any}("RoleName" => RoleName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1913,6 +2006,7 @@ function delete_service_specific_credential(
         "DeleteServiceSpecificCredential",
         Dict{String,Any}("ServiceSpecificCredentialId" => ServiceSpecificCredentialId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_service_specific_credential(
@@ -1932,6 +2026,7 @@ function delete_service_specific_credential(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1965,6 +2060,7 @@ function delete_signing_certificate(
         "DeleteSigningCertificate",
         Dict{String,Any}("CertificateId" => CertificateId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_signing_certificate(
@@ -1978,6 +2074,7 @@ function delete_signing_certificate(
             mergewith(_merge, Dict{String,Any}("CertificateId" => CertificateId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2007,6 +2104,7 @@ function delete_sshpublic_key(
         "DeleteSSHPublicKey",
         Dict{String,Any}("SSHPublicKeyId" => SSHPublicKeyId, "UserName" => UserName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_sshpublic_key(
@@ -2027,6 +2125,7 @@ function delete_sshpublic_key(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2052,7 +2151,10 @@ authentication (MFA) device (DeactivateMFADevice, DeleteVirtualMFADevice)   Inli
 """
 function delete_user(UserName; aws_config::AbstractAWSConfig=global_aws_config())
     return iam(
-        "DeleteUser", Dict{String,Any}("UserName" => UserName); aws_config=aws_config
+        "DeleteUser",
+        Dict{String,Any}("UserName" => UserName);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_user(
@@ -2066,6 +2168,7 @@ function delete_user(
             mergewith(_merge, Dict{String,Any}("UserName" => UserName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2089,6 +2192,7 @@ function delete_user_permissions_boundary(
         "DeleteUserPermissionsBoundary",
         Dict{String,Any}("UserName" => UserName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_user_permissions_boundary(
@@ -2102,6 +2206,7 @@ function delete_user_permissions_boundary(
             mergewith(_merge, Dict{String,Any}("UserName" => UserName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2132,6 +2237,7 @@ function delete_user_policy(
         "DeleteUserPolicy",
         Dict{String,Any}("PolicyName" => PolicyName, "UserName" => UserName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_user_policy(
@@ -2150,6 +2256,7 @@ function delete_user_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2174,6 +2281,7 @@ function delete_virtual_mfadevice(
         "DeleteVirtualMFADevice",
         Dict{String,Any}("SerialNumber" => SerialNumber);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_virtual_mfadevice(
@@ -2187,6 +2295,7 @@ function delete_virtual_mfadevice(
             mergewith(_merge, Dict{String,Any}("SerialNumber" => SerialNumber), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2215,6 +2324,7 @@ function detach_group_policy(
         "DetachGroupPolicy",
         Dict{String,Any}("GroupName" => GroupName, "PolicyArn" => PolicyArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function detach_group_policy(
@@ -2233,6 +2343,7 @@ function detach_group_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2261,6 +2372,7 @@ function detach_role_policy(
         "DetachRolePolicy",
         Dict{String,Any}("PolicyArn" => PolicyArn, "RoleName" => RoleName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function detach_role_policy(
@@ -2279,6 +2391,7 @@ function detach_role_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2307,6 +2420,7 @@ function detach_user_policy(
         "DetachUserPolicy",
         Dict{String,Any}("PolicyArn" => PolicyArn, "UserName" => UserName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function detach_user_policy(
@@ -2325,6 +2439,7 @@ function detach_user_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2375,6 +2490,7 @@ function enable_mfadevice(
             "UserName" => UserName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function enable_mfadevice(
@@ -2400,6 +2516,7 @@ function enable_mfadevice(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2412,12 +2529,19 @@ about the credential report, see Getting credential reports in the IAM User Guid
 
 """
 function generate_credential_report(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iam("GenerateCredentialReport"; aws_config=aws_config)
+    return iam(
+        "GenerateCredentialReport"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function generate_credential_report(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iam("GenerateCredentialReport", params; aws_config=aws_config)
+    return iam(
+        "GenerateCredentialReport",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2519,6 +2643,7 @@ function generate_organizations_access_report(
         "GenerateOrganizationsAccessReport",
         Dict{String,Any}("EntityPath" => EntityPath);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function generate_organizations_access_report(
@@ -2532,6 +2657,7 @@ function generate_organizations_access_report(
             mergewith(_merge, Dict{String,Any}("EntityPath" => EntityPath), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2593,6 +2719,7 @@ function generate_service_last_accessed_details(
         "GenerateServiceLastAccessedDetails",
         Dict{String,Any}("Arn" => Arn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function generate_service_last_accessed_details(
@@ -2602,6 +2729,7 @@ function generate_service_last_accessed_details(
         "GenerateServiceLastAccessedDetails",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Arn" => Arn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2626,6 +2754,7 @@ function get_access_key_last_used(
         "GetAccessKeyLastUsed",
         Dict{String,Any}("AccessKeyId" => AccessKeyId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_access_key_last_used(
@@ -2639,6 +2768,7 @@ function get_access_key_last_used(
             mergewith(_merge, Dict{String,Any}("AccessKeyId" => AccessKeyId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2677,12 +2807,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function get_account_authorization_details(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iam("GetAccountAuthorizationDetails"; aws_config=aws_config)
+    return iam(
+        "GetAccountAuthorizationDetails";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_account_authorization_details(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iam("GetAccountAuthorizationDetails", params; aws_config=aws_config)
+    return iam(
+        "GetAccountAuthorizationDetails",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2696,12 +2835,19 @@ policy.
 
 """
 function get_account_password_policy(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iam("GetAccountPasswordPolicy"; aws_config=aws_config)
+    return iam(
+        "GetAccountPasswordPolicy"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_account_password_policy(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iam("GetAccountPasswordPolicy", params; aws_config=aws_config)
+    return iam(
+        "GetAccountPasswordPolicy",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2713,12 +2859,14 @@ account.  For information about IAM quotas, see IAM and STS quotas in the IAM Us
 
 """
 function get_account_summary(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iam("GetAccountSummary"; aws_config=aws_config)
+    return iam("GetAccountSummary"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function get_account_summary(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iam("GetAccountSummary", params; aws_config=aws_config)
+    return iam(
+        "GetAccountSummary", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -2753,6 +2901,7 @@ function get_context_keys_for_custom_policy(
         "GetContextKeysForCustomPolicy",
         Dict{String,Any}("PolicyInputList" => PolicyInputList);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_context_keys_for_custom_policy(
@@ -2768,6 +2917,7 @@ function get_context_keys_for_custom_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2815,6 +2965,7 @@ function get_context_keys_for_principal_policy(
         "GetContextKeysForPrincipalPolicy",
         Dict{String,Any}("PolicySourceArn" => PolicySourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_context_keys_for_principal_policy(
@@ -2830,6 +2981,7 @@ function get_context_keys_for_principal_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2842,12 +2994,19 @@ about the credential report, see Getting credential reports in the IAM User Guid
 
 """
 function get_credential_report(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iam("GetCredentialReport"; aws_config=aws_config)
+    return iam(
+        "GetCredentialReport"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_credential_report(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iam("GetCredentialReport", params; aws_config=aws_config)
+    return iam(
+        "GetCredentialReport",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2877,7 +3036,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function get_group(GroupName; aws_config::AbstractAWSConfig=global_aws_config())
     return iam(
-        "GetGroup", Dict{String,Any}("GroupName" => GroupName); aws_config=aws_config
+        "GetGroup",
+        Dict{String,Any}("GroupName" => GroupName);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_group(
@@ -2891,6 +3053,7 @@ function get_group(
             mergewith(_merge, Dict{String,Any}("GroupName" => GroupName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2925,6 +3088,7 @@ function get_group_policy(
         "GetGroupPolicy",
         Dict{String,Any}("GroupName" => GroupName, "PolicyName" => PolicyName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_group_policy(
@@ -2943,6 +3107,7 @@ function get_group_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2968,6 +3133,7 @@ function get_instance_profile(
         "GetInstanceProfile",
         Dict{String,Any}("InstanceProfileName" => InstanceProfileName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_instance_profile(
@@ -2985,6 +3151,7 @@ function get_instance_profile(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3011,7 +3178,10 @@ for the user to access the Amazon Web Services Management Console.
 """
 function get_login_profile(UserName; aws_config::AbstractAWSConfig=global_aws_config())
     return iam(
-        "GetLoginProfile", Dict{String,Any}("UserName" => UserName); aws_config=aws_config
+        "GetLoginProfile",
+        Dict{String,Any}("UserName" => UserName);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_login_profile(
@@ -3025,6 +3195,7 @@ function get_login_profile(
             mergewith(_merge, Dict{String,Any}("UserName" => UserName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3049,6 +3220,7 @@ function get_open_idconnect_provider(
         "GetOpenIDConnectProvider",
         Dict{String,Any}("OpenIDConnectProviderArn" => OpenIDConnectProviderArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_open_idconnect_provider(
@@ -3066,6 +3238,7 @@ function get_open_idconnect_provider(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3114,6 +3287,7 @@ function get_organizations_access_report(
         "GetOrganizationsAccessReport",
         Dict{String,Any}("JobId" => JobId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_organizations_access_report(
@@ -3123,6 +3297,7 @@ function get_organizations_access_report(
         "GetOrganizationsAccessReport",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("JobId" => JobId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3148,7 +3323,10 @@ Managed policies and inline policies in the IAM User Guide.
 """
 function get_policy(PolicyArn; aws_config::AbstractAWSConfig=global_aws_config())
     return iam(
-        "GetPolicy", Dict{String,Any}("PolicyArn" => PolicyArn); aws_config=aws_config
+        "GetPolicy",
+        Dict{String,Any}("PolicyArn" => PolicyArn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_policy(
@@ -3162,6 +3340,7 @@ function get_policy(
             mergewith(_merge, Dict{String,Any}("PolicyArn" => PolicyArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3198,6 +3377,7 @@ function get_policy_version(
         "GetPolicyVersion",
         Dict{String,Any}("PolicyArn" => PolicyArn, "VersionId" => VersionId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_policy_version(
@@ -3216,6 +3396,7 @@ function get_policy_version(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3239,7 +3420,12 @@ functionality.
 
 """
 function get_role(RoleName; aws_config::AbstractAWSConfig=global_aws_config())
-    return iam("GetRole", Dict{String,Any}("RoleName" => RoleName); aws_config=aws_config)
+    return iam(
+        "GetRole",
+        Dict{String,Any}("RoleName" => RoleName);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_role(
     RoleName,
@@ -3252,6 +3438,7 @@ function get_role(
             mergewith(_merge, Dict{String,Any}("RoleName" => RoleName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3287,6 +3474,7 @@ function get_role_policy(
         "GetRolePolicy",
         Dict{String,Any}("PolicyName" => PolicyName, "RoleName" => RoleName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_role_policy(
@@ -3305,6 +3493,7 @@ function get_role_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3328,6 +3517,7 @@ function get_samlprovider(
         "GetSAMLProvider",
         Dict{String,Any}("SAMLProviderArn" => SAMLProviderArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_samlprovider(
@@ -3343,6 +3533,7 @@ function get_samlprovider(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3369,6 +3560,7 @@ function get_server_certificate(
         "GetServerCertificate",
         Dict{String,Any}("ServerCertificateName" => ServerCertificateName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_server_certificate(
@@ -3386,6 +3578,7 @@ function get_server_certificate(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3446,6 +3639,7 @@ function get_service_last_accessed_details(
         "GetServiceLastAccessedDetails",
         Dict{String,Any}("JobId" => JobId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_service_last_accessed_details(
@@ -3455,6 +3649,7 @@ function get_service_last_accessed_details(
         "GetServiceLastAccessedDetails",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("JobId" => JobId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3506,6 +3701,7 @@ function get_service_last_accessed_details_with_entities(
         "GetServiceLastAccessedDetailsWithEntities",
         Dict{String,Any}("JobId" => JobId, "ServiceNamespace" => ServiceNamespace);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_service_last_accessed_details_with_entities(
@@ -3524,6 +3720,7 @@ function get_service_last_accessed_details_with_entities(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3550,6 +3747,7 @@ function get_service_linked_role_deletion_status(
         "GetServiceLinkedRoleDeletionStatus",
         Dict{String,Any}("DeletionTaskId" => DeletionTaskId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_service_linked_role_deletion_status(
@@ -3563,6 +3761,7 @@ function get_service_linked_role_deletion_status(
             mergewith(_merge, Dict{String,Any}("DeletionTaskId" => DeletionTaskId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3600,6 +3799,7 @@ function get_sshpublic_key(
             "UserName" => UserName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_sshpublic_key(
@@ -3623,6 +3823,7 @@ function get_sshpublic_key(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3644,12 +3845,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   characters: _+=,.@-
 """
 function get_user(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iam("GetUser"; aws_config=aws_config)
+    return iam("GetUser"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function get_user(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iam("GetUser", params; aws_config=aws_config)
+    return iam("GetUser", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 
 """
@@ -3683,6 +3884,7 @@ function get_user_policy(
         "GetUserPolicy",
         Dict{String,Any}("PolicyName" => PolicyName, "UserName" => UserName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_user_policy(
@@ -3701,6 +3903,7 @@ function get_user_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3735,12 +3938,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   spaces. You can also include any of the following characters: _+=,.@-
 """
 function list_access_keys(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iam("ListAccessKeys"; aws_config=aws_config)
+    return iam("ListAccessKeys"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_access_keys(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iam("ListAccessKeys", params; aws_config=aws_config)
+    return iam(
+        "ListAccessKeys", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -3765,12 +3970,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   continue from.
 """
 function list_account_aliases(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iam("ListAccountAliases"; aws_config=aws_config)
+    return iam("ListAccountAliases"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_account_aliases(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iam("ListAccountAliases", params; aws_config=aws_config)
+    return iam(
+        "ListAccountAliases", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -3818,6 +4025,7 @@ function list_attached_group_policies(
         "ListAttachedGroupPolicies",
         Dict{String,Any}("GroupName" => GroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_attached_group_policies(
@@ -3831,6 +4039,7 @@ function list_attached_group_policies(
             mergewith(_merge, Dict{String,Any}("GroupName" => GroupName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3879,6 +4088,7 @@ function list_attached_role_policies(
         "ListAttachedRolePolicies",
         Dict{String,Any}("RoleName" => RoleName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_attached_role_policies(
@@ -3892,6 +4102,7 @@ function list_attached_role_policies(
             mergewith(_merge, Dict{String,Any}("RoleName" => RoleName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3940,6 +4151,7 @@ function list_attached_user_policies(
         "ListAttachedUserPolicies",
         Dict{String,Any}("UserName" => UserName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_attached_user_policies(
@@ -3953,6 +4165,7 @@ function list_attached_user_policies(
             mergewith(_merge, Dict{String,Any}("UserName" => UserName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4006,6 +4219,7 @@ function list_entities_for_policy(
         "ListEntitiesForPolicy",
         Dict{String,Any}("PolicyArn" => PolicyArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_entities_for_policy(
@@ -4019,6 +4233,7 @@ function list_entities_for_policy(
             mergewith(_merge, Dict{String,Any}("PolicyArn" => PolicyArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4056,6 +4271,7 @@ function list_group_policies(GroupName; aws_config::AbstractAWSConfig=global_aws
         "ListGroupPolicies",
         Dict{String,Any}("GroupName" => GroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_group_policies(
@@ -4069,6 +4285,7 @@ function list_group_policies(
             mergewith(_merge, Dict{String,Any}("GroupName" => GroupName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4101,12 +4318,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   characters, digits, and upper and lowercased letters.
 """
 function list_groups(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iam("ListGroups"; aws_config=aws_config)
+    return iam("ListGroups"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_groups(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iam("ListGroups", params; aws_config=aws_config)
+    return iam("ListGroups", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 
 """
@@ -4136,7 +4353,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function list_groups_for_user(UserName; aws_config::AbstractAWSConfig=global_aws_config())
     return iam(
-        "ListGroupsForUser", Dict{String,Any}("UserName" => UserName); aws_config=aws_config
+        "ListGroupsForUser",
+        Dict{String,Any}("UserName" => UserName);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_groups_for_user(
@@ -4150,6 +4370,7 @@ function list_groups_for_user(
             mergewith(_merge, Dict{String,Any}("UserName" => UserName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4187,6 +4408,7 @@ function list_instance_profile_tags(
         "ListInstanceProfileTags",
         Dict{String,Any}("InstanceProfileName" => InstanceProfileName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_instance_profile_tags(
@@ -4204,6 +4426,7 @@ function list_instance_profile_tags(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4241,12 +4464,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   punctuation characters, digits, and upper and lowercased letters.
 """
 function list_instance_profiles(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iam("ListInstanceProfiles"; aws_config=aws_config)
+    return iam(
+        "ListInstanceProfiles"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_instance_profiles(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iam("ListInstanceProfiles", params; aws_config=aws_config)
+    return iam(
+        "ListInstanceProfiles",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -4284,6 +4514,7 @@ function list_instance_profiles_for_role(
         "ListInstanceProfilesForRole",
         Dict{String,Any}("RoleName" => RoleName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_instance_profiles_for_role(
@@ -4297,6 +4528,7 @@ function list_instance_profiles_for_role(
             mergewith(_merge, Dict{String,Any}("RoleName" => RoleName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4335,6 +4567,7 @@ function list_mfadevice_tags(
         "ListMFADeviceTags",
         Dict{String,Any}("SerialNumber" => SerialNumber);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_mfadevice_tags(
@@ -4348,6 +4581,7 @@ function list_mfadevice_tags(
             mergewith(_merge, Dict{String,Any}("SerialNumber" => SerialNumber), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4379,12 +4613,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   characters: _+=,.@-
 """
 function list_mfadevices(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iam("ListMFADevices"; aws_config=aws_config)
+    return iam("ListMFADevices"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_mfadevices(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iam("ListMFADevices", params; aws_config=aws_config)
+    return iam(
+        "ListMFADevices", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -4422,6 +4658,7 @@ function list_open_idconnect_provider_tags(
         "ListOpenIDConnectProviderTags",
         Dict{String,Any}("OpenIDConnectProviderArn" => OpenIDConnectProviderArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_open_idconnect_provider_tags(
@@ -4439,6 +4676,7 @@ function list_open_idconnect_provider_tags(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4454,12 +4692,19 @@ for an OIDC provider, see GetOpenIDConnectProvider.
 
 """
 function list_open_idconnect_providers(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iam("ListOpenIDConnectProviders"; aws_config=aws_config)
+    return iam(
+        "ListOpenIDConnectProviders"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_open_idconnect_providers(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iam("ListOpenIDConnectProviders", params; aws_config=aws_config)
+    return iam(
+        "ListOpenIDConnectProviders",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -4510,12 +4755,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   included, or if it is set to All, all policies are returned.
 """
 function list_policies(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iam("ListPolicies"; aws_config=aws_config)
+    return iam("ListPolicies"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_policies(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iam("ListPolicies", params; aws_config=aws_config)
+    return iam(
+        "ListPolicies", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -4565,6 +4812,7 @@ function list_policies_granting_service_access(
         "ListPoliciesGrantingServiceAccess",
         Dict{String,Any}("Arn" => Arn, "ServiceNamespaces" => ServiceNamespaces);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_policies_granting_service_access(
@@ -4583,6 +4831,7 @@ function list_policies_granting_service_access(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4615,7 +4864,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function list_policy_tags(PolicyArn; aws_config::AbstractAWSConfig=global_aws_config())
     return iam(
-        "ListPolicyTags", Dict{String,Any}("PolicyArn" => PolicyArn); aws_config=aws_config
+        "ListPolicyTags",
+        Dict{String,Any}("PolicyArn" => PolicyArn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_policy_tags(
@@ -4629,6 +4881,7 @@ function list_policy_tags(
             mergewith(_merge, Dict{String,Any}("PolicyArn" => PolicyArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4663,6 +4916,7 @@ function list_policy_versions(PolicyArn; aws_config::AbstractAWSConfig=global_aw
         "ListPolicyVersions",
         Dict{String,Any}("PolicyArn" => PolicyArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_policy_versions(
@@ -4676,6 +4930,7 @@ function list_policy_versions(
             mergewith(_merge, Dict{String,Any}("PolicyArn" => PolicyArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4710,7 +4965,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function list_role_policies(RoleName; aws_config::AbstractAWSConfig=global_aws_config())
     return iam(
-        "ListRolePolicies", Dict{String,Any}("RoleName" => RoleName); aws_config=aws_config
+        "ListRolePolicies",
+        Dict{String,Any}("RoleName" => RoleName);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_role_policies(
@@ -4724,6 +4982,7 @@ function list_role_policies(
             mergewith(_merge, Dict{String,Any}("RoleName" => RoleName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4756,7 +5015,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function list_role_tags(RoleName; aws_config::AbstractAWSConfig=global_aws_config())
     return iam(
-        "ListRoleTags", Dict{String,Any}("RoleName" => RoleName); aws_config=aws_config
+        "ListRoleTags",
+        Dict{String,Any}("RoleName" => RoleName);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_role_tags(
@@ -4770,6 +5032,7 @@ function list_role_tags(
             mergewith(_merge, Dict{String,Any}("RoleName" => RoleName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4806,12 +5069,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   characters, digits, and upper and lowercased letters.
 """
 function list_roles(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iam("ListRoles"; aws_config=aws_config)
+    return iam("ListRoles"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_roles(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iam("ListRoles", params; aws_config=aws_config)
+    return iam("ListRoles", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 
 """
@@ -4849,6 +5112,7 @@ function list_samlprovider_tags(
         "ListSAMLProviderTags",
         Dict{String,Any}("SAMLProviderArn" => SAMLProviderArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_samlprovider_tags(
@@ -4864,6 +5128,7 @@ function list_samlprovider_tags(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4879,12 +5144,14 @@ This operation requires Signature Version 4.
 
 """
 function list_samlproviders(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iam("ListSAMLProviders"; aws_config=aws_config)
+    return iam("ListSAMLProviders"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_samlproviders(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iam("ListSAMLProviders", params; aws_config=aws_config)
+    return iam(
+        "ListSAMLProviders", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -4924,6 +5191,7 @@ function list_server_certificate_tags(
         "ListServerCertificateTags",
         Dict{String,Any}("ServerCertificateName" => ServerCertificateName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_server_certificate_tags(
@@ -4941,6 +5209,7 @@ function list_server_certificate_tags(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4980,12 +5249,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   characters, digits, and upper and lowercased letters.
 """
 function list_server_certificates(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iam("ListServerCertificates"; aws_config=aws_config)
+    return iam(
+        "ListServerCertificates"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_server_certificates(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iam("ListServerCertificates", params; aws_config=aws_config)
+    return iam(
+        "ListServerCertificates",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -5013,12 +5289,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function list_service_specific_credentials(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iam("ListServiceSpecificCredentials"; aws_config=aws_config)
+    return iam(
+        "ListServiceSpecificCredentials";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_service_specific_credentials(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iam("ListServiceSpecificCredentials", params; aws_config=aws_config)
+    return iam(
+        "ListServiceSpecificCredentials",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -5052,12 +5337,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   following characters: _+=,.@-
 """
 function list_signing_certificates(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iam("ListSigningCertificates"; aws_config=aws_config)
+    return iam(
+        "ListSigningCertificates"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_signing_certificates(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iam("ListSigningCertificates", params; aws_config=aws_config)
+    return iam(
+        "ListSigningCertificates",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -5091,12 +5383,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   can also include any of the following characters: _+=,.@-
 """
 function list_sshpublic_keys(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iam("ListSSHPublicKeys"; aws_config=aws_config)
+    return iam("ListSSHPublicKeys"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_sshpublic_keys(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iam("ListSSHPublicKeys", params; aws_config=aws_config)
+    return iam(
+        "ListSSHPublicKeys", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -5130,7 +5424,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function list_user_policies(UserName; aws_config::AbstractAWSConfig=global_aws_config())
     return iam(
-        "ListUserPolicies", Dict{String,Any}("UserName" => UserName); aws_config=aws_config
+        "ListUserPolicies",
+        Dict{String,Any}("UserName" => UserName);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_user_policies(
@@ -5144,6 +5441,7 @@ function list_user_policies(
             mergewith(_merge, Dict{String,Any}("UserName" => UserName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5176,7 +5474,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function list_user_tags(UserName; aws_config::AbstractAWSConfig=global_aws_config())
     return iam(
-        "ListUserTags", Dict{String,Any}("UserName" => UserName); aws_config=aws_config
+        "ListUserTags",
+        Dict{String,Any}("UserName" => UserName);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_user_tags(
@@ -5190,6 +5491,7 @@ function list_user_tags(
             mergewith(_merge, Dict{String,Any}("UserName" => UserName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5227,12 +5529,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   characters, digits, and upper and lowercased letters.
 """
 function list_users(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iam("ListUsers"; aws_config=aws_config)
+    return iam("ListUsers"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_users(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iam("ListUsers", params; aws_config=aws_config)
+    return iam("ListUsers", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 
 """
@@ -5265,12 +5567,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   continue from.
 """
 function list_virtual_mfadevices(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iam("ListVirtualMFADevices"; aws_config=aws_config)
+    return iam(
+        "ListVirtualMFADevices"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_virtual_mfadevices(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iam("ListVirtualMFADevices", params; aws_config=aws_config)
+    return iam(
+        "ListVirtualMFADevices",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -5315,6 +5624,7 @@ function put_group_policy(
             "PolicyName" => PolicyName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_group_policy(
@@ -5338,6 +5648,7 @@ function put_group_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5370,6 +5681,7 @@ function put_role_permissions_boundary(
             "PermissionsBoundary" => PermissionsBoundary, "RoleName" => RoleName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_role_permissions_boundary(
@@ -5390,6 +5702,7 @@ function put_role_permissions_boundary(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5440,6 +5753,7 @@ function put_role_policy(
             "RoleName" => RoleName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_role_policy(
@@ -5463,6 +5777,7 @@ function put_role_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5495,6 +5810,7 @@ function put_user_permissions_boundary(
             "PermissionsBoundary" => PermissionsBoundary, "UserName" => UserName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_user_permissions_boundary(
@@ -5515,6 +5831,7 @@ function put_user_permissions_boundary(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5560,6 +5877,7 @@ function put_user_policy(
             "UserName" => UserName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_user_policy(
@@ -5583,6 +5901,7 @@ function put_user_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5613,6 +5932,7 @@ function remove_client_idfrom_open_idconnect_provider(
             "ClientID" => ClientID, "OpenIDConnectProviderArn" => OpenIDConnectProviderArn
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function remove_client_idfrom_open_idconnect_provider(
@@ -5634,6 +5954,7 @@ function remove_client_idfrom_open_idconnect_provider(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5667,6 +5988,7 @@ function remove_role_from_instance_profile(
             "InstanceProfileName" => InstanceProfileName, "RoleName" => RoleName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function remove_role_from_instance_profile(
@@ -5687,6 +6009,7 @@ function remove_role_from_instance_profile(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5712,6 +6035,7 @@ function remove_user_from_group(
         "RemoveUserFromGroup",
         Dict{String,Any}("GroupName" => GroupName, "UserName" => UserName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function remove_user_from_group(
@@ -5730,6 +6054,7 @@ function remove_user_from_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5762,6 +6087,7 @@ function reset_service_specific_credential(
         "ResetServiceSpecificCredential",
         Dict{String,Any}("ServiceSpecificCredentialId" => ServiceSpecificCredentialId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function reset_service_specific_credential(
@@ -5781,6 +6107,7 @@ function reset_service_specific_credential(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5823,6 +6150,7 @@ function resync_mfadevice(
             "UserName" => UserName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function resync_mfadevice(
@@ -5848,6 +6176,7 @@ function resync_mfadevice(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5877,6 +6206,7 @@ function set_default_policy_version(
         "SetDefaultPolicyVersion",
         Dict{String,Any}("PolicyArn" => PolicyArn, "VersionId" => VersionId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function set_default_policy_version(
@@ -5895,6 +6225,7 @@ function set_default_policy_version(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5934,6 +6265,7 @@ function set_security_token_service_preferences(
         "SetSecurityTokenServicePreferences",
         Dict{String,Any}("GlobalEndpointTokenVersion" => GlobalEndpointTokenVersion);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function set_security_token_service_preferences(
@@ -5953,6 +6285,7 @@ function set_security_token_service_preferences(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6086,6 +6419,7 @@ function simulate_custom_policy(
             "ActionNames" => ActionNames, "PolicyInputList" => PolicyInputList
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function simulate_custom_policy(
@@ -6106,6 +6440,7 @@ function simulate_custom_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6250,6 +6585,7 @@ function simulate_principal_policy(
             "ActionNames" => ActionNames, "PolicySourceArn" => PolicySourceArn
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function simulate_principal_policy(
@@ -6270,6 +6606,7 @@ function simulate_principal_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6309,6 +6646,7 @@ function tag_instance_profile(
         "TagInstanceProfile",
         Dict{String,Any}("InstanceProfileName" => InstanceProfileName, "Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_instance_profile(
@@ -6329,6 +6667,7 @@ function tag_instance_profile(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6370,6 +6709,7 @@ function tag_mfadevice(
         "TagMFADevice",
         Dict{String,Any}("SerialNumber" => SerialNumber, "Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_mfadevice(
@@ -6388,6 +6728,7 @@ function tag_mfadevice(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6430,6 +6771,7 @@ function tag_open_idconnect_provider(
             "OpenIDConnectProviderArn" => OpenIDConnectProviderArn, "Tags" => Tags
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_open_idconnect_provider(
@@ -6450,6 +6792,7 @@ function tag_open_idconnect_provider(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6487,6 +6830,7 @@ function tag_policy(PolicyArn, Tags; aws_config::AbstractAWSConfig=global_aws_co
         "TagPolicy",
         Dict{String,Any}("PolicyArn" => PolicyArn, "Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_policy(
@@ -6503,6 +6847,7 @@ function tag_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6544,6 +6889,7 @@ function tag_role(RoleName, Tags; aws_config::AbstractAWSConfig=global_aws_confi
         "TagRole",
         Dict{String,Any}("RoleName" => RoleName, "Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_role(
@@ -6560,6 +6906,7 @@ function tag_role(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6600,6 +6947,7 @@ function tag_samlprovider(
         "TagSAMLProvider",
         Dict{String,Any}("SAMLProviderArn" => SAMLProviderArn, "Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_samlprovider(
@@ -6618,6 +6966,7 @@ function tag_samlprovider(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6662,6 +7011,7 @@ function tag_server_certificate(
         "TagServerCertificate",
         Dict{String,Any}("ServerCertificateName" => ServerCertificateName, "Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_server_certificate(
@@ -6682,6 +7032,7 @@ function tag_server_certificate(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6722,6 +7073,7 @@ function tag_user(Tags, UserName; aws_config::AbstractAWSConfig=global_aws_confi
         "TagUser",
         Dict{String,Any}("Tags" => Tags, "UserName" => UserName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_user(
@@ -6738,6 +7090,7 @@ function tag_user(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6766,6 +7119,7 @@ function untag_instance_profile(
             "InstanceProfileName" => InstanceProfileName, "TagKeys" => TagKeys
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_instance_profile(
@@ -6786,6 +7140,7 @@ function untag_instance_profile(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6813,6 +7168,7 @@ function untag_mfadevice(
         "UntagMFADevice",
         Dict{String,Any}("SerialNumber" => SerialNumber, "TagKeys" => TagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_mfadevice(
@@ -6831,6 +7187,7 @@ function untag_mfadevice(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6861,6 +7218,7 @@ function untag_open_idconnect_provider(
             "OpenIDConnectProviderArn" => OpenIDConnectProviderArn, "TagKeys" => TagKeys
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_open_idconnect_provider(
@@ -6882,6 +7240,7 @@ function untag_open_idconnect_provider(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6906,6 +7265,7 @@ function untag_policy(PolicyArn, TagKeys; aws_config::AbstractAWSConfig=global_a
         "UntagPolicy",
         Dict{String,Any}("PolicyArn" => PolicyArn, "TagKeys" => TagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_policy(
@@ -6924,6 +7284,7 @@ function untag_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6948,6 +7309,7 @@ function untag_role(RoleName, TagKeys; aws_config::AbstractAWSConfig=global_aws_
         "UntagRole",
         Dict{String,Any}("RoleName" => RoleName, "TagKeys" => TagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_role(
@@ -6966,6 +7328,7 @@ function untag_role(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6994,6 +7357,7 @@ function untag_samlprovider(
         "UntagSAMLProvider",
         Dict{String,Any}("SAMLProviderArn" => SAMLProviderArn, "TagKeys" => TagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_samlprovider(
@@ -7014,6 +7378,7 @@ function untag_samlprovider(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -7046,6 +7411,7 @@ function untag_server_certificate(
             "ServerCertificateName" => ServerCertificateName, "TagKeys" => TagKeys
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_server_certificate(
@@ -7066,6 +7432,7 @@ function untag_server_certificate(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -7090,6 +7457,7 @@ function untag_user(TagKeys, UserName; aws_config::AbstractAWSConfig=global_aws_
         "UntagUser",
         Dict{String,Any}("TagKeys" => TagKeys, "UserName" => UserName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_user(
@@ -7108,6 +7476,7 @@ function untag_user(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -7146,6 +7515,7 @@ function update_access_key(
         "UpdateAccessKey",
         Dict{String,Any}("AccessKeyId" => AccessKeyId, "Status" => Status);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_access_key(
@@ -7164,6 +7534,7 @@ function update_access_key(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -7220,12 +7591,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   result is that passwords do not require at least one uppercase character.
 """
 function update_account_password_policy(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iam("UpdateAccountPasswordPolicy"; aws_config=aws_config)
+    return iam(
+        "UpdateAccountPasswordPolicy";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function update_account_password_policy(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iam("UpdateAccountPasswordPolicy", params; aws_config=aws_config)
+    return iam(
+        "UpdateAccountPasswordPolicy",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -7259,6 +7639,7 @@ function update_assume_role_policy(
         "UpdateAssumeRolePolicy",
         Dict{String,Any}("PolicyDocument" => PolicyDocument, "RoleName" => RoleName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_assume_role_policy(
@@ -7279,6 +7660,7 @@ function update_assume_role_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -7316,7 +7698,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function update_group(GroupName; aws_config::AbstractAWSConfig=global_aws_config())
     return iam(
-        "UpdateGroup", Dict{String,Any}("GroupName" => GroupName); aws_config=aws_config
+        "UpdateGroup",
+        Dict{String,Any}("GroupName" => GroupName);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_group(
@@ -7330,6 +7715,7 @@ function update_group(
             mergewith(_merge, Dict{String,Any}("GroupName" => GroupName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -7367,6 +7753,7 @@ function update_login_profile(UserName; aws_config::AbstractAWSConfig=global_aws
         "UpdateLoginProfile",
         Dict{String,Any}("UserName" => UserName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_login_profile(
@@ -7380,6 +7767,7 @@ function update_login_profile(
             mergewith(_merge, Dict{String,Any}("UserName" => UserName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -7425,6 +7813,7 @@ function update_open_idconnect_provider_thumbprint(
             "ThumbprintList" => ThumbprintList,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_open_idconnect_provider_thumbprint(
@@ -7446,6 +7835,7 @@ function update_open_idconnect_provider_thumbprint(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -7475,7 +7865,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function update_role(RoleName; aws_config::AbstractAWSConfig=global_aws_config())
     return iam(
-        "UpdateRole", Dict{String,Any}("RoleName" => RoleName); aws_config=aws_config
+        "UpdateRole",
+        Dict{String,Any}("RoleName" => RoleName);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_role(
@@ -7489,6 +7882,7 @@ function update_role(
             mergewith(_merge, Dict{String,Any}("RoleName" => RoleName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -7511,6 +7905,7 @@ function update_role_description(
         "UpdateRoleDescription",
         Dict{String,Any}("Description" => Description, "RoleName" => RoleName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_role_description(
@@ -7529,6 +7924,7 @@ function update_role_description(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -7560,6 +7956,7 @@ function update_samlprovider(
             "SAMLProviderArn" => SAMLProviderArn,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_samlprovider(
@@ -7581,6 +7978,7 @@ function update_samlprovider(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -7628,6 +8026,7 @@ function update_server_certificate(
         "UpdateServerCertificate",
         Dict{String,Any}("ServerCertificateName" => ServerCertificateName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_server_certificate(
@@ -7645,6 +8044,7 @@ function update_server_certificate(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -7680,6 +8080,7 @@ function update_service_specific_credential(
             "ServiceSpecificCredentialId" => ServiceSpecificCredentialId, "Status" => Status
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_service_specific_credential(
@@ -7701,6 +8102,7 @@ function update_service_specific_credential(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -7738,6 +8140,7 @@ function update_signing_certificate(
         "UpdateSigningCertificate",
         Dict{String,Any}("CertificateId" => CertificateId, "Status" => Status);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_signing_certificate(
@@ -7756,6 +8159,7 @@ function update_signing_certificate(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -7792,6 +8196,7 @@ function update_sshpublic_key(
             "SSHPublicKeyId" => SSHPublicKeyId, "Status" => Status, "UserName" => UserName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_sshpublic_key(
@@ -7815,6 +8220,7 @@ function update_sshpublic_key(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -7851,7 +8257,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function update_user(UserName; aws_config::AbstractAWSConfig=global_aws_config())
     return iam(
-        "UpdateUser", Dict{String,Any}("UserName" => UserName); aws_config=aws_config
+        "UpdateUser",
+        Dict{String,Any}("UserName" => UserName);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_user(
@@ -7865,6 +8274,7 @@ function update_user(
             mergewith(_merge, Dict{String,Any}("UserName" => UserName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -7947,6 +8357,7 @@ function upload_server_certificate(
             "ServerCertificateName" => ServerCertificateName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function upload_server_certificate(
@@ -7970,6 +8381,7 @@ function upload_server_certificate(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -8014,6 +8426,7 @@ function upload_signing_certificate(
         "UploadSigningCertificate",
         Dict{String,Any}("CertificateBody" => CertificateBody);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function upload_signing_certificate(
@@ -8029,6 +8442,7 @@ function upload_signing_certificate(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -8064,6 +8478,7 @@ function upload_sshpublic_key(
         "UploadSSHPublicKey",
         Dict{String,Any}("SSHPublicKeyBody" => SSHPublicKeyBody, "UserName" => UserName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function upload_sshpublic_key(
@@ -8084,5 +8499,6 @@ function upload_sshpublic_key(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/identitystore.jl
+++ b/src/services/identitystore.jl
@@ -25,6 +25,7 @@ function describe_group(
         "DescribeGroup",
         Dict{String,Any}("GroupId" => GroupId, "IdentityStoreId" => IdentityStoreId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_group(
@@ -45,6 +46,7 @@ function describe_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -69,6 +71,7 @@ function describe_user(
         "DescribeUser",
         Dict{String,Any}("IdentityStoreId" => IdentityStoreId, "UserId" => UserId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_user(
@@ -87,6 +90,7 @@ function describe_user(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -122,6 +126,7 @@ function list_groups(IdentityStoreId; aws_config::AbstractAWSConfig=global_aws_c
         "ListGroups",
         Dict{String,Any}("IdentityStoreId" => IdentityStoreId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_groups(
@@ -137,6 +142,7 @@ function list_groups(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -171,6 +177,7 @@ function list_users(IdentityStoreId; aws_config::AbstractAWSConfig=global_aws_co
         "ListUsers",
         Dict{String,Any}("IdentityStoreId" => IdentityStoreId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_users(
@@ -186,5 +193,6 @@ function list_users(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/imagebuilder.jl
+++ b/src/services/imagebuilder.jl
@@ -27,6 +27,7 @@ function cancel_image_creation(
             "clientToken" => clientToken, "imageBuildVersionArn" => imageBuildVersionArn
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function cancel_image_creation(
@@ -49,6 +50,7 @@ function cancel_image_creation(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -108,6 +110,7 @@ function create_component(
             "semanticVersion" => semanticVersion,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_component(
@@ -134,6 +137,7 @@ function create_component(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -200,6 +204,7 @@ function create_container_recipe(
             "targetRepository" => targetRepository,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_container_recipe(
@@ -232,6 +237,7 @@ function create_container_recipe(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -262,6 +268,7 @@ function create_distribution_configuration(
             "clientToken" => clientToken, "distributions" => distributions, "name" => name
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_distribution_configuration(
@@ -286,6 +293,7 @@ function create_distribution_configuration(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -329,6 +337,7 @@ function create_image(
             "infrastructureConfigurationArn" => infrastructureConfigurationArn,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_image(
@@ -351,6 +360,7 @@ function create_image(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -400,6 +410,7 @@ function create_image_pipeline(
             "name" => name,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_image_pipeline(
@@ -424,6 +435,7 @@ function create_image_pipeline(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -482,6 +494,7 @@ function create_image_recipe(
             "semanticVersion" => semanticVersion,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_image_recipe(
@@ -510,6 +523,7 @@ function create_image_recipe(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -565,6 +579,7 @@ function create_infrastructure_configuration(
             "name" => name,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_infrastructure_configuration(
@@ -589,6 +604,7 @@ function create_infrastructure_configuration(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -611,6 +627,7 @@ function delete_component(
         "/DeleteComponent",
         Dict{String,Any}("componentBuildVersionArn" => componentBuildVersionArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_component(
@@ -629,6 +646,7 @@ function delete_component(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -650,6 +668,7 @@ function delete_container_recipe(
         "/DeleteContainerRecipe",
         Dict{String,Any}("containerRecipeArn" => containerRecipeArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_container_recipe(
@@ -666,6 +685,7 @@ function delete_container_recipe(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -688,6 +708,7 @@ function delete_distribution_configuration(
         "/DeleteDistributionConfiguration",
         Dict{String,Any}("distributionConfigurationArn" => distributionConfigurationArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_distribution_configuration(
@@ -708,6 +729,7 @@ function delete_distribution_configuration(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -736,6 +758,7 @@ function delete_image(
         "/DeleteImage",
         Dict{String,Any}("imageBuildVersionArn" => imageBuildVersionArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_image(
@@ -754,6 +777,7 @@ function delete_image(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -775,6 +799,7 @@ function delete_image_pipeline(
         "/DeleteImagePipeline",
         Dict{String,Any}("imagePipelineArn" => imagePipelineArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_image_pipeline(
@@ -791,6 +816,7 @@ function delete_image_pipeline(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -812,6 +838,7 @@ function delete_image_recipe(
         "/DeleteImageRecipe",
         Dict{String,Any}("imageRecipeArn" => imageRecipeArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_image_recipe(
@@ -826,6 +853,7 @@ function delete_image_recipe(
             mergewith(_merge, Dict{String,Any}("imageRecipeArn" => imageRecipeArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -850,6 +878,7 @@ function delete_infrastructure_configuration(
             "infrastructureConfigurationArn" => infrastructureConfigurationArn
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_infrastructure_configuration(
@@ -870,6 +899,7 @@ function delete_infrastructure_configuration(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -892,6 +922,7 @@ function get_component(
         "/GetComponent",
         Dict{String,Any}("componentBuildVersionArn" => componentBuildVersionArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_component(
@@ -910,6 +941,7 @@ function get_component(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -932,6 +964,7 @@ function get_component_policy(
         "/GetComponentPolicy",
         Dict{String,Any}("componentArn" => componentArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_component_policy(
@@ -946,6 +979,7 @@ function get_component_policy(
             mergewith(_merge, Dict{String,Any}("componentArn" => componentArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -968,6 +1002,7 @@ function get_container_recipe(
         "/GetContainerRecipe",
         Dict{String,Any}("containerRecipeArn" => containerRecipeArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_container_recipe(
@@ -984,6 +1019,7 @@ function get_container_recipe(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1006,6 +1042,7 @@ function get_container_recipe_policy(
         "/GetContainerRecipePolicy",
         Dict{String,Any}("containerRecipeArn" => containerRecipeArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_container_recipe_policy(
@@ -1022,6 +1059,7 @@ function get_container_recipe_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1044,6 +1082,7 @@ function get_distribution_configuration(
         "/GetDistributionConfiguration",
         Dict{String,Any}("distributionConfigurationArn" => distributionConfigurationArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_distribution_configuration(
@@ -1064,6 +1103,7 @@ function get_distribution_configuration(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1084,6 +1124,7 @@ function get_image(imageBuildVersionArn; aws_config::AbstractAWSConfig=global_aw
         "/GetImage",
         Dict{String,Any}("imageBuildVersionArn" => imageBuildVersionArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_image(
@@ -1102,6 +1143,7 @@ function get_image(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1124,6 +1166,7 @@ function get_image_pipeline(
         "/GetImagePipeline",
         Dict{String,Any}("imagePipelineArn" => imagePipelineArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_image_pipeline(
@@ -1140,6 +1183,7 @@ function get_image_pipeline(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1160,6 +1204,7 @@ function get_image_policy(imageArn; aws_config::AbstractAWSConfig=global_aws_con
         "/GetImagePolicy",
         Dict{String,Any}("imageArn" => imageArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_image_policy(
@@ -1174,6 +1219,7 @@ function get_image_policy(
             mergewith(_merge, Dict{String,Any}("imageArn" => imageArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1194,6 +1240,7 @@ function get_image_recipe(imageRecipeArn; aws_config::AbstractAWSConfig=global_a
         "/GetImageRecipe",
         Dict{String,Any}("imageRecipeArn" => imageRecipeArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_image_recipe(
@@ -1208,6 +1255,7 @@ function get_image_recipe(
             mergewith(_merge, Dict{String,Any}("imageRecipeArn" => imageRecipeArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1230,6 +1278,7 @@ function get_image_recipe_policy(
         "/GetImageRecipePolicy",
         Dict{String,Any}("imageRecipeArn" => imageRecipeArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_image_recipe_policy(
@@ -1244,6 +1293,7 @@ function get_image_recipe_policy(
             mergewith(_merge, Dict{String,Any}("imageRecipeArn" => imageRecipeArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1268,6 +1318,7 @@ function get_infrastructure_configuration(
             "infrastructureConfigurationArn" => infrastructureConfigurationArn
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_infrastructure_configuration(
@@ -1288,6 +1339,7 @@ function get_infrastructure_configuration(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1349,6 +1401,7 @@ function import_component(
             "type" => type,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function import_component(
@@ -1379,6 +1432,7 @@ function import_component(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1412,6 +1466,7 @@ function list_component_build_versions(
         "/ListComponentBuildVersions",
         Dict{String,Any}("componentVersionArn" => componentVersionArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_component_build_versions(
@@ -1430,6 +1485,7 @@ function list_component_build_versions(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1459,12 +1515,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   shared with you by other customers.
 """
 function list_components(; aws_config::AbstractAWSConfig=global_aws_config())
-    return imagebuilder("POST", "/ListComponents"; aws_config=aws_config)
+    return imagebuilder(
+        "POST", "/ListComponents"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_components(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return imagebuilder("POST", "/ListComponents", params; aws_config=aws_config)
+    return imagebuilder(
+        "POST",
+        "/ListComponents",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1485,12 +1549,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   account.
 """
 function list_container_recipes(; aws_config::AbstractAWSConfig=global_aws_config())
-    return imagebuilder("POST", "/ListContainerRecipes"; aws_config=aws_config)
+    return imagebuilder(
+        "POST",
+        "/ListContainerRecipes";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_container_recipes(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return imagebuilder("POST", "/ListContainerRecipes", params; aws_config=aws_config)
+    return imagebuilder(
+        "POST",
+        "/ListContainerRecipes",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1509,13 +1584,22 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function list_distribution_configurations(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return imagebuilder("POST", "/ListDistributionConfigurations"; aws_config=aws_config)
+    return imagebuilder(
+        "POST",
+        "/ListDistributionConfigurations";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_distribution_configurations(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return imagebuilder(
-        "POST", "/ListDistributionConfigurations", params; aws_config=aws_config
+        "POST",
+        "/ListDistributionConfigurations",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1545,6 +1629,7 @@ function list_image_build_versions(
         "/ListImageBuildVersions",
         Dict{String,Any}("imageVersionArn" => imageVersionArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_image_build_versions(
@@ -1561,6 +1646,7 @@ function list_image_build_versions(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1590,6 +1676,7 @@ function list_image_packages(
         "/ListImagePackages",
         Dict{String,Any}("imageBuildVersionArn" => imageBuildVersionArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_image_packages(
@@ -1608,6 +1695,7 @@ function list_image_packages(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1636,6 +1724,7 @@ function list_image_pipeline_images(
         "/ListImagePipelineImages",
         Dict{String,Any}("imagePipelineArn" => imagePipelineArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_image_pipeline_images(
@@ -1652,6 +1741,7 @@ function list_image_pipeline_images(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1671,12 +1761,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   previously truncated response.
 """
 function list_image_pipelines(; aws_config::AbstractAWSConfig=global_aws_config())
-    return imagebuilder("POST", "/ListImagePipelines"; aws_config=aws_config)
+    return imagebuilder(
+        "POST",
+        "/ListImagePipelines";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_image_pipelines(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return imagebuilder("POST", "/ListImagePipelines", params; aws_config=aws_config)
+    return imagebuilder(
+        "POST",
+        "/ListImagePipelines",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1698,12 +1799,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   recipes that have been shared with you by other customers.
 """
 function list_image_recipes(; aws_config::AbstractAWSConfig=global_aws_config())
-    return imagebuilder("POST", "/ListImageRecipes"; aws_config=aws_config)
+    return imagebuilder(
+        "POST", "/ListImageRecipes"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_image_recipes(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return imagebuilder("POST", "/ListImageRecipes", params; aws_config=aws_config)
+    return imagebuilder(
+        "POST",
+        "/ListImageRecipes",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1727,12 +1836,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   other customers.
 """
 function list_images(; aws_config::AbstractAWSConfig=global_aws_config())
-    return imagebuilder("POST", "/ListImages"; aws_config=aws_config)
+    return imagebuilder(
+        "POST", "/ListImages"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_images(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return imagebuilder("POST", "/ListImages", params; aws_config=aws_config)
+    return imagebuilder(
+        "POST",
+        "/ListImages",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1751,13 +1868,22 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function list_infrastructure_configurations(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return imagebuilder("POST", "/ListInfrastructureConfigurations"; aws_config=aws_config)
+    return imagebuilder(
+        "POST",
+        "/ListInfrastructureConfigurations";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_infrastructure_configurations(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return imagebuilder(
-        "POST", "/ListInfrastructureConfigurations", params; aws_config=aws_config
+        "POST",
+        "/ListInfrastructureConfigurations",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1775,14 +1901,25 @@ end
 function list_tags_for_resource(
     resourceArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return imagebuilder("GET", "/tags/$(resourceArn)"; aws_config=aws_config)
+    return imagebuilder(
+        "GET",
+        "/tags/$(resourceArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_tags_for_resource(
     resourceArn,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return imagebuilder("GET", "/tags/$(resourceArn)", params; aws_config=aws_config)
+    return imagebuilder(
+        "GET",
+        "/tags/$(resourceArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1808,6 +1945,7 @@ function put_component_policy(
         "/PutComponentPolicy",
         Dict{String,Any}("componentArn" => componentArn, "policy" => policy);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_component_policy(
@@ -1827,6 +1965,7 @@ function put_component_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1857,6 +1996,7 @@ function put_container_recipe_policy(
         "/PutContainerRecipePolicy",
         Dict{String,Any}("containerRecipeArn" => containerRecipeArn, "policy" => policy);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_container_recipe_policy(
@@ -1878,6 +2018,7 @@ function put_container_recipe_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1904,6 +2045,7 @@ function put_image_policy(
         "/PutImagePolicy",
         Dict{String,Any}("imageArn" => imageArn, "policy" => policy);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_image_policy(
@@ -1921,6 +2063,7 @@ function put_image_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1947,6 +2090,7 @@ function put_image_recipe_policy(
         "/PutImageRecipePolicy",
         Dict{String,Any}("imageRecipeArn" => imageRecipeArn, "policy" => policy);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_image_recipe_policy(
@@ -1966,6 +2110,7 @@ function put_image_recipe_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1991,6 +2136,7 @@ function start_image_pipeline_execution(
             "clientToken" => clientToken, "imagePipelineArn" => imagePipelineArn
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_image_pipeline_execution(
@@ -2012,6 +2158,7 @@ function start_image_pipeline_execution(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2032,6 +2179,7 @@ function tag_resource(resourceArn, tags; aws_config::AbstractAWSConfig=global_aw
         "/tags/$(resourceArn)",
         Dict{String,Any}("tags" => tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -2045,6 +2193,7 @@ function tag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tags" => tags), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2067,6 +2216,7 @@ function untag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}("tagKeys" => tagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -2080,6 +2230,7 @@ function untag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tagKeys" => tagKeys), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2115,6 +2266,7 @@ function update_distribution_configuration(
             "distributions" => distributions,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_distribution_configuration(
@@ -2139,6 +2291,7 @@ function update_distribution_configuration(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2190,6 +2343,7 @@ function update_image_pipeline(
             "infrastructureConfigurationArn" => infrastructureConfigurationArn,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_image_pipeline(
@@ -2214,6 +2368,7 @@ function update_image_pipeline(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2271,6 +2426,7 @@ function update_infrastructure_configuration(
             "instanceProfileName" => instanceProfileName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_infrastructure_configuration(
@@ -2295,5 +2451,6 @@ function update_infrastructure_configuration(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/importexport.jl
+++ b/src/services/importexport.jl
@@ -20,7 +20,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function cancel_job(JobId; aws_config::AbstractAWSConfig=global_aws_config())
     return importexport(
-        "CancelJob", Dict{String,Any}("JobId" => JobId); aws_config=aws_config
+        "CancelJob",
+        Dict{String,Any}("JobId" => JobId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function cancel_job(
@@ -30,6 +33,7 @@ function cancel_job(
         "CancelJob",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("JobId" => JobId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -62,6 +66,7 @@ function create_job(
             "JobType" => JobType, "Manifest" => Manifest, "ValidateOnly" => ValidateOnly
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_job(
@@ -85,6 +90,7 @@ function create_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -114,7 +120,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function get_shipping_label(jobIds; aws_config::AbstractAWSConfig=global_aws_config())
     return importexport(
-        "GetShippingLabel", Dict{String,Any}("jobIds" => jobIds); aws_config=aws_config
+        "GetShippingLabel",
+        Dict{String,Any}("jobIds" => jobIds);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_shipping_label(
@@ -124,6 +133,7 @@ function get_shipping_label(
         "GetShippingLabel",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("jobIds" => jobIds), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -144,7 +154,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function get_status(JobId; aws_config::AbstractAWSConfig=global_aws_config())
     return importexport(
-        "GetStatus", Dict{String,Any}("JobId" => JobId); aws_config=aws_config
+        "GetStatus",
+        Dict{String,Any}("JobId" => JobId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_status(
@@ -154,6 +167,7 @@ function get_status(
         "GetStatus",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("JobId" => JobId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -173,12 +187,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"MaxJobs"`:
 """
 function list_jobs(; aws_config::AbstractAWSConfig=global_aws_config())
-    return importexport("ListJobs"; aws_config=aws_config)
+    return importexport("ListJobs"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_jobs(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return importexport("ListJobs", params; aws_config=aws_config)
+    return importexport(
+        "ListJobs", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -216,6 +232,7 @@ function update_job(
             "ValidateOnly" => ValidateOnly,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_job(
@@ -241,5 +258,6 @@ function update_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/inspector.jl
+++ b/src/services/inspector.jl
@@ -23,6 +23,7 @@ function add_attributes_to_findings(
         "AddAttributesToFindings",
         Dict{String,Any}("attributes" => attributes, "findingArns" => findingArns);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function add_attributes_to_findings(
@@ -41,6 +42,7 @@ function add_attributes_to_findings(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -73,6 +75,7 @@ function create_assessment_target(
         "CreateAssessmentTarget",
         Dict{String,Any}("assessmentTargetName" => assessmentTargetName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_assessment_target(
@@ -90,6 +93,7 @@ function create_assessment_target(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -136,6 +140,7 @@ function create_assessment_template(
             "rulesPackageArns" => rulesPackageArns,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_assessment_template(
@@ -161,6 +166,7 @@ function create_assessment_template(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -184,6 +190,7 @@ function create_exclusions_preview(
         "CreateExclusionsPreview",
         Dict{String,Any}("assessmentTemplateArn" => assessmentTemplateArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_exclusions_preview(
@@ -201,6 +208,7 @@ function create_exclusions_preview(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -226,6 +234,7 @@ function create_resource_group(
         "CreateResourceGroup",
         Dict{String,Any}("resourceGroupTags" => resourceGroupTags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_resource_group(
@@ -241,6 +250,7 @@ function create_resource_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -261,6 +271,7 @@ function delete_assessment_run(
         "DeleteAssessmentRun",
         Dict{String,Any}("assessmentRunArn" => assessmentRunArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_assessment_run(
@@ -276,6 +287,7 @@ function delete_assessment_run(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -297,6 +309,7 @@ function delete_assessment_target(
         "DeleteAssessmentTarget",
         Dict{String,Any}("assessmentTargetArn" => assessmentTargetArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_assessment_target(
@@ -314,6 +327,7 @@ function delete_assessment_target(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -335,6 +349,7 @@ function delete_assessment_template(
         "DeleteAssessmentTemplate",
         Dict{String,Any}("assessmentTemplateArn" => assessmentTemplateArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_assessment_template(
@@ -352,6 +367,7 @@ function delete_assessment_template(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -373,6 +389,7 @@ function describe_assessment_runs(
         "DescribeAssessmentRuns",
         Dict{String,Any}("assessmentRunArns" => assessmentRunArns);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_assessment_runs(
@@ -388,6 +405,7 @@ function describe_assessment_runs(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -409,6 +427,7 @@ function describe_assessment_targets(
         "DescribeAssessmentTargets",
         Dict{String,Any}("assessmentTargetArns" => assessmentTargetArns);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_assessment_targets(
@@ -426,6 +445,7 @@ function describe_assessment_targets(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -447,6 +467,7 @@ function describe_assessment_templates(
         "DescribeAssessmentTemplates",
         Dict{String,Any}("assessmentTemplateArns" => assessmentTemplateArns);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_assessment_templates(
@@ -464,6 +485,7 @@ function describe_assessment_templates(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -477,12 +499,21 @@ Describes the IAM role that enables Amazon Inspector to access your AWS account.
 function describe_cross_account_access_role(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return inspector("DescribeCrossAccountAccessRole"; aws_config=aws_config)
+    return inspector(
+        "DescribeCrossAccountAccessRole";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_cross_account_access_role(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return inspector("DescribeCrossAccountAccessRole", params; aws_config=aws_config)
+    return inspector(
+        "DescribeCrossAccountAccessRole",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -506,6 +537,7 @@ function describe_exclusions(
         "DescribeExclusions",
         Dict{String,Any}("exclusionArns" => exclusionArns);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_exclusions(
@@ -519,6 +551,7 @@ function describe_exclusions(
             mergewith(_merge, Dict{String,Any}("exclusionArns" => exclusionArns), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -541,6 +574,7 @@ function describe_findings(findingArns; aws_config::AbstractAWSConfig=global_aws
         "DescribeFindings",
         Dict{String,Any}("findingArns" => findingArns);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_findings(
@@ -554,6 +588,7 @@ function describe_findings(
             mergewith(_merge, Dict{String,Any}("findingArns" => findingArns), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -575,6 +610,7 @@ function describe_resource_groups(
         "DescribeResourceGroups",
         Dict{String,Any}("resourceGroupArns" => resourceGroupArns);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_resource_groups(
@@ -590,6 +626,7 @@ function describe_resource_groups(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -613,6 +650,7 @@ function describe_rules_packages(
         "DescribeRulesPackages",
         Dict{String,Any}("rulesPackageArns" => rulesPackageArns);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_rules_packages(
@@ -628,6 +666,7 @@ function describe_rules_packages(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -662,6 +701,7 @@ function get_assessment_report(
             "reportType" => reportType,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_assessment_report(
@@ -685,6 +725,7 @@ function get_assessment_report(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -720,6 +761,7 @@ function get_exclusions_preview(
             "assessmentTemplateArn" => assessmentTemplateArn, "previewToken" => previewToken
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_exclusions_preview(
@@ -741,6 +783,7 @@ function get_exclusions_preview(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -762,6 +805,7 @@ function get_telemetry_metadata(
         "GetTelemetryMetadata",
         Dict{String,Any}("assessmentRunArn" => assessmentRunArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_telemetry_metadata(
@@ -777,6 +821,7 @@ function get_telemetry_metadata(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -811,6 +856,7 @@ function list_assessment_run_agents(
         "ListAssessmentRunAgents",
         Dict{String,Any}("assessmentRunArn" => assessmentRunArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_assessment_run_agents(
@@ -826,6 +872,7 @@ function list_assessment_run_agents(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -852,12 +899,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   response to continue listing data.
 """
 function list_assessment_runs(; aws_config::AbstractAWSConfig=global_aws_config())
-    return inspector("ListAssessmentRuns"; aws_config=aws_config)
+    return inspector(
+        "ListAssessmentRuns"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_assessment_runs(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return inspector("ListAssessmentRuns", params; aws_config=aws_config)
+    return inspector(
+        "ListAssessmentRuns", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -881,12 +932,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   response to continue listing data.
 """
 function list_assessment_targets(; aws_config::AbstractAWSConfig=global_aws_config())
-    return inspector("ListAssessmentTargets"; aws_config=aws_config)
+    return inspector(
+        "ListAssessmentTargets"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_assessment_targets(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return inspector("ListAssessmentTargets", params; aws_config=aws_config)
+    return inspector(
+        "ListAssessmentTargets",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -912,12 +970,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   previous response to continue listing data.
 """
 function list_assessment_templates(; aws_config::AbstractAWSConfig=global_aws_config())
-    return inspector("ListAssessmentTemplates"; aws_config=aws_config)
+    return inspector(
+        "ListAssessmentTemplates"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_assessment_templates(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return inspector("ListAssessmentTemplates", params; aws_config=aws_config)
+    return inspector(
+        "ListAssessmentTemplates",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -940,12 +1005,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   existing event subscriptions.
 """
 function list_event_subscriptions(; aws_config::AbstractAWSConfig=global_aws_config())
-    return inspector("ListEventSubscriptions"; aws_config=aws_config)
+    return inspector(
+        "ListEventSubscriptions"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_event_subscriptions(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return inspector("ListEventSubscriptions", params; aws_config=aws_config)
+    return inspector(
+        "ListEventSubscriptions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -974,6 +1046,7 @@ function list_exclusions(
         "ListExclusions",
         Dict{String,Any}("assessmentRunArn" => assessmentRunArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_exclusions(
@@ -989,6 +1062,7 @@ function list_exclusions(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1015,12 +1089,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   to continue listing data.
 """
 function list_findings(; aws_config::AbstractAWSConfig=global_aws_config())
-    return inspector("ListFindings"; aws_config=aws_config)
+    return inspector("ListFindings"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_findings(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return inspector("ListFindings", params; aws_config=aws_config)
+    return inspector(
+        "ListFindings", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1039,12 +1115,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   response to continue listing data.
 """
 function list_rules_packages(; aws_config::AbstractAWSConfig=global_aws_config())
-    return inspector("ListRulesPackages"; aws_config=aws_config)
+    return inspector(
+        "ListRulesPackages"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_rules_packages(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return inspector("ListRulesPackages", params; aws_config=aws_config)
+    return inspector(
+        "ListRulesPackages", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1065,6 +1145,7 @@ function list_tags_for_resource(
         "ListTagsForResource",
         Dict{String,Any}("resourceArn" => resourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags_for_resource(
@@ -1078,6 +1159,7 @@ function list_tags_for_resource(
             mergewith(_merge, Dict{String,Any}("resourceArn" => resourceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1105,6 +1187,7 @@ function preview_agents(previewAgentsArn; aws_config::AbstractAWSConfig=global_a
         "PreviewAgents",
         Dict{String,Any}("previewAgentsArn" => previewAgentsArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function preview_agents(
@@ -1120,6 +1203,7 @@ function preview_agents(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1142,6 +1226,7 @@ function register_cross_account_access_role(
         "RegisterCrossAccountAccessRole",
         Dict{String,Any}("roleArn" => roleArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function register_cross_account_access_role(
@@ -1151,6 +1236,7 @@ function register_cross_account_access_role(
         "RegisterCrossAccountAccessRole",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("roleArn" => roleArn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1175,6 +1261,7 @@ function remove_attributes_from_findings(
         "RemoveAttributesFromFindings",
         Dict{String,Any}("attributeKeys" => attributeKeys, "findingArns" => findingArns);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function remove_attributes_from_findings(
@@ -1195,6 +1282,7 @@ function remove_attributes_from_findings(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1220,6 +1308,7 @@ function set_tags_for_resource(
         "SetTagsForResource",
         Dict{String,Any}("resourceArn" => resourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function set_tags_for_resource(
@@ -1233,6 +1322,7 @@ function set_tags_for_resource(
             mergewith(_merge, Dict{String,Any}("resourceArn" => resourceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1260,6 +1350,7 @@ function start_assessment_run(
         "StartAssessmentRun",
         Dict{String,Any}("assessmentTemplateArn" => assessmentTemplateArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_assessment_run(
@@ -1277,6 +1368,7 @@ function start_assessment_run(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1303,6 +1395,7 @@ function stop_assessment_run(
         "StopAssessmentRun",
         Dict{String,Any}("assessmentRunArn" => assessmentRunArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function stop_assessment_run(
@@ -1318,6 +1411,7 @@ function stop_assessment_run(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1344,6 +1438,7 @@ function subscribe_to_event(
             "event" => event, "resourceArn" => resourceArn, "topicArn" => topicArn
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function subscribe_to_event(
@@ -1365,6 +1460,7 @@ function subscribe_to_event(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1391,6 +1487,7 @@ function unsubscribe_from_event(
             "event" => event, "resourceArn" => resourceArn, "topicArn" => topicArn
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function unsubscribe_from_event(
@@ -1412,6 +1509,7 @@ function unsubscribe_from_event(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1444,6 +1542,7 @@ function update_assessment_target(
             "assessmentTargetName" => assessmentTargetName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_assessment_target(
@@ -1465,5 +1564,6 @@ function update_assessment_target(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/iot.jl
+++ b/src/services/iot.jl
@@ -24,7 +24,10 @@ function accept_certificate_transfer(
     certificateId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return iot(
-        "PATCH", "/accept-certificate-transfer/$(certificateId)"; aws_config=aws_config
+        "PATCH",
+        "/accept-certificate-transfer/$(certificateId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function accept_certificate_transfer(
@@ -37,6 +40,7 @@ function accept_certificate_transfer(
         "/accept-certificate-transfer/$(certificateId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -55,13 +59,22 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"thingName"`: The name of the thing to be added to the billing group.
 """
 function add_thing_to_billing_group(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot("PUT", "/billing-groups/addThingToBillingGroup"; aws_config=aws_config)
+    return iot(
+        "PUT",
+        "/billing-groups/addThingToBillingGroup";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function add_thing_to_billing_group(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return iot(
-        "PUT", "/billing-groups/addThingToBillingGroup", params; aws_config=aws_config
+        "PUT",
+        "/billing-groups/addThingToBillingGroup",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -84,12 +97,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"thingName"`: The name of the thing to add to a group.
 """
 function add_thing_to_thing_group(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot("PUT", "/thing-groups/addThingToThingGroup"; aws_config=aws_config)
+    return iot(
+        "PUT",
+        "/thing-groups/addThingToThingGroup";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function add_thing_to_thing_group(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("PUT", "/thing-groups/addThingToThingGroup", params; aws_config=aws_config)
+    return iot(
+        "PUT",
+        "/thing-groups/addThingToThingGroup",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -123,6 +147,7 @@ function associate_targets_with_job(
         "/jobs/$(jobId)/targets",
         Dict{String,Any}("targets" => targets);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_targets_with_job(
@@ -136,6 +161,7 @@ function associate_targets_with_job(
         "/jobs/$(jobId)/targets",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("targets" => targets), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -160,6 +186,7 @@ function attach_policy(
         "/target-policies/$(policyName)",
         Dict{String,Any}("target" => target);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function attach_policy(
@@ -173,6 +200,7 @@ function attach_policy(
         "/target-policies/$(policyName)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("target" => target), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -200,6 +228,7 @@ function attach_principal_policy(
             "headers" => Dict{String,Any}("x-amzn-iot-principal" => x_amzn_iot_principal)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function attach_principal_policy(
@@ -222,6 +251,7 @@ function attach_principal_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -249,6 +279,7 @@ function attach_security_profile(
         "/security-profiles/$(securityProfileName)/targets",
         Dict{String,Any}("securityProfileTargetArn" => securityProfileTargetArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function attach_security_profile(
@@ -268,6 +299,7 @@ function attach_security_profile(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -295,6 +327,7 @@ function attach_thing_principal(
             "headers" => Dict{String,Any}("x-amzn-principal" => x_amzn_principal)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function attach_thing_principal(
@@ -316,6 +349,7 @@ function attach_thing_principal(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -335,7 +369,10 @@ function cancel_audit_mitigation_actions_task(
     taskId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return iot(
-        "PUT", "/audit/mitigationactions/tasks/$(taskId)/cancel"; aws_config=aws_config
+        "PUT",
+        "/audit/mitigationactions/tasks/$(taskId)/cancel";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function cancel_audit_mitigation_actions_task(
@@ -346,6 +383,7 @@ function cancel_audit_mitigation_actions_task(
         "/audit/mitigationactions/tasks/$(taskId)/cancel",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -363,12 +401,23 @@ access the CancelAuditTask action.
 
 """
 function cancel_audit_task(taskId; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot("PUT", "/audit/tasks/$(taskId)/cancel"; aws_config=aws_config)
+    return iot(
+        "PUT",
+        "/audit/tasks/$(taskId)/cancel";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function cancel_audit_task(
     taskId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("PUT", "/audit/tasks/$(taskId)/cancel", params; aws_config=aws_config)
+    return iot(
+        "PUT",
+        "/audit/tasks/$(taskId)/cancel",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -392,7 +441,10 @@ function cancel_certificate_transfer(
     certificateId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return iot(
-        "PATCH", "/cancel-certificate-transfer/$(certificateId)"; aws_config=aws_config
+        "PATCH",
+        "/cancel-certificate-transfer/$(certificateId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function cancel_certificate_transfer(
@@ -405,6 +457,7 @@ function cancel_certificate_transfer(
         "/cancel-certificate-transfer/$(certificateId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -423,7 +476,10 @@ function cancel_detect_mitigation_actions_task(
     taskId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return iot(
-        "PUT", "/detect/mitigationactions/tasks/$(taskId)/cancel"; aws_config=aws_config
+        "PUT",
+        "/detect/mitigationactions/tasks/$(taskId)/cancel";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function cancel_detect_mitigation_actions_task(
@@ -434,6 +490,7 @@ function cancel_detect_mitigation_actions_task(
         "/detect/mitigationactions/tasks/$(taskId)/cancel",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -457,12 +514,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"reasonCode"`: (Optional)A reason code string that explains why the job was canceled.
 """
 function cancel_job(jobId; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot("PUT", "/jobs/$(jobId)/cancel"; aws_config=aws_config)
+    return iot(
+        "PUT",
+        "/jobs/$(jobId)/cancel";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function cancel_job(
     jobId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("PUT", "/jobs/$(jobId)/cancel", params; aws_config=aws_config)
+    return iot(
+        "PUT",
+        "/jobs/$(jobId)/cancel",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -498,7 +566,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function cancel_job_execution(
     jobId, thingName; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("PUT", "/things/$(thingName)/jobs/$(jobId)/cancel"; aws_config=aws_config)
+    return iot(
+        "PUT",
+        "/things/$(thingName)/jobs/$(jobId)/cancel";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function cancel_job_execution(
     jobId,
@@ -507,7 +580,11 @@ function cancel_job_execution(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return iot(
-        "PUT", "/things/$(thingName)/jobs/$(jobId)/cancel", params; aws_config=aws_config
+        "PUT",
+        "/things/$(thingName)/jobs/$(jobId)/cancel",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -520,12 +597,23 @@ action.
 
 """
 function clear_default_authorizer(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot("DELETE", "/default-authorizer"; aws_config=aws_config)
+    return iot(
+        "DELETE",
+        "/default-authorizer";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function clear_default_authorizer(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("DELETE", "/default-authorizer", params; aws_config=aws_config)
+    return iot(
+        "DELETE",
+        "/default-authorizer",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -546,7 +634,12 @@ ConfirmTopicRuleDestination action.
 function confirm_topic_rule_destination(
     confirmationToken; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("GET", "/confirmdestination/$(confirmationToken)"; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/confirmdestination/$(confirmationToken)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function confirm_topic_rule_destination(
     confirmationToken,
@@ -554,7 +647,11 @@ function confirm_topic_rule_destination(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return iot(
-        "GET", "/confirmdestination/$(confirmationToken)", params; aws_config=aws_config
+        "GET",
+        "/confirmdestination/$(confirmationToken)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -595,6 +692,7 @@ function create_audit_suppression(
             "resourceIdentifier" => resourceIdentifier,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_audit_suppression(
@@ -619,6 +717,7 @@ function create_audit_suppression(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -654,6 +753,7 @@ function create_authorizer(
         "/authorizer/$(authorizerName)",
         Dict{String,Any}("authorizerFunctionArn" => authorizerFunctionArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_authorizer(
@@ -673,6 +773,7 @@ function create_authorizer(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -693,14 +794,25 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function create_billing_group(
     billingGroupName; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("POST", "/billing-groups/$(billingGroupName)"; aws_config=aws_config)
+    return iot(
+        "POST",
+        "/billing-groups/$(billingGroupName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function create_billing_group(
     billingGroupName,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return iot("POST", "/billing-groups/$(billingGroupName)", params; aws_config=aws_config)
+    return iot(
+        "POST",
+        "/billing-groups/$(billingGroupName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -745,6 +857,7 @@ function create_certificate_from_csr(
         "/certificates",
         Dict{String,Any}("certificateSigningRequest" => certificateSigningRequest);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_certificate_from_csr(
@@ -763,6 +876,7 @@ function create_certificate_from_csr(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -803,6 +917,7 @@ function create_custom_metric(
             "clientRequestToken" => clientRequestToken, "metricType" => metricType
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_custom_metric(
@@ -825,6 +940,7 @@ function create_custom_metric(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -869,6 +985,7 @@ function create_dimension(
             "type" => type,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_dimension(
@@ -894,6 +1011,7 @@ function create_dimension(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -929,7 +1047,10 @@ function create_domain_configuration(
     domainConfigurationName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return iot(
-        "POST", "/domainConfigurations/$(domainConfigurationName)"; aws_config=aws_config
+        "POST",
+        "/domainConfigurations/$(domainConfigurationName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_domain_configuration(
@@ -942,6 +1063,7 @@ function create_domain_configuration(
         "/domainConfigurations/$(domainConfigurationName)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -974,6 +1096,7 @@ function create_dynamic_thing_group(
         "/dynamic-thing-groups/$(thingGroupName)",
         Dict{String,Any}("queryString" => queryString);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_dynamic_thing_group(
@@ -989,6 +1112,7 @@ function create_dynamic_thing_group(
             mergewith(_merge, Dict{String,Any}("queryString" => queryString), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1033,6 +1157,7 @@ function create_fleet_metric(
             "queryString" => queryString,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_fleet_metric(
@@ -1060,6 +1185,7 @@ function create_fleet_metric(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1109,6 +1235,7 @@ function create_job(jobId, targets; aws_config::AbstractAWSConfig=global_aws_con
         "/jobs/$(jobId)",
         Dict{String,Any}("targets" => targets);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_job(
@@ -1122,6 +1249,7 @@ function create_job(
         "/jobs/$(jobId)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("targets" => targets), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1159,6 +1287,7 @@ function create_job_template(
         "/job-templates/$(jobTemplateId)",
         Dict{String,Any}("description" => description);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_job_template(
@@ -1174,6 +1303,7 @@ function create_job_template(
             mergewith(_merge, Dict{String,Any}("description" => description), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1192,12 +1322,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"setAsActive"`: Specifies whether the certificate is active.
 """
 function create_keys_and_certificate(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot("POST", "/keys-and-certificate"; aws_config=aws_config)
+    return iot(
+        "POST",
+        "/keys-and-certificate";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function create_keys_and_certificate(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("POST", "/keys-and-certificate", params; aws_config=aws_config)
+    return iot(
+        "POST",
+        "/keys-and-certificate",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1228,6 +1369,7 @@ function create_mitigation_action(
         "/mitigationactions/actions/$(actionName)",
         Dict{String,Any}("actionParams" => actionParams, "roleArn" => roleArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_mitigation_action(
@@ -1248,6 +1390,7 @@ function create_mitigation_action(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1296,6 +1439,7 @@ function create_otaupdate(
         "/otaUpdates/$(otaUpdateId)",
         Dict{String,Any}("files" => files, "roleArn" => roleArn, "targets" => targets);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_otaupdate(
@@ -1319,6 +1463,7 @@ function create_otaupdate(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1350,6 +1495,7 @@ function create_policy(
         "/policies/$(policyName)",
         Dict{String,Any}("policyDocument" => policyDocument);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_policy(
@@ -1365,6 +1511,7 @@ function create_policy(
             mergewith(_merge, Dict{String,Any}("policyDocument" => policyDocument), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1399,6 +1546,7 @@ function create_policy_version(
         "/policies/$(policyName)/version",
         Dict{String,Any}("policyDocument" => policyDocument);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_policy_version(
@@ -1414,6 +1562,7 @@ function create_policy_version(
             mergewith(_merge, Dict{String,Any}("policyDocument" => policyDocument), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1435,6 +1584,7 @@ function create_provisioning_claim(
         "POST",
         "/provisioning-templates/$(templateName)/provisioning-claim";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_provisioning_claim(
@@ -1447,6 +1597,7 @@ function create_provisioning_claim(
         "/provisioning-templates/$(templateName)/provisioning-claim",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1488,6 +1639,7 @@ function create_provisioning_template(
             "templateName" => templateName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_provisioning_template(
@@ -1512,6 +1664,7 @@ function create_provisioning_template(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1538,6 +1691,7 @@ function create_provisioning_template_version(
         "/provisioning-templates/$(templateName)/versions",
         Dict{String,Any}("templateBody" => templateBody);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_provisioning_template_version(
@@ -1553,6 +1707,7 @@ function create_provisioning_template_version(
             mergewith(_merge, Dict{String,Any}("templateBody" => templateBody), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1584,6 +1739,7 @@ function create_role_alias(
         "/role-aliases/$(roleAlias)",
         Dict{String,Any}("roleArn" => roleArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_role_alias(
@@ -1597,6 +1753,7 @@ function create_role_alias(
         "/role-aliases/$(roleAlias)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("roleArn" => roleArn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1638,6 +1795,7 @@ function create_scheduled_audit(
         "/audit/scheduledaudits/$(scheduledAuditName)",
         Dict{String,Any}("frequency" => frequency, "targetCheckNames" => targetCheckNames);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_scheduled_audit(
@@ -1660,6 +1818,7 @@ function create_scheduled_audit(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1694,7 +1853,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function create_security_profile(
     securityProfileName; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("POST", "/security-profiles/$(securityProfileName)"; aws_config=aws_config)
+    return iot(
+        "POST",
+        "/security-profiles/$(securityProfileName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function create_security_profile(
     securityProfileName,
@@ -1702,7 +1866,11 @@ function create_security_profile(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return iot(
-        "POST", "/security-profiles/$(securityProfileName)", params; aws_config=aws_config
+        "POST",
+        "/security-profiles/$(securityProfileName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1734,6 +1902,7 @@ function create_stream(
         "/streams/$(streamId)",
         Dict{String,Any}("files" => files, "roleArn" => roleArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_stream(
@@ -1752,6 +1921,7 @@ function create_stream(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1778,14 +1948,25 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"thingTypeName"`: The name of the thing type associated with the new thing.
 """
 function create_thing(thingName; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot("POST", "/things/$(thingName)"; aws_config=aws_config)
+    return iot(
+        "POST",
+        "/things/$(thingName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function create_thing(
     thingName,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return iot("POST", "/things/$(thingName)", params; aws_config=aws_config)
+    return iot(
+        "POST",
+        "/things/$(thingName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1808,14 +1989,25 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function create_thing_group(
     thingGroupName; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("POST", "/thing-groups/$(thingGroupName)"; aws_config=aws_config)
+    return iot(
+        "POST",
+        "/thing-groups/$(thingGroupName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function create_thing_group(
     thingGroupName,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return iot("POST", "/thing-groups/$(thingGroupName)", params; aws_config=aws_config)
+    return iot(
+        "POST",
+        "/thing-groups/$(thingGroupName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1835,14 +2027,25 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   searchable thing attribute names.
 """
 function create_thing_type(thingTypeName; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot("POST", "/thing-types/$(thingTypeName)"; aws_config=aws_config)
+    return iot(
+        "POST",
+        "/thing-types/$(thingTypeName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function create_thing_type(
     thingTypeName,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return iot("POST", "/thing-types/$(thingTypeName)", params; aws_config=aws_config)
+    return iot(
+        "POST",
+        "/thing-types/$(thingTypeName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1872,6 +2075,7 @@ function create_topic_rule(
         "/rules/$(ruleName)",
         Dict{String,Any}("topicRulePayload" => topicRulePayload);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_topic_rule(
@@ -1889,6 +2093,7 @@ function create_topic_rule(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1911,6 +2116,7 @@ function create_topic_rule_destination(
         "/destinations",
         Dict{String,Any}("destinationConfiguration" => destinationConfiguration);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_topic_rule_destination(
@@ -1929,6 +2135,7 @@ function create_topic_rule_destination(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1947,12 +2154,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function delete_account_audit_configuration(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("DELETE", "/audit/configuration"; aws_config=aws_config)
+    return iot(
+        "DELETE",
+        "/audit/configuration";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_account_audit_configuration(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("DELETE", "/audit/configuration", params; aws_config=aws_config)
+    return iot(
+        "DELETE",
+        "/audit/configuration",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1977,6 +2195,7 @@ function delete_audit_suppression(
             "checkName" => checkName, "resourceIdentifier" => resourceIdentifier
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_audit_suppression(
@@ -1998,6 +2217,7 @@ function delete_audit_suppression(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2014,14 +2234,25 @@ Deletes an authorizer. Requires permission to access the DeleteAuthorizer action
 function delete_authorizer(
     authorizerName; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("DELETE", "/authorizer/$(authorizerName)"; aws_config=aws_config)
+    return iot(
+        "DELETE",
+        "/authorizer/$(authorizerName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_authorizer(
     authorizerName,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return iot("DELETE", "/authorizer/$(authorizerName)", params; aws_config=aws_config)
+    return iot(
+        "DELETE",
+        "/authorizer/$(authorizerName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2042,7 +2273,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function delete_billing_group(
     billingGroupName; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("DELETE", "/billing-groups/$(billingGroupName)"; aws_config=aws_config)
+    return iot(
+        "DELETE",
+        "/billing-groups/$(billingGroupName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_billing_group(
     billingGroupName,
@@ -2050,7 +2286,11 @@ function delete_billing_group(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return iot(
-        "DELETE", "/billing-groups/$(billingGroupName)", params; aws_config=aws_config
+        "DELETE",
+        "/billing-groups/$(billingGroupName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2069,14 +2309,25 @@ action.
 function delete_cacertificate(
     caCertificateId; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("DELETE", "/cacertificate/$(caCertificateId)"; aws_config=aws_config)
+    return iot(
+        "DELETE",
+        "/cacertificate/$(caCertificateId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_cacertificate(
     caCertificateId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return iot("DELETE", "/cacertificate/$(caCertificateId)", params; aws_config=aws_config)
+    return iot(
+        "DELETE",
+        "/cacertificate/$(caCertificateId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2101,14 +2352,25 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function delete_certificate(
     certificateId; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("DELETE", "/certificates/$(certificateId)"; aws_config=aws_config)
+    return iot(
+        "DELETE",
+        "/certificates/$(certificateId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_certificate(
     certificateId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return iot("DELETE", "/certificates/$(certificateId)", params; aws_config=aws_config)
+    return iot(
+        "DELETE",
+        "/certificates/$(certificateId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2126,14 +2388,25 @@ metricName set to your custom metric name.
 
 """
 function delete_custom_metric(metricName; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot("DELETE", "/custom-metric/$(metricName)"; aws_config=aws_config)
+    return iot(
+        "DELETE",
+        "/custom-metric/$(metricName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_custom_metric(
     metricName,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return iot("DELETE", "/custom-metric/$(metricName)", params; aws_config=aws_config)
+    return iot(
+        "DELETE",
+        "/custom-metric/$(metricName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2148,12 +2421,23 @@ to access the DeleteDimension action.
 
 """
 function delete_dimension(name; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot("DELETE", "/dimensions/$(name)"; aws_config=aws_config)
+    return iot(
+        "DELETE",
+        "/dimensions/$(name)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_dimension(
     name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("DELETE", "/dimensions/$(name)", params; aws_config=aws_config)
+    return iot(
+        "DELETE",
+        "/dimensions/$(name)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2171,7 +2455,10 @@ function delete_domain_configuration(
     domainConfigurationName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return iot(
-        "DELETE", "/domainConfigurations/$(domainConfigurationName)"; aws_config=aws_config
+        "DELETE",
+        "/domainConfigurations/$(domainConfigurationName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_domain_configuration(
@@ -2184,6 +2471,7 @@ function delete_domain_configuration(
         "/domainConfigurations/$(domainConfigurationName)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2204,7 +2492,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function delete_dynamic_thing_group(
     thingGroupName; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("DELETE", "/dynamic-thing-groups/$(thingGroupName)"; aws_config=aws_config)
+    return iot(
+        "DELETE",
+        "/dynamic-thing-groups/$(thingGroupName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_dynamic_thing_group(
     thingGroupName,
@@ -2212,7 +2505,11 @@ function delete_dynamic_thing_group(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return iot(
-        "DELETE", "/dynamic-thing-groups/$(thingGroupName)", params; aws_config=aws_config
+        "DELETE",
+        "/dynamic-thing-groups/$(thingGroupName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2232,14 +2529,25 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"expectedVersion"`: The expected version of the fleet metric to delete.
 """
 function delete_fleet_metric(metricName; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot("DELETE", "/fleet-metric/$(metricName)"; aws_config=aws_config)
+    return iot(
+        "DELETE",
+        "/fleet-metric/$(metricName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_fleet_metric(
     metricName,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return iot("DELETE", "/fleet-metric/$(metricName)", params; aws_config=aws_config)
+    return iot(
+        "DELETE",
+        "/fleet-metric/$(metricName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2273,12 +2581,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   is in public preview.
 """
 function delete_job(jobId; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot("DELETE", "/jobs/$(jobId)"; aws_config=aws_config)
+    return iot(
+        "DELETE", "/jobs/$(jobId)"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function delete_job(
     jobId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("DELETE", "/jobs/$(jobId)", params; aws_config=aws_config)
+    return iot(
+        "DELETE",
+        "/jobs/$(jobId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2316,6 +2632,7 @@ function delete_job_execution(
         "DELETE",
         "/things/$(thingName)/jobs/$(jobId)/executionNumber/$(executionNumber)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_job_execution(
@@ -2330,6 +2647,7 @@ function delete_job_execution(
         "/things/$(thingName)/jobs/$(jobId)/executionNumber/$(executionNumber)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2346,14 +2664,25 @@ Deletes the specified job template.
 function delete_job_template(
     jobTemplateId; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("DELETE", "/job-templates/$(jobTemplateId)"; aws_config=aws_config)
+    return iot(
+        "DELETE",
+        "/job-templates/$(jobTemplateId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_job_template(
     jobTemplateId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return iot("DELETE", "/job-templates/$(jobTemplateId)", params; aws_config=aws_config)
+    return iot(
+        "DELETE",
+        "/job-templates/$(jobTemplateId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2370,7 +2699,12 @@ permission to access the DeleteMitigationAction action.
 function delete_mitigation_action(
     actionName; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("DELETE", "/mitigationactions/actions/$(actionName)"; aws_config=aws_config)
+    return iot(
+        "DELETE",
+        "/mitigationactions/actions/$(actionName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_mitigation_action(
     actionName,
@@ -2378,7 +2712,11 @@ function delete_mitigation_action(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return iot(
-        "DELETE", "/mitigationactions/actions/$(actionName)", params; aws_config=aws_config
+        "DELETE",
+        "/mitigationactions/actions/$(actionName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2401,14 +2739,25 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   (\"COMPLETED\" or \"CANCELED\") an exception will occur. The default is false.
 """
 function delete_otaupdate(otaUpdateId; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot("DELETE", "/otaUpdates/$(otaUpdateId)"; aws_config=aws_config)
+    return iot(
+        "DELETE",
+        "/otaUpdates/$(otaUpdateId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_otaupdate(
     otaUpdateId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return iot("DELETE", "/otaUpdates/$(otaUpdateId)", params; aws_config=aws_config)
+    return iot(
+        "DELETE",
+        "/otaUpdates/$(otaUpdateId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2429,14 +2778,25 @@ the DeletePolicy action.
 
 """
 function delete_policy(policyName; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot("DELETE", "/policies/$(policyName)"; aws_config=aws_config)
+    return iot(
+        "DELETE",
+        "/policies/$(policyName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_policy(
     policyName,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return iot("DELETE", "/policies/$(policyName)", params; aws_config=aws_config)
+    return iot(
+        "DELETE",
+        "/policies/$(policyName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2460,6 +2820,7 @@ function delete_policy_version(
         "DELETE",
         "/policies/$(policyName)/version/$(policyVersionId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_policy_version(
@@ -2473,6 +2834,7 @@ function delete_policy_version(
         "/policies/$(policyName)/version/$(policyVersionId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2490,7 +2852,12 @@ DeleteProvisioningTemplate action.
 function delete_provisioning_template(
     templateName; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("DELETE", "/provisioning-templates/$(templateName)"; aws_config=aws_config)
+    return iot(
+        "DELETE",
+        "/provisioning-templates/$(templateName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_provisioning_template(
     templateName,
@@ -2498,7 +2865,11 @@ function delete_provisioning_template(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return iot(
-        "DELETE", "/provisioning-templates/$(templateName)", params; aws_config=aws_config
+        "DELETE",
+        "/provisioning-templates/$(templateName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2521,6 +2892,7 @@ function delete_provisioning_template_version(
         "DELETE",
         "/provisioning-templates/$(templateName)/versions/$(versionId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_provisioning_template_version(
@@ -2534,6 +2906,7 @@ function delete_provisioning_template_version(
         "/provisioning-templates/$(templateName)/versions/$(versionId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2546,12 +2919,23 @@ DeleteRegistrationCode action.
 
 """
 function delete_registration_code(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot("DELETE", "/registrationcode"; aws_config=aws_config)
+    return iot(
+        "DELETE",
+        "/registrationcode";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_registration_code(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("DELETE", "/registrationcode", params; aws_config=aws_config)
+    return iot(
+        "DELETE",
+        "/registrationcode",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2565,14 +2949,25 @@ Deletes a role alias Requires permission to access the DeleteRoleAlias action.
 
 """
 function delete_role_alias(roleAlias; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot("DELETE", "/role-aliases/$(roleAlias)"; aws_config=aws_config)
+    return iot(
+        "DELETE",
+        "/role-aliases/$(roleAlias)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_role_alias(
     roleAlias,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return iot("DELETE", "/role-aliases/$(roleAlias)", params; aws_config=aws_config)
+    return iot(
+        "DELETE",
+        "/role-aliases/$(roleAlias)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2589,7 +2984,10 @@ function delete_scheduled_audit(
     scheduledAuditName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return iot(
-        "DELETE", "/audit/scheduledaudits/$(scheduledAuditName)"; aws_config=aws_config
+        "DELETE",
+        "/audit/scheduledaudits/$(scheduledAuditName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_scheduled_audit(
@@ -2602,6 +3000,7 @@ function delete_scheduled_audit(
         "/audit/scheduledaudits/$(scheduledAuditName)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2624,7 +3023,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function delete_security_profile(
     securityProfileName; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("DELETE", "/security-profiles/$(securityProfileName)"; aws_config=aws_config)
+    return iot(
+        "DELETE",
+        "/security-profiles/$(securityProfileName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_security_profile(
     securityProfileName,
@@ -2632,7 +3036,11 @@ function delete_security_profile(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return iot(
-        "DELETE", "/security-profiles/$(securityProfileName)", params; aws_config=aws_config
+        "DELETE",
+        "/security-profiles/$(securityProfileName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2647,14 +3055,25 @@ Deletes a stream. Requires permission to access the DeleteStream action.
 
 """
 function delete_stream(streamId; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot("DELETE", "/streams/$(streamId)"; aws_config=aws_config)
+    return iot(
+        "DELETE",
+        "/streams/$(streamId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_stream(
     streamId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return iot("DELETE", "/streams/$(streamId)", params; aws_config=aws_config)
+    return iot(
+        "DELETE",
+        "/streams/$(streamId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2675,14 +3094,25 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   request, the DeleteThing request is rejected with a VersionConflictException.
 """
 function delete_thing(thingName; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot("DELETE", "/things/$(thingName)"; aws_config=aws_config)
+    return iot(
+        "DELETE",
+        "/things/$(thingName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_thing(
     thingName,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return iot("DELETE", "/things/$(thingName)", params; aws_config=aws_config)
+    return iot(
+        "DELETE",
+        "/things/$(thingName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2701,14 +3131,25 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function delete_thing_group(
     thingGroupName; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("DELETE", "/thing-groups/$(thingGroupName)"; aws_config=aws_config)
+    return iot(
+        "DELETE",
+        "/thing-groups/$(thingGroupName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_thing_group(
     thingGroupName,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return iot("DELETE", "/thing-groups/$(thingGroupName)", params; aws_config=aws_config)
+    return iot(
+        "DELETE",
+        "/thing-groups/$(thingGroupName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2726,14 +3167,25 @@ type. Requires permission to access the DeleteThingType action.
 
 """
 function delete_thing_type(thingTypeName; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot("DELETE", "/thing-types/$(thingTypeName)"; aws_config=aws_config)
+    return iot(
+        "DELETE",
+        "/thing-types/$(thingTypeName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_thing_type(
     thingTypeName,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return iot("DELETE", "/thing-types/$(thingTypeName)", params; aws_config=aws_config)
+    return iot(
+        "DELETE",
+        "/thing-types/$(thingTypeName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2747,14 +3199,25 @@ Deletes the rule. Requires permission to access the DeleteTopicRule action.
 
 """
 function delete_topic_rule(ruleName; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot("DELETE", "/rules/$(ruleName)"; aws_config=aws_config)
+    return iot(
+        "DELETE",
+        "/rules/$(ruleName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_topic_rule(
     ruleName,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return iot("DELETE", "/rules/$(ruleName)", params; aws_config=aws_config)
+    return iot(
+        "DELETE",
+        "/rules/$(ruleName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2771,12 +3234,23 @@ DeleteTopicRuleDestination action.
 function delete_topic_rule_destination(
     arn; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("DELETE", "/destinations/$(arn)"; aws_config=aws_config)
+    return iot(
+        "DELETE",
+        "/destinations/$(arn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_topic_rule_destination(
     arn, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("DELETE", "/destinations/$(arn)", params; aws_config=aws_config)
+    return iot(
+        "DELETE",
+        "/destinations/$(arn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2799,6 +3273,7 @@ function delete_v2_logging_level(
         "/v2LoggingLevel",
         Dict{String,Any}("targetName" => targetName, "targetType" => targetType);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_v2_logging_level(
@@ -2818,6 +3293,7 @@ function delete_v2_logging_level(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2839,7 +3315,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function deprecate_thing_type(
     thingTypeName; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("POST", "/thing-types/$(thingTypeName)/deprecate"; aws_config=aws_config)
+    return iot(
+        "POST",
+        "/thing-types/$(thingTypeName)/deprecate";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function deprecate_thing_type(
     thingTypeName,
@@ -2847,7 +3328,11 @@ function deprecate_thing_type(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return iot(
-        "POST", "/thing-types/$(thingTypeName)/deprecate", params; aws_config=aws_config
+        "POST",
+        "/thing-types/$(thingTypeName)/deprecate",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2863,12 +3348,23 @@ Requires permission to access the DescribeAccountAuditConfiguration action.
 function describe_account_audit_configuration(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("GET", "/audit/configuration"; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/audit/configuration";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_account_audit_configuration(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("GET", "/audit/configuration", params; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/audit/configuration",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2887,14 +3383,25 @@ the finding. Requires permission to access the DescribeAuditFinding action.
 function describe_audit_finding(
     findingId; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("GET", "/audit/findings/$(findingId)"; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/audit/findings/$(findingId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_audit_finding(
     findingId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return iot("GET", "/audit/findings/$(findingId)", params; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/audit/findings/$(findingId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2912,13 +3419,22 @@ which they're being applied, the task status, and aggregated task statistics.
 function describe_audit_mitigation_actions_task(
     taskId; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("GET", "/audit/mitigationactions/tasks/$(taskId)"; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/audit/mitigationactions/tasks/$(taskId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_audit_mitigation_actions_task(
     taskId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return iot(
-        "GET", "/audit/mitigationactions/tasks/$(taskId)", params; aws_config=aws_config
+        "GET",
+        "/audit/mitigationactions/tasks/$(taskId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2943,6 +3459,7 @@ function describe_audit_suppression(
             "checkName" => checkName, "resourceIdentifier" => resourceIdentifier
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_audit_suppression(
@@ -2964,6 +3481,7 @@ function describe_audit_suppression(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2979,12 +3497,23 @@ DescribeAuditTask action.
 
 """
 function describe_audit_task(taskId; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot("GET", "/audit/tasks/$(taskId)"; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/audit/tasks/$(taskId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_audit_task(
     taskId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("GET", "/audit/tasks/$(taskId)", params; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/audit/tasks/$(taskId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -3000,14 +3529,25 @@ Describes an authorizer. Requires permission to access the DescribeAuthorizer ac
 function describe_authorizer(
     authorizerName; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("GET", "/authorizer/$(authorizerName)"; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/authorizer/$(authorizerName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_authorizer(
     authorizerName,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return iot("GET", "/authorizer/$(authorizerName)", params; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/authorizer/$(authorizerName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -3024,14 +3564,25 @@ DescribeBillingGroup action.
 function describe_billing_group(
     billingGroupName; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("GET", "/billing-groups/$(billingGroupName)"; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/billing-groups/$(billingGroupName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_billing_group(
     billingGroupName,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return iot("GET", "/billing-groups/$(billingGroupName)", params; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/billing-groups/$(billingGroupName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -3048,14 +3599,25 @@ DescribeCACertificate action.
 function describe_cacertificate(
     caCertificateId; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("GET", "/cacertificate/$(caCertificateId)"; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/cacertificate/$(caCertificateId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_cacertificate(
     caCertificateId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return iot("GET", "/cacertificate/$(caCertificateId)", params; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/cacertificate/$(caCertificateId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -3073,14 +3635,25 @@ DescribeCertificate action.
 function describe_certificate(
     certificateId; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("GET", "/certificates/$(certificateId)"; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/certificates/$(certificateId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_certificate(
     certificateId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return iot("GET", "/certificates/$(certificateId)", params; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/certificates/$(certificateId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -3097,14 +3670,25 @@ access the DescribeCustomMetric action.
 function describe_custom_metric(
     metricName; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("GET", "/custom-metric/$(metricName)"; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/custom-metric/$(metricName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_custom_metric(
     metricName,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return iot("GET", "/custom-metric/$(metricName)", params; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/custom-metric/$(metricName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -3116,12 +3700,20 @@ DescribeDefaultAuthorizer action.
 
 """
 function describe_default_authorizer(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot("GET", "/default-authorizer"; aws_config=aws_config)
+    return iot(
+        "GET", "/default-authorizer"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_default_authorizer(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("GET", "/default-authorizer", params; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/default-authorizer",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -3138,13 +3730,22 @@ to access the DescribeDetectMitigationActionsTask action.
 function describe_detect_mitigation_actions_task(
     taskId; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("GET", "/detect/mitigationactions/tasks/$(taskId)"; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/detect/mitigationactions/tasks/$(taskId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_detect_mitigation_actions_task(
     taskId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return iot(
-        "GET", "/detect/mitigationactions/tasks/$(taskId)", params; aws_config=aws_config
+        "GET",
+        "/detect/mitigationactions/tasks/$(taskId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3160,12 +3761,20 @@ Requires permission to access the DescribeDimension action.
 
 """
 function describe_dimension(name; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot("GET", "/dimensions/$(name)"; aws_config=aws_config)
+    return iot(
+        "GET", "/dimensions/$(name)"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_dimension(
     name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("GET", "/dimensions/$(name)", params; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/dimensions/$(name)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -3183,7 +3792,10 @@ function describe_domain_configuration(
     domainConfigurationName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return iot(
-        "GET", "/domainConfigurations/$(domainConfigurationName)"; aws_config=aws_config
+        "GET",
+        "/domainConfigurations/$(domainConfigurationName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_domain_configuration(
@@ -3196,6 +3808,7 @@ function describe_domain_configuration(
         "/domainConfigurations/$(domainConfigurationName)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3216,12 +3829,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   widespread distrust of Symantec certificate authorities.
 """
 function describe_endpoint(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot("GET", "/endpoint"; aws_config=aws_config)
+    return iot("GET", "/endpoint"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function describe_endpoint(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("GET", "/endpoint", params; aws_config=aws_config)
+    return iot(
+        "GET", "/endpoint", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -3233,12 +3848,23 @@ DescribeEventConfigurations action.
 
 """
 function describe_event_configurations(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot("GET", "/event-configurations"; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/event-configurations";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_event_configurations(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("GET", "/event-configurations", params; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/event-configurations",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -3255,14 +3881,25 @@ DescribeFleetMetric action.
 function describe_fleet_metric(
     metricName; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("GET", "/fleet-metric/$(metricName)"; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/fleet-metric/$(metricName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_fleet_metric(
     metricName,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return iot("GET", "/fleet-metric/$(metricName)", params; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/fleet-metric/$(metricName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -3276,14 +3913,25 @@ Describes a search index. Requires permission to access the DescribeIndex action
 
 """
 function describe_index(indexName; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot("GET", "/indices/$(indexName)"; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/indices/$(indexName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_index(
     indexName,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return iot("GET", "/indices/$(indexName)", params; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/indices/$(indexName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -3297,12 +3945,20 @@ Describes a job. Requires permission to access the DescribeJob action.
 
 """
 function describe_job(jobId; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot("GET", "/jobs/$(jobId)"; aws_config=aws_config)
+    return iot(
+        "GET", "/jobs/$(jobId)"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_job(
     jobId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("GET", "/jobs/$(jobId)", params; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/jobs/$(jobId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -3323,7 +3979,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_job_execution(
     jobId, thingName; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("GET", "/things/$(thingName)/jobs/$(jobId)"; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/things/$(thingName)/jobs/$(jobId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_job_execution(
     jobId,
@@ -3331,7 +3992,13 @@ function describe_job_execution(
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return iot("GET", "/things/$(thingName)/jobs/$(jobId)", params; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/things/$(thingName)/jobs/$(jobId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -3347,14 +4014,25 @@ Returns information about a job template.
 function describe_job_template(
     jobTemplateId; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("GET", "/job-templates/$(jobTemplateId)"; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/job-templates/$(jobTemplateId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_job_template(
     jobTemplateId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return iot("GET", "/job-templates/$(jobTemplateId)", params; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/job-templates/$(jobTemplateId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -3371,7 +4049,12 @@ DescribeMitigationAction action.
 function describe_mitigation_action(
     actionName; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("GET", "/mitigationactions/actions/$(actionName)"; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/mitigationactions/actions/$(actionName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_mitigation_action(
     actionName,
@@ -3379,7 +4062,11 @@ function describe_mitigation_action(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return iot(
-        "GET", "/mitigationactions/actions/$(actionName)", params; aws_config=aws_config
+        "GET",
+        "/mitigationactions/actions/$(actionName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3397,7 +4084,12 @@ DescribeProvisioningTemplate action.
 function describe_provisioning_template(
     templateName; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("GET", "/provisioning-templates/$(templateName)"; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/provisioning-templates/$(templateName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_provisioning_template(
     templateName,
@@ -3405,7 +4097,11 @@ function describe_provisioning_template(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return iot(
-        "GET", "/provisioning-templates/$(templateName)", params; aws_config=aws_config
+        "GET",
+        "/provisioning-templates/$(templateName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3428,6 +4124,7 @@ function describe_provisioning_template_version(
         "GET",
         "/provisioning-templates/$(templateName)/versions/$(versionId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_provisioning_template_version(
@@ -3441,6 +4138,7 @@ function describe_provisioning_template_version(
         "/provisioning-templates/$(templateName)/versions/$(versionId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3455,14 +4153,25 @@ Describes a role alias. Requires permission to access the DescribeRoleAlias acti
 
 """
 function describe_role_alias(roleAlias; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot("GET", "/role-aliases/$(roleAlias)"; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/role-aliases/$(roleAlias)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_role_alias(
     roleAlias,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return iot("GET", "/role-aliases/$(roleAlias)", params; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/role-aliases/$(roleAlias)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -3479,7 +4188,12 @@ DescribeScheduledAudit action.
 function describe_scheduled_audit(
     scheduledAuditName; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("GET", "/audit/scheduledaudits/$(scheduledAuditName)"; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/audit/scheduledaudits/$(scheduledAuditName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_scheduled_audit(
     scheduledAuditName,
@@ -3487,7 +4201,11 @@ function describe_scheduled_audit(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return iot(
-        "GET", "/audit/scheduledaudits/$(scheduledAuditName)", params; aws_config=aws_config
+        "GET",
+        "/audit/scheduledaudits/$(scheduledAuditName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3506,7 +4224,12 @@ the DescribeSecurityProfile action.
 function describe_security_profile(
     securityProfileName; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("GET", "/security-profiles/$(securityProfileName)"; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/security-profiles/$(securityProfileName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_security_profile(
     securityProfileName,
@@ -3514,7 +4237,11 @@ function describe_security_profile(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return iot(
-        "GET", "/security-profiles/$(securityProfileName)", params; aws_config=aws_config
+        "GET",
+        "/security-profiles/$(securityProfileName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3529,14 +4256,25 @@ Gets information about a stream. Requires permission to access the DescribeStrea
 
 """
 function describe_stream(streamId; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot("GET", "/streams/$(streamId)"; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/streams/$(streamId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_stream(
     streamId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return iot("GET", "/streams/$(streamId)", params; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/streams/$(streamId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -3551,14 +4289,25 @@ action.
 
 """
 function describe_thing(thingName; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot("GET", "/things/$(thingName)"; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/things/$(thingName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_thing(
     thingName,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return iot("GET", "/things/$(thingName)", params; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/things/$(thingName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -3574,14 +4323,25 @@ Describe a thing group. Requires permission to access the DescribeThingGroup act
 function describe_thing_group(
     thingGroupName; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("GET", "/thing-groups/$(thingGroupName)"; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/thing-groups/$(thingGroupName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_thing_group(
     thingGroupName,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return iot("GET", "/thing-groups/$(thingGroupName)", params; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/thing-groups/$(thingGroupName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -3598,12 +4358,23 @@ DescribeThingRegistrationTask action.
 function describe_thing_registration_task(
     taskId; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("GET", "/thing-registration-tasks/$(taskId)"; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/thing-registration-tasks/$(taskId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_thing_registration_task(
     taskId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("GET", "/thing-registration-tasks/$(taskId)", params; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/thing-registration-tasks/$(taskId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -3620,14 +4391,25 @@ DescribeThingType action.
 function describe_thing_type(
     thingTypeName; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("GET", "/thing-types/$(thingTypeName)"; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/thing-types/$(thingTypeName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_thing_type(
     thingTypeName,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return iot("GET", "/thing-types/$(thingTypeName)", params; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/thing-types/$(thingTypeName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -3651,6 +4433,7 @@ function detach_policy(
         "/target-policies/$(policyName)",
         Dict{String,Any}("target" => target);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function detach_policy(
@@ -3664,6 +4447,7 @@ function detach_policy(
         "/target-policies/$(policyName)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("target" => target), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3692,6 +4476,7 @@ function detach_principal_policy(
             "headers" => Dict{String,Any}("x-amzn-iot-principal" => x_amzn_iot_principal)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function detach_principal_policy(
@@ -3714,6 +4499,7 @@ function detach_principal_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3740,6 +4526,7 @@ function detach_security_profile(
         "/security-profiles/$(securityProfileName)/targets",
         Dict{String,Any}("securityProfileTargetArn" => securityProfileTargetArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function detach_security_profile(
@@ -3759,6 +4546,7 @@ function detach_security_profile(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3788,6 +4576,7 @@ function detach_thing_principal(
             "headers" => Dict{String,Any}("x-amzn-principal" => x_amzn_principal)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function detach_thing_principal(
@@ -3809,6 +4598,7 @@ function detach_thing_principal(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3823,14 +4613,25 @@ Disables the rule. Requires permission to access the DisableTopicRule action.
 
 """
 function disable_topic_rule(ruleName; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot("POST", "/rules/$(ruleName)/disable"; aws_config=aws_config)
+    return iot(
+        "POST",
+        "/rules/$(ruleName)/disable";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function disable_topic_rule(
     ruleName,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return iot("POST", "/rules/$(ruleName)/disable", params; aws_config=aws_config)
+    return iot(
+        "POST",
+        "/rules/$(ruleName)/disable",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -3844,14 +4645,25 @@ Enables the rule. Requires permission to access the EnableTopicRule action.
 
 """
 function enable_topic_rule(ruleName; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot("POST", "/rules/$(ruleName)/enable"; aws_config=aws_config)
+    return iot(
+        "POST",
+        "/rules/$(ruleName)/enable";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function enable_topic_rule(
     ruleName,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return iot("POST", "/rules/$(ruleName)/enable", params; aws_config=aws_config)
+    return iot(
+        "POST",
+        "/rules/$(ruleName)/enable",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -3870,12 +4682,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function get_behavior_model_training_summaries(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("GET", "/behavior-model-training/summaries"; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/behavior-model-training/summaries";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_behavior_model_training_summaries(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("GET", "/behavior-model-training/summaries", params; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/behavior-model-training/summaries",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -3911,6 +4734,7 @@ function get_buckets_aggregation(
             "queryString" => queryString,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_buckets_aggregation(
@@ -3935,6 +4759,7 @@ function get_buckets_aggregation(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3960,6 +4785,7 @@ function get_cardinality(queryString; aws_config::AbstractAWSConfig=global_aws_c
         "/indices/cardinality",
         Dict{String,Any}("queryString" => queryString);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_cardinality(
@@ -3974,6 +4800,7 @@ function get_cardinality(
             mergewith(_merge, Dict{String,Any}("queryString" => queryString), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3994,12 +4821,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"thingName"`: The thing name.
 """
 function get_effective_policies(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot("POST", "/effective-policies"; aws_config=aws_config)
+    return iot(
+        "POST",
+        "/effective-policies";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_effective_policies(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("POST", "/effective-policies", params; aws_config=aws_config)
+    return iot(
+        "POST",
+        "/effective-policies",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -4011,12 +4849,20 @@ action.
 
 """
 function get_indexing_configuration(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot("GET", "/indexing/config"; aws_config=aws_config)
+    return iot(
+        "GET", "/indexing/config"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_indexing_configuration(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("GET", "/indexing/config", params; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/indexing/config",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -4030,12 +4876,23 @@ Gets a job document. Requires permission to access the GetJobDocument action.
 
 """
 function get_job_document(jobId; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot("GET", "/jobs/$(jobId)/job-document"; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/jobs/$(jobId)/job-document";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_job_document(
     jobId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("GET", "/jobs/$(jobId)/job-document", params; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/jobs/$(jobId)/job-document",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -4047,12 +4904,20 @@ GetV2LoggingOptions instead. Requires permission to access the GetLoggingOptions
 
 """
 function get_logging_options(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot("GET", "/loggingOptions"; aws_config=aws_config)
+    return iot(
+        "GET", "/loggingOptions"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_logging_options(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("GET", "/loggingOptions", params; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/loggingOptions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -4066,14 +4931,25 @@ Gets an OTA update. Requires permission to access the GetOTAUpdate action.
 
 """
 function get_otaupdate(otaUpdateId; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot("GET", "/otaUpdates/$(otaUpdateId)"; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/otaUpdates/$(otaUpdateId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_otaupdate(
     otaUpdateId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return iot("GET", "/otaUpdates/$(otaUpdateId)", params; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/otaUpdates/$(otaUpdateId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -4106,6 +4982,7 @@ function get_percentiles(queryString; aws_config::AbstractAWSConfig=global_aws_c
         "/indices/percentiles",
         Dict{String,Any}("queryString" => queryString);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_percentiles(
@@ -4120,6 +4997,7 @@ function get_percentiles(
             mergewith(_merge, Dict{String,Any}("queryString" => queryString), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4135,14 +5013,25 @@ version. Requires permission to access the GetPolicy action.
 
 """
 function get_policy(policyName; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot("GET", "/policies/$(policyName)"; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/policies/$(policyName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_policy(
     policyName,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return iot("GET", "/policies/$(policyName)", params; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/policies/$(policyName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -4161,7 +5050,10 @@ function get_policy_version(
     policyName, policyVersionId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return iot(
-        "GET", "/policies/$(policyName)/version/$(policyVersionId)"; aws_config=aws_config
+        "GET",
+        "/policies/$(policyName)/version/$(policyVersionId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_policy_version(
@@ -4175,6 +5067,7 @@ function get_policy_version(
         "/policies/$(policyName)/version/$(policyVersionId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4187,12 +5080,20 @@ access the GetRegistrationCode action.
 
 """
 function get_registration_code(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot("GET", "/registrationcode"; aws_config=aws_config)
+    return iot(
+        "GET", "/registrationcode"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_registration_code(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("GET", "/registrationcode", params; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/registrationcode",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -4220,6 +5121,7 @@ function get_statistics(queryString; aws_config::AbstractAWSConfig=global_aws_co
         "/indices/statistics",
         Dict{String,Any}("queryString" => queryString);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_statistics(
@@ -4234,6 +5136,7 @@ function get_statistics(
             mergewith(_merge, Dict{String,Any}("queryString" => queryString), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4248,14 +5151,22 @@ Gets information about the rule. Requires permission to access the GetTopicRule 
 
 """
 function get_topic_rule(ruleName; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot("GET", "/rules/$(ruleName)"; aws_config=aws_config)
+    return iot(
+        "GET", "/rules/$(ruleName)"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_topic_rule(
     ruleName,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return iot("GET", "/rules/$(ruleName)", params; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/rules/$(ruleName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -4270,12 +5181,23 @@ GetTopicRuleDestination action.
 
 """
 function get_topic_rule_destination(arn; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot("GET", "/destinations/$(arn)"; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/destinations/$(arn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_topic_rule_destination(
     arn, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("GET", "/destinations/$(arn)", params; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/destinations/$(arn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -4287,12 +5209,20 @@ GetV2LoggingOptions action.
 
 """
 function get_v2_logging_options(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot("GET", "/v2LoggingOptions"; aws_config=aws_config)
+    return iot(
+        "GET", "/v2LoggingOptions"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_v2_logging_options(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("GET", "/v2LoggingOptions", params; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/v2LoggingOptions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -4314,12 +5244,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"verificationState"`: The verification state of the violation (detect alarm).
 """
 function list_active_violations(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot("GET", "/active-violations"; aws_config=aws_config)
+    return iot(
+        "GET", "/active-violations"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_active_violations(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("GET", "/active-violations", params; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/active-violations",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -4341,12 +5279,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"recursive"`: When true, recursively list attached policies.
 """
 function list_attached_policies(target; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot("POST", "/attached-policies/$(target)"; aws_config=aws_config)
+    return iot(
+        "POST",
+        "/attached-policies/$(target)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_attached_policies(
     target, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("POST", "/attached-policies/$(target)", params; aws_config=aws_config)
+    return iot(
+        "POST",
+        "/attached-policies/$(target)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -4374,12 +5323,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   specify either the taskId or the startTime and endTime, but not both.
 """
 function list_audit_findings(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot("POST", "/audit/findings"; aws_config=aws_config)
+    return iot(
+        "POST", "/audit/findings"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_audit_findings(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("POST", "/audit/findings", params; aws_config=aws_config)
+    return iot(
+        "POST",
+        "/audit/findings",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -4409,6 +5366,7 @@ function list_audit_mitigation_actions_executions(
         "/audit/mitigationactions/executions",
         Dict{String,Any}("findingId" => findingId, "taskId" => taskId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_audit_mitigation_actions_executions(
@@ -4428,6 +5386,7 @@ function list_audit_mitigation_actions_executions(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4463,6 +5422,7 @@ function list_audit_mitigation_actions_tasks(
         "/audit/mitigationactions/tasks",
         Dict{String,Any}("endTime" => endTime, "startTime" => startTime);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_audit_mitigation_actions_tasks(
@@ -4482,6 +5442,7 @@ function list_audit_mitigation_actions_tasks(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4502,12 +5463,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"resourceIdentifier"`:
 """
 function list_audit_suppressions(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot("POST", "/audit/suppressions/list"; aws_config=aws_config)
+    return iot(
+        "POST",
+        "/audit/suppressions/list";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_audit_suppressions(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("POST", "/audit/suppressions/list", params; aws_config=aws_config)
+    return iot(
+        "POST",
+        "/audit/suppressions/list",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -4540,6 +5512,7 @@ function list_audit_tasks(
         "/audit/tasks",
         Dict{String,Any}("endTime" => endTime, "startTime" => startTime);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_audit_tasks(
@@ -4559,6 +5532,7 @@ function list_audit_tasks(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4577,12 +5551,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"status"`: The status of the list authorizers request.
 """
 function list_authorizers(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot("GET", "/authorizers/"; aws_config=aws_config)
+    return iot(
+        "GET", "/authorizers/"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_authorizers(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("GET", "/authorizers/", params; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/authorizers/",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -4601,12 +5583,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   response; otherwise null to receive the first set of results.
 """
 function list_billing_groups(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot("GET", "/billing-groups"; aws_config=aws_config)
+    return iot(
+        "GET", "/billing-groups"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_billing_groups(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("GET", "/billing-groups", params; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/billing-groups",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -4624,12 +5614,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"pageSize"`: The result page size.
 """
 function list_cacertificates(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot("GET", "/cacertificates"; aws_config=aws_config)
+    return iot(
+        "GET", "/cacertificates"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_cacertificates(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("GET", "/cacertificates", params; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/cacertificates",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -4648,12 +5646,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"pageSize"`: The result page size.
 """
 function list_certificates(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot("GET", "/certificates"; aws_config=aws_config)
+    return iot(
+        "GET", "/certificates"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_certificates(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("GET", "/certificates", params; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/certificates",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -4677,7 +5683,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function list_certificates_by_ca(
     caCertificateId; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("GET", "/certificates-by-ca/$(caCertificateId)"; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/certificates-by-ca/$(caCertificateId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_certificates_by_ca(
     caCertificateId,
@@ -4685,7 +5696,11 @@ function list_certificates_by_ca(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return iot(
-        "GET", "/certificates-by-ca/$(caCertificateId)", params; aws_config=aws_config
+        "GET",
+        "/certificates-by-ca/$(caCertificateId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4702,12 +5717,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`:  The token for the next set of results.
 """
 function list_custom_metrics(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot("GET", "/custom-metrics"; aws_config=aws_config)
+    return iot(
+        "GET", "/custom-metrics"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_custom_metrics(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("GET", "/custom-metrics", params; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/custom-metrics",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -4732,12 +5755,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function list_detect_mitigation_actions_executions(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("GET", "/detect/mitigationactions/executions"; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/detect/mitigationactions/executions";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_detect_mitigation_actions_executions(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("GET", "/detect/mitigationactions/executions", params; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/detect/mitigationactions/executions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -4766,6 +5800,7 @@ function list_detect_mitigation_actions_tasks(
         "/detect/mitigationactions/tasks",
         Dict{String,Any}("endTime" => endTime, "startTime" => startTime);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_detect_mitigation_actions_tasks(
@@ -4785,6 +5820,7 @@ function list_detect_mitigation_actions_tasks(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4801,12 +5837,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: The token for the next set of results.
 """
 function list_dimensions(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot("GET", "/dimensions"; aws_config=aws_config)
+    return iot("GET", "/dimensions"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_dimensions(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("GET", "/dimensions", params; aws_config=aws_config)
+    return iot(
+        "GET", "/dimensions", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -4824,12 +5862,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"serviceType"`: The type of service delivered by the endpoint.
 """
 function list_domain_configurations(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot("GET", "/domainConfigurations"; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/domainConfigurations";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_domain_configurations(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("GET", "/domainConfigurations", params; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/domainConfigurations",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -4845,12 +5894,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   response; otherwise null to receive the first set of results.
 """
 function list_fleet_metrics(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot("GET", "/fleet-metrics"; aws_config=aws_config)
+    return iot(
+        "GET", "/fleet-metrics"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_fleet_metrics(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("GET", "/fleet-metrics", params; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/fleet-metrics",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -4866,12 +5923,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   additional results.
 """
 function list_indices(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot("GET", "/indices"; aws_config=aws_config)
+    return iot("GET", "/indices"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_indices(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("GET", "/indices", params; aws_config=aws_config)
+    return iot(
+        "GET", "/indices", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -4893,12 +5952,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function list_job_executions_for_job(
     jobId; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("GET", "/jobs/$(jobId)/things"; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/jobs/$(jobId)/things";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_job_executions_for_job(
     jobId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("GET", "/jobs/$(jobId)/things", params; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/jobs/$(jobId)/things",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -4926,14 +5996,25 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function list_job_executions_for_thing(
     thingName; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("GET", "/things/$(thingName)/jobs"; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/things/$(thingName)/jobs";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_job_executions_for_thing(
     thingName,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return iot("GET", "/things/$(thingName)/jobs", params; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/things/$(thingName)/jobs",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -4948,12 +6029,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: The token to use to return the next set of results in the list.
 """
 function list_job_templates(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot("GET", "/job-templates"; aws_config=aws_config)
+    return iot(
+        "GET", "/job-templates"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_job_templates(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("GET", "/job-templates", params; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/job-templates",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -4983,12 +6072,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   group.
 """
 function list_jobs(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot("GET", "/jobs"; aws_config=aws_config)
+    return iot("GET", "/jobs"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_jobs(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("GET", "/jobs", params; aws_config=aws_config)
+    return iot(
+        "GET", "/jobs", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -5006,12 +6097,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: The token for the next set of results.
 """
 function list_mitigation_actions(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot("GET", "/mitigationactions/actions"; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/mitigationactions/actions";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_mitigation_actions(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("GET", "/mitigationactions/actions", params; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/mitigationactions/actions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -5027,12 +6129,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"otaUpdateStatus"`: The OTA update job status.
 """
 function list_otaupdates(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot("GET", "/otaUpdates"; aws_config=aws_config)
+    return iot("GET", "/otaUpdates"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_otaupdates(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("GET", "/otaUpdates", params; aws_config=aws_config)
+    return iot(
+        "GET", "/otaUpdates", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -5050,12 +6154,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"pageSize"`: The result page size.
 """
 function list_outgoing_certificates(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot("GET", "/certificates-out-going"; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/certificates-out-going";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_outgoing_certificates(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("GET", "/certificates-out-going", params; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/certificates-out-going",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -5072,12 +6187,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"pageSize"`: The result page size.
 """
 function list_policies(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot("GET", "/policies"; aws_config=aws_config)
+    return iot("GET", "/policies"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_policies(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("GET", "/policies", params; aws_config=aws_config)
+    return iot(
+        "GET", "/policies", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -5108,6 +6225,7 @@ function list_policy_principals(
             "headers" => Dict{String,Any}("x-amzn-iot-policy" => x_amzn_iot_policy)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_policy_principals(
@@ -5128,6 +6246,7 @@ function list_policy_principals(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5143,14 +6262,25 @@ permission to access the ListPolicyVersions action.
 
 """
 function list_policy_versions(policyName; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot("GET", "/policies/$(policyName)/version"; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/policies/$(policyName)/version";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_policy_versions(
     policyName,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return iot("GET", "/policies/$(policyName)/version", params; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/policies/$(policyName)/version",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -5184,6 +6314,7 @@ function list_principal_policies(
             "headers" => Dict{String,Any}("x-amzn-iot-principal" => x_amzn_iot_principal)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_principal_policies(
@@ -5205,6 +6336,7 @@ function list_principal_policies(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5235,6 +6367,7 @@ function list_principal_things(
             "headers" => Dict{String,Any}("x-amzn-principal" => x_amzn_principal)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_principal_things(
@@ -5255,6 +6388,7 @@ function list_principal_things(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5277,7 +6411,10 @@ function list_provisioning_template_versions(
     templateName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return iot(
-        "GET", "/provisioning-templates/$(templateName)/versions"; aws_config=aws_config
+        "GET",
+        "/provisioning-templates/$(templateName)/versions";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_provisioning_template_versions(
@@ -5290,6 +6427,7 @@ function list_provisioning_template_versions(
         "/provisioning-templates/$(templateName)/versions",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5306,12 +6444,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: A token to retrieve the next set of results.
 """
 function list_provisioning_templates(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot("GET", "/provisioning-templates"; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/provisioning-templates";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_provisioning_templates(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("GET", "/provisioning-templates", params; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/provisioning-templates",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -5328,12 +6477,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"pageSize"`: The maximum number of results to return at one time.
 """
 function list_role_aliases(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot("GET", "/role-aliases"; aws_config=aws_config)
+    return iot(
+        "GET", "/role-aliases"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_role_aliases(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("GET", "/role-aliases", params; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/role-aliases",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -5349,12 +6506,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: The token for the next set of results.
 """
 function list_scheduled_audits(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot("GET", "/audit/scheduledaudits"; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/audit/scheduledaudits";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_scheduled_audits(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("GET", "/audit/scheduledaudits", params; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/audit/scheduledaudits",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -5375,12 +6543,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: The token for the next set of results.
 """
 function list_security_profiles(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot("GET", "/security-profiles"; aws_config=aws_config)
+    return iot(
+        "GET", "/security-profiles"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_security_profiles(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("GET", "/security-profiles", params; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/security-profiles",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -5408,6 +6584,7 @@ function list_security_profiles_for_target(
         "/security-profiles-for-target",
         Dict{String,Any}("securityProfileTargetArn" => securityProfileTargetArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_security_profiles_for_target(
@@ -5426,6 +6603,7 @@ function list_security_profiles_for_target(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5443,12 +6621,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: A token used to get the next set of results.
 """
 function list_streams(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot("GET", "/streams"; aws_config=aws_config)
+    return iot("GET", "/streams"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_streams(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("GET", "/streams", params; aws_config=aws_config)
+    return iot(
+        "GET", "/streams", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -5474,6 +6654,7 @@ function list_tags_for_resource(
         "/tags",
         Dict{String,Any}("resourceArn" => resourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags_for_resource(
@@ -5488,6 +6669,7 @@ function list_tags_for_resource(
             mergewith(_merge, Dict{String,Any}("resourceArn" => resourceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5509,14 +6691,25 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function list_targets_for_policy(
     policyName; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("POST", "/policy-targets/$(policyName)"; aws_config=aws_config)
+    return iot(
+        "POST",
+        "/policy-targets/$(policyName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_targets_for_policy(
     policyName,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return iot("POST", "/policy-targets/$(policyName)", params; aws_config=aws_config)
+    return iot(
+        "POST",
+        "/policy-targets/$(policyName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -5538,7 +6731,10 @@ function list_targets_for_security_profile(
     securityProfileName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return iot(
-        "GET", "/security-profiles/$(securityProfileName)/targets"; aws_config=aws_config
+        "GET",
+        "/security-profiles/$(securityProfileName)/targets";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_targets_for_security_profile(
@@ -5551,6 +6747,7 @@ function list_targets_for_security_profile(
         "/security-profiles/$(securityProfileName)/targets",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5573,12 +6770,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"recursive"`: If true, return child groups as well.
 """
 function list_thing_groups(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot("GET", "/thing-groups"; aws_config=aws_config)
+    return iot(
+        "GET", "/thing-groups"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_thing_groups(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("GET", "/thing-groups", params; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/thing-groups",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -5600,14 +6805,25 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function list_thing_groups_for_thing(
     thingName; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("GET", "/things/$(thingName)/thing-groups"; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/things/$(thingName)/thing-groups";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_thing_groups_for_thing(
     thingName,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return iot("GET", "/things/$(thingName)/thing-groups", params; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/things/$(thingName)/thing-groups",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -5628,14 +6844,25 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   response; otherwise null to receive the first set of results.
 """
 function list_thing_principals(thingName; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot("GET", "/things/$(thingName)/principals"; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/things/$(thingName)/principals";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_thing_principals(
     thingName,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return iot("GET", "/things/$(thingName)/principals", params; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/things/$(thingName)/principals",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -5662,6 +6889,7 @@ function list_thing_registration_task_reports(
         "/thing-registration-tasks/$(taskId)/reports",
         Dict{String,Any}("reportType" => reportType);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_thing_registration_task_reports(
@@ -5677,6 +6905,7 @@ function list_thing_registration_task_reports(
             mergewith(_merge, Dict{String,Any}("reportType" => reportType), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5695,12 +6924,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"status"`: The status of the bulk thing provisioning task.
 """
 function list_thing_registration_tasks(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot("GET", "/thing-registration-tasks"; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/thing-registration-tasks";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_thing_registration_tasks(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("GET", "/thing-registration-tasks", params; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/thing-registration-tasks",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -5717,12 +6957,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"thingTypeName"`: The name of the thing type.
 """
 function list_thing_types(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot("GET", "/thing-types"; aws_config=aws_config)
+    return iot(
+        "GET", "/thing-types"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_thing_types(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("GET", "/thing-types", params; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/thing-types",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -5751,12 +6999,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   attributeValue provided.
 """
 function list_things(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot("GET", "/things"; aws_config=aws_config)
+    return iot("GET", "/things"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_things(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("GET", "/things", params; aws_config=aws_config)
+    return iot(
+        "GET", "/things", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -5778,7 +7028,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function list_things_in_billing_group(
     billingGroupName; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("GET", "/billing-groups/$(billingGroupName)/things"; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/billing-groups/$(billingGroupName)/things";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_things_in_billing_group(
     billingGroupName,
@@ -5786,7 +7041,11 @@ function list_things_in_billing_group(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return iot(
-        "GET", "/billing-groups/$(billingGroupName)/things", params; aws_config=aws_config
+        "GET",
+        "/billing-groups/$(billingGroupName)/things",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5810,7 +7069,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function list_things_in_thing_group(
     thingGroupName; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("GET", "/thing-groups/$(thingGroupName)/things"; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/thing-groups/$(thingGroupName)/things";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_things_in_thing_group(
     thingGroupName,
@@ -5818,7 +7082,11 @@ function list_things_in_thing_group(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return iot(
-        "GET", "/thing-groups/$(thingGroupName)/things", params; aws_config=aws_config
+        "GET",
+        "/thing-groups/$(thingGroupName)/things",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5836,12 +7104,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   response; otherwise null to receive the first set of results.
 """
 function list_topic_rule_destinations(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot("GET", "/destinations"; aws_config=aws_config)
+    return iot(
+        "GET", "/destinations"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_topic_rule_destinations(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("GET", "/destinations", params; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/destinations",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -5860,12 +7136,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"topic"`: The topic.
 """
 function list_topic_rules(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot("GET", "/rules"; aws_config=aws_config)
+    return iot("GET", "/rules"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_topic_rules(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("GET", "/rules", params; aws_config=aws_config)
+    return iot(
+        "GET", "/rules", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -5883,12 +7161,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   THING_Group.
 """
 function list_v2_logging_levels(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot("GET", "/v2LoggingLevel"; aws_config=aws_config)
+    return iot(
+        "GET", "/v2LoggingLevel"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_v2_logging_levels(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("GET", "/v2LoggingLevel", params; aws_config=aws_config)
+    return iot(
+        "GET",
+        "/v2LoggingLevel",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -5923,6 +7209,7 @@ function list_violation_events(
         "/violation-events",
         Dict{String,Any}("endTime" => endTime, "startTime" => startTime);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_violation_events(
@@ -5942,6 +7229,7 @@ function list_violation_events(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5969,6 +7257,7 @@ function put_verification_state_on_violation(
         "/violations/verification-state/$(violationId)",
         Dict{String,Any}("verificationState" => verificationState);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_verification_state_on_violation(
@@ -5986,6 +7275,7 @@ function put_verification_state_on_violation(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6029,6 +7319,7 @@ function register_cacertificate(
             "verificationCertificate" => verificationCertificate,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function register_cacertificate(
@@ -6051,6 +7342,7 @@ function register_cacertificate(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6081,6 +7373,7 @@ function register_certificate(
         "/certificate/register",
         Dict{String,Any}("certificatePem" => certificatePem);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function register_certificate(
@@ -6095,6 +7388,7 @@ function register_certificate(
             mergewith(_merge, Dict{String,Any}("certificatePem" => certificatePem), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6119,6 +7413,7 @@ function register_certificate_without_ca(
         "/certificate/register-no-ca",
         Dict{String,Any}("certificatePem" => certificatePem);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function register_certificate_without_ca(
@@ -6133,6 +7428,7 @@ function register_certificate_without_ca(
             mergewith(_merge, Dict{String,Any}("certificatePem" => certificatePem), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6160,6 +7456,7 @@ function register_thing(templateBody; aws_config::AbstractAWSConfig=global_aws_c
         "/things",
         Dict{String,Any}("templateBody" => templateBody);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function register_thing(
@@ -6174,6 +7471,7 @@ function register_thing(
             mergewith(_merge, Dict{String,Any}("templateBody" => templateBody), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6200,7 +7498,10 @@ function reject_certificate_transfer(
     certificateId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return iot(
-        "PATCH", "/reject-certificate-transfer/$(certificateId)"; aws_config=aws_config
+        "PATCH",
+        "/reject-certificate-transfer/$(certificateId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function reject_certificate_transfer(
@@ -6213,6 +7514,7 @@ function reject_certificate_transfer(
         "/reject-certificate-transfer/$(certificateId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6233,13 +7535,22 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function remove_thing_from_billing_group(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("PUT", "/billing-groups/removeThingFromBillingGroup"; aws_config=aws_config)
+    return iot(
+        "PUT",
+        "/billing-groups/removeThingFromBillingGroup";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function remove_thing_from_billing_group(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return iot(
-        "PUT", "/billing-groups/removeThingFromBillingGroup", params; aws_config=aws_config
+        "PUT",
+        "/billing-groups/removeThingFromBillingGroup",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6260,13 +7571,22 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"thingName"`: The name of the thing to remove from the group.
 """
 function remove_thing_from_thing_group(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot("PUT", "/thing-groups/removeThingFromThingGroup"; aws_config=aws_config)
+    return iot(
+        "PUT",
+        "/thing-groups/removeThingFromThingGroup";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function remove_thing_from_thing_group(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return iot(
-        "PUT", "/thing-groups/removeThingFromThingGroup", params; aws_config=aws_config
+        "PUT",
+        "/thing-groups/removeThingFromThingGroup",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6292,6 +7612,7 @@ function replace_topic_rule(
         "/rules/$(ruleName)",
         Dict{String,Any}("topicRulePayload" => topicRulePayload);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function replace_topic_rule(
@@ -6309,6 +7630,7 @@ function replace_topic_rule(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6335,6 +7657,7 @@ function search_index(queryString; aws_config::AbstractAWSConfig=global_aws_conf
         "/indices/search",
         Dict{String,Any}("queryString" => queryString);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function search_index(
@@ -6349,6 +7672,7 @@ function search_index(
             mergewith(_merge, Dict{String,Any}("queryString" => queryString), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6371,6 +7695,7 @@ function set_default_authorizer(
         "/default-authorizer",
         Dict{String,Any}("authorizerName" => authorizerName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function set_default_authorizer(
@@ -6385,6 +7710,7 @@ function set_default_authorizer(
             mergewith(_merge, Dict{String,Any}("authorizerName" => authorizerName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6406,7 +7732,10 @@ function set_default_policy_version(
     policyName, policyVersionId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return iot(
-        "PATCH", "/policies/$(policyName)/version/$(policyVersionId)"; aws_config=aws_config
+        "PATCH",
+        "/policies/$(policyName)/version/$(policyVersionId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function set_default_policy_version(
@@ -6420,6 +7749,7 @@ function set_default_policy_version(
         "/policies/$(policyName)/version/$(policyVersionId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6442,6 +7772,7 @@ function set_logging_options(
         "/loggingOptions",
         Dict{String,Any}("loggingOptionsPayload" => loggingOptionsPayload);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function set_logging_options(
@@ -6460,6 +7791,7 @@ function set_logging_options(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6482,6 +7814,7 @@ function set_v2_logging_level(
         "/v2LoggingLevel",
         Dict{String,Any}("logLevel" => logLevel, "logTarget" => logTarget);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function set_v2_logging_level(
@@ -6501,6 +7834,7 @@ function set_v2_logging_level(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6518,12 +7852,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"roleArn"`: The ARN of the role that allows IoT to write to Cloudwatch logs.
 """
 function set_v2_logging_options(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot("POST", "/v2LoggingOptions"; aws_config=aws_config)
+    return iot(
+        "POST", "/v2LoggingOptions"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function set_v2_logging_options(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("POST", "/v2LoggingOptions", params; aws_config=aws_config)
+    return iot(
+        "POST",
+        "/v2LoggingOptions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -6563,6 +7905,7 @@ function start_audit_mitigation_actions_task(
             "target" => target,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_audit_mitigation_actions_task(
@@ -6588,6 +7931,7 @@ function start_audit_mitigation_actions_task(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6630,6 +7974,7 @@ function start_detect_mitigation_actions_task(
             "target" => target,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_detect_mitigation_actions_task(
@@ -6655,6 +8000,7 @@ function start_detect_mitigation_actions_task(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6680,6 +8026,7 @@ function start_on_demand_audit_task(
         "/audit/tasks",
         Dict{String,Any}("targetCheckNames" => targetCheckNames);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_on_demand_audit_task(
@@ -6696,6 +8043,7 @@ function start_on_demand_audit_task(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6732,6 +8080,7 @@ function start_thing_registration_task(
             "templateBody" => templateBody,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_thing_registration_task(
@@ -6758,6 +8107,7 @@ function start_thing_registration_task(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6775,13 +8125,22 @@ StopThingRegistrationTask action.
 function stop_thing_registration_task(
     taskId; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("PUT", "/thing-registration-tasks/$(taskId)/cancel"; aws_config=aws_config)
+    return iot(
+        "PUT",
+        "/thing-registration-tasks/$(taskId)/cancel";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function stop_thing_registration_task(
     taskId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return iot(
-        "PUT", "/thing-registration-tasks/$(taskId)/cancel", params; aws_config=aws_config
+        "PUT",
+        "/thing-registration-tasks/$(taskId)/cancel",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6803,6 +8162,7 @@ function tag_resource(resourceArn, tags; aws_config::AbstractAWSConfig=global_aw
         "/tags",
         Dict{String,Any}("resourceArn" => resourceArn, "tags" => tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -6822,6 +8182,7 @@ function tag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6855,6 +8216,7 @@ function test_authorization(authInfos; aws_config::AbstractAWSConfig=global_aws_
         "/test-authorization",
         Dict{String,Any}("authInfos" => authInfos);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function test_authorization(
@@ -6869,6 +8231,7 @@ function test_authorization(
             mergewith(_merge, Dict{String,Any}("authInfos" => authInfos), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6895,14 +8258,25 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function test_invoke_authorizer(
     authorizerName; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("POST", "/authorizer/$(authorizerName)/test"; aws_config=aws_config)
+    return iot(
+        "POST",
+        "/authorizer/$(authorizerName)/test";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function test_invoke_authorizer(
     authorizerName,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return iot("POST", "/authorizer/$(authorizerName)/test", params; aws_config=aws_config)
+    return iot(
+        "POST",
+        "/authorizer/$(authorizerName)/test",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -6934,6 +8308,7 @@ function transfer_certificate(
         "/transfer-certificate/$(certificateId)",
         Dict{String,Any}("targetAwsAccount" => targetAwsAccount);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function transfer_certificate(
@@ -6951,6 +8326,7 @@ function transfer_certificate(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6974,6 +8350,7 @@ function untag_resource(
         "/untag",
         Dict{String,Any}("resourceArn" => resourceArn, "tagKeys" => tagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -6993,6 +8370,7 @@ function untag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -7023,12 +8401,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function update_account_audit_configuration(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("PATCH", "/audit/configuration"; aws_config=aws_config)
+    return iot(
+        "PATCH",
+        "/audit/configuration";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function update_account_audit_configuration(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("PATCH", "/audit/configuration", params; aws_config=aws_config)
+    return iot(
+        "PATCH",
+        "/audit/configuration",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -7059,6 +8448,7 @@ function update_audit_suppression(
             "checkName" => checkName, "resourceIdentifier" => resourceIdentifier
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_audit_suppression(
@@ -7080,6 +8470,7 @@ function update_audit_suppression(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -7102,14 +8493,25 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function update_authorizer(
     authorizerName; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("PUT", "/authorizer/$(authorizerName)"; aws_config=aws_config)
+    return iot(
+        "PUT",
+        "/authorizer/$(authorizerName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function update_authorizer(
     authorizerName,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return iot("PUT", "/authorizer/$(authorizerName)", params; aws_config=aws_config)
+    return iot(
+        "PUT",
+        "/authorizer/$(authorizerName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -7139,6 +8541,7 @@ function update_billing_group(
         "/billing-groups/$(billingGroupName)",
         Dict{String,Any}("billingGroupProperties" => billingGroupProperties);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_billing_group(
@@ -7158,6 +8561,7 @@ function update_billing_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -7183,14 +8587,25 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function update_cacertificate(
     caCertificateId; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("PUT", "/cacertificate/$(caCertificateId)"; aws_config=aws_config)
+    return iot(
+        "PUT",
+        "/cacertificate/$(caCertificateId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function update_cacertificate(
     caCertificateId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return iot("PUT", "/cacertificate/$(caCertificateId)", params; aws_config=aws_config)
+    return iot(
+        "PUT",
+        "/cacertificate/$(caCertificateId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -7221,6 +8636,7 @@ function update_certificate(
         "/certificates/$(certificateId)",
         Dict{String,Any}("newStatus" => newStatus);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_certificate(
@@ -7236,6 +8652,7 @@ function update_certificate(
             mergewith(_merge, Dict{String,Any}("newStatus" => newStatus), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -7261,6 +8678,7 @@ function update_custom_metric(
         "/custom-metric/$(metricName)",
         Dict{String,Any}("displayName" => displayName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_custom_metric(
@@ -7276,6 +8694,7 @@ function update_custom_metric(
             mergewith(_merge, Dict{String,Any}("displayName" => displayName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -7303,6 +8722,7 @@ function update_dimension(
         "/dimensions/$(name)",
         Dict{String,Any}("stringValues" => stringValues);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_dimension(
@@ -7318,6 +8738,7 @@ function update_dimension(
             mergewith(_merge, Dict{String,Any}("stringValues" => stringValues), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -7343,7 +8764,10 @@ function update_domain_configuration(
     domainConfigurationName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return iot(
-        "PUT", "/domainConfigurations/$(domainConfigurationName)"; aws_config=aws_config
+        "PUT",
+        "/domainConfigurations/$(domainConfigurationName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_domain_configuration(
@@ -7356,6 +8780,7 @@ function update_domain_configuration(
         "/domainConfigurations/$(domainConfigurationName)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -7388,6 +8813,7 @@ function update_dynamic_thing_group(
         "/dynamic-thing-groups/$(thingGroupName)",
         Dict{String,Any}("thingGroupProperties" => thingGroupProperties);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_dynamic_thing_group(
@@ -7407,6 +8833,7 @@ function update_dynamic_thing_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -7422,12 +8849,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"eventConfigurations"`: The new event configuration values.
 """
 function update_event_configurations(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot("PATCH", "/event-configurations"; aws_config=aws_config)
+    return iot(
+        "PATCH",
+        "/event-configurations";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function update_event_configurations(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("PATCH", "/event-configurations", params; aws_config=aws_config)
+    return iot(
+        "PATCH",
+        "/event-configurations",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -7462,6 +8900,7 @@ function update_fleet_metric(
         "/fleet-metric/$(metricName)",
         Dict{String,Any}("indexName" => indexName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_fleet_metric(
@@ -7477,6 +8916,7 @@ function update_fleet_metric(
             mergewith(_merge, Dict{String,Any}("indexName" => indexName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -7493,12 +8933,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"thingIndexingConfiguration"`: Thing indexing configuration.
 """
 function update_indexing_configuration(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot("POST", "/indexing/config"; aws_config=aws_config)
+    return iot(
+        "POST", "/indexing/config"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function update_indexing_configuration(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("POST", "/indexing/config", params; aws_config=aws_config)
+    return iot(
+        "POST",
+        "/indexing/config",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -7528,12 +8976,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   will be automatically set to TIMED_OUT.
 """
 function update_job(jobId; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot("PATCH", "/jobs/$(jobId)"; aws_config=aws_config)
+    return iot(
+        "PATCH", "/jobs/$(jobId)"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function update_job(
     jobId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("PATCH", "/jobs/$(jobId)", params; aws_config=aws_config)
+    return iot(
+        "PATCH",
+        "/jobs/$(jobId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -7556,7 +9012,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function update_mitigation_action(
     actionName; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("PATCH", "/mitigationactions/actions/$(actionName)"; aws_config=aws_config)
+    return iot(
+        "PATCH",
+        "/mitigationactions/actions/$(actionName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function update_mitigation_action(
     actionName,
@@ -7564,7 +9025,11 @@ function update_mitigation_action(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return iot(
-        "PATCH", "/mitigationactions/actions/$(actionName)", params; aws_config=aws_config
+        "PATCH",
+        "/mitigationactions/actions/$(actionName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -7591,7 +9056,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function update_provisioning_template(
     templateName; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("PATCH", "/provisioning-templates/$(templateName)"; aws_config=aws_config)
+    return iot(
+        "PATCH",
+        "/provisioning-templates/$(templateName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function update_provisioning_template(
     templateName,
@@ -7599,7 +9069,11 @@ function update_provisioning_template(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return iot(
-        "PATCH", "/provisioning-templates/$(templateName)", params; aws_config=aws_config
+        "PATCH",
+        "/provisioning-templates/$(templateName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -7618,14 +9092,25 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"roleArn"`: The role ARN.
 """
 function update_role_alias(roleAlias; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot("PUT", "/role-aliases/$(roleAlias)"; aws_config=aws_config)
+    return iot(
+        "PUT",
+        "/role-aliases/$(roleAlias)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function update_role_alias(
     roleAlias,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return iot("PUT", "/role-aliases/$(roleAlias)", params; aws_config=aws_config)
+    return iot(
+        "PUT",
+        "/role-aliases/$(roleAlias)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -7658,7 +9143,10 @@ function update_scheduled_audit(
     scheduledAuditName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return iot(
-        "PATCH", "/audit/scheduledaudits/$(scheduledAuditName)"; aws_config=aws_config
+        "PATCH",
+        "/audit/scheduledaudits/$(scheduledAuditName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_scheduled_audit(
@@ -7671,6 +9159,7 @@ function update_scheduled_audit(
         "/audit/scheduledaudits/$(scheduledAuditName)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -7713,7 +9202,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function update_security_profile(
     securityProfileName; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot("PATCH", "/security-profiles/$(securityProfileName)"; aws_config=aws_config)
+    return iot(
+        "PATCH",
+        "/security-profiles/$(securityProfileName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function update_security_profile(
     securityProfileName,
@@ -7721,7 +9215,11 @@ function update_security_profile(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return iot(
-        "PATCH", "/security-profiles/$(securityProfileName)", params; aws_config=aws_config
+        "PATCH",
+        "/security-profiles/$(securityProfileName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -7743,14 +9241,25 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   files.
 """
 function update_stream(streamId; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot("PUT", "/streams/$(streamId)"; aws_config=aws_config)
+    return iot(
+        "PUT",
+        "/streams/$(streamId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function update_stream(
     streamId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return iot("PUT", "/streams/$(streamId)", params; aws_config=aws_config)
+    return iot(
+        "PUT",
+        "/streams/$(streamId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -7776,14 +9285,25 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"thingTypeName"`: The name of the thing type.
 """
 function update_thing(thingName; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot("PATCH", "/things/$(thingName)"; aws_config=aws_config)
+    return iot(
+        "PATCH",
+        "/things/$(thingName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function update_thing(
     thingName,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return iot("PATCH", "/things/$(thingName)", params; aws_config=aws_config)
+    return iot(
+        "PATCH",
+        "/things/$(thingName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -7809,6 +9329,7 @@ function update_thing_group(
         "/thing-groups/$(thingGroupName)",
         Dict{String,Any}("thingGroupProperties" => thingGroupProperties);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_thing_group(
@@ -7828,6 +9349,7 @@ function update_thing_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -7849,13 +9371,22 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"thingName"`: The thing whose group memberships will be updated.
 """
 function update_thing_groups_for_thing(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot("PUT", "/thing-groups/updateThingGroupsForThing"; aws_config=aws_config)
+    return iot(
+        "PUT",
+        "/thing-groups/updateThingGroupsForThing";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function update_thing_groups_for_thing(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return iot(
-        "PUT", "/thing-groups/updateThingGroupsForThing", params; aws_config=aws_config
+        "PUT",
+        "/thing-groups/updateThingGroupsForThing",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -7891,6 +9422,7 @@ function update_topic_rule_destination(
         "/destinations",
         Dict{String,Any}("arn" => arn, "status" => status);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_topic_rule_destination(
@@ -7906,6 +9438,7 @@ function update_topic_rule_destination(
             mergewith(_merge, Dict{String,Any}("arn" => arn, "status" => status), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -7929,6 +9462,7 @@ function validate_security_profile_behaviors(
         "/security-profile-behaviors/validate",
         Dict{String,Any}("behaviors" => behaviors);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function validate_security_profile_behaviors(
@@ -7943,5 +9477,6 @@ function validate_security_profile_behaviors(
             mergewith(_merge, Dict{String,Any}("behaviors" => behaviors), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/iot_1click_devices_service.jl
+++ b/src/services/iot_1click_devices_service.jl
@@ -19,7 +19,12 @@ received a claim code with the device(s).
 function claim_devices_by_claim_code(
     claimCode; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot_1click_devices_service("PUT", "/claims/$(claimCode)"; aws_config=aws_config)
+    return iot_1click_devices_service(
+        "PUT",
+        "/claims/$(claimCode)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function claim_devices_by_claim_code(
     claimCode,
@@ -27,7 +32,11 @@ function claim_devices_by_claim_code(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return iot_1click_devices_service(
-        "PUT", "/claims/$(claimCode)", params; aws_config=aws_config
+        "PUT",
+        "/claims/$(claimCode)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -44,7 +53,12 @@ device.
 
 """
 function describe_device(deviceId; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot_1click_devices_service("GET", "/devices/$(deviceId)"; aws_config=aws_config)
+    return iot_1click_devices_service(
+        "GET",
+        "/devices/$(deviceId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_device(
     deviceId,
@@ -52,7 +66,11 @@ function describe_device(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return iot_1click_devices_service(
-        "GET", "/devices/$(deviceId)", params; aws_config=aws_config
+        "GET",
+        "/devices/$(deviceId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -79,7 +97,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function finalize_device_claim(deviceId; aws_config::AbstractAWSConfig=global_aws_config())
     return iot_1click_devices_service(
-        "PUT", "/devices/$(deviceId)/finalize-claim"; aws_config=aws_config
+        "PUT",
+        "/devices/$(deviceId)/finalize-claim";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function finalize_device_claim(
@@ -88,7 +109,11 @@ function finalize_device_claim(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return iot_1click_devices_service(
-        "PUT", "/devices/$(deviceId)/finalize-claim", params; aws_config=aws_config
+        "PUT",
+        "/devices/$(deviceId)/finalize-claim",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -104,7 +129,10 @@ Given a device ID, returns the invokable methods associated with the device.
 """
 function get_device_methods(deviceId; aws_config::AbstractAWSConfig=global_aws_config())
     return iot_1click_devices_service(
-        "GET", "/devices/$(deviceId)/methods"; aws_config=aws_config
+        "GET",
+        "/devices/$(deviceId)/methods";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_device_methods(
@@ -113,7 +141,11 @@ function get_device_methods(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return iot_1click_devices_service(
-        "GET", "/devices/$(deviceId)/methods", params; aws_config=aws_config
+        "GET",
+        "/devices/$(deviceId)/methods",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -135,7 +167,10 @@ device.
 """
 function initiate_device_claim(deviceId; aws_config::AbstractAWSConfig=global_aws_config())
     return iot_1click_devices_service(
-        "PUT", "/devices/$(deviceId)/initiate-claim"; aws_config=aws_config
+        "PUT",
+        "/devices/$(deviceId)/initiate-claim";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function initiate_device_claim(
@@ -144,7 +179,11 @@ function initiate_device_claim(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return iot_1click_devices_service(
-        "PUT", "/devices/$(deviceId)/initiate-claim", params; aws_config=aws_config
+        "PUT",
+        "/devices/$(deviceId)/initiate-claim",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -166,7 +205,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function invoke_device_method(deviceId; aws_config::AbstractAWSConfig=global_aws_config())
     return iot_1click_devices_service(
-        "POST", "/devices/$(deviceId)/methods"; aws_config=aws_config
+        "POST",
+        "/devices/$(deviceId)/methods";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function invoke_device_method(
@@ -175,7 +217,11 @@ function invoke_device_method(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return iot_1click_devices_service(
-        "POST", "/devices/$(deviceId)/methods", params; aws_config=aws_config
+        "POST",
+        "/devices/$(deviceId)/methods",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -211,6 +257,7 @@ function list_device_events(
         "/devices/$(deviceId)/events",
         Dict{String,Any}("fromTimeStamp" => fromTimeStamp, "toTimeStamp" => toTimeStamp);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_device_events(
@@ -233,6 +280,7 @@ function list_device_events(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -251,12 +299,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: The token to retrieve the next set of results.
 """
 function list_devices(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot_1click_devices_service("GET", "/devices"; aws_config=aws_config)
+    return iot_1click_devices_service(
+        "GET", "/devices"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_devices(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot_1click_devices_service("GET", "/devices", params; aws_config=aws_config)
+    return iot_1click_devices_service(
+        "GET", "/devices", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -272,7 +324,12 @@ Lists the tags associated with the specified resource ARN.
 function list_tags_for_resource(
     resource_arn; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot_1click_devices_service("GET", "/tags/$(resource-arn)"; aws_config=aws_config)
+    return iot_1click_devices_service(
+        "GET",
+        "/tags/$(resource-arn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_tags_for_resource(
     resource_arn,
@@ -280,7 +337,11 @@ function list_tags_for_resource(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return iot_1click_devices_service(
-        "GET", "/tags/$(resource-arn)", params; aws_config=aws_config
+        "GET",
+        "/tags/$(resource-arn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -305,6 +366,7 @@ function tag_resource(resource_arn, tags; aws_config::AbstractAWSConfig=global_a
         "/tags/$(resource-arn)",
         Dict{String,Any}("tags" => tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -318,6 +380,7 @@ function tag_resource(
         "/tags/$(resource-arn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tags" => tags), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -333,7 +396,10 @@ Disassociates a device from your AWS account using its device ID.
 """
 function unclaim_device(deviceId; aws_config::AbstractAWSConfig=global_aws_config())
     return iot_1click_devices_service(
-        "PUT", "/devices/$(deviceId)/unclaim"; aws_config=aws_config
+        "PUT",
+        "/devices/$(deviceId)/unclaim";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function unclaim_device(
@@ -342,7 +408,11 @@ function unclaim_device(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return iot_1click_devices_service(
-        "PUT", "/devices/$(deviceId)/unclaim", params; aws_config=aws_config
+        "PUT",
+        "/devices/$(deviceId)/unclaim",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -367,6 +437,7 @@ function untag_resource(
         "/tags/$(resource-arn)",
         Dict{String,Any}("tagKeys" => tagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -380,6 +451,7 @@ function untag_resource(
         "/tags/$(resource-arn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tagKeys" => tagKeys), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -401,7 +473,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function update_device_state(deviceId; aws_config::AbstractAWSConfig=global_aws_config())
     return iot_1click_devices_service(
-        "PUT", "/devices/$(deviceId)/state"; aws_config=aws_config
+        "PUT",
+        "/devices/$(deviceId)/state";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_device_state(
@@ -410,6 +485,10 @@ function update_device_state(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return iot_1click_devices_service(
-        "PUT", "/devices/$(deviceId)/state", params; aws_config=aws_config
+        "PUT",
+        "/devices/$(deviceId)/state",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/iot_1click_projects.jl
+++ b/src/services/iot_1click_projects.jl
@@ -31,6 +31,7 @@ function associate_device_with_placement(
         "/projects/$(projectName)/placements/$(placementName)/devices/$(deviceTemplateName)",
         Dict{String,Any}("deviceId" => deviceId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_device_with_placement(
@@ -48,6 +49,7 @@ function associate_device_with_placement(
             mergewith(_merge, Dict{String,Any}("deviceId" => deviceId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -74,6 +76,7 @@ function create_placement(
         "/projects/$(projectName)/placements",
         Dict{String,Any}("placementName" => placementName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_placement(
@@ -89,6 +92,7 @@ function create_placement(
             mergewith(_merge, Dict{String,Any}("placementName" => placementName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -119,6 +123,7 @@ function create_project(projectName; aws_config::AbstractAWSConfig=global_aws_co
         "/projects",
         Dict{String,Any}("projectName" => projectName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_project(
@@ -133,6 +138,7 @@ function create_project(
             mergewith(_merge, Dict{String,Any}("projectName" => projectName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -155,6 +161,7 @@ function delete_placement(
         "DELETE",
         "/projects/$(projectName)/placements/$(placementName)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_placement(
@@ -168,6 +175,7 @@ function delete_placement(
         "/projects/$(projectName)/placements/$(placementName)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -183,7 +191,12 @@ Deletes a project. To delete a project, it must not have any placements associat
 
 """
 function delete_project(projectName; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot_1click_projects("DELETE", "/projects/$(projectName)"; aws_config=aws_config)
+    return iot_1click_projects(
+        "DELETE",
+        "/projects/$(projectName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_project(
     projectName,
@@ -191,7 +204,11 @@ function delete_project(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return iot_1click_projects(
-        "DELETE", "/projects/$(projectName)", params; aws_config=aws_config
+        "DELETE",
+        "/projects/$(projectName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -210,7 +227,10 @@ function describe_placement(
     placementName, projectName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return iot_1click_projects(
-        "GET", "/projects/$(projectName)/placements/$(placementName)"; aws_config=aws_config
+        "GET",
+        "/projects/$(projectName)/placements/$(placementName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_placement(
@@ -224,6 +244,7 @@ function describe_placement(
         "/projects/$(projectName)/placements/$(placementName)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -238,7 +259,12 @@ Returns an object describing a project.
 
 """
 function describe_project(projectName; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot_1click_projects("GET", "/projects/$(projectName)"; aws_config=aws_config)
+    return iot_1click_projects(
+        "GET",
+        "/projects/$(projectName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_project(
     projectName,
@@ -246,7 +272,11 @@ function describe_project(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return iot_1click_projects(
-        "GET", "/projects/$(projectName)", params; aws_config=aws_config
+        "GET",
+        "/projects/$(projectName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -272,6 +302,7 @@ function disassociate_device_from_placement(
         "DELETE",
         "/projects/$(projectName)/placements/$(placementName)/devices/$(deviceTemplateName)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disassociate_device_from_placement(
@@ -286,6 +317,7 @@ function disassociate_device_from_placement(
         "/projects/$(projectName)/placements/$(placementName)/devices/$(deviceTemplateName)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -307,6 +339,7 @@ function get_devices_in_placement(
         "GET",
         "/projects/$(projectName)/placements/$(placementName)/devices";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_devices_in_placement(
@@ -320,6 +353,7 @@ function get_devices_in_placement(
         "/projects/$(projectName)/placements/$(placementName)/devices",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -340,7 +374,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function list_placements(projectName; aws_config::AbstractAWSConfig=global_aws_config())
     return iot_1click_projects(
-        "GET", "/projects/$(projectName)/placements"; aws_config=aws_config
+        "GET",
+        "/projects/$(projectName)/placements";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_placements(
@@ -349,7 +386,11 @@ function list_placements(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return iot_1click_projects(
-        "GET", "/projects/$(projectName)/placements", params; aws_config=aws_config
+        "GET",
+        "/projects/$(projectName)/placements",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -366,12 +407,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: The token to retrieve the next set of results.
 """
 function list_projects(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot_1click_projects("GET", "/projects"; aws_config=aws_config)
+    return iot_1click_projects(
+        "GET", "/projects"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_projects(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot_1click_projects("GET", "/projects", params; aws_config=aws_config)
+    return iot_1click_projects(
+        "GET", "/projects", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -387,14 +432,25 @@ Lists the tags (metadata key/value pairs) which you have assigned to the resourc
 function list_tags_for_resource(
     resourceArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot_1click_projects("GET", "/tags/$(resourceArn)"; aws_config=aws_config)
+    return iot_1click_projects(
+        "GET",
+        "/tags/$(resourceArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_tags_for_resource(
     resourceArn,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return iot_1click_projects("GET", "/tags/$(resourceArn)", params; aws_config=aws_config)
+    return iot_1click_projects(
+        "GET",
+        "/tags/$(resourceArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -416,6 +472,7 @@ function tag_resource(resourceArn, tags; aws_config::AbstractAWSConfig=global_aw
         "/tags/$(resourceArn)",
         Dict{String,Any}("tags" => tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -429,6 +486,7 @@ function tag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tags" => tags), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -451,6 +509,7 @@ function untag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}("tagKeys" => tagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -464,6 +523,7 @@ function untag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tagKeys" => tagKeys), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -487,7 +547,10 @@ function update_placement(
     placementName, projectName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return iot_1click_projects(
-        "PUT", "/projects/$(projectName)/placements/$(placementName)"; aws_config=aws_config
+        "PUT",
+        "/projects/$(projectName)/placements/$(placementName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_placement(
@@ -501,6 +564,7 @@ function update_placement(
         "/projects/$(projectName)/placements/$(placementName)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -525,7 +589,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   definition using this API.
 """
 function update_project(projectName; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot_1click_projects("PUT", "/projects/$(projectName)"; aws_config=aws_config)
+    return iot_1click_projects(
+        "PUT",
+        "/projects/$(projectName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function update_project(
     projectName,
@@ -533,6 +602,10 @@ function update_project(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return iot_1click_projects(
-        "PUT", "/projects/$(projectName)", params; aws_config=aws_config
+        "PUT",
+        "/projects/$(projectName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/iot_data_plane.jl
+++ b/src/services/iot_data_plane.jl
@@ -20,7 +20,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"name"`: The name of the shadow.
 """
 function delete_thing_shadow(thingName; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot_data_plane("DELETE", "/things/$(thingName)/shadow"; aws_config=aws_config)
+    return iot_data_plane(
+        "DELETE",
+        "/things/$(thingName)/shadow";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_thing_shadow(
     thingName,
@@ -28,7 +33,11 @@ function delete_thing_shadow(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return iot_data_plane(
-        "DELETE", "/things/$(thingName)/shadow", params; aws_config=aws_config
+        "DELETE",
+        "/things/$(thingName)/shadow",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -47,12 +56,23 @@ Core pricing - Messaging.
 
 """
 function get_retained_message(topic; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot_data_plane("GET", "/retainedMessage/$(topic)"; aws_config=aws_config)
+    return iot_data_plane(
+        "GET",
+        "/retainedMessage/$(topic)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_retained_message(
     topic, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot_data_plane("GET", "/retainedMessage/$(topic)", params; aws_config=aws_config)
+    return iot_data_plane(
+        "GET",
+        "/retainedMessage/$(topic)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -70,7 +90,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"name"`: The name of the shadow.
 """
 function get_thing_shadow(thingName; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot_data_plane("GET", "/things/$(thingName)/shadow"; aws_config=aws_config)
+    return iot_data_plane(
+        "GET",
+        "/things/$(thingName)/shadow";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_thing_shadow(
     thingName,
@@ -78,7 +103,11 @@ function get_thing_shadow(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return iot_data_plane(
-        "GET", "/things/$(thingName)/shadow", params; aws_config=aws_config
+        "GET",
+        "/things/$(thingName)/shadow",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -104,6 +133,7 @@ function list_named_shadows_for_thing(
         "GET",
         "/api/things/shadow/ListNamedShadowsForThing/$(thingName)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_named_shadows_for_thing(
@@ -116,6 +146,7 @@ function list_named_shadows_for_thing(
         "/api/things/shadow/ListNamedShadowsForThing/$(thingName)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -138,12 +169,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   response; otherwise null to receive the first set of results.
 """
 function list_retained_messages(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot_data_plane("GET", "/retainedMessage"; aws_config=aws_config)
+    return iot_data_plane(
+        "GET", "/retainedMessage"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_retained_messages(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot_data_plane("GET", "/retainedMessage", params; aws_config=aws_config)
+    return iot_data_plane(
+        "GET",
+        "/retainedMessage",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -168,12 +207,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   new subscribers to the topic. Valid values: true | false  Default value: false
 """
 function publish(topic; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot_data_plane("POST", "/topics/$(topic)"; aws_config=aws_config)
+    return iot_data_plane(
+        "POST", "/topics/$(topic)"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function publish(
     topic, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot_data_plane("POST", "/topics/$(topic)", params; aws_config=aws_config)
+    return iot_data_plane(
+        "POST",
+        "/topics/$(topic)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -200,6 +247,7 @@ function update_thing_shadow(
         "/things/$(thingName)/shadow",
         Dict{String,Any}("payload" => payload);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_thing_shadow(
@@ -213,5 +261,6 @@ function update_thing_shadow(
         "/things/$(thingName)/shadow",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("payload" => payload), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/iot_events.jl
+++ b/src/services/iot_events.jl
@@ -46,6 +46,7 @@ function create_alarm_model(
             "roleArn" => roleArn,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_alarm_model(
@@ -70,6 +71,7 @@ function create_alarm_model(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -112,6 +114,7 @@ function create_detector_model(
             "roleArn" => roleArn,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_detector_model(
@@ -136,6 +139,7 @@ function create_detector_model(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -162,6 +166,7 @@ function create_input(
         "/inputs",
         Dict{String,Any}("inputDefinition" => inputDefinition, "inputName" => inputName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_input(
@@ -183,6 +188,7 @@ function create_input(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -200,7 +206,12 @@ also deleted. This action can't be undone.
 function delete_alarm_model(
     alarmModelName; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot_events("DELETE", "/alarm-models/$(alarmModelName)"; aws_config=aws_config)
+    return iot_events(
+        "DELETE",
+        "/alarm-models/$(alarmModelName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_alarm_model(
     alarmModelName,
@@ -208,7 +219,11 @@ function delete_alarm_model(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return iot_events(
-        "DELETE", "/alarm-models/$(alarmModelName)", params; aws_config=aws_config
+        "DELETE",
+        "/alarm-models/$(alarmModelName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -226,7 +241,10 @@ function delete_detector_model(
     detectorModelName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return iot_events(
-        "DELETE", "/detector-models/$(detectorModelName)"; aws_config=aws_config
+        "DELETE",
+        "/detector-models/$(detectorModelName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_detector_model(
@@ -235,7 +253,11 @@ function delete_detector_model(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return iot_events(
-        "DELETE", "/detector-models/$(detectorModelName)", params; aws_config=aws_config
+        "DELETE",
+        "/detector-models/$(detectorModelName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -250,14 +272,25 @@ Deletes an input.
 
 """
 function delete_input(inputName; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot_events("DELETE", "/inputs/$(inputName)"; aws_config=aws_config)
+    return iot_events(
+        "DELETE",
+        "/inputs/$(inputName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_input(
     inputName,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return iot_events("DELETE", "/inputs/$(inputName)", params; aws_config=aws_config)
+    return iot_events(
+        "DELETE",
+        "/inputs/$(inputName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -277,7 +310,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_alarm_model(
     alarmModelName; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot_events("GET", "/alarm-models/$(alarmModelName)"; aws_config=aws_config)
+    return iot_events(
+        "GET",
+        "/alarm-models/$(alarmModelName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_alarm_model(
     alarmModelName,
@@ -285,7 +323,11 @@ function describe_alarm_model(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return iot_events(
-        "GET", "/alarm-models/$(alarmModelName)", params; aws_config=aws_config
+        "GET",
+        "/alarm-models/$(alarmModelName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -306,7 +348,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_detector_model(
     detectorModelName; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot_events("GET", "/detector-models/$(detectorModelName)"; aws_config=aws_config)
+    return iot_events(
+        "GET",
+        "/detector-models/$(detectorModelName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_detector_model(
     detectorModelName,
@@ -314,7 +361,11 @@ function describe_detector_model(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return iot_events(
-        "GET", "/detector-models/$(detectorModelName)", params; aws_config=aws_config
+        "GET",
+        "/detector-models/$(detectorModelName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -333,7 +384,10 @@ function describe_detector_model_analysis(
     analysisId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return iot_events(
-        "GET", "/analysis/detector-models/$(analysisId)"; aws_config=aws_config
+        "GET",
+        "/analysis/detector-models/$(analysisId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_detector_model_analysis(
@@ -342,7 +396,11 @@ function describe_detector_model_analysis(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return iot_events(
-        "GET", "/analysis/detector-models/$(analysisId)", params; aws_config=aws_config
+        "GET",
+        "/analysis/detector-models/$(analysisId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -357,14 +415,25 @@ Describes an input.
 
 """
 function describe_input(inputName; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot_events("GET", "/inputs/$(inputName)"; aws_config=aws_config)
+    return iot_events(
+        "GET",
+        "/inputs/$(inputName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_input(
     inputName,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return iot_events("GET", "/inputs/$(inputName)", params; aws_config=aws_config)
+    return iot_events(
+        "GET",
+        "/inputs/$(inputName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -375,12 +444,16 @@ Retrieves the current settings of the AWS IoT Events logging options.
 
 """
 function describe_logging_options(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot_events("GET", "/logging"; aws_config=aws_config)
+    return iot_events(
+        "GET", "/logging"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_logging_options(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot_events("GET", "/logging", params; aws_config=aws_config)
+    return iot_events(
+        "GET", "/logging", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -402,7 +475,10 @@ function get_detector_model_analysis_results(
     analysisId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return iot_events(
-        "GET", "/analysis/detector-models/$(analysisId)/results"; aws_config=aws_config
+        "GET",
+        "/analysis/detector-models/$(analysisId)/results";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_detector_model_analysis_results(
@@ -415,6 +491,7 @@ function get_detector_model_analysis_results(
         "/analysis/detector-models/$(analysisId)/results",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -437,7 +514,10 @@ function list_alarm_model_versions(
     alarmModelName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return iot_events(
-        "GET", "/alarm-models/$(alarmModelName)/versions"; aws_config=aws_config
+        "GET",
+        "/alarm-models/$(alarmModelName)/versions";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_alarm_model_versions(
@@ -446,7 +526,11 @@ function list_alarm_model_versions(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return iot_events(
-        "GET", "/alarm-models/$(alarmModelName)/versions", params; aws_config=aws_config
+        "GET",
+        "/alarm-models/$(alarmModelName)/versions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -463,12 +547,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: The token that you can use to return the next set of results.
 """
 function list_alarm_models(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot_events("GET", "/alarm-models"; aws_config=aws_config)
+    return iot_events(
+        "GET", "/alarm-models"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_alarm_models(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot_events("GET", "/alarm-models", params; aws_config=aws_config)
+    return iot_events(
+        "GET",
+        "/alarm-models",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -490,7 +582,10 @@ function list_detector_model_versions(
     detectorModelName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return iot_events(
-        "GET", "/detector-models/$(detectorModelName)/versions"; aws_config=aws_config
+        "GET",
+        "/detector-models/$(detectorModelName)/versions";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_detector_model_versions(
@@ -503,6 +598,7 @@ function list_detector_model_versions(
         "/detector-models/$(detectorModelName)/versions",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -519,12 +615,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: The token that you can use to return the next set of results.
 """
 function list_detector_models(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot_events("GET", "/detector-models"; aws_config=aws_config)
+    return iot_events(
+        "GET", "/detector-models"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_detector_models(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot_events("GET", "/detector-models", params; aws_config=aws_config)
+    return iot_events(
+        "GET",
+        "/detector-models",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -549,6 +653,7 @@ function list_input_routings(
         "/input-routings",
         Dict{String,Any}("inputIdentifier" => inputIdentifier);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_input_routings(
@@ -565,6 +670,7 @@ function list_input_routings(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -580,12 +686,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: The token that you can use to return the next set of results.
 """
 function list_inputs(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot_events("GET", "/inputs"; aws_config=aws_config)
+    return iot_events(
+        "GET", "/inputs"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_inputs(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot_events("GET", "/inputs", params; aws_config=aws_config)
+    return iot_events(
+        "GET", "/inputs", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -606,6 +716,7 @@ function list_tags_for_resource(
         "/tags",
         Dict{String,Any}("resourceArn" => resourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags_for_resource(
@@ -620,6 +731,7 @@ function list_tags_for_resource(
             mergewith(_merge, Dict{String,Any}("resourceArn" => resourceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -644,6 +756,7 @@ function put_logging_options(
         "/logging",
         Dict{String,Any}("loggingOptions" => loggingOptions);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_logging_options(
@@ -658,6 +771,7 @@ function put_logging_options(
             mergewith(_merge, Dict{String,Any}("loggingOptions" => loggingOptions), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -680,6 +794,7 @@ function start_detector_model_analysis(
         "/analysis/detector-models/",
         Dict{String,Any}("detectorModelDefinition" => detectorModelDefinition);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_detector_model_analysis(
@@ -698,6 +813,7 @@ function start_detector_model_analysis(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -719,6 +835,7 @@ function tag_resource(resourceArn, tags; aws_config::AbstractAWSConfig=global_aw
         "/tags",
         Dict{String,Any}("resourceArn" => resourceArn, "tags" => tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -738,6 +855,7 @@ function tag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -760,6 +878,7 @@ function untag_resource(
         "/tags",
         Dict{String,Any}("resourceArn" => resourceArn, "tagKeys" => tagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -779,6 +898,7 @@ function untag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -812,6 +932,7 @@ function update_alarm_model(
         "/alarm-models/$(alarmModelName)",
         Dict{String,Any}("alarmRule" => alarmRule, "roleArn" => roleArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_alarm_model(
@@ -832,6 +953,7 @@ function update_alarm_model(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -867,6 +989,7 @@ function update_detector_model(
             "detectorModelDefinition" => detectorModelDefinition, "roleArn" => roleArn
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_detector_model(
@@ -890,6 +1013,7 @@ function update_detector_model(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -915,6 +1039,7 @@ function update_input(
         "/inputs/$(inputName)",
         Dict{String,Any}("inputDefinition" => inputDefinition);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_input(
@@ -932,5 +1057,6 @@ function update_input(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/iot_events_data.jl
+++ b/src/services/iot_events_data.jl
@@ -24,6 +24,7 @@ function batch_acknowledge_alarm(
         "/alarms/acknowledge",
         Dict{String,Any}("acknowledgeActionRequests" => acknowledgeActionRequests);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_acknowledge_alarm(
@@ -42,6 +43,7 @@ function batch_acknowledge_alarm(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -64,6 +66,7 @@ function batch_disable_alarm(
         "/alarms/disable",
         Dict{String,Any}("disableActionRequests" => disableActionRequests);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_disable_alarm(
@@ -82,6 +85,7 @@ function batch_disable_alarm(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -104,6 +108,7 @@ function batch_enable_alarm(
         "/alarms/enable",
         Dict{String,Any}("enableActionRequests" => enableActionRequests);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_enable_alarm(
@@ -122,6 +127,7 @@ function batch_enable_alarm(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -146,6 +152,7 @@ function batch_put_message(messages; aws_config::AbstractAWSConfig=global_aws_co
         "/inputs/messages",
         Dict{String,Any}("messages" => messages);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_put_message(
@@ -160,6 +167,7 @@ function batch_put_message(
             mergewith(_merge, Dict{String,Any}("messages" => messages), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -182,6 +190,7 @@ function batch_reset_alarm(
         "/alarms/reset",
         Dict{String,Any}("resetActionRequests" => resetActionRequests);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_reset_alarm(
@@ -200,6 +209,7 @@ function batch_reset_alarm(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -223,6 +233,7 @@ function batch_snooze_alarm(
         "/alarms/snooze",
         Dict{String,Any}("snoozeActionRequests" => snoozeActionRequests);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_snooze_alarm(
@@ -241,6 +252,7 @@ function batch_snooze_alarm(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -261,6 +273,7 @@ function batch_update_detector(detectors; aws_config::AbstractAWSConfig=global_a
         "/detectors",
         Dict{String,Any}("detectors" => detectors);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_update_detector(
@@ -275,6 +288,7 @@ function batch_update_detector(
             mergewith(_merge, Dict{String,Any}("detectors" => detectors), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -294,7 +308,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function describe_alarm(alarmModelName; aws_config::AbstractAWSConfig=global_aws_config())
     return iot_events_data(
-        "GET", "/alarms/$(alarmModelName)/keyValues/"; aws_config=aws_config
+        "GET",
+        "/alarms/$(alarmModelName)/keyValues/";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_alarm(
@@ -303,7 +320,11 @@ function describe_alarm(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return iot_events_data(
-        "GET", "/alarms/$(alarmModelName)/keyValues/", params; aws_config=aws_config
+        "GET",
+        "/alarms/$(alarmModelName)/keyValues/",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -326,7 +347,10 @@ function describe_detector(
     detectorModelName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return iot_events_data(
-        "GET", "/detectors/$(detectorModelName)/keyValues/"; aws_config=aws_config
+        "GET",
+        "/detectors/$(detectorModelName)/keyValues/";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_detector(
@@ -335,7 +359,11 @@ function describe_detector(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return iot_events_data(
-        "GET", "/detectors/$(detectorModelName)/keyValues/", params; aws_config=aws_config
+        "GET",
+        "/detectors/$(detectorModelName)/keyValues/",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -355,7 +383,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: The token that you can use to return the next set of results.
 """
 function list_alarms(alarmModelName; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot_events_data("GET", "/alarms/$(alarmModelName)"; aws_config=aws_config)
+    return iot_events_data(
+        "GET",
+        "/alarms/$(alarmModelName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_alarms(
     alarmModelName,
@@ -363,7 +396,11 @@ function list_alarms(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return iot_events_data(
-        "GET", "/alarms/$(alarmModelName)", params; aws_config=aws_config
+        "GET",
+        "/alarms/$(alarmModelName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -387,7 +424,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function list_detectors(
     detectorModelName; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot_events_data("GET", "/detectors/$(detectorModelName)"; aws_config=aws_config)
+    return iot_events_data(
+        "GET",
+        "/detectors/$(detectorModelName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_detectors(
     detectorModelName,
@@ -395,6 +437,10 @@ function list_detectors(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return iot_events_data(
-        "GET", "/detectors/$(detectorModelName)", params; aws_config=aws_config
+        "GET",
+        "/detectors/$(detectorModelName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/iot_jobs_data_plane.jl
+++ b/src/services/iot_jobs_data_plane.jl
@@ -25,7 +25,10 @@ function describe_job_execution(
     jobId, thingName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return iot_jobs_data_plane(
-        "GET", "/things/$(thingName)/jobs/$(jobId)"; aws_config=aws_config
+        "GET",
+        "/things/$(thingName)/jobs/$(jobId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_job_execution(
@@ -35,7 +38,11 @@ function describe_job_execution(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return iot_jobs_data_plane(
-        "GET", "/things/$(thingName)/jobs/$(jobId)", params; aws_config=aws_config
+        "GET",
+        "/things/$(thingName)/jobs/$(jobId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -52,7 +59,12 @@ Gets the list of all jobs for a thing that are not in a terminal status.
 function get_pending_job_executions(
     thingName; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot_jobs_data_plane("GET", "/things/$(thingName)/jobs"; aws_config=aws_config)
+    return iot_jobs_data_plane(
+        "GET",
+        "/things/$(thingName)/jobs";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_pending_job_executions(
     thingName,
@@ -60,7 +72,11 @@ function get_pending_job_executions(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return iot_jobs_data_plane(
-        "GET", "/things/$(thingName)/jobs", params; aws_config=aws_config
+        "GET",
+        "/things/$(thingName)/jobs",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -89,7 +105,10 @@ function start_next_pending_job_execution(
     thingName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return iot_jobs_data_plane(
-        "PUT", "/things/$(thingName)/jobs/$next"; aws_config=aws_config
+        "PUT",
+        "/things/$(thingName)/jobs/$next";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_next_pending_job_execution(
@@ -98,7 +117,11 @@ function start_next_pending_job_execution(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return iot_jobs_data_plane(
-        "PUT", "/things/$(thingName)/jobs/$next", params; aws_config=aws_config
+        "PUT",
+        "/things/$(thingName)/jobs/$next",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -146,6 +169,7 @@ function update_job_execution(
         "/things/$(thingName)/jobs/$(jobId)",
         Dict{String,Any}("status" => status);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_job_execution(
@@ -160,5 +184,6 @@ function update_job_execution(
         "/things/$(thingName)/jobs/$(jobId)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("status" => status), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/iot_wireless.jl
+++ b/src/services/iot_wireless.jl
@@ -30,6 +30,7 @@ function associate_aws_account_with_partner_account(
         "/partner-accounts",
         Dict{String,Any}("Sidewalk" => Sidewalk, "ClientRequestToken" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_aws_account_with_partner_account(
@@ -50,6 +51,7 @@ function associate_aws_account_with_partner_account(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -72,6 +74,7 @@ function associate_wireless_device_with_thing(
         "/wireless-devices/$(Id)/thing",
         Dict{String,Any}("ThingArn" => ThingArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_wireless_device_with_thing(
@@ -87,6 +90,7 @@ function associate_wireless_device_with_thing(
             mergewith(_merge, Dict{String,Any}("ThingArn" => ThingArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -109,6 +113,7 @@ function associate_wireless_gateway_with_certificate(
         "/wireless-gateways/$(Id)/certificate",
         Dict{String,Any}("IotCertificateId" => IotCertificateId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_wireless_gateway_with_certificate(
@@ -126,6 +131,7 @@ function associate_wireless_gateway_with_certificate(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -148,6 +154,7 @@ function associate_wireless_gateway_with_thing(
         "/wireless-gateways/$(Id)/thing",
         Dict{String,Any}("ThingArn" => ThingArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_wireless_gateway_with_thing(
@@ -163,6 +170,7 @@ function associate_wireless_gateway_with_thing(
             mergewith(_merge, Dict{String,Any}("ThingArn" => ThingArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -206,6 +214,7 @@ function create_destination(
             "ClientRequestToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_destination(
@@ -233,6 +242,7 @@ function create_destination(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -259,6 +269,7 @@ function create_device_profile(; aws_config::AbstractAWSConfig=global_aws_config
         "/device-profiles",
         Dict{String,Any}("ClientRequestToken" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_device_profile(
@@ -273,6 +284,7 @@ function create_device_profile(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -299,6 +311,7 @@ function create_service_profile(; aws_config::AbstractAWSConfig=global_aws_confi
         "/service-profiles",
         Dict{String,Any}("ClientRequestToken" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_service_profile(
@@ -313,6 +326,7 @@ function create_service_profile(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -350,6 +364,7 @@ function create_wireless_device(
             "ClientRequestToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_wireless_device(
@@ -373,6 +388,7 @@ function create_wireless_device(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -402,6 +418,7 @@ function create_wireless_gateway(LoRaWAN; aws_config::AbstractAWSConfig=global_a
         "/wireless-gateways",
         Dict{String,Any}("LoRaWAN" => LoRaWAN, "ClientRequestToken" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_wireless_gateway(
@@ -420,6 +437,7 @@ function create_wireless_gateway(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -444,6 +462,7 @@ function create_wireless_gateway_task(
             "WirelessGatewayTaskDefinitionId" => WirelessGatewayTaskDefinitionId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_wireless_gateway_task(
@@ -465,6 +484,7 @@ function create_wireless_gateway_task(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -500,6 +520,7 @@ function create_wireless_gateway_task_definition(
             "AutoCreateTasks" => AutoCreateTasks, "ClientRequestToken" => string(uuid4())
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_wireless_gateway_task_definition(
@@ -521,6 +542,7 @@ function create_wireless_gateway_task_definition(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -535,12 +557,23 @@ Deletes a destination.
 
 """
 function delete_destination(Name; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot_wireless("DELETE", "/destinations/$(Name)"; aws_config=aws_config)
+    return iot_wireless(
+        "DELETE",
+        "/destinations/$(Name)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_destination(
     Name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot_wireless("DELETE", "/destinations/$(Name)", params; aws_config=aws_config)
+    return iot_wireless(
+        "DELETE",
+        "/destinations/$(Name)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -554,12 +587,23 @@ Deletes a device profile.
 
 """
 function delete_device_profile(Id; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot_wireless("DELETE", "/device-profiles/$(Id)"; aws_config=aws_config)
+    return iot_wireless(
+        "DELETE",
+        "/device-profiles/$(Id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_device_profile(
     Id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot_wireless("DELETE", "/device-profiles/$(Id)", params; aws_config=aws_config)
+    return iot_wireless(
+        "DELETE",
+        "/device-profiles/$(Id)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -573,12 +617,23 @@ Deletes a service profile.
 
 """
 function delete_service_profile(Id; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot_wireless("DELETE", "/service-profiles/$(Id)"; aws_config=aws_config)
+    return iot_wireless(
+        "DELETE",
+        "/service-profiles/$(Id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_service_profile(
     Id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot_wireless("DELETE", "/service-profiles/$(Id)", params; aws_config=aws_config)
+    return iot_wireless(
+        "DELETE",
+        "/service-profiles/$(Id)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -592,12 +647,23 @@ Deletes a wireless device.
 
 """
 function delete_wireless_device(Id; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot_wireless("DELETE", "/wireless-devices/$(Id)"; aws_config=aws_config)
+    return iot_wireless(
+        "DELETE",
+        "/wireless-devices/$(Id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_wireless_device(
     Id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot_wireless("DELETE", "/wireless-devices/$(Id)", params; aws_config=aws_config)
+    return iot_wireless(
+        "DELETE",
+        "/wireless-devices/$(Id)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -611,12 +677,23 @@ Deletes a wireless gateway.
 
 """
 function delete_wireless_gateway(Id; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot_wireless("DELETE", "/wireless-gateways/$(Id)"; aws_config=aws_config)
+    return iot_wireless(
+        "DELETE",
+        "/wireless-gateways/$(Id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_wireless_gateway(
     Id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot_wireless("DELETE", "/wireless-gateways/$(Id)", params; aws_config=aws_config)
+    return iot_wireless(
+        "DELETE",
+        "/wireless-gateways/$(Id)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -630,13 +707,22 @@ Deletes a wireless gateway task.
 
 """
 function delete_wireless_gateway_task(Id; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot_wireless("DELETE", "/wireless-gateways/$(Id)/tasks"; aws_config=aws_config)
+    return iot_wireless(
+        "DELETE",
+        "/wireless-gateways/$(Id)/tasks";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_wireless_gateway_task(
     Id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return iot_wireless(
-        "DELETE", "/wireless-gateways/$(Id)/tasks", params; aws_config=aws_config
+        "DELETE",
+        "/wireless-gateways/$(Id)/tasks",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -655,14 +741,21 @@ function delete_wireless_gateway_task_definition(
     Id; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return iot_wireless(
-        "DELETE", "/wireless-gateway-task-definitions/$(Id)"; aws_config=aws_config
+        "DELETE",
+        "/wireless-gateway-task-definitions/$(Id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_wireless_gateway_task_definition(
     Id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return iot_wireless(
-        "DELETE", "/wireless-gateway-task-definitions/$(Id)", params; aws_config=aws_config
+        "DELETE",
+        "/wireless-gateway-task-definitions/$(Id)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -686,6 +779,7 @@ function disassociate_aws_account_from_partner_account(
         "/partner-accounts/$(PartnerAccountId)",
         Dict{String,Any}("partnerType" => partnerType);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disassociate_aws_account_from_partner_account(
@@ -701,6 +795,7 @@ function disassociate_aws_account_from_partner_account(
             mergewith(_merge, Dict{String,Any}("partnerType" => partnerType), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -717,13 +812,22 @@ Disassociates a wireless device from its currently associated thing.
 function disassociate_wireless_device_from_thing(
     Id; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot_wireless("DELETE", "/wireless-devices/$(Id)/thing"; aws_config=aws_config)
+    return iot_wireless(
+        "DELETE",
+        "/wireless-devices/$(Id)/thing";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function disassociate_wireless_device_from_thing(
     Id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return iot_wireless(
-        "DELETE", "/wireless-devices/$(Id)/thing", params; aws_config=aws_config
+        "DELETE",
+        "/wireless-devices/$(Id)/thing",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -741,14 +845,21 @@ function disassociate_wireless_gateway_from_certificate(
     Id; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return iot_wireless(
-        "DELETE", "/wireless-gateways/$(Id)/certificate"; aws_config=aws_config
+        "DELETE",
+        "/wireless-gateways/$(Id)/certificate";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disassociate_wireless_gateway_from_certificate(
     Id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return iot_wireless(
-        "DELETE", "/wireless-gateways/$(Id)/certificate", params; aws_config=aws_config
+        "DELETE",
+        "/wireless-gateways/$(Id)/certificate",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -765,13 +876,22 @@ Disassociates a wireless gateway from its currently associated thing.
 function disassociate_wireless_gateway_from_thing(
     Id; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot_wireless("DELETE", "/wireless-gateways/$(Id)/thing"; aws_config=aws_config)
+    return iot_wireless(
+        "DELETE",
+        "/wireless-gateways/$(Id)/thing";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function disassociate_wireless_gateway_from_thing(
     Id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return iot_wireless(
-        "DELETE", "/wireless-gateways/$(Id)/thing", params; aws_config=aws_config
+        "DELETE",
+        "/wireless-gateways/$(Id)/thing",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -786,12 +906,23 @@ Gets information about a destination.
 
 """
 function get_destination(Name; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot_wireless("GET", "/destinations/$(Name)"; aws_config=aws_config)
+    return iot_wireless(
+        "GET",
+        "/destinations/$(Name)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_destination(
     Name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot_wireless("GET", "/destinations/$(Name)", params; aws_config=aws_config)
+    return iot_wireless(
+        "GET",
+        "/destinations/$(Name)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -805,12 +936,23 @@ Gets information about a device profile.
 
 """
 function get_device_profile(Id; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot_wireless("GET", "/device-profiles/$(Id)"; aws_config=aws_config)
+    return iot_wireless(
+        "GET",
+        "/device-profiles/$(Id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_device_profile(
     Id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot_wireless("GET", "/device-profiles/$(Id)", params; aws_config=aws_config)
+    return iot_wireless(
+        "GET",
+        "/device-profiles/$(Id)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -824,12 +966,16 @@ types, log levels can be for wireless device log options or wireless gateway log
 function get_log_levels_by_resource_types(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot_wireless("GET", "/log-levels"; aws_config=aws_config)
+    return iot_wireless(
+        "GET", "/log-levels"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_log_levels_by_resource_types(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot_wireless("GET", "/log-levels", params; aws_config=aws_config)
+    return iot_wireless(
+        "GET", "/log-levels", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -852,6 +998,7 @@ function get_partner_account(
         "/partner-accounts/$(PartnerAccountId)",
         Dict{String,Any}("partnerType" => partnerType);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_partner_account(
@@ -867,6 +1014,7 @@ function get_partner_account(
             mergewith(_merge, Dict{String,Any}("partnerType" => partnerType), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -890,6 +1038,7 @@ function get_resource_log_level(
         "/log-levels/$(ResourceIdentifier)",
         Dict{String,Any}("resourceType" => resourceType);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_resource_log_level(
@@ -905,6 +1054,7 @@ function get_resource_log_level(
             mergewith(_merge, Dict{String,Any}("resourceType" => resourceType), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -922,12 +1072,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Server endpoint.
 """
 function get_service_endpoint(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot_wireless("GET", "/service-endpoint"; aws_config=aws_config)
+    return iot_wireless(
+        "GET", "/service-endpoint"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_service_endpoint(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot_wireless("GET", "/service-endpoint", params; aws_config=aws_config)
+    return iot_wireless(
+        "GET",
+        "/service-endpoint",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -941,12 +1099,23 @@ Gets information about a service profile.
 
 """
 function get_service_profile(Id; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot_wireless("GET", "/service-profiles/$(Id)"; aws_config=aws_config)
+    return iot_wireless(
+        "GET",
+        "/service-profiles/$(Id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_service_profile(
     Id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot_wireless("GET", "/service-profiles/$(Id)", params; aws_config=aws_config)
+    return iot_wireless(
+        "GET",
+        "/service-profiles/$(Id)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -968,6 +1137,7 @@ function get_wireless_device(
         "/wireless-devices/$(Identifier)",
         Dict{String,Any}("identifierType" => identifierType);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_wireless_device(
@@ -983,6 +1153,7 @@ function get_wireless_device(
             mergewith(_merge, Dict{String,Any}("identifierType" => identifierType), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -999,13 +1170,22 @@ Gets operating information about a wireless device.
 function get_wireless_device_statistics(
     Id; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot_wireless("GET", "/wireless-devices/$(Id)/statistics"; aws_config=aws_config)
+    return iot_wireless(
+        "GET",
+        "/wireless-devices/$(Id)/statistics";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_wireless_device_statistics(
     Id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return iot_wireless(
-        "GET", "/wireless-devices/$(Id)/statistics", params; aws_config=aws_config
+        "GET",
+        "/wireless-devices/$(Id)/statistics",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1028,6 +1208,7 @@ function get_wireless_gateway(
         "/wireless-gateways/$(Identifier)",
         Dict{String,Any}("identifierType" => identifierType);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_wireless_gateway(
@@ -1043,6 +1224,7 @@ function get_wireless_gateway(
             mergewith(_merge, Dict{String,Any}("identifierType" => identifierType), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1060,14 +1242,21 @@ function get_wireless_gateway_certificate(
     Id; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return iot_wireless(
-        "GET", "/wireless-gateways/$(Id)/certificate"; aws_config=aws_config
+        "GET",
+        "/wireless-gateways/$(Id)/certificate";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_wireless_gateway_certificate(
     Id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return iot_wireless(
-        "GET", "/wireless-gateways/$(Id)/certificate", params; aws_config=aws_config
+        "GET",
+        "/wireless-gateways/$(Id)/certificate",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1085,7 +1274,10 @@ function get_wireless_gateway_firmware_information(
     Id; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return iot_wireless(
-        "GET", "/wireless-gateways/$(Id)/firmware-information"; aws_config=aws_config
+        "GET",
+        "/wireless-gateways/$(Id)/firmware-information";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_wireless_gateway_firmware_information(
@@ -1096,6 +1288,7 @@ function get_wireless_gateway_firmware_information(
         "/wireless-gateways/$(Id)/firmware-information",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1112,13 +1305,22 @@ Gets operating information about a wireless gateway.
 function get_wireless_gateway_statistics(
     Id; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot_wireless("GET", "/wireless-gateways/$(Id)/statistics"; aws_config=aws_config)
+    return iot_wireless(
+        "GET",
+        "/wireless-gateways/$(Id)/statistics";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_wireless_gateway_statistics(
     Id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return iot_wireless(
-        "GET", "/wireless-gateways/$(Id)/statistics", params; aws_config=aws_config
+        "GET",
+        "/wireless-gateways/$(Id)/statistics",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1133,13 +1335,22 @@ Gets information about a wireless gateway task.
 
 """
 function get_wireless_gateway_task(Id; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot_wireless("GET", "/wireless-gateways/$(Id)/tasks"; aws_config=aws_config)
+    return iot_wireless(
+        "GET",
+        "/wireless-gateways/$(Id)/tasks";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_wireless_gateway_task(
     Id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return iot_wireless(
-        "GET", "/wireless-gateways/$(Id)/tasks", params; aws_config=aws_config
+        "GET",
+        "/wireless-gateways/$(Id)/tasks",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1157,14 +1368,21 @@ function get_wireless_gateway_task_definition(
     Id; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return iot_wireless(
-        "GET", "/wireless-gateway-task-definitions/$(Id)"; aws_config=aws_config
+        "GET",
+        "/wireless-gateway-task-definitions/$(Id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_wireless_gateway_task_definition(
     Id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return iot_wireless(
-        "GET", "/wireless-gateway-task-definitions/$(Id)", params; aws_config=aws_config
+        "GET",
+        "/wireless-gateway-task-definitions/$(Id)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1181,12 +1399,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   response; otherwise null to receive the first set of results.
 """
 function list_destinations(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot_wireless("GET", "/destinations"; aws_config=aws_config)
+    return iot_wireless(
+        "GET", "/destinations"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_destinations(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot_wireless("GET", "/destinations", params; aws_config=aws_config)
+    return iot_wireless(
+        "GET",
+        "/destinations",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1202,12 +1428,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   response; otherwise null to receive the first set of results.
 """
 function list_device_profiles(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot_wireless("GET", "/device-profiles"; aws_config=aws_config)
+    return iot_wireless(
+        "GET", "/device-profiles"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_device_profiles(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot_wireless("GET", "/device-profiles", params; aws_config=aws_config)
+    return iot_wireless(
+        "GET",
+        "/device-profiles",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1223,12 +1457,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   response; otherwise null to receive the first set of results.
 """
 function list_partner_accounts(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot_wireless("GET", "/partner-accounts"; aws_config=aws_config)
+    return iot_wireless(
+        "GET", "/partner-accounts"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_partner_accounts(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot_wireless("GET", "/partner-accounts", params; aws_config=aws_config)
+    return iot_wireless(
+        "GET",
+        "/partner-accounts",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1244,12 +1486,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   response; otherwise null to receive the first set of results.
 """
 function list_service_profiles(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot_wireless("GET", "/service-profiles"; aws_config=aws_config)
+    return iot_wireless(
+        "GET", "/service-profiles"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_service_profiles(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot_wireless("GET", "/service-profiles", params; aws_config=aws_config)
+    return iot_wireless(
+        "GET",
+        "/service-profiles",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1270,6 +1520,7 @@ function list_tags_for_resource(
         "/tags",
         Dict{String,Any}("resourceArn" => resourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags_for_resource(
@@ -1284,6 +1535,7 @@ function list_tags_for_resource(
             mergewith(_merge, Dict{String,Any}("resourceArn" => resourceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1307,12 +1559,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   device type.
 """
 function list_wireless_devices(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot_wireless("GET", "/wireless-devices"; aws_config=aws_config)
+    return iot_wireless(
+        "GET", "/wireless-devices"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_wireless_devices(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot_wireless("GET", "/wireless-devices", params; aws_config=aws_config)
+    return iot_wireless(
+        "GET",
+        "/wireless-devices",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1332,13 +1592,22 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function list_wireless_gateway_task_definitions(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot_wireless("GET", "/wireless-gateway-task-definitions"; aws_config=aws_config)
+    return iot_wireless(
+        "GET",
+        "/wireless-gateway-task-definitions";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_wireless_gateway_task_definitions(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return iot_wireless(
-        "GET", "/wireless-gateway-task-definitions", params; aws_config=aws_config
+        "GET",
+        "/wireless-gateway-task-definitions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1355,12 +1624,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   response; otherwise null to receive the first set of results.
 """
 function list_wireless_gateways(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot_wireless("GET", "/wireless-gateways"; aws_config=aws_config)
+    return iot_wireless(
+        "GET", "/wireless-gateways"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_wireless_gateways(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot_wireless("GET", "/wireless-gateways", params; aws_config=aws_config)
+    return iot_wireless(
+        "GET",
+        "/wireless-gateways",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1388,6 +1665,7 @@ function put_resource_log_level(
         "/log-levels/$(ResourceIdentifier)",
         Dict{String,Any}("LogLevel" => LogLevel, "resourceType" => resourceType);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_resource_log_level(
@@ -1408,6 +1686,7 @@ function put_resource_log_level(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1420,12 +1699,20 @@ gateways.
 
 """
 function reset_all_resource_log_levels(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot_wireless("DELETE", "/log-levels"; aws_config=aws_config)
+    return iot_wireless(
+        "DELETE", "/log-levels"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function reset_all_resource_log_levels(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot_wireless("DELETE", "/log-levels", params; aws_config=aws_config)
+    return iot_wireless(
+        "DELETE",
+        "/log-levels",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1448,6 +1735,7 @@ function reset_resource_log_level(
         "/log-levels/$(ResourceIdentifier)",
         Dict{String,Any}("resourceType" => resourceType);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function reset_resource_log_level(
@@ -1463,6 +1751,7 @@ function reset_resource_log_level(
             mergewith(_merge, Dict{String,Any}("resourceType" => resourceType), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1490,6 +1779,7 @@ function send_data_to_wireless_device(
         "/wireless-devices/$(Id)/data",
         Dict{String,Any}("PayloadData" => PayloadData, "TransmitMode" => TransmitMode);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function send_data_to_wireless_device(
@@ -1512,6 +1802,7 @@ function send_data_to_wireless_device(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1533,6 +1824,7 @@ function tag_resource(Tags, resourceArn; aws_config::AbstractAWSConfig=global_aw
         "/tags",
         Dict{String,Any}("Tags" => Tags, "resourceArn" => resourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -1552,6 +1844,7 @@ function tag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1566,13 +1859,22 @@ Simulates a provisioned device by sending an uplink data payload of Hello.
 
 """
 function test_wireless_device(Id; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot_wireless("POST", "/wireless-devices/$(Id)/test"; aws_config=aws_config)
+    return iot_wireless(
+        "POST",
+        "/wireless-devices/$(Id)/test";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function test_wireless_device(
     Id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return iot_wireless(
-        "POST", "/wireless-devices/$(Id)/test", params; aws_config=aws_config
+        "POST",
+        "/wireless-devices/$(Id)/test",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1595,6 +1897,7 @@ function untag_resource(
         "/tags",
         Dict{String,Any}("resourceArn" => resourceArn, "tagKeys" => tagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -1614,6 +1917,7 @@ function untag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1634,12 +1938,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"RoleArn"`: The ARN of the IAM Role that authorizes the destination.
 """
 function update_destination(Name; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot_wireless("PATCH", "/destinations/$(Name)"; aws_config=aws_config)
+    return iot_wireless(
+        "PATCH",
+        "/destinations/$(Name)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function update_destination(
     Name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot_wireless("PATCH", "/destinations/$(Name)", params; aws_config=aws_config)
+    return iot_wireless(
+        "PATCH",
+        "/destinations/$(Name)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1659,12 +1974,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function update_log_levels_by_resource_types(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot_wireless("POST", "/log-levels"; aws_config=aws_config)
+    return iot_wireless(
+        "POST", "/log-levels"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function update_log_levels_by_resource_types(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot_wireless("POST", "/log-levels", params; aws_config=aws_config)
+    return iot_wireless(
+        "POST",
+        "/log-levels",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1690,6 +2013,7 @@ function update_partner_account(
         "/partner-accounts/$(PartnerAccountId)",
         Dict{String,Any}("Sidewalk" => Sidewalk, "partnerType" => partnerType);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_partner_account(
@@ -1710,6 +2034,7 @@ function update_partner_account(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1730,12 +2055,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"Name"`: The new name of the resource.
 """
 function update_wireless_device(Id; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot_wireless("PATCH", "/wireless-devices/$(Id)"; aws_config=aws_config)
+    return iot_wireless(
+        "PATCH",
+        "/wireless-devices/$(Id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function update_wireless_device(
     Id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot_wireless("PATCH", "/wireless-devices/$(Id)", params; aws_config=aws_config)
+    return iot_wireless(
+        "PATCH",
+        "/wireless-devices/$(Id)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1755,10 +2091,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NetIdFilters"`:
 """
 function update_wireless_gateway(Id; aws_config::AbstractAWSConfig=global_aws_config())
-    return iot_wireless("PATCH", "/wireless-gateways/$(Id)"; aws_config=aws_config)
+    return iot_wireless(
+        "PATCH",
+        "/wireless-gateways/$(Id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function update_wireless_gateway(
     Id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iot_wireless("PATCH", "/wireless-gateways/$(Id)", params; aws_config=aws_config)
+    return iot_wireless(
+        "PATCH",
+        "/wireless-gateways/$(Id)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end

--- a/src/services/iotanalytics.jl
+++ b/src/services/iotanalytics.jl
@@ -32,6 +32,7 @@ function batch_put_message(
         "/messages/batch",
         Dict{String,Any}("channelName" => channelName, "messages" => messages);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_put_message(
@@ -51,6 +52,7 @@ function batch_put_message(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -73,6 +75,7 @@ function cancel_pipeline_reprocessing(
         "DELETE",
         "/pipelines/$(pipelineName)/reprocessing/$(reprocessingId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function cancel_pipeline_reprocessing(
@@ -86,6 +89,7 @@ function cancel_pipeline_reprocessing(
         "/pipelines/$(pipelineName)/reprocessing/$(reprocessingId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -114,6 +118,7 @@ function create_channel(channelName; aws_config::AbstractAWSConfig=global_aws_co
         "/channels",
         Dict{String,Any}("channelName" => channelName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_channel(
@@ -128,6 +133,7 @@ function create_channel(
             mergewith(_merge, Dict{String,Any}("channelName" => channelName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -173,6 +179,7 @@ function create_dataset(
         "/datasets",
         Dict{String,Any}("actions" => actions, "datasetName" => datasetName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_dataset(
@@ -192,6 +199,7 @@ function create_dataset(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -213,7 +221,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function create_dataset_content(
     datasetName; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iotanalytics("POST", "/datasets/$(datasetName)/content"; aws_config=aws_config)
+    return iotanalytics(
+        "POST",
+        "/datasets/$(datasetName)/content";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function create_dataset_content(
     datasetName,
@@ -221,7 +234,11 @@ function create_dataset_content(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return iotanalytics(
-        "POST", "/datasets/$(datasetName)/content", params; aws_config=aws_config
+        "POST",
+        "/datasets/$(datasetName)/content",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -255,6 +272,7 @@ function create_datastore(datastoreName; aws_config::AbstractAWSConfig=global_aw
         "/datastores",
         Dict{String,Any}("datastoreName" => datastoreName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_datastore(
@@ -269,6 +287,7 @@ function create_datastore(
             mergewith(_merge, Dict{String,Any}("datastoreName" => datastoreName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -305,6 +324,7 @@ function create_pipeline(
             "pipelineActivities" => pipelineActivities, "pipelineName" => pipelineName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_pipeline(
@@ -327,6 +347,7 @@ function create_pipeline(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -341,14 +362,25 @@ Deletes the specified channel.
 
 """
 function delete_channel(channelName; aws_config::AbstractAWSConfig=global_aws_config())
-    return iotanalytics("DELETE", "/channels/$(channelName)"; aws_config=aws_config)
+    return iotanalytics(
+        "DELETE",
+        "/channels/$(channelName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_channel(
     channelName,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return iotanalytics("DELETE", "/channels/$(channelName)", params; aws_config=aws_config)
+    return iotanalytics(
+        "DELETE",
+        "/channels/$(channelName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -363,14 +395,25 @@ you perform this operation.
 
 """
 function delete_dataset(datasetName; aws_config::AbstractAWSConfig=global_aws_config())
-    return iotanalytics("DELETE", "/datasets/$(datasetName)"; aws_config=aws_config)
+    return iotanalytics(
+        "DELETE",
+        "/datasets/$(datasetName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_dataset(
     datasetName,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return iotanalytics("DELETE", "/datasets/$(datasetName)", params; aws_config=aws_config)
+    return iotanalytics(
+        "DELETE",
+        "/datasets/$(datasetName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -391,7 +434,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function delete_dataset_content(
     datasetName; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iotanalytics("DELETE", "/datasets/$(datasetName)/content"; aws_config=aws_config)
+    return iotanalytics(
+        "DELETE",
+        "/datasets/$(datasetName)/content";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_dataset_content(
     datasetName,
@@ -399,7 +447,11 @@ function delete_dataset_content(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return iotanalytics(
-        "DELETE", "/datasets/$(datasetName)/content", params; aws_config=aws_config
+        "DELETE",
+        "/datasets/$(datasetName)/content",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -414,7 +466,12 @@ Deletes the specified data store.
 
 """
 function delete_datastore(datastoreName; aws_config::AbstractAWSConfig=global_aws_config())
-    return iotanalytics("DELETE", "/datastores/$(datastoreName)"; aws_config=aws_config)
+    return iotanalytics(
+        "DELETE",
+        "/datastores/$(datastoreName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_datastore(
     datastoreName,
@@ -422,7 +479,11 @@ function delete_datastore(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return iotanalytics(
-        "DELETE", "/datastores/$(datastoreName)", params; aws_config=aws_config
+        "DELETE",
+        "/datastores/$(datastoreName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -437,7 +498,12 @@ Deletes the specified pipeline.
 
 """
 function delete_pipeline(pipelineName; aws_config::AbstractAWSConfig=global_aws_config())
-    return iotanalytics("DELETE", "/pipelines/$(pipelineName)"; aws_config=aws_config)
+    return iotanalytics(
+        "DELETE",
+        "/pipelines/$(pipelineName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_pipeline(
     pipelineName,
@@ -445,7 +511,11 @@ function delete_pipeline(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return iotanalytics(
-        "DELETE", "/pipelines/$(pipelineName)", params; aws_config=aws_config
+        "DELETE",
+        "/pipelines/$(pipelineName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -465,14 +535,25 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   customer-managed.
 """
 function describe_channel(channelName; aws_config::AbstractAWSConfig=global_aws_config())
-    return iotanalytics("GET", "/channels/$(channelName)"; aws_config=aws_config)
+    return iotanalytics(
+        "GET",
+        "/channels/$(channelName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_channel(
     channelName,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return iotanalytics("GET", "/channels/$(channelName)", params; aws_config=aws_config)
+    return iotanalytics(
+        "GET",
+        "/channels/$(channelName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -486,14 +567,25 @@ Retrieves information about a dataset.
 
 """
 function describe_dataset(datasetName; aws_config::AbstractAWSConfig=global_aws_config())
-    return iotanalytics("GET", "/datasets/$(datasetName)"; aws_config=aws_config)
+    return iotanalytics(
+        "GET",
+        "/datasets/$(datasetName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_dataset(
     datasetName,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return iotanalytics("GET", "/datasets/$(datasetName)", params; aws_config=aws_config)
+    return iotanalytics(
+        "GET",
+        "/datasets/$(datasetName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -514,7 +606,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_datastore(
     datastoreName; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iotanalytics("GET", "/datastores/$(datastoreName)"; aws_config=aws_config)
+    return iotanalytics(
+        "GET",
+        "/datastores/$(datastoreName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_datastore(
     datastoreName,
@@ -522,7 +619,11 @@ function describe_datastore(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return iotanalytics(
-        "GET", "/datastores/$(datastoreName)", params; aws_config=aws_config
+        "GET",
+        "/datastores/$(datastoreName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -534,12 +635,16 @@ Retrieves the current settings of the IoT Analytics logging options.
 
 """
 function describe_logging_options(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iotanalytics("GET", "/logging"; aws_config=aws_config)
+    return iotanalytics(
+        "GET", "/logging"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_logging_options(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iotanalytics("GET", "/logging", params; aws_config=aws_config)
+    return iotanalytics(
+        "GET", "/logging", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -553,14 +658,25 @@ Retrieves information about a pipeline.
 
 """
 function describe_pipeline(pipelineName; aws_config::AbstractAWSConfig=global_aws_config())
-    return iotanalytics("GET", "/pipelines/$(pipelineName)"; aws_config=aws_config)
+    return iotanalytics(
+        "GET",
+        "/pipelines/$(pipelineName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_pipeline(
     pipelineName,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return iotanalytics("GET", "/pipelines/$(pipelineName)", params; aws_config=aws_config)
+    return iotanalytics(
+        "GET",
+        "/pipelines/$(pipelineName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -580,7 +696,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   default.
 """
 function get_dataset_content(datasetName; aws_config::AbstractAWSConfig=global_aws_config())
-    return iotanalytics("GET", "/datasets/$(datasetName)/content"; aws_config=aws_config)
+    return iotanalytics(
+        "GET",
+        "/datasets/$(datasetName)/content";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_dataset_content(
     datasetName,
@@ -588,7 +709,11 @@ function get_dataset_content(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return iotanalytics(
-        "GET", "/datasets/$(datasetName)/content", params; aws_config=aws_config
+        "GET",
+        "/datasets/$(datasetName)/content",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -605,12 +730,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: The token for the next set of results.
 """
 function list_channels(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iotanalytics("GET", "/channels"; aws_config=aws_config)
+    return iotanalytics(
+        "GET", "/channels"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_channels(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iotanalytics("GET", "/channels", params; aws_config=aws_config)
+    return iotanalytics(
+        "GET", "/channels", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -636,7 +765,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function list_dataset_contents(
     datasetName; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iotanalytics("GET", "/datasets/$(datasetName)/contents"; aws_config=aws_config)
+    return iotanalytics(
+        "GET",
+        "/datasets/$(datasetName)/contents";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_dataset_contents(
     datasetName,
@@ -644,7 +778,11 @@ function list_dataset_contents(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return iotanalytics(
-        "GET", "/datasets/$(datasetName)/contents", params; aws_config=aws_config
+        "GET",
+        "/datasets/$(datasetName)/contents",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -661,12 +799,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: The token for the next set of results.
 """
 function list_datasets(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iotanalytics("GET", "/datasets"; aws_config=aws_config)
+    return iotanalytics(
+        "GET", "/datasets"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_datasets(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iotanalytics("GET", "/datasets", params; aws_config=aws_config)
+    return iotanalytics(
+        "GET", "/datasets", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -682,12 +824,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: The token for the next set of results.
 """
 function list_datastores(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iotanalytics("GET", "/datastores"; aws_config=aws_config)
+    return iotanalytics(
+        "GET", "/datastores"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_datastores(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iotanalytics("GET", "/datastores", params; aws_config=aws_config)
+    return iotanalytics(
+        "GET", "/datastores", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -703,12 +849,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: The token for the next set of results.
 """
 function list_pipelines(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iotanalytics("GET", "/pipelines"; aws_config=aws_config)
+    return iotanalytics(
+        "GET", "/pipelines"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_pipelines(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iotanalytics("GET", "/pipelines", params; aws_config=aws_config)
+    return iotanalytics(
+        "GET", "/pipelines", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -729,6 +879,7 @@ function list_tags_for_resource(
         "/tags",
         Dict{String,Any}("resourceArn" => resourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags_for_resource(
@@ -743,6 +894,7 @@ function list_tags_for_resource(
             mergewith(_merge, Dict{String,Any}("resourceArn" => resourceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -767,6 +919,7 @@ function put_logging_options(
         "/logging",
         Dict{String,Any}("loggingOptions" => loggingOptions);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_logging_options(
@@ -781,6 +934,7 @@ function put_logging_options(
             mergewith(_merge, Dict{String,Any}("loggingOptions" => loggingOptions), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -807,6 +961,7 @@ function run_pipeline_activity(
         "/pipelineactivities/run",
         Dict{String,Any}("payloads" => payloads, "pipelineActivity" => pipelineActivity);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function run_pipeline_activity(
@@ -828,6 +983,7 @@ function run_pipeline_activity(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -849,7 +1005,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"startTime"`: The start of the time window from which sample messages are retrieved.
 """
 function sample_channel_data(channelName; aws_config::AbstractAWSConfig=global_aws_config())
-    return iotanalytics("GET", "/channels/$(channelName)/sample"; aws_config=aws_config)
+    return iotanalytics(
+        "GET",
+        "/channels/$(channelName)/sample";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function sample_channel_data(
     channelName,
@@ -857,7 +1018,11 @@ function sample_channel_data(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return iotanalytics(
-        "GET", "/channels/$(channelName)/sample", params; aws_config=aws_config
+        "GET",
+        "/channels/$(channelName)/sample",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -884,7 +1049,10 @@ function start_pipeline_reprocessing(
     pipelineName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return iotanalytics(
-        "POST", "/pipelines/$(pipelineName)/reprocessing"; aws_config=aws_config
+        "POST",
+        "/pipelines/$(pipelineName)/reprocessing";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_pipeline_reprocessing(
@@ -893,7 +1061,11 @@ function start_pipeline_reprocessing(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return iotanalytics(
-        "POST", "/pipelines/$(pipelineName)/reprocessing", params; aws_config=aws_config
+        "POST",
+        "/pipelines/$(pipelineName)/reprocessing",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -915,6 +1087,7 @@ function tag_resource(resourceArn, tags; aws_config::AbstractAWSConfig=global_aw
         "/tags",
         Dict{String,Any}("resourceArn" => resourceArn, "tags" => tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -934,6 +1107,7 @@ function tag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -956,6 +1130,7 @@ function untag_resource(
         "/tags",
         Dict{String,Any}("resourceArn" => resourceArn, "tagKeys" => tagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -975,6 +1150,7 @@ function untag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -996,14 +1172,25 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   retention period can't be updated if the channel's Amazon S3 storage is customer-managed.
 """
 function update_channel(channelName; aws_config::AbstractAWSConfig=global_aws_config())
-    return iotanalytics("PUT", "/channels/$(channelName)"; aws_config=aws_config)
+    return iotanalytics(
+        "PUT",
+        "/channels/$(channelName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function update_channel(
     channelName,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return iotanalytics("PUT", "/channels/$(channelName)", params; aws_config=aws_config)
+    return iotanalytics(
+        "PUT",
+        "/channels/$(channelName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1039,6 +1226,7 @@ function update_dataset(
         "/datasets/$(datasetName)",
         Dict{String,Any}("actions" => actions);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_dataset(
@@ -1052,6 +1240,7 @@ function update_dataset(
         "/datasets/$(datasetName)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("actions" => actions), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1077,7 +1266,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   retention period can't be updated if the data store's Amazon S3 storage is customer-managed.
 """
 function update_datastore(datastoreName; aws_config::AbstractAWSConfig=global_aws_config())
-    return iotanalytics("PUT", "/datastores/$(datastoreName)"; aws_config=aws_config)
+    return iotanalytics(
+        "PUT",
+        "/datastores/$(datastoreName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function update_datastore(
     datastoreName,
@@ -1085,7 +1279,11 @@ function update_datastore(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return iotanalytics(
-        "PUT", "/datastores/$(datastoreName)", params; aws_config=aws_config
+        "PUT",
+        "/datastores/$(datastoreName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1116,6 +1314,7 @@ function update_pipeline(
         "/pipelines/$(pipelineName)",
         Dict{String,Any}("pipelineActivities" => pipelineActivities);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_pipeline(
@@ -1133,5 +1332,6 @@ function update_pipeline(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/iotdeviceadvisor.jl
+++ b/src/services/iotdeviceadvisor.jl
@@ -17,12 +17,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"tags"`: The tags to be attached to the suite definition.
 """
 function create_suite_definition(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iotdeviceadvisor("POST", "/suiteDefinitions"; aws_config=aws_config)
+    return iotdeviceadvisor(
+        "POST", "/suiteDefinitions"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function create_suite_definition(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iotdeviceadvisor("POST", "/suiteDefinitions", params; aws_config=aws_config)
+    return iotdeviceadvisor(
+        "POST",
+        "/suiteDefinitions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -39,7 +47,10 @@ function delete_suite_definition(
     suiteDefinitionId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return iotdeviceadvisor(
-        "DELETE", "/suiteDefinitions/$(suiteDefinitionId)"; aws_config=aws_config
+        "DELETE",
+        "/suiteDefinitions/$(suiteDefinitionId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_suite_definition(
@@ -48,7 +59,11 @@ function delete_suite_definition(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return iotdeviceadvisor(
-        "DELETE", "/suiteDefinitions/$(suiteDefinitionId)", params; aws_config=aws_config
+        "DELETE",
+        "/suiteDefinitions/$(suiteDefinitionId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -69,7 +84,10 @@ function get_suite_definition(
     suiteDefinitionId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return iotdeviceadvisor(
-        "GET", "/suiteDefinitions/$(suiteDefinitionId)"; aws_config=aws_config
+        "GET",
+        "/suiteDefinitions/$(suiteDefinitionId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_suite_definition(
@@ -78,7 +96,11 @@ function get_suite_definition(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return iotdeviceadvisor(
-        "GET", "/suiteDefinitions/$(suiteDefinitionId)", params; aws_config=aws_config
+        "GET",
+        "/suiteDefinitions/$(suiteDefinitionId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -100,6 +122,7 @@ function get_suite_run(
         "GET",
         "/suiteDefinitions/$(suiteDefinitionId)/suiteRuns/$(suiteRunId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_suite_run(
@@ -113,6 +136,7 @@ function get_suite_run(
         "/suiteDefinitions/$(suiteDefinitionId)/suiteRuns/$(suiteRunId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -134,6 +158,7 @@ function get_suite_run_report(
         "GET",
         "/suiteDefinitions/$(suiteDefinitionId)/suiteRuns/$(suiteRunId)/report";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_suite_run_report(
@@ -147,6 +172,7 @@ function get_suite_run_report(
         "/suiteDefinitions/$(suiteDefinitionId)/suiteRuns/$(suiteRunId)/report",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -162,12 +188,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: A token used to get the next set of results.
 """
 function list_suite_definitions(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iotdeviceadvisor("GET", "/suiteDefinitions"; aws_config=aws_config)
+    return iotdeviceadvisor(
+        "GET", "/suiteDefinitions"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_suite_definitions(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iotdeviceadvisor("GET", "/suiteDefinitions", params; aws_config=aws_config)
+    return iotdeviceadvisor(
+        "GET",
+        "/suiteDefinitions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -187,12 +221,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   suite runs of the specified test suite based on suite definition version.
 """
 function list_suite_runs(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iotdeviceadvisor("GET", "/suiteRuns"; aws_config=aws_config)
+    return iotdeviceadvisor(
+        "GET", "/suiteRuns"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_suite_runs(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iotdeviceadvisor("GET", "/suiteRuns", params; aws_config=aws_config)
+    return iotdeviceadvisor(
+        "GET", "/suiteRuns", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -208,14 +246,25 @@ Lists the tags attached to an IoT Device Advisor resource.
 function list_tags_for_resource(
     resourceArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iotdeviceadvisor("GET", "/tags/$(resourceArn)"; aws_config=aws_config)
+    return iotdeviceadvisor(
+        "GET",
+        "/tags/$(resourceArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_tags_for_resource(
     resourceArn,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return iotdeviceadvisor("GET", "/tags/$(resourceArn)", params; aws_config=aws_config)
+    return iotdeviceadvisor(
+        "GET",
+        "/tags/$(resourceArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -237,7 +286,10 @@ function start_suite_run(
     suiteDefinitionId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return iotdeviceadvisor(
-        "POST", "/suiteDefinitions/$(suiteDefinitionId)/suiteRuns"; aws_config=aws_config
+        "POST",
+        "/suiteDefinitions/$(suiteDefinitionId)/suiteRuns";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_suite_run(
@@ -250,6 +302,7 @@ function start_suite_run(
         "/suiteDefinitions/$(suiteDefinitionId)/suiteRuns",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -271,6 +324,7 @@ function stop_suite_run(
         "POST",
         "/suiteDefinitions/$(suiteDefinitionId)/suiteRuns/$(suiteRunId)/stop";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function stop_suite_run(
@@ -284,6 +338,7 @@ function stop_suite_run(
         "/suiteDefinitions/$(suiteDefinitionId)/suiteRuns/$(suiteRunId)/stop",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -304,6 +359,7 @@ function tag_resource(resourceArn, tags; aws_config::AbstractAWSConfig=global_aw
         "/tags/$(resourceArn)",
         Dict{String,Any}("tags" => tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -317,6 +373,7 @@ function tag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tags" => tags), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -339,6 +396,7 @@ function untag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}("tagKeys" => tagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -352,6 +410,7 @@ function untag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tagKeys" => tagKeys), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -373,7 +432,10 @@ function update_suite_definition(
     suiteDefinitionId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return iotdeviceadvisor(
-        "PATCH", "/suiteDefinitions/$(suiteDefinitionId)"; aws_config=aws_config
+        "PATCH",
+        "/suiteDefinitions/$(suiteDefinitionId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_suite_definition(
@@ -382,6 +444,10 @@ function update_suite_definition(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return iotdeviceadvisor(
-        "PATCH", "/suiteDefinitions/$(suiteDefinitionId)", params; aws_config=aws_config
+        "PATCH",
+        "/suiteDefinitions/$(suiteDefinitionId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/iotfleethub.jl
+++ b/src/services/iotfleethub.jl
@@ -37,6 +37,7 @@ function create_application(
             "clientToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_application(
@@ -60,6 +61,7 @@ function create_application(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -87,6 +89,7 @@ function delete_application(
         "/applications/$(applicationId)",
         Dict{String,Any}("clientToken" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_application(
@@ -101,6 +104,7 @@ function delete_application(
             mergewith(_merge, Dict{String,Any}("clientToken" => string(uuid4())), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -118,7 +122,12 @@ Hub for AWS IoT Device Management is in public preview and is subject to change.
 function describe_application(
     applicationId; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iotfleethub("GET", "/applications/$(applicationId)"; aws_config=aws_config)
+    return iotfleethub(
+        "GET",
+        "/applications/$(applicationId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_application(
     applicationId,
@@ -126,7 +135,11 @@ function describe_application(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return iotfleethub(
-        "GET", "/applications/$(applicationId)", params; aws_config=aws_config
+        "GET",
+        "/applications/$(applicationId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -143,12 +156,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: A token used to get the next set of results.
 """
 function list_applications(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iotfleethub("GET", "/applications"; aws_config=aws_config)
+    return iotfleethub(
+        "GET", "/applications"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_applications(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iotfleethub("GET", "/applications", params; aws_config=aws_config)
+    return iotfleethub(
+        "GET",
+        "/applications",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -165,14 +186,25 @@ public preview and is subject to change.
 function list_tags_for_resource(
     resourceArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iotfleethub("GET", "/tags/$(resourceArn)"; aws_config=aws_config)
+    return iotfleethub(
+        "GET",
+        "/tags/$(resourceArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_tags_for_resource(
     resourceArn,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return iotfleethub("GET", "/tags/$(resourceArn)", params; aws_config=aws_config)
+    return iotfleethub(
+        "GET",
+        "/tags/$(resourceArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -194,6 +226,7 @@ function tag_resource(resourceArn, tags; aws_config::AbstractAWSConfig=global_aw
         "/tags/$(resourceArn)",
         Dict{String,Any}("tags" => tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -207,6 +240,7 @@ function tag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tags" => tags), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -230,6 +264,7 @@ function untag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}("tagKeys" => tagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -243,6 +278,7 @@ function untag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tagKeys" => tagKeys), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -272,6 +308,7 @@ function update_application(
         "/applications/$(applicationId)",
         Dict{String,Any}("clientToken" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_application(
@@ -286,5 +323,6 @@ function update_application(
             mergewith(_merge, Dict{String,Any}("clientToken" => string(uuid4())), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/iotsecuretunneling.jl
+++ b/src/services/iotsecuretunneling.jl
@@ -22,7 +22,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function close_tunnel(tunnelId; aws_config::AbstractAWSConfig=global_aws_config())
     return iotsecuretunneling(
-        "CloseTunnel", Dict{String,Any}("tunnelId" => tunnelId); aws_config=aws_config
+        "CloseTunnel",
+        Dict{String,Any}("tunnelId" => tunnelId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function close_tunnel(
@@ -36,6 +39,7 @@ function close_tunnel(
             mergewith(_merge, Dict{String,Any}("tunnelId" => tunnelId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -51,7 +55,10 @@ Gets information about a tunnel identified by the unique tunnel id.
 """
 function describe_tunnel(tunnelId; aws_config::AbstractAWSConfig=global_aws_config())
     return iotsecuretunneling(
-        "DescribeTunnel", Dict{String,Any}("tunnelId" => tunnelId); aws_config=aws_config
+        "DescribeTunnel",
+        Dict{String,Any}("tunnelId" => tunnelId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_tunnel(
@@ -65,6 +72,7 @@ function describe_tunnel(
             mergewith(_merge, Dict{String,Any}("tunnelId" => tunnelId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -85,6 +93,7 @@ function list_tags_for_resource(
         "ListTagsForResource",
         Dict{String,Any}("resourceArn" => resourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags_for_resource(
@@ -98,6 +107,7 @@ function list_tags_for_resource(
             mergewith(_merge, Dict{String,Any}("resourceArn" => resourceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -115,12 +125,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"thingName"`: The name of the IoT thing associated with the destination device.
 """
 function list_tunnels(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iotsecuretunneling("ListTunnels"; aws_config=aws_config)
+    return iotsecuretunneling(
+        "ListTunnels"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_tunnels(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iotsecuretunneling("ListTunnels", params; aws_config=aws_config)
+    return iotsecuretunneling(
+        "ListTunnels", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -138,12 +152,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"timeoutConfig"`: Timeout configuration for a tunnel.
 """
 function open_tunnel(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iotsecuretunneling("OpenTunnel"; aws_config=aws_config)
+    return iotsecuretunneling(
+        "OpenTunnel"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function open_tunnel(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iotsecuretunneling("OpenTunnel", params; aws_config=aws_config)
+    return iotsecuretunneling(
+        "OpenTunnel", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -162,6 +180,7 @@ function tag_resource(resourceArn, tags; aws_config::AbstractAWSConfig=global_aw
         "TagResource",
         Dict{String,Any}("resourceArn" => resourceArn, "tags" => tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -180,6 +199,7 @@ function tag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -201,6 +221,7 @@ function untag_resource(
         "UntagResource",
         Dict{String,Any}("resourceArn" => resourceArn, "tagKeys" => tagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -219,5 +240,6 @@ function untag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/iotsitewise.jl
+++ b/src/services/iotsitewise.jl
@@ -37,6 +37,7 @@ function associate_assets(
             "clientToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_assets(
@@ -61,6 +62,7 @@ function associate_assets(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -88,6 +90,7 @@ function batch_associate_project_assets(
         "/projects/$(projectId)/assets/associate",
         Dict{String,Any}("assetIds" => assetIds, "clientToken" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_associate_project_assets(
@@ -107,6 +110,7 @@ function batch_associate_project_assets(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -134,6 +138,7 @@ function batch_disassociate_project_assets(
         "/projects/$(projectId)/assets/disassociate",
         Dict{String,Any}("assetIds" => assetIds, "clientToken" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_disassociate_project_assets(
@@ -153,6 +158,7 @@ function batch_disassociate_project_assets(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -184,7 +190,11 @@ function batch_put_asset_property_value(
     entries; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return iotsitewise(
-        "POST", "/properties", Dict{String,Any}("entries" => entries); aws_config=aws_config
+        "POST",
+        "/properties",
+        Dict{String,Any}("entries" => entries);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_put_asset_property_value(
@@ -195,6 +205,7 @@ function batch_put_asset_property_value(
         "/properties",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("entries" => entries), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -238,6 +249,7 @@ function create_access_policy(
             "clientToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_access_policy(
@@ -263,6 +275,7 @@ function create_access_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -297,6 +310,7 @@ function create_asset(
             "clientToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_asset(
@@ -320,6 +334,7 @@ function create_asset(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -367,6 +382,7 @@ function create_asset_model(
             "assetModelName" => assetModelName, "clientToken" => string(uuid4())
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_asset_model(
@@ -387,6 +403,7 @@ function create_asset_model(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -427,6 +444,7 @@ function create_dashboard(
             "clientToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_dashboard(
@@ -452,6 +470,7 @@ function create_dashboard(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -483,6 +502,7 @@ function create_gateway(
             "gatewayName" => gatewayName, "gatewayPlatform" => gatewayPlatform
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_gateway(
@@ -504,6 +524,7 @@ function create_gateway(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -567,6 +588,7 @@ function create_portal(
             "clientToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_portal(
@@ -592,6 +614,7 @@ function create_portal(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -626,6 +649,7 @@ function create_project(
             "clientToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_project(
@@ -649,6 +673,7 @@ function create_project(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -677,6 +702,7 @@ function delete_access_policy(
         "/access-policies/$(accessPolicyId)",
         Dict{String,Any}("clientToken" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_access_policy(
@@ -691,6 +717,7 @@ function delete_access_policy(
             mergewith(_merge, Dict{String,Any}("clientToken" => string(uuid4())), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -717,6 +744,7 @@ function delete_asset(assetId; aws_config::AbstractAWSConfig=global_aws_config()
         "/assets/$(assetId)",
         Dict{String,Any}("clientToken" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_asset(
@@ -729,6 +757,7 @@ function delete_asset(
             mergewith(_merge, Dict{String,Any}("clientToken" => string(uuid4())), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -757,6 +786,7 @@ function delete_asset_model(assetModelId; aws_config::AbstractAWSConfig=global_a
         "/asset-models/$(assetModelId)",
         Dict{String,Any}("clientToken" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_asset_model(
@@ -771,6 +801,7 @@ function delete_asset_model(
             mergewith(_merge, Dict{String,Any}("clientToken" => string(uuid4())), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -795,6 +826,7 @@ function delete_dashboard(dashboardId; aws_config::AbstractAWSConfig=global_aws_
         "/dashboards/$(dashboardId)",
         Dict{String,Any}("clientToken" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_dashboard(
@@ -809,6 +841,7 @@ function delete_dashboard(
             mergewith(_merge, Dict{String,Any}("clientToken" => string(uuid4())), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -824,7 +857,12 @@ remain in your gateway's file system.
 
 """
 function delete_gateway(gatewayId; aws_config::AbstractAWSConfig=global_aws_config())
-    return iotsitewise("DELETE", "/20200301/gateways/$(gatewayId)"; aws_config=aws_config)
+    return iotsitewise(
+        "DELETE",
+        "/20200301/gateways/$(gatewayId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_gateway(
     gatewayId,
@@ -832,7 +870,11 @@ function delete_gateway(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return iotsitewise(
-        "DELETE", "/20200301/gateways/$(gatewayId)", params; aws_config=aws_config
+        "DELETE",
+        "/20200301/gateways/$(gatewayId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -857,6 +899,7 @@ function delete_portal(portalId; aws_config::AbstractAWSConfig=global_aws_config
         "/portals/$(portalId)",
         Dict{String,Any}("clientToken" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_portal(
@@ -871,6 +914,7 @@ function delete_portal(
             mergewith(_merge, Dict{String,Any}("clientToken" => string(uuid4())), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -895,6 +939,7 @@ function delete_project(projectId; aws_config::AbstractAWSConfig=global_aws_conf
         "/projects/$(projectId)",
         Dict{String,Any}("clientToken" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_project(
@@ -909,6 +954,7 @@ function delete_project(
             mergewith(_merge, Dict{String,Any}("clientToken" => string(uuid4())), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -926,7 +972,12 @@ portal or project.
 function describe_access_policy(
     accessPolicyId; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iotsitewise("GET", "/access-policies/$(accessPolicyId)"; aws_config=aws_config)
+    return iotsitewise(
+        "GET",
+        "/access-policies/$(accessPolicyId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_access_policy(
     accessPolicyId,
@@ -934,7 +985,11 @@ function describe_access_policy(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return iotsitewise(
-        "GET", "/access-policies/$(accessPolicyId)", params; aws_config=aws_config
+        "GET",
+        "/access-policies/$(accessPolicyId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -949,12 +1004,20 @@ Retrieves information about an asset.
 
 """
 function describe_asset(assetId; aws_config::AbstractAWSConfig=global_aws_config())
-    return iotsitewise("GET", "/assets/$(assetId)"; aws_config=aws_config)
+    return iotsitewise(
+        "GET", "/assets/$(assetId)"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_asset(
     assetId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iotsitewise("GET", "/assets/$(assetId)", params; aws_config=aws_config)
+    return iotsitewise(
+        "GET",
+        "/assets/$(assetId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -970,7 +1033,12 @@ Retrieves information about an asset model.
 function describe_asset_model(
     assetModelId; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iotsitewise("GET", "/asset-models/$(assetModelId)"; aws_config=aws_config)
+    return iotsitewise(
+        "GET",
+        "/asset-models/$(assetModelId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_asset_model(
     assetModelId,
@@ -978,7 +1046,11 @@ function describe_asset_model(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return iotsitewise(
-        "GET", "/asset-models/$(assetModelId)", params; aws_config=aws_config
+        "GET",
+        "/asset-models/$(assetModelId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1001,7 +1073,10 @@ function describe_asset_property(
     assetId, propertyId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return iotsitewise(
-        "GET", "/assets/$(assetId)/properties/$(propertyId)"; aws_config=aws_config
+        "GET",
+        "/assets/$(assetId)/properties/$(propertyId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_asset_property(
@@ -1011,7 +1086,11 @@ function describe_asset_property(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return iotsitewise(
-        "GET", "/assets/$(assetId)/properties/$(propertyId)", params; aws_config=aws_config
+        "GET",
+        "/assets/$(assetId)/properties/$(propertyId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1026,14 +1105,25 @@ Retrieves information about a dashboard.
 
 """
 function describe_dashboard(dashboardId; aws_config::AbstractAWSConfig=global_aws_config())
-    return iotsitewise("GET", "/dashboards/$(dashboardId)"; aws_config=aws_config)
+    return iotsitewise(
+        "GET",
+        "/dashboards/$(dashboardId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_dashboard(
     dashboardId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return iotsitewise("GET", "/dashboards/$(dashboardId)", params; aws_config=aws_config)
+    return iotsitewise(
+        "GET",
+        "/dashboards/$(dashboardId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1048,13 +1138,22 @@ management in the IoT SiteWise User Guide.
 function describe_default_encryption_configuration(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iotsitewise("GET", "/configuration/account/encryption"; aws_config=aws_config)
+    return iotsitewise(
+        "GET",
+        "/configuration/account/encryption";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_default_encryption_configuration(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return iotsitewise(
-        "GET", "/configuration/account/encryption", params; aws_config=aws_config
+        "GET",
+        "/configuration/account/encryption",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1069,7 +1168,12 @@ Retrieves information about a gateway.
 
 """
 function describe_gateway(gatewayId; aws_config::AbstractAWSConfig=global_aws_config())
-    return iotsitewise("GET", "/20200301/gateways/$(gatewayId)"; aws_config=aws_config)
+    return iotsitewise(
+        "GET",
+        "/20200301/gateways/$(gatewayId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_gateway(
     gatewayId,
@@ -1077,7 +1181,11 @@ function describe_gateway(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return iotsitewise(
-        "GET", "/20200301/gateways/$(gatewayId)", params; aws_config=aws_config
+        "GET",
+        "/20200301/gateways/$(gatewayId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1106,6 +1214,7 @@ function describe_gateway_capability_configuration(
         "GET",
         "/20200301/gateways/$(gatewayId)/capability/$(capabilityNamespace)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_gateway_capability_configuration(
@@ -1119,6 +1228,7 @@ function describe_gateway_capability_configuration(
         "/20200301/gateways/$(gatewayId)/capability/$(capabilityNamespace)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1130,12 +1240,16 @@ Retrieves the current IoT SiteWise logging options.
 
 """
 function describe_logging_options(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iotsitewise("GET", "/logging"; aws_config=aws_config)
+    return iotsitewise(
+        "GET", "/logging"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_logging_options(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iotsitewise("GET", "/logging", params; aws_config=aws_config)
+    return iotsitewise(
+        "GET", "/logging", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1149,14 +1263,25 @@ Retrieves information about a portal.
 
 """
 function describe_portal(portalId; aws_config::AbstractAWSConfig=global_aws_config())
-    return iotsitewise("GET", "/portals/$(portalId)"; aws_config=aws_config)
+    return iotsitewise(
+        "GET",
+        "/portals/$(portalId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_portal(
     portalId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return iotsitewise("GET", "/portals/$(portalId)", params; aws_config=aws_config)
+    return iotsitewise(
+        "GET",
+        "/portals/$(portalId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1170,14 +1295,25 @@ Retrieves information about a project.
 
 """
 function describe_project(projectId; aws_config::AbstractAWSConfig=global_aws_config())
-    return iotsitewise("GET", "/projects/$(projectId)"; aws_config=aws_config)
+    return iotsitewise(
+        "GET",
+        "/projects/$(projectId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_project(
     projectId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return iotsitewise("GET", "/projects/$(projectId)", params; aws_config=aws_config)
+    return iotsitewise(
+        "GET",
+        "/projects/$(projectId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1188,13 +1324,22 @@ Retrieves information about the storage configuration for IoT SiteWise.
 
 """
 function describe_storage_configuration(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iotsitewise("GET", "/configuration/account/storage"; aws_config=aws_config)
+    return iotsitewise(
+        "GET",
+        "/configuration/account/storage";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_storage_configuration(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return iotsitewise(
-        "GET", "/configuration/account/storage", params; aws_config=aws_config
+        "GET",
+        "/configuration/account/storage",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1231,6 +1376,7 @@ function disassociate_assets(
             "clientToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disassociate_assets(
@@ -1255,6 +1401,7 @@ function disassociate_assets(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1307,6 +1454,7 @@ function get_asset_property_aggregates(
             "startDate" => startDate,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_asset_property_aggregates(
@@ -1333,6 +1481,7 @@ function get_asset_property_aggregates(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1355,12 +1504,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"propertyId"`: The ID of the asset property.
 """
 function get_asset_property_value(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iotsitewise("GET", "/properties/latest"; aws_config=aws_config)
+    return iotsitewise(
+        "GET", "/properties/latest"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_asset_property_value(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iotsitewise("GET", "/properties/latest", params; aws_config=aws_config)
+    return iotsitewise(
+        "GET",
+        "/properties/latest",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1395,12 +1552,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function get_asset_property_value_history(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iotsitewise("GET", "/properties/history"; aws_config=aws_config)
+    return iotsitewise(
+        "GET", "/properties/history"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_asset_property_value_history(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iotsitewise("GET", "/properties/history", params; aws_config=aws_config)
+    return iotsitewise(
+        "GET",
+        "/properties/history",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1485,6 +1650,7 @@ function get_interpolated_asset_property_values(
             "type" => type,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_interpolated_asset_property_values(
@@ -1513,6 +1679,7 @@ function get_interpolated_asset_property_values(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1541,12 +1708,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   you specify resourceId.
 """
 function list_access_policies(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iotsitewise("GET", "/access-policies"; aws_config=aws_config)
+    return iotsitewise(
+        "GET", "/access-policies"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_access_policies(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iotsitewise("GET", "/access-policies", params; aws_config=aws_config)
+    return iotsitewise(
+        "GET",
+        "/access-policies",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1562,12 +1737,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: The token to be used for the next set of paginated results.
 """
 function list_asset_models(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iotsitewise("GET", "/asset-models"; aws_config=aws_config)
+    return iotsitewise(
+        "GET", "/asset-models"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_asset_models(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iotsitewise("GET", "/asset-models", params; aws_config=aws_config)
+    return iotsitewise(
+        "GET",
+        "/asset-models",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1597,6 +1780,7 @@ function list_asset_relationships(
         "/assets/$(assetId)/assetRelationships",
         Dict{String,Any}("traversalType" => traversalType);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_asset_relationships(
@@ -1612,6 +1796,7 @@ function list_asset_relationships(
             mergewith(_merge, Dict{String,Any}("traversalType" => traversalType), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1638,12 +1823,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: The token to be used for the next set of paginated results.
 """
 function list_assets(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iotsitewise("GET", "/assets"; aws_config=aws_config)
+    return iotsitewise(
+        "GET", "/assets"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_assets(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iotsitewise("GET", "/assets", params; aws_config=aws_config)
+    return iotsitewise(
+        "GET", "/assets", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1672,13 +1861,22 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   the asset's parent asset.   Default: CHILD
 """
 function list_associated_assets(assetId; aws_config::AbstractAWSConfig=global_aws_config())
-    return iotsitewise("GET", "/assets/$(assetId)/hierarchies"; aws_config=aws_config)
+    return iotsitewise(
+        "GET",
+        "/assets/$(assetId)/hierarchies";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_associated_assets(
     assetId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return iotsitewise(
-        "GET", "/assets/$(assetId)/hierarchies", params; aws_config=aws_config
+        "GET",
+        "/assets/$(assetId)/hierarchies",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1703,6 +1901,7 @@ function list_dashboards(projectId; aws_config::AbstractAWSConfig=global_aws_con
         "/dashboards",
         Dict{String,Any}("projectId" => projectId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_dashboards(
@@ -1717,6 +1916,7 @@ function list_dashboards(
             mergewith(_merge, Dict{String,Any}("projectId" => projectId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1733,12 +1933,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: The token to be used for the next set of paginated results.
 """
 function list_gateways(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iotsitewise("GET", "/20200301/gateways"; aws_config=aws_config)
+    return iotsitewise(
+        "GET", "/20200301/gateways"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_gateways(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iotsitewise("GET", "/20200301/gateways", params; aws_config=aws_config)
+    return iotsitewise(
+        "GET",
+        "/20200301/gateways",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1754,12 +1962,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: The token to be used for the next set of paginated results.
 """
 function list_portals(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iotsitewise("GET", "/portals"; aws_config=aws_config)
+    return iotsitewise(
+        "GET", "/portals"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_portals(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iotsitewise("GET", "/portals", params; aws_config=aws_config)
+    return iotsitewise(
+        "GET", "/portals", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1778,7 +1990,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: The token to be used for the next set of paginated results.
 """
 function list_project_assets(projectId; aws_config::AbstractAWSConfig=global_aws_config())
-    return iotsitewise("GET", "/projects/$(projectId)/assets"; aws_config=aws_config)
+    return iotsitewise(
+        "GET",
+        "/projects/$(projectId)/assets";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_project_assets(
     projectId,
@@ -1786,7 +2003,11 @@ function list_project_assets(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return iotsitewise(
-        "GET", "/projects/$(projectId)/assets", params; aws_config=aws_config
+        "GET",
+        "/projects/$(projectId)/assets",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1807,7 +2028,11 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function list_projects(portalId; aws_config::AbstractAWSConfig=global_aws_config())
     return iotsitewise(
-        "GET", "/projects", Dict{String,Any}("portalId" => portalId); aws_config=aws_config
+        "GET",
+        "/projects",
+        Dict{String,Any}("portalId" => portalId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_projects(
@@ -1822,6 +2047,7 @@ function list_projects(
             mergewith(_merge, Dict{String,Any}("portalId" => portalId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1843,6 +2069,7 @@ function list_tags_for_resource(
         "/tags",
         Dict{String,Any}("resourceArn" => resourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags_for_resource(
@@ -1857,6 +2084,7 @@ function list_tags_for_resource(
             mergewith(_merge, Dict{String,Any}("resourceArn" => resourceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1883,6 +2111,7 @@ function put_default_encryption_configuration(
         "/configuration/account/encryption",
         Dict{String,Any}("encryptionType" => encryptionType);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_default_encryption_configuration(
@@ -1897,6 +2126,7 @@ function put_default_encryption_configuration(
             mergewith(_merge, Dict{String,Any}("encryptionType" => encryptionType), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1918,6 +2148,7 @@ function put_logging_options(
         "/logging",
         Dict{String,Any}("loggingOptions" => loggingOptions);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_logging_options(
@@ -1932,6 +2163,7 @@ function put_logging_options(
             mergewith(_merge, Dict{String,Any}("loggingOptions" => loggingOptions), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1961,6 +2193,7 @@ function put_storage_configuration(
         "/configuration/account/storage",
         Dict{String,Any}("storageType" => storageType);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_storage_configuration(
@@ -1975,6 +2208,7 @@ function put_storage_configuration(
             mergewith(_merge, Dict{String,Any}("storageType" => storageType), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1997,6 +2231,7 @@ function tag_resource(resourceArn, tags; aws_config::AbstractAWSConfig=global_aw
         "/tags",
         Dict{String,Any}("resourceArn" => resourceArn, "tags" => tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -2016,6 +2251,7 @@ function tag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2038,6 +2274,7 @@ function untag_resource(
         "/tags",
         Dict{String,Any}("resourceArn" => resourceArn, "tagKeys" => tagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -2057,6 +2294,7 @@ function untag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2099,6 +2337,7 @@ function update_access_policy(
             "clientToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_access_policy(
@@ -2125,6 +2364,7 @@ function update_access_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2151,6 +2391,7 @@ function update_asset(assetId, assetName; aws_config::AbstractAWSConfig=global_a
         "/assets/$(assetId)",
         Dict{String,Any}("assetName" => assetName, "clientToken" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_asset(
@@ -2172,6 +2413,7 @@ function update_asset(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2223,6 +2465,7 @@ function update_asset_model(
             "assetModelName" => assetModelName, "clientToken" => string(uuid4())
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_asset_model(
@@ -2244,6 +2487,7 @@ function update_asset_model(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2283,6 +2527,7 @@ function update_asset_property(
         "/assets/$(assetId)/properties/$(propertyId)",
         Dict{String,Any}("clientToken" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_asset_property(
@@ -2298,6 +2543,7 @@ function update_asset_property(
             mergewith(_merge, Dict{String,Any}("clientToken" => string(uuid4())), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2335,6 +2581,7 @@ function update_dashboard(
             "clientToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_dashboard(
@@ -2359,6 +2606,7 @@ function update_dashboard(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2381,6 +2629,7 @@ function update_gateway(
         "/20200301/gateways/$(gatewayId)",
         Dict{String,Any}("gatewayName" => gatewayName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_gateway(
@@ -2396,6 +2645,7 @@ function update_gateway(
             mergewith(_merge, Dict{String,Any}("gatewayName" => gatewayName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2434,6 +2684,7 @@ function update_gateway_capability_configuration(
             "capabilityNamespace" => capabilityNamespace,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_gateway_capability_configuration(
@@ -2457,6 +2708,7 @@ function update_gateway_capability_configuration(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2504,6 +2756,7 @@ function update_portal(
             "clientToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_portal(
@@ -2530,6 +2783,7 @@ function update_portal(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2558,6 +2812,7 @@ function update_project(
         "/projects/$(projectId)",
         Dict{String,Any}("projectName" => projectName, "clientToken" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_project(
@@ -2579,5 +2834,6 @@ function update_project(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/iotthingsgraph.jl
+++ b/src/services/iotthingsgraph.jl
@@ -29,6 +29,7 @@ function associate_entity_to_thing(
         "AssociateEntityToThing",
         Dict{String,Any}("entityId" => entityId, "thingName" => thingName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_entity_to_thing(
@@ -47,6 +48,7 @@ function associate_entity_to_thing(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -72,6 +74,7 @@ function create_flow_template(definition; aws_config::AbstractAWSConfig=global_a
         "CreateFlowTemplate",
         Dict{String,Any}("definition" => definition);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_flow_template(
@@ -85,6 +88,7 @@ function create_flow_template(
             mergewith(_merge, Dict{String,Any}("definition" => definition), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -131,6 +135,7 @@ function create_system_instance(
         "CreateSystemInstance",
         Dict{String,Any}("definition" => definition, "target" => target);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_system_instance(
@@ -149,6 +154,7 @@ function create_system_instance(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -174,6 +180,7 @@ function create_system_template(
         "CreateSystemTemplate",
         Dict{String,Any}("definition" => definition);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_system_template(
@@ -187,6 +194,7 @@ function create_system_template(
             mergewith(_merge, Dict{String,Any}("definition" => definition), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -205,7 +213,10 @@ update or deploy. Existing deployments that contain the workflow will continue t
 """
 function delete_flow_template(id; aws_config::AbstractAWSConfig=global_aws_config())
     return iotthingsgraph(
-        "DeleteFlowTemplate", Dict{String,Any}("id" => id); aws_config=aws_config
+        "DeleteFlowTemplate",
+        Dict{String,Any}("id" => id);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_flow_template(
@@ -215,6 +226,7 @@ function delete_flow_template(
         "DeleteFlowTemplate",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("id" => id), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -228,12 +240,16 @@ action.
 
 """
 function delete_namespace(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iotthingsgraph("DeleteNamespace"; aws_config=aws_config)
+    return iotthingsgraph(
+        "DeleteNamespace"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function delete_namespace(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iotthingsgraph("DeleteNamespace", params; aws_config=aws_config)
+    return iotthingsgraph(
+        "DeleteNamespace", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -249,12 +265,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"id"`: The ID of the system instance to be deleted.
 """
 function delete_system_instance(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iotthingsgraph("DeleteSystemInstance"; aws_config=aws_config)
+    return iotthingsgraph(
+        "DeleteSystemInstance"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function delete_system_instance(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iotthingsgraph("DeleteSystemInstance", params; aws_config=aws_config)
+    return iotthingsgraph(
+        "DeleteSystemInstance",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -272,7 +295,10 @@ the system that is taken when it is deployed.
 """
 function delete_system_template(id; aws_config::AbstractAWSConfig=global_aws_config())
     return iotthingsgraph(
-        "DeleteSystemTemplate", Dict{String,Any}("id" => id); aws_config=aws_config
+        "DeleteSystemTemplate",
+        Dict{String,Any}("id" => id);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_system_template(
@@ -282,6 +308,7 @@ function delete_system_template(
         "DeleteSystemTemplate",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("id" => id), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -305,12 +332,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   ID/default:deployment:DEPLOYMENTNAME
 """
 function deploy_system_instance(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iotthingsgraph("DeploySystemInstance"; aws_config=aws_config)
+    return iotthingsgraph(
+        "DeploySystemInstance"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function deploy_system_instance(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iotthingsgraph("DeploySystemInstance", params; aws_config=aws_config)
+    return iotthingsgraph(
+        "DeploySystemInstance",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -327,7 +361,10 @@ flows can't be deployed, but existing deployments will continue to run.
 """
 function deprecate_flow_template(id; aws_config::AbstractAWSConfig=global_aws_config())
     return iotthingsgraph(
-        "DeprecateFlowTemplate", Dict{String,Any}("id" => id); aws_config=aws_config
+        "DeprecateFlowTemplate",
+        Dict{String,Any}("id" => id);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function deprecate_flow_template(
@@ -337,6 +374,7 @@ function deprecate_flow_template(
         "DeprecateFlowTemplate",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("id" => id), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -353,7 +391,10 @@ Deprecates the specified system.
 """
 function deprecate_system_template(id; aws_config::AbstractAWSConfig=global_aws_config())
     return iotthingsgraph(
-        "DeprecateSystemTemplate", Dict{String,Any}("id" => id); aws_config=aws_config
+        "DeprecateSystemTemplate",
+        Dict{String,Any}("id" => id);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function deprecate_system_template(
@@ -363,6 +404,7 @@ function deprecate_system_template(
         "DeprecateSystemTemplate",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("id" => id), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -378,12 +420,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   namespace.
 """
 function describe_namespace(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iotthingsgraph("DescribeNamespace"; aws_config=aws_config)
+    return iotthingsgraph(
+        "DescribeNamespace"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_namespace(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iotthingsgraph("DescribeNamespace", params; aws_config=aws_config)
+    return iotthingsgraph(
+        "DescribeNamespace", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -406,6 +452,7 @@ function dissociate_entity_from_thing(
         "DissociateEntityFromThing",
         Dict{String,Any}("entityType" => entityType, "thingName" => thingName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function dissociate_entity_from_thing(
@@ -424,6 +471,7 @@ function dissociate_entity_from_thing(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -447,7 +495,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function get_entities(ids; aws_config::AbstractAWSConfig=global_aws_config())
     return iotthingsgraph(
-        "GetEntities", Dict{String,Any}("ids" => ids); aws_config=aws_config
+        "GetEntities",
+        Dict{String,Any}("ids" => ids);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_entities(
@@ -457,6 +508,7 @@ function get_entities(
         "GetEntities",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("ids" => ids), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -477,7 +529,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function get_flow_template(id; aws_config::AbstractAWSConfig=global_aws_config())
     return iotthingsgraph(
-        "GetFlowTemplate", Dict{String,Any}("id" => id); aws_config=aws_config
+        "GetFlowTemplate",
+        Dict{String,Any}("id" => id);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_flow_template(
@@ -487,6 +542,7 @@ function get_flow_template(
         "GetFlowTemplate",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("id" => id), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -510,7 +566,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function get_flow_template_revisions(id; aws_config::AbstractAWSConfig=global_aws_config())
     return iotthingsgraph(
-        "GetFlowTemplateRevisions", Dict{String,Any}("id" => id); aws_config=aws_config
+        "GetFlowTemplateRevisions",
+        Dict{String,Any}("id" => id);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_flow_template_revisions(
@@ -520,6 +579,7 @@ function get_flow_template_revisions(
         "GetFlowTemplateRevisions",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("id" => id), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -531,12 +591,19 @@ Gets the status of a namespace deletion task.
 
 """
 function get_namespace_deletion_status(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iotthingsgraph("GetNamespaceDeletionStatus"; aws_config=aws_config)
+    return iotthingsgraph(
+        "GetNamespaceDeletionStatus"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_namespace_deletion_status(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iotthingsgraph("GetNamespaceDeletionStatus", params; aws_config=aws_config)
+    return iotthingsgraph(
+        "GetNamespaceDeletionStatus",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -553,7 +620,10 @@ Gets a system instance.
 """
 function get_system_instance(id; aws_config::AbstractAWSConfig=global_aws_config())
     return iotthingsgraph(
-        "GetSystemInstance", Dict{String,Any}("id" => id); aws_config=aws_config
+        "GetSystemInstance",
+        Dict{String,Any}("id" => id);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_system_instance(
@@ -563,6 +633,7 @@ function get_system_instance(
         "GetSystemInstance",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("id" => id), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -582,7 +653,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function get_system_template(id; aws_config::AbstractAWSConfig=global_aws_config())
     return iotthingsgraph(
-        "GetSystemTemplate", Dict{String,Any}("id" => id); aws_config=aws_config
+        "GetSystemTemplate",
+        Dict{String,Any}("id" => id);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_system_template(
@@ -592,6 +666,7 @@ function get_system_template(
         "GetSystemTemplate",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("id" => id), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -617,7 +692,10 @@ function get_system_template_revisions(
     id; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return iotthingsgraph(
-        "GetSystemTemplateRevisions", Dict{String,Any}("id" => id); aws_config=aws_config
+        "GetSystemTemplateRevisions",
+        Dict{String,Any}("id" => id);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_system_template_revisions(
@@ -627,6 +705,7 @@ function get_system_template_revisions(
         "GetSystemTemplateRevisions",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("id" => id), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -643,7 +722,10 @@ Gets the status of the specified upload.
 """
 function get_upload_status(uploadId; aws_config::AbstractAWSConfig=global_aws_config())
     return iotthingsgraph(
-        "GetUploadStatus", Dict{String,Any}("uploadId" => uploadId); aws_config=aws_config
+        "GetUploadStatus",
+        Dict{String,Any}("uploadId" => uploadId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_upload_status(
@@ -657,6 +739,7 @@ function get_upload_status(
             mergewith(_merge, Dict{String,Any}("uploadId" => uploadId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -682,6 +765,7 @@ function list_flow_execution_messages(
         "ListFlowExecutionMessages",
         Dict{String,Any}("flowExecutionId" => flowExecutionId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_flow_execution_messages(
@@ -697,6 +781,7 @@ function list_flow_execution_messages(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -722,6 +807,7 @@ function list_tags_for_resource(
         "ListTagsForResource",
         Dict{String,Any}("resourceArn" => resourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags_for_resource(
@@ -735,6 +821,7 @@ function list_tags_for_resource(
             mergewith(_merge, Dict{String,Any}("resourceArn" => resourceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -766,6 +853,7 @@ function search_entities(entityTypes; aws_config::AbstractAWSConfig=global_aws_c
         "SearchEntities",
         Dict{String,Any}("entityTypes" => entityTypes);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function search_entities(
@@ -779,6 +867,7 @@ function search_entities(
             mergewith(_merge, Dict{String,Any}("entityTypes" => entityTypes), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -807,6 +896,7 @@ function search_flow_executions(
         "SearchFlowExecutions",
         Dict{String,Any}("systemInstanceId" => systemInstanceId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function search_flow_executions(
@@ -822,6 +912,7 @@ function search_flow_executions(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -840,12 +931,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   paginating results.
 """
 function search_flow_templates(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iotthingsgraph("SearchFlowTemplates"; aws_config=aws_config)
+    return iotthingsgraph(
+        "SearchFlowTemplates"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function search_flow_templates(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iotthingsgraph("SearchFlowTemplates", params; aws_config=aws_config)
+    return iotthingsgraph(
+        "SearchFlowTemplates",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -864,12 +962,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   paginating results.
 """
 function search_system_instances(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iotthingsgraph("SearchSystemInstances"; aws_config=aws_config)
+    return iotthingsgraph(
+        "SearchSystemInstances"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function search_system_instances(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iotthingsgraph("SearchSystemInstances", params; aws_config=aws_config)
+    return iotthingsgraph(
+        "SearchSystemInstances",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -888,12 +993,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   paginating results.
 """
 function search_system_templates(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iotthingsgraph("SearchSystemTemplates"; aws_config=aws_config)
+    return iotthingsgraph(
+        "SearchSystemTemplates"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function search_system_templates(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iotthingsgraph("SearchSystemTemplates", params; aws_config=aws_config)
+    return iotthingsgraph(
+        "SearchSystemTemplates",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -921,7 +1033,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function search_things(entityId; aws_config::AbstractAWSConfig=global_aws_config())
     return iotthingsgraph(
-        "SearchThings", Dict{String,Any}("entityId" => entityId); aws_config=aws_config
+        "SearchThings",
+        Dict{String,Any}("entityId" => entityId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function search_things(
@@ -935,6 +1050,7 @@ function search_things(
             mergewith(_merge, Dict{String,Any}("entityId" => entityId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -954,6 +1070,7 @@ function tag_resource(resourceArn, tags; aws_config::AbstractAWSConfig=global_aw
         "TagResource",
         Dict{String,Any}("resourceArn" => resourceArn, "tags" => tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -972,6 +1089,7 @@ function tag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -986,12 +1104,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"id"`: The ID of the system instance to remove from its target.
 """
 function undeploy_system_instance(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iotthingsgraph("UndeploySystemInstance"; aws_config=aws_config)
+    return iotthingsgraph(
+        "UndeploySystemInstance"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function undeploy_system_instance(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iotthingsgraph("UndeploySystemInstance", params; aws_config=aws_config)
+    return iotthingsgraph(
+        "UndeploySystemInstance",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1017,6 +1142,7 @@ function untag_resource(
         "UntagResource",
         Dict{String,Any}("resourceArn" => resourceArn, "tagKeys" => tagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -1035,6 +1161,7 @@ function untag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1065,6 +1192,7 @@ function update_flow_template(
         "UpdateFlowTemplate",
         Dict{String,Any}("definition" => definition, "id" => id);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_flow_template(
@@ -1081,6 +1209,7 @@ function update_flow_template(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1110,6 +1239,7 @@ function update_system_template(
         "UpdateSystemTemplate",
         Dict{String,Any}("definition" => definition, "id" => id);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_system_template(
@@ -1126,6 +1256,7 @@ function update_system_template(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1159,10 +1290,17 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   namespace version.
 """
 function upload_entity_definitions(; aws_config::AbstractAWSConfig=global_aws_config())
-    return iotthingsgraph("UploadEntityDefinitions"; aws_config=aws_config)
+    return iotthingsgraph(
+        "UploadEntityDefinitions"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function upload_entity_definitions(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return iotthingsgraph("UploadEntityDefinitions", params; aws_config=aws_config)
+    return iotthingsgraph(
+        "UploadEntityDefinitions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end

--- a/src/services/ivs.jl
+++ b/src/services/ivs.jl
@@ -16,7 +16,11 @@ Performs GetChannel on multiple ARNs simultaneously.
 """
 function batch_get_channel(arns; aws_config::AbstractAWSConfig=global_aws_config())
     return ivs(
-        "POST", "/BatchGetChannel", Dict{String,Any}("arns" => arns); aws_config=aws_config
+        "POST",
+        "/BatchGetChannel",
+        Dict{String,Any}("arns" => arns);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_get_channel(
@@ -27,6 +31,7 @@ function batch_get_channel(
         "/BatchGetChannel",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("arns" => arns), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -46,6 +51,7 @@ function batch_get_stream_key(arns; aws_config::AbstractAWSConfig=global_aws_con
         "/BatchGetStreamKey",
         Dict{String,Any}("arns" => arns);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_get_stream_key(
@@ -56,6 +62,7 @@ function batch_get_stream_key(
         "/BatchGetStreamKey",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("arns" => arns), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -86,12 +93,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   and bitrate can be up to 1.5 Mbps.
 """
 function create_channel(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ivs("POST", "/CreateChannel"; aws_config=aws_config)
+    return ivs(
+        "POST", "/CreateChannel"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function create_channel(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ivs("POST", "/CreateChannel", params; aws_config=aws_config)
+    return ivs(
+        "POST",
+        "/CreateChannel",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -125,6 +140,7 @@ function create_recording_configuration(
         "/CreateRecordingConfiguration",
         Dict{String,Any}("destinationConfiguration" => destinationConfiguration);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_recording_configuration(
@@ -143,6 +159,7 @@ function create_recording_configuration(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -169,6 +186,7 @@ function create_stream_key(channelArn; aws_config::AbstractAWSConfig=global_aws_
         "/CreateStreamKey",
         Dict{String,Any}("channelArn" => channelArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_stream_key(
@@ -183,6 +201,7 @@ function create_stream_key(
             mergewith(_merge, Dict{String,Any}("channelArn" => channelArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -202,7 +221,11 @@ EventBridge with Amazon IVS.)
 """
 function delete_channel(arn; aws_config::AbstractAWSConfig=global_aws_config())
     return ivs(
-        "POST", "/DeleteChannel", Dict{String,Any}("arn" => arn); aws_config=aws_config
+        "POST",
+        "/DeleteChannel",
+        Dict{String,Any}("arn" => arn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_channel(
@@ -213,6 +236,7 @@ function delete_channel(
         "/DeleteChannel",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("arn" => arn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -234,6 +258,7 @@ function delete_playback_key_pair(arn; aws_config::AbstractAWSConfig=global_aws_
         "/DeletePlaybackKeyPair",
         Dict{String,Any}("arn" => arn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_playback_key_pair(
@@ -244,6 +269,7 @@ function delete_playback_key_pair(
         "/DeletePlaybackKeyPair",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("arn" => arn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -269,6 +295,7 @@ function delete_recording_configuration(
         "/DeleteRecordingConfiguration",
         Dict{String,Any}("arn" => arn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_recording_configuration(
@@ -279,6 +306,7 @@ function delete_recording_configuration(
         "/DeleteRecordingConfiguration",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("arn" => arn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -294,7 +322,11 @@ Deletes the stream key for the specified ARN, so it can no longer be used to str
 """
 function delete_stream_key(arn; aws_config::AbstractAWSConfig=global_aws_config())
     return ivs(
-        "POST", "/DeleteStreamKey", Dict{String,Any}("arn" => arn); aws_config=aws_config
+        "POST",
+        "/DeleteStreamKey",
+        Dict{String,Any}("arn" => arn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_stream_key(
@@ -305,6 +337,7 @@ function delete_stream_key(
         "/DeleteStreamKey",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("arn" => arn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -319,7 +352,13 @@ Gets the channel configuration for the specified channel ARN. See also BatchGetC
 
 """
 function get_channel(arn; aws_config::AbstractAWSConfig=global_aws_config())
-    return ivs("POST", "/GetChannel", Dict{String,Any}("arn" => arn); aws_config=aws_config)
+    return ivs(
+        "POST",
+        "/GetChannel",
+        Dict{String,Any}("arn" => arn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_channel(
     arn, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -329,6 +368,7 @@ function get_channel(
         "/GetChannel",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("arn" => arn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -347,7 +387,11 @@ in the Amazon IVS User Guide.
 """
 function get_playback_key_pair(arn; aws_config::AbstractAWSConfig=global_aws_config())
     return ivs(
-        "POST", "/GetPlaybackKeyPair", Dict{String,Any}("arn" => arn); aws_config=aws_config
+        "POST",
+        "/GetPlaybackKeyPair",
+        Dict{String,Any}("arn" => arn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_playback_key_pair(
@@ -358,6 +402,7 @@ function get_playback_key_pair(
         "/GetPlaybackKeyPair",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("arn" => arn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -377,6 +422,7 @@ function get_recording_configuration(arn; aws_config::AbstractAWSConfig=global_a
         "/GetRecordingConfiguration",
         Dict{String,Any}("arn" => arn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_recording_configuration(
@@ -387,6 +433,7 @@ function get_recording_configuration(
         "/GetRecordingConfiguration",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("arn" => arn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -406,6 +453,7 @@ function get_stream(channelArn; aws_config::AbstractAWSConfig=global_aws_config(
         "/GetStream",
         Dict{String,Any}("channelArn" => channelArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_stream(
@@ -420,6 +468,7 @@ function get_stream(
             mergewith(_merge, Dict{String,Any}("channelArn" => channelArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -435,7 +484,11 @@ Gets stream-key information for a specified ARN.
 """
 function get_stream_key(arn; aws_config::AbstractAWSConfig=global_aws_config())
     return ivs(
-        "POST", "/GetStreamKey", Dict{String,Any}("arn" => arn); aws_config=aws_config
+        "POST",
+        "/GetStreamKey",
+        Dict{String,Any}("arn" => arn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_stream_key(
@@ -446,6 +499,7 @@ function get_stream_key(
         "/GetStreamKey",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("arn" => arn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -475,6 +529,7 @@ function import_playback_key_pair(
         "/ImportPlaybackKeyPair",
         Dict{String,Any}("publicKeyMaterial" => publicKeyMaterial);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function import_playback_key_pair(
@@ -491,6 +546,7 @@ function import_playback_key_pair(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -513,12 +569,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   nextToken response field.
 """
 function list_channels(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ivs("POST", "/ListChannels"; aws_config=aws_config)
+    return ivs(
+        "POST", "/ListChannels"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_channels(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ivs("POST", "/ListChannels", params; aws_config=aws_config)
+    return ivs(
+        "POST",
+        "/ListChannels",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -535,12 +599,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: Maximum number of key pairs to return.
 """
 function list_playback_key_pairs(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ivs("POST", "/ListPlaybackKeyPairs"; aws_config=aws_config)
+    return ivs(
+        "POST",
+        "/ListPlaybackKeyPairs";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_playback_key_pairs(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ivs("POST", "/ListPlaybackKeyPairs", params; aws_config=aws_config)
+    return ivs(
+        "POST",
+        "/ListPlaybackKeyPairs",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -557,12 +632,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   pagination; see the nextToken response field.
 """
 function list_recording_configurations(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ivs("POST", "/ListRecordingConfigurations"; aws_config=aws_config)
+    return ivs(
+        "POST",
+        "/ListRecordingConfigurations";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_recording_configurations(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ivs("POST", "/ListRecordingConfigurations", params; aws_config=aws_config)
+    return ivs(
+        "POST",
+        "/ListRecordingConfigurations",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -586,6 +672,7 @@ function list_stream_keys(channelArn; aws_config::AbstractAWSConfig=global_aws_c
         "/ListStreamKeys",
         Dict{String,Any}("channelArn" => channelArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_stream_keys(
@@ -600,6 +687,7 @@ function list_stream_keys(
             mergewith(_merge, Dict{String,Any}("channelArn" => channelArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -617,12 +705,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   nextToken response field.
 """
 function list_streams(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ivs("POST", "/ListStreams"; aws_config=aws_config)
+    return ivs(
+        "POST", "/ListStreams"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_streams(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ivs("POST", "/ListStreams", params; aws_config=aws_config)
+    return ivs(
+        "POST",
+        "/ListStreams",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -643,14 +739,25 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function list_tags_for_resource(
     resourceArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ivs("GET", "/tags/$(resourceArn)"; aws_config=aws_config)
+    return ivs(
+        "GET",
+        "/tags/$(resourceArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_tags_for_resource(
     resourceArn,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return ivs("GET", "/tags/$(resourceArn)", params; aws_config=aws_config)
+    return ivs(
+        "GET",
+        "/tags/$(resourceArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -676,6 +783,7 @@ function put_metadata(
         "/PutMetadata",
         Dict{String,Any}("channelArn" => channelArn, "metadata" => metadata);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_metadata(
@@ -695,6 +803,7 @@ function put_metadata(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -717,6 +826,7 @@ function stop_stream(channelArn; aws_config::AbstractAWSConfig=global_aws_config
         "/StopStream",
         Dict{String,Any}("channelArn" => channelArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function stop_stream(
@@ -731,6 +841,7 @@ function stop_stream(
             mergewith(_merge, Dict{String,Any}("channelArn" => channelArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -751,6 +862,7 @@ function tag_resource(resourceArn, tags; aws_config::AbstractAWSConfig=global_aw
         "/tags/$(resourceArn)",
         Dict{String,Any}("tags" => tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -764,6 +876,7 @@ function tag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tags" => tags), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -786,6 +899,7 @@ function untag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}("tagKeys" => tagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -799,6 +913,7 @@ function untag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tagKeys" => tagKeys), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -833,7 +948,11 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function update_channel(arn; aws_config::AbstractAWSConfig=global_aws_config())
     return ivs(
-        "POST", "/UpdateChannel", Dict{String,Any}("arn" => arn); aws_config=aws_config
+        "POST",
+        "/UpdateChannel",
+        Dict{String,Any}("arn" => arn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_channel(
@@ -844,5 +963,6 @@ function update_channel(
         "/UpdateChannel",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("arn" => arn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/kafka.jl
+++ b/src/services/kafka.jl
@@ -27,6 +27,7 @@ function batch_associate_scram_secret(
         "/v1/clusters/$(clusterArn)/scram-secrets",
         Dict{String,Any}("secretArnList" => secretArnList);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_associate_scram_secret(
@@ -42,6 +43,7 @@ function batch_associate_scram_secret(
             mergewith(_merge, Dict{String,Any}("secretArnList" => secretArnList), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -68,6 +70,7 @@ function batch_disassociate_scram_secret(
         "/v1/clusters/$(clusterArn)/scram-secrets",
         Dict{String,Any}("secretArnList" => secretArnList);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_disassociate_scram_secret(
@@ -83,6 +86,7 @@ function batch_disassociate_scram_secret(
             mergewith(_merge, Dict{String,Any}("secretArnList" => secretArnList), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -142,6 +146,7 @@ function create_cluster(
             "numberOfBrokerNodes" => numberOfBrokerNodes,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_cluster(
@@ -168,6 +173,7 @@ function create_cluster(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -204,6 +210,7 @@ function create_configuration(
         "/v1/configurations",
         Dict{String,Any}("name" => name, "serverProperties" => serverProperties);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_configuration(
@@ -223,6 +230,7 @@ function create_configuration(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -245,14 +253,25 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
             The current version of the MSK cluster.
 """
 function delete_cluster(clusterArn; aws_config::AbstractAWSConfig=global_aws_config())
-    return kafka("DELETE", "/v1/clusters/$(clusterArn)"; aws_config=aws_config)
+    return kafka(
+        "DELETE",
+        "/v1/clusters/$(clusterArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_cluster(
     clusterArn,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return kafka("DELETE", "/v1/clusters/$(clusterArn)", params; aws_config=aws_config)
+    return kafka(
+        "DELETE",
+        "/v1/clusters/$(clusterArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -269,12 +288,23 @@ end
 
 """
 function delete_configuration(arn; aws_config::AbstractAWSConfig=global_aws_config())
-    return kafka("DELETE", "/v1/configurations/$(arn)"; aws_config=aws_config)
+    return kafka(
+        "DELETE",
+        "/v1/configurations/$(arn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_configuration(
     arn, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return kafka("DELETE", "/v1/configurations/$(arn)", params; aws_config=aws_config)
+    return kafka(
+        "DELETE",
+        "/v1/configurations/$(arn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -292,14 +322,25 @@ specified in the request.
 
 """
 function describe_cluster(clusterArn; aws_config::AbstractAWSConfig=global_aws_config())
-    return kafka("GET", "/v1/clusters/$(clusterArn)"; aws_config=aws_config)
+    return kafka(
+        "GET",
+        "/v1/clusters/$(clusterArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_cluster(
     clusterArn,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return kafka("GET", "/v1/clusters/$(clusterArn)", params; aws_config=aws_config)
+    return kafka(
+        "GET",
+        "/v1/clusters/$(clusterArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -318,7 +359,12 @@ end
 function describe_cluster_operation(
     clusterOperationArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return kafka("GET", "/v1/operations/$(clusterOperationArn)"; aws_config=aws_config)
+    return kafka(
+        "GET",
+        "/v1/operations/$(clusterOperationArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_cluster_operation(
     clusterOperationArn,
@@ -326,7 +372,11 @@ function describe_cluster_operation(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return kafka(
-        "GET", "/v1/operations/$(clusterOperationArn)", params; aws_config=aws_config
+        "GET",
+        "/v1/operations/$(clusterOperationArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -344,12 +394,23 @@ end
 
 """
 function describe_configuration(arn; aws_config::AbstractAWSConfig=global_aws_config())
-    return kafka("GET", "/v1/configurations/$(arn)"; aws_config=aws_config)
+    return kafka(
+        "GET",
+        "/v1/configurations/$(arn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_configuration(
     arn, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return kafka("GET", "/v1/configurations/$(arn)", params; aws_config=aws_config)
+    return kafka(
+        "GET",
+        "/v1/configurations/$(arn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -372,7 +433,10 @@ function describe_configuration_revision(
     arn, revision; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return kafka(
-        "GET", "/v1/configurations/$(arn)/revisions/$(revision)"; aws_config=aws_config
+        "GET",
+        "/v1/configurations/$(arn)/revisions/$(revision)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_configuration_revision(
@@ -386,6 +450,7 @@ function describe_configuration_revision(
         "/v1/configurations/$(arn)/revisions/$(revision)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -406,7 +471,10 @@ function get_bootstrap_brokers(
     clusterArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return kafka(
-        "GET", "/v1/clusters/$(clusterArn)/bootstrap-brokers"; aws_config=aws_config
+        "GET",
+        "/v1/clusters/$(clusterArn)/bootstrap-brokers";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_bootstrap_brokers(
@@ -415,7 +483,11 @@ function get_bootstrap_brokers(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return kafka(
-        "GET", "/v1/clusters/$(clusterArn)/bootstrap-brokers", params; aws_config=aws_config
+        "GET",
+        "/v1/clusters/$(clusterArn)/bootstrap-brokers",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -434,12 +506,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   
 """
 function get_compatible_kafka_versions(; aws_config::AbstractAWSConfig=global_aws_config())
-    return kafka("GET", "/v1/compatible-kafka-versions"; aws_config=aws_config)
+    return kafka(
+        "GET",
+        "/v1/compatible-kafka-versions";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_compatible_kafka_versions(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return kafka("GET", "/v1/compatible-kafka-versions", params; aws_config=aws_config)
+    return kafka(
+        "GET",
+        "/v1/compatible-kafka-versions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -469,7 +552,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function list_cluster_operations(
     clusterArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return kafka("GET", "/v1/clusters/$(clusterArn)/operations"; aws_config=aws_config)
+    return kafka(
+        "GET",
+        "/v1/clusters/$(clusterArn)/operations";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_cluster_operations(
     clusterArn,
@@ -477,7 +565,11 @@ function list_cluster_operations(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return kafka(
-        "GET", "/v1/clusters/$(clusterArn)/operations", params; aws_config=aws_config
+        "GET",
+        "/v1/clusters/$(clusterArn)/operations",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -504,12 +596,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   next batch, provide this token in your next request.
 """
 function list_clusters(; aws_config::AbstractAWSConfig=global_aws_config())
-    return kafka("GET", "/v1/clusters"; aws_config=aws_config)
+    return kafka(
+        "GET", "/v1/clusters"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_clusters(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return kafka("GET", "/v1/clusters", params; aws_config=aws_config)
+    return kafka(
+        "GET",
+        "/v1/clusters",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -538,13 +638,22 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function list_configuration_revisions(
     arn; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return kafka("GET", "/v1/configurations/$(arn)/revisions"; aws_config=aws_config)
+    return kafka(
+        "GET",
+        "/v1/configurations/$(arn)/revisions";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_configuration_revisions(
     arn, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return kafka(
-        "GET", "/v1/configurations/$(arn)/revisions", params; aws_config=aws_config
+        "GET",
+        "/v1/configurations/$(arn)/revisions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -567,12 +676,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   next batch, provide this token in your next request.
 """
 function list_configurations(; aws_config::AbstractAWSConfig=global_aws_config())
-    return kafka("GET", "/v1/configurations"; aws_config=aws_config)
+    return kafka(
+        "GET", "/v1/configurations"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_configurations(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return kafka("GET", "/v1/configurations", params; aws_config=aws_config)
+    return kafka(
+        "GET",
+        "/v1/configurations",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -593,12 +710,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   provide this token in your next request.
 """
 function list_kafka_versions(; aws_config::AbstractAWSConfig=global_aws_config())
-    return kafka("GET", "/v1/kafka-versions"; aws_config=aws_config)
+    return kafka(
+        "GET", "/v1/kafka-versions"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_kafka_versions(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return kafka("GET", "/v1/kafka-versions", params; aws_config=aws_config)
+    return kafka(
+        "GET",
+        "/v1/kafka-versions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -625,14 +750,25 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   next batch, provide this token in your next request.
 """
 function list_nodes(clusterArn; aws_config::AbstractAWSConfig=global_aws_config())
-    return kafka("GET", "/v1/clusters/$(clusterArn)/nodes"; aws_config=aws_config)
+    return kafka(
+        "GET",
+        "/v1/clusters/$(clusterArn)/nodes";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_nodes(
     clusterArn,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return kafka("GET", "/v1/clusters/$(clusterArn)/nodes", params; aws_config=aws_config)
+    return kafka(
+        "GET",
+        "/v1/clusters/$(clusterArn)/nodes",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -655,7 +791,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
             The nextToken of the query.
 """
 function list_scram_secrets(clusterArn; aws_config::AbstractAWSConfig=global_aws_config())
-    return kafka("GET", "/v1/clusters/$(clusterArn)/scram-secrets"; aws_config=aws_config)
+    return kafka(
+        "GET",
+        "/v1/clusters/$(clusterArn)/scram-secrets";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_scram_secrets(
     clusterArn,
@@ -663,7 +804,11 @@ function list_scram_secrets(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return kafka(
-        "GET", "/v1/clusters/$(clusterArn)/scram-secrets", params; aws_config=aws_config
+        "GET",
+        "/v1/clusters/$(clusterArn)/scram-secrets",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -683,14 +828,25 @@ end
 function list_tags_for_resource(
     resourceArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return kafka("GET", "/v1/tags/$(resourceArn)"; aws_config=aws_config)
+    return kafka(
+        "GET",
+        "/v1/tags/$(resourceArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_tags_for_resource(
     resourceArn,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return kafka("GET", "/v1/tags/$(resourceArn)", params; aws_config=aws_config)
+    return kafka(
+        "GET",
+        "/v1/tags/$(resourceArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -716,6 +872,7 @@ function reboot_broker(
         "/v1/clusters/$(clusterArn)/reboot-broker",
         Dict{String,Any}("brokerIds" => brokerIds);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function reboot_broker(
@@ -731,6 +888,7 @@ function reboot_broker(
             mergewith(_merge, Dict{String,Any}("brokerIds" => brokerIds), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -755,6 +913,7 @@ function tag_resource(resourceArn, tags; aws_config::AbstractAWSConfig=global_aw
         "/v1/tags/$(resourceArn)",
         Dict{String,Any}("tags" => tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -768,6 +927,7 @@ function tag_resource(
         "/v1/tags/$(resourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tags" => tags), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -811,6 +971,7 @@ function untag_resource(
         "/v1/tags/$(resourceArn)",
         Dict{String,Any}("tagKeys" => tagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -824,6 +985,7 @@ function untag_resource(
         "/v1/tags/$(resourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tagKeys" => tagKeys), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -860,6 +1022,7 @@ function update_broker_count(
             "targetNumberOfBrokerNodes" => targetNumberOfBrokerNodes,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_broker_count(
@@ -883,6 +1046,7 @@ function update_broker_count(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -919,6 +1083,7 @@ function update_broker_storage(
             "targetBrokerEBSVolumeInfo" => targetBrokerEBSVolumeInfo,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_broker_storage(
@@ -942,6 +1107,7 @@ function update_broker_storage(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -977,6 +1143,7 @@ function update_broker_type(
             "currentVersion" => currentVersion, "targetInstanceType" => targetInstanceType
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_broker_type(
@@ -1000,6 +1167,7 @@ function update_broker_type(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1036,6 +1204,7 @@ function update_cluster_configuration(
             "configurationInfo" => configurationInfo, "currentVersion" => currentVersion
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_cluster_configuration(
@@ -1059,6 +1228,7 @@ function update_cluster_configuration(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1097,6 +1267,7 @@ function update_cluster_kafka_version(
             "currentVersion" => currentVersion, "targetKafkaVersion" => targetKafkaVersion
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_cluster_kafka_version(
@@ -1120,6 +1291,7 @@ function update_cluster_kafka_version(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1153,6 +1325,7 @@ function update_configuration(
         "/v1/configurations/$(arn)",
         Dict{String,Any}("serverProperties" => serverProperties);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_configuration(
@@ -1170,6 +1343,7 @@ function update_configuration(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1208,6 +1382,7 @@ function update_monitoring(
         "/v1/clusters/$(clusterArn)/monitoring",
         Dict{String,Any}("currentVersion" => currentVersion);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_monitoring(
@@ -1223,6 +1398,7 @@ function update_monitoring(
             mergewith(_merge, Dict{String,Any}("currentVersion" => currentVersion), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1259,6 +1435,7 @@ function update_security(
         "/v1/clusters/$(clusterArn)/security",
         Dict{String,Any}("currentVersion" => currentVersion);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_security(
@@ -1274,5 +1451,6 @@ function update_security(
             mergewith(_merge, Dict{String,Any}("currentVersion" => currentVersion), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/kafkaconnect.jl
+++ b/src/services/kafkaconnect.jl
@@ -62,6 +62,7 @@ function create_connector(
             "serviceExecutionRoleArn" => serviceExecutionRoleArn,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_connector(
@@ -98,6 +99,7 @@ function create_connector(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -126,6 +128,7 @@ function create_custom_plugin(
             "contentType" => contentType, "location" => location, "name" => name
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_custom_plugin(
@@ -148,6 +151,7 @@ function create_custom_plugin(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -173,6 +177,7 @@ function create_worker_configuration(
         "/v1/worker-configurations",
         Dict{String,Any}("name" => name, "propertiesFileContent" => propertiesFileContent);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_worker_configuration(
@@ -194,6 +199,7 @@ function create_worker_configuration(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -211,7 +217,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"currentVersion"`: The current version of the connector that you want to delete.
 """
 function delete_connector(connectorArn; aws_config::AbstractAWSConfig=global_aws_config())
-    return kafkaconnect("DELETE", "/v1/connectors/$(connectorArn)"; aws_config=aws_config)
+    return kafkaconnect(
+        "DELETE",
+        "/v1/connectors/$(connectorArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_connector(
     connectorArn,
@@ -219,7 +230,11 @@ function delete_connector(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return kafkaconnect(
-        "DELETE", "/v1/connectors/$(connectorArn)", params; aws_config=aws_config
+        "DELETE",
+        "/v1/connectors/$(connectorArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -235,7 +250,12 @@ Returns summary information about the connector.
 
 """
 function describe_connector(connectorArn; aws_config::AbstractAWSConfig=global_aws_config())
-    return kafkaconnect("GET", "/v1/connectors/$(connectorArn)"; aws_config=aws_config)
+    return kafkaconnect(
+        "GET",
+        "/v1/connectors/$(connectorArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_connector(
     connectorArn,
@@ -243,7 +263,11 @@ function describe_connector(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return kafkaconnect(
-        "GET", "/v1/connectors/$(connectorArn)", params; aws_config=aws_config
+        "GET",
+        "/v1/connectors/$(connectorArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -261,7 +285,10 @@ function describe_custom_plugin(
     customPluginArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return kafkaconnect(
-        "GET", "/v1/custom-plugins/$(customPluginArn)"; aws_config=aws_config
+        "GET",
+        "/v1/custom-plugins/$(customPluginArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_custom_plugin(
@@ -270,7 +297,11 @@ function describe_custom_plugin(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return kafkaconnect(
-        "GET", "/v1/custom-plugins/$(customPluginArn)", params; aws_config=aws_config
+        "GET",
+        "/v1/custom-plugins/$(customPluginArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -289,7 +320,10 @@ function describe_worker_configuration(
     workerConfigurationArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return kafkaconnect(
-        "GET", "/v1/worker-configurations/$(workerConfigurationArn)"; aws_config=aws_config
+        "GET",
+        "/v1/worker-configurations/$(workerConfigurationArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_worker_configuration(
@@ -302,6 +336,7 @@ function describe_worker_configuration(
         "/v1/worker-configurations/$(workerConfigurationArn)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -323,12 +358,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   where the previous operation left off.
 """
 function list_connectors(; aws_config::AbstractAWSConfig=global_aws_config())
-    return kafkaconnect("GET", "/v1/connectors"; aws_config=aws_config)
+    return kafkaconnect(
+        "GET", "/v1/connectors"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_connectors(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return kafkaconnect("GET", "/v1/connectors", params; aws_config=aws_config)
+    return kafkaconnect(
+        "GET",
+        "/v1/connectors",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -345,12 +388,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   where the previous operation left off.
 """
 function list_custom_plugins(; aws_config::AbstractAWSConfig=global_aws_config())
-    return kafkaconnect("GET", "/v1/custom-plugins"; aws_config=aws_config)
+    return kafkaconnect(
+        "GET", "/v1/custom-plugins"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_custom_plugins(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return kafkaconnect("GET", "/v1/custom-plugins", params; aws_config=aws_config)
+    return kafkaconnect(
+        "GET",
+        "/v1/custom-plugins",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -367,12 +418,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   from where the previous operation left off.
 """
 function list_worker_configurations(; aws_config::AbstractAWSConfig=global_aws_config())
-    return kafkaconnect("GET", "/v1/worker-configurations"; aws_config=aws_config)
+    return kafkaconnect(
+        "GET",
+        "/v1/worker-configurations";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_worker_configurations(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return kafkaconnect("GET", "/v1/worker-configurations", params; aws_config=aws_config)
+    return kafkaconnect(
+        "GET",
+        "/v1/worker-configurations",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -398,6 +460,7 @@ function update_connector(
         "/v1/connectors/$(connectorArn)",
         Dict{String,Any}("capacity" => capacity, "currentVersion" => currentVersion);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_connector(
@@ -420,5 +483,6 @@ function update_connector(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/kendra.jl
+++ b/src/services/kendra.jl
@@ -28,6 +28,7 @@ function batch_delete_document(
         "BatchDeleteDocument",
         Dict{String,Any}("DocumentIdList" => DocumentIdList, "IndexId" => IndexId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_delete_document(
@@ -46,6 +47,7 @@ function batch_delete_document(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -76,6 +78,7 @@ function batch_get_document_status(
         "BatchGetDocumentStatus",
         Dict{String,Any}("DocumentInfoList" => DocumentInfoList, "IndexId" => IndexId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_get_document_status(
@@ -96,6 +99,7 @@ function batch_get_document_status(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -135,6 +139,7 @@ function batch_put_document(
         "BatchPutDocument",
         Dict{String,Any}("Documents" => Documents, "IndexId" => IndexId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_put_document(
@@ -153,6 +158,7 @@ function batch_put_document(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -175,6 +181,7 @@ function clear_query_suggestions(IndexId; aws_config::AbstractAWSConfig=global_a
         "ClearQuerySuggestions",
         Dict{String,Any}("IndexId" => IndexId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function clear_query_suggestions(
@@ -184,6 +191,7 @@ function clear_query_suggestions(
         "ClearQuerySuggestions",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("IndexId" => IndexId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -237,6 +245,7 @@ function create_data_source(
             "ClientToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_data_source(
@@ -261,6 +270,7 @@ function create_data_source(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -303,6 +313,7 @@ function create_faq(
             "ClientToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_faq(
@@ -329,6 +340,7 @@ function create_faq(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -379,6 +391,7 @@ function create_index(Name, RoleArn; aws_config::AbstractAWSConfig=global_aws_co
             "Name" => Name, "RoleArn" => RoleArn, "ClientToken" => string(uuid4())
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_index(
@@ -399,6 +412,7 @@ function create_index(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -448,6 +462,7 @@ function create_query_suggestions_block_list(
             "ClientToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_query_suggestions_block_list(
@@ -474,6 +489,7 @@ function create_query_suggestions_block_list(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -512,6 +528,7 @@ function create_thesaurus(
             "ClientToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_thesaurus(
@@ -538,6 +555,7 @@ function create_thesaurus(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -560,6 +578,7 @@ function delete_data_source(Id, IndexId; aws_config::AbstractAWSConfig=global_aw
         "DeleteDataSource",
         Dict{String,Any}("Id" => Id, "IndexId" => IndexId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_data_source(
@@ -574,6 +593,7 @@ function delete_data_source(
             mergewith(_merge, Dict{String,Any}("Id" => Id, "IndexId" => IndexId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -593,6 +613,7 @@ function delete_faq(Id, IndexId; aws_config::AbstractAWSConfig=global_aws_config
         "DeleteFaq",
         Dict{String,Any}("Id" => Id, "IndexId" => IndexId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_faq(
@@ -607,6 +628,7 @@ function delete_faq(
             mergewith(_merge, Dict{String,Any}("Id" => Id, "IndexId" => IndexId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -623,7 +645,12 @@ DescribeIndex operation is set to DELETING.
 
 """
 function delete_index(Id; aws_config::AbstractAWSConfig=global_aws_config())
-    return kendra("DeleteIndex", Dict{String,Any}("Id" => Id); aws_config=aws_config)
+    return kendra(
+        "DeleteIndex",
+        Dict{String,Any}("Id" => Id);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_index(
     Id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -632,6 +659,7 @@ function delete_index(
         "DeleteIndex",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Id" => Id), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -681,6 +709,7 @@ function delete_principal_mapping(
         "DeletePrincipalMapping",
         Dict{String,Any}("GroupId" => GroupId, "IndexId" => IndexId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_principal_mapping(
@@ -697,6 +726,7 @@ function delete_principal_mapping(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -720,6 +750,7 @@ function delete_query_suggestions_block_list(
         "DeleteQuerySuggestionsBlockList",
         Dict{String,Any}("Id" => Id, "IndexId" => IndexId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_query_suggestions_block_list(
@@ -734,6 +765,7 @@ function delete_query_suggestions_block_list(
             mergewith(_merge, Dict{String,Any}("Id" => Id, "IndexId" => IndexId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -753,6 +785,7 @@ function delete_thesaurus(Id, IndexId; aws_config::AbstractAWSConfig=global_aws_
         "DeleteThesaurus",
         Dict{String,Any}("Id" => Id, "IndexId" => IndexId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_thesaurus(
@@ -767,6 +800,7 @@ function delete_thesaurus(
             mergewith(_merge, Dict{String,Any}("Id" => Id, "IndexId" => IndexId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -788,6 +822,7 @@ function describe_data_source(
         "DescribeDataSource",
         Dict{String,Any}("Id" => Id, "IndexId" => IndexId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_data_source(
@@ -802,6 +837,7 @@ function describe_data_source(
             mergewith(_merge, Dict{String,Any}("Id" => Id, "IndexId" => IndexId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -821,6 +857,7 @@ function describe_faq(Id, IndexId; aws_config::AbstractAWSConfig=global_aws_conf
         "DescribeFaq",
         Dict{String,Any}("Id" => Id, "IndexId" => IndexId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_faq(
@@ -835,6 +872,7 @@ function describe_faq(
             mergewith(_merge, Dict{String,Any}("Id" => Id, "IndexId" => IndexId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -849,7 +887,12 @@ Describes an existing Amazon Kendra index
 
 """
 function describe_index(Id; aws_config::AbstractAWSConfig=global_aws_config())
-    return kendra("DescribeIndex", Dict{String,Any}("Id" => Id); aws_config=aws_config)
+    return kendra(
+        "DescribeIndex",
+        Dict{String,Any}("Id" => Id);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_index(
     Id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -858,6 +901,7 @@ function describe_index(
         "DescribeIndex",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Id" => Id), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -889,6 +933,7 @@ function describe_principal_mapping(
         "DescribePrincipalMapping",
         Dict{String,Any}("GroupId" => GroupId, "IndexId" => IndexId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_principal_mapping(
@@ -905,6 +950,7 @@ function describe_principal_mapping(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -927,6 +973,7 @@ function describe_query_suggestions_block_list(
         "DescribeQuerySuggestionsBlockList",
         Dict{String,Any}("Id" => Id, "IndexId" => IndexId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_query_suggestions_block_list(
@@ -941,6 +988,7 @@ function describe_query_suggestions_block_list(
             mergewith(_merge, Dict{String,Any}("Id" => Id, "IndexId" => IndexId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -963,6 +1011,7 @@ function describe_query_suggestions_config(
         "DescribeQuerySuggestionsConfig",
         Dict{String,Any}("IndexId" => IndexId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_query_suggestions_config(
@@ -972,6 +1021,7 @@ function describe_query_suggestions_config(
         "DescribeQuerySuggestionsConfig",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("IndexId" => IndexId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -991,6 +1041,7 @@ function describe_thesaurus(Id, IndexId; aws_config::AbstractAWSConfig=global_aw
         "DescribeThesaurus",
         Dict{String,Any}("Id" => Id, "IndexId" => IndexId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_thesaurus(
@@ -1005,6 +1056,7 @@ function describe_thesaurus(
             mergewith(_merge, Dict{String,Any}("Id" => Id, "IndexId" => IndexId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1034,6 +1086,7 @@ function get_query_suggestions(
         "GetQuerySuggestions",
         Dict{String,Any}("IndexId" => IndexId, "QueryText" => QueryText);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_query_suggestions(
@@ -1052,6 +1105,7 @@ function get_query_suggestions(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1083,6 +1137,7 @@ function list_data_source_sync_jobs(
         "ListDataSourceSyncJobs",
         Dict{String,Any}("Id" => Id, "IndexId" => IndexId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_data_source_sync_jobs(
@@ -1097,6 +1152,7 @@ function list_data_source_sync_jobs(
             mergewith(_merge, Dict{String,Any}("Id" => Id, "IndexId" => IndexId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1118,7 +1174,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function list_data_sources(IndexId; aws_config::AbstractAWSConfig=global_aws_config())
     return kendra(
-        "ListDataSources", Dict{String,Any}("IndexId" => IndexId); aws_config=aws_config
+        "ListDataSources",
+        Dict{String,Any}("IndexId" => IndexId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_data_sources(
@@ -1128,6 +1187,7 @@ function list_data_sources(
         "ListDataSources",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("IndexId" => IndexId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1148,7 +1208,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   the NextToken to fetch the next set of FAQs.
 """
 function list_faqs(IndexId; aws_config::AbstractAWSConfig=global_aws_config())
-    return kendra("ListFaqs", Dict{String,Any}("IndexId" => IndexId); aws_config=aws_config)
+    return kendra(
+        "ListFaqs",
+        Dict{String,Any}("IndexId" => IndexId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_faqs(
     IndexId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -1157,6 +1222,7 @@ function list_faqs(
         "ListFaqs",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("IndexId" => IndexId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1188,6 +1254,7 @@ function list_groups_older_than_ordering_id(
         "ListGroupsOlderThanOrderingId",
         Dict{String,Any}("IndexId" => IndexId, "OrderingId" => OrderingId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_groups_older_than_ordering_id(
@@ -1206,6 +1273,7 @@ function list_groups_older_than_ordering_id(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1223,12 +1291,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   pagination token to retrieve the next set of indexes (DataSourceSummaryItems).
 """
 function list_indices(; aws_config::AbstractAWSConfig=global_aws_config())
-    return kendra("ListIndices"; aws_config=aws_config)
+    return kendra("ListIndices"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_indices(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return kendra("ListIndices", params; aws_config=aws_config)
+    return kendra(
+        "ListIndices", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1257,6 +1327,7 @@ function list_query_suggestions_block_lists(
         "ListQuerySuggestionsBlockLists",
         Dict{String,Any}("IndexId" => IndexId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_query_suggestions_block_lists(
@@ -1266,6 +1337,7 @@ function list_query_suggestions_block_lists(
         "ListQuerySuggestionsBlockLists",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("IndexId" => IndexId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1288,6 +1360,7 @@ function list_tags_for_resource(
         "ListTagsForResource",
         Dict{String,Any}("ResourceARN" => ResourceARN);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags_for_resource(
@@ -1301,6 +1374,7 @@ function list_tags_for_resource(
             mergewith(_merge, Dict{String,Any}("ResourceARN" => ResourceARN), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1322,7 +1396,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function list_thesauri(IndexId; aws_config::AbstractAWSConfig=global_aws_config())
     return kendra(
-        "ListThesauri", Dict{String,Any}("IndexId" => IndexId); aws_config=aws_config
+        "ListThesauri",
+        Dict{String,Any}("IndexId" => IndexId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_thesauri(
@@ -1332,6 +1409,7 @@ function list_thesauri(
         "ListThesauri",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("IndexId" => IndexId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1391,6 +1469,7 @@ function put_principal_mapping(
             "GroupId" => GroupId, "GroupMembers" => GroupMembers, "IndexId" => IndexId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_principal_mapping(
@@ -1414,6 +1493,7 @@ function put_principal_mapping(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1481,6 +1561,7 @@ function query(IndexId, QueryText; aws_config::AbstractAWSConfig=global_aws_conf
         "Query",
         Dict{String,Any}("IndexId" => IndexId, "QueryText" => QueryText);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function query(
@@ -1499,6 +1580,7 @@ function query(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1521,6 +1603,7 @@ function start_data_source_sync_job(
         "StartDataSourceSyncJob",
         Dict{String,Any}("Id" => Id, "IndexId" => IndexId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_data_source_sync_job(
@@ -1535,6 +1618,7 @@ function start_data_source_sync_job(
             mergewith(_merge, Dict{String,Any}("Id" => Id, "IndexId" => IndexId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1556,6 +1640,7 @@ function stop_data_source_sync_job(
         "StopDataSourceSyncJob",
         Dict{String,Any}("Id" => Id, "IndexId" => IndexId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function stop_data_source_sync_job(
@@ -1570,6 +1655,7 @@ function stop_data_source_sync_job(
             mergewith(_merge, Dict{String,Any}("Id" => Id, "IndexId" => IndexId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1598,6 +1684,7 @@ function submit_feedback(
         "SubmitFeedback",
         Dict{String,Any}("IndexId" => IndexId, "QueryId" => QueryId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function submit_feedback(
@@ -1614,6 +1701,7 @@ function submit_feedback(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1635,6 +1723,7 @@ function tag_resource(ResourceARN, Tags; aws_config::AbstractAWSConfig=global_aw
         "TagResource",
         Dict{String,Any}("ResourceARN" => ResourceARN, "Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -1653,6 +1742,7 @@ function tag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1676,6 +1766,7 @@ function untag_resource(
         "UntagResource",
         Dict{String,Any}("ResourceARN" => ResourceARN, "TagKeys" => TagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -1694,6 +1785,7 @@ function untag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1722,6 +1814,7 @@ function update_data_source(Id, IndexId; aws_config::AbstractAWSConfig=global_aw
         "UpdateDataSource",
         Dict{String,Any}("Id" => Id, "IndexId" => IndexId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_data_source(
@@ -1736,6 +1829,7 @@ function update_data_source(
             mergewith(_merge, Dict{String,Any}("Id" => Id, "IndexId" => IndexId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1763,7 +1857,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"UserTokenConfigurations"`: The user token configuration.
 """
 function update_index(Id; aws_config::AbstractAWSConfig=global_aws_config())
-    return kendra("UpdateIndex", Dict{String,Any}("Id" => Id); aws_config=aws_config)
+    return kendra(
+        "UpdateIndex",
+        Dict{String,Any}("Id" => Id);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function update_index(
     Id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -1772,6 +1871,7 @@ function update_index(
         "UpdateIndex",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Id" => Id), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1811,6 +1911,7 @@ function update_query_suggestions_block_list(
         "UpdateQuerySuggestionsBlockList",
         Dict{String,Any}("Id" => Id, "IndexId" => IndexId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_query_suggestions_block_list(
@@ -1825,6 +1926,7 @@ function update_query_suggestions_block_list(
             mergewith(_merge, Dict{String,Any}("Id" => Id, "IndexId" => IndexId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1878,6 +1980,7 @@ function update_query_suggestions_config(
         "UpdateQuerySuggestionsConfig",
         Dict{String,Any}("IndexId" => IndexId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_query_suggestions_config(
@@ -1887,6 +1990,7 @@ function update_query_suggestions_config(
         "UpdateQuerySuggestionsConfig",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("IndexId" => IndexId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1912,6 +2016,7 @@ function update_thesaurus(Id, IndexId; aws_config::AbstractAWSConfig=global_aws_
         "UpdateThesaurus",
         Dict{String,Any}("Id" => Id, "IndexId" => IndexId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_thesaurus(
@@ -1926,5 +2031,6 @@ function update_thesaurus(
             mergewith(_merge, Dict{String,Any}("Id" => Id, "IndexId" => IndexId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/kinesis.jl
+++ b/src/services/kinesis.jl
@@ -27,6 +27,7 @@ function add_tags_to_stream(
         "AddTagsToStream",
         Dict{String,Any}("StreamName" => StreamName, "Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function add_tags_to_stream(
@@ -43,6 +44,7 @@ function add_tags_to_stream(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -90,6 +92,7 @@ function create_stream(
         "CreateStream",
         Dict{String,Any}("ShardCount" => ShardCount, "StreamName" => StreamName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_stream(
@@ -108,6 +111,7 @@ function create_stream(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -136,6 +140,7 @@ function decrease_stream_retention_period(
             "RetentionPeriodHours" => RetentionPeriodHours, "StreamName" => StreamName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function decrease_stream_retention_period(
@@ -157,6 +162,7 @@ function decrease_stream_retention_period(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -187,7 +193,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function delete_stream(StreamName; aws_config::AbstractAWSConfig=global_aws_config())
     return kinesis(
-        "DeleteStream", Dict{String,Any}("StreamName" => StreamName); aws_config=aws_config
+        "DeleteStream",
+        Dict{String,Any}("StreamName" => StreamName);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_stream(
@@ -201,6 +210,7 @@ function delete_stream(
             mergewith(_merge, Dict{String,Any}("StreamName" => StreamName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -228,12 +238,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   For more information, see Amazon Resource Names (ARNs) and AWS Service Namespaces.
 """
 function deregister_stream_consumer(; aws_config::AbstractAWSConfig=global_aws_config())
-    return kinesis("DeregisterStreamConsumer"; aws_config=aws_config)
+    return kinesis(
+        "DeregisterStreamConsumer"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function deregister_stream_consumer(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return kinesis("DeregisterStreamConsumer", params; aws_config=aws_config)
+    return kinesis(
+        "DeregisterStreamConsumer",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -246,12 +263,14 @@ transaction per second per account.
 
 """
 function describe_limits(; aws_config::AbstractAWSConfig=global_aws_config())
-    return kinesis("DescribeLimits"; aws_config=aws_config)
+    return kinesis("DescribeLimits"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function describe_limits(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return kinesis("DescribeLimits", params; aws_config=aws_config)
+    return kinesis(
+        "DescribeLimits", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -284,6 +303,7 @@ function describe_stream(StreamName; aws_config::AbstractAWSConfig=global_aws_co
         "DescribeStream",
         Dict{String,Any}("StreamName" => StreamName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_stream(
@@ -297,6 +317,7 @@ function describe_stream(
             mergewith(_merge, Dict{String,Any}("StreamName" => StreamName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -321,12 +342,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   For more information, see Amazon Resource Names (ARNs) and AWS Service Namespaces.
 """
 function describe_stream_consumer(; aws_config::AbstractAWSConfig=global_aws_config())
-    return kinesis("DescribeStreamConsumer"; aws_config=aws_config)
+    return kinesis(
+        "DescribeStreamConsumer"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_stream_consumer(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return kinesis("DescribeStreamConsumer", params; aws_config=aws_config)
+    return kinesis(
+        "DescribeStreamConsumer",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -350,6 +378,7 @@ function describe_stream_summary(
         "DescribeStreamSummary",
         Dict{String,Any}("StreamName" => StreamName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_stream_summary(
@@ -363,6 +392,7 @@ function describe_stream_summary(
             mergewith(_merge, Dict{String,Any}("StreamName" => StreamName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -393,6 +423,7 @@ function disable_enhanced_monitoring(
             "ShardLevelMetrics" => ShardLevelMetrics, "StreamName" => StreamName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disable_enhanced_monitoring(
@@ -413,6 +444,7 @@ function disable_enhanced_monitoring(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -442,6 +474,7 @@ function enable_enhanced_monitoring(
             "ShardLevelMetrics" => ShardLevelMetrics, "StreamName" => StreamName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function enable_enhanced_monitoring(
@@ -462,6 +495,7 @@ function enable_enhanced_monitoring(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -526,6 +560,7 @@ function get_records(ShardIterator; aws_config::AbstractAWSConfig=global_aws_con
         "GetRecords",
         Dict{String,Any}("ShardIterator" => ShardIterator);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_records(
@@ -539,6 +574,7 @@ function get_records(
             mergewith(_merge, Dict{String,Any}("ShardIterator" => ShardIterator), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -612,6 +648,7 @@ function get_shard_iterator(
             "StreamName" => StreamName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_shard_iterator(
@@ -635,6 +672,7 @@ function get_shard_iterator(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -666,6 +704,7 @@ function increase_stream_retention_period(
             "RetentionPeriodHours" => RetentionPeriodHours, "StreamName" => StreamName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function increase_stream_retention_period(
@@ -687,6 +726,7 @@ function increase_stream_retention_period(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -736,12 +776,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   specify this parameter if you specify the NextToken parameter.
 """
 function list_shards(; aws_config::AbstractAWSConfig=global_aws_config())
-    return kinesis("ListShards"; aws_config=aws_config)
+    return kinesis("ListShards"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_shards(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return kinesis("ListShards", params; aws_config=aws_config)
+    return kinesis(
+        "ListShards", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -787,6 +829,7 @@ function list_stream_consumers(StreamARN; aws_config::AbstractAWSConfig=global_a
         "ListStreamConsumers",
         Dict{String,Any}("StreamARN" => StreamARN);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_stream_consumers(
@@ -800,6 +843,7 @@ function list_stream_consumers(
             mergewith(_merge, Dict{String,Any}("StreamARN" => StreamARN), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -825,12 +869,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"Limit"`: The maximum number of streams to list.
 """
 function list_streams(; aws_config::AbstractAWSConfig=global_aws_config())
-    return kinesis("ListStreams"; aws_config=aws_config)
+    return kinesis("ListStreams"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_streams(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return kinesis("ListStreams", params; aws_config=aws_config)
+    return kinesis(
+        "ListStreams", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -857,6 +903,7 @@ function list_tags_for_stream(StreamName; aws_config::AbstractAWSConfig=global_a
         "ListTagsForStream",
         Dict{String,Any}("StreamName" => StreamName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags_for_stream(
@@ -870,6 +917,7 @@ function list_tags_for_stream(
             mergewith(_merge, Dict{String,Any}("StreamName" => StreamName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -922,6 +970,7 @@ function merge_shards(
             "StreamName" => StreamName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function merge_shards(
@@ -945,6 +994,7 @@ function merge_shards(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1012,6 +1062,7 @@ function put_record(
             "Data" => Data, "PartitionKey" => PartitionKey, "StreamName" => StreamName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_record(
@@ -1035,6 +1086,7 @@ function put_record(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1096,6 +1148,7 @@ function put_records(Records, StreamName; aws_config::AbstractAWSConfig=global_a
         "PutRecords",
         Dict{String,Any}("Records" => Records, "StreamName" => StreamName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_records(
@@ -1114,6 +1167,7 @@ function put_records(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1147,6 +1201,7 @@ function register_stream_consumer(
         "RegisterStreamConsumer",
         Dict{String,Any}("ConsumerName" => ConsumerName, "StreamARN" => StreamARN);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function register_stream_consumer(
@@ -1165,6 +1220,7 @@ function register_stream_consumer(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1189,6 +1245,7 @@ function remove_tags_from_stream(
         "RemoveTagsFromStream",
         Dict{String,Any}("StreamName" => StreamName, "TagKeys" => TagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function remove_tags_from_stream(
@@ -1207,6 +1264,7 @@ function remove_tags_from_stream(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1269,6 +1327,7 @@ function split_shard(
             "StreamName" => StreamName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function split_shard(
@@ -1292,6 +1351,7 @@ function split_shard(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1334,6 +1394,7 @@ function start_stream_encryption(
             "EncryptionType" => EncryptionType, "KeyId" => KeyId, "StreamName" => StreamName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_stream_encryption(
@@ -1357,6 +1418,7 @@ function start_stream_encryption(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1399,6 +1461,7 @@ function stop_stream_encryption(
             "EncryptionType" => EncryptionType, "KeyId" => KeyId, "StreamName" => StreamName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function stop_stream_encryption(
@@ -1422,6 +1485,7 @@ function stop_stream_encryption(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1477,6 +1541,7 @@ function update_shard_count(
             "TargetShardCount" => TargetShardCount,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_shard_count(
@@ -1500,5 +1565,6 @@ function update_shard_count(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/kinesis_analytics.jl
+++ b/src/services/kinesis_analytics.jl
@@ -37,6 +37,7 @@ function add_application_cloud_watch_logging_option(
             "CurrentApplicationVersionId" => CurrentApplicationVersionId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function add_application_cloud_watch_logging_option(
@@ -60,6 +61,7 @@ function add_application_cloud_watch_logging_option(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -102,6 +104,7 @@ function add_application_input(
             "Input" => Input,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function add_application_input(
@@ -125,6 +128,7 @@ function add_application_input(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -169,6 +173,7 @@ function add_application_input_processing_configuration(
             "InputProcessingConfiguration" => InputProcessingConfiguration,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function add_application_input_processing_configuration(
@@ -194,6 +199,7 @@ function add_application_input_processing_configuration(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -246,6 +252,7 @@ function add_application_output(
             "Output" => Output,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function add_application_output(
@@ -269,6 +276,7 @@ function add_application_output(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -316,6 +324,7 @@ function add_application_reference_data_source(
             "ReferenceDataSource" => ReferenceDataSource,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function add_application_reference_data_source(
@@ -339,6 +348,7 @@ function add_application_reference_data_source(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -419,6 +429,7 @@ function create_application(
         "CreateApplication",
         Dict{String,Any}("ApplicationName" => ApplicationName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_application(
@@ -434,6 +445,7 @@ function create_application(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -463,6 +475,7 @@ function delete_application(
             "ApplicationName" => ApplicationName, "CreateTimestamp" => CreateTimestamp
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_application(
@@ -484,6 +497,7 @@ function delete_application(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -520,6 +534,7 @@ function delete_application_cloud_watch_logging_option(
             "CurrentApplicationVersionId" => CurrentApplicationVersionId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_application_cloud_watch_logging_option(
@@ -543,6 +558,7 @@ function delete_application_cloud_watch_logging_option(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -577,6 +593,7 @@ function delete_application_input_processing_configuration(
             "InputId" => InputId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_application_input_processing_configuration(
@@ -600,6 +617,7 @@ function delete_application_input_processing_configuration(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -642,6 +660,7 @@ function delete_application_output(
             "OutputId" => OutputId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_application_output(
@@ -665,6 +684,7 @@ function delete_application_output(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -705,6 +725,7 @@ function delete_application_reference_data_source(
             "ReferenceId" => ReferenceId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_application_reference_data_source(
@@ -728,6 +749,7 @@ function delete_application_reference_data_source(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -755,6 +777,7 @@ function describe_application(
         "DescribeApplication",
         Dict{String,Any}("ApplicationName" => ApplicationName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_application(
@@ -770,6 +793,7 @@ function describe_application(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -803,12 +827,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   S3 object.
 """
 function discover_input_schema(; aws_config::AbstractAWSConfig=global_aws_config())
-    return kinesis_analytics("DiscoverInputSchema"; aws_config=aws_config)
+    return kinesis_analytics(
+        "DiscoverInputSchema"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function discover_input_schema(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return kinesis_analytics("DiscoverInputSchema", params; aws_config=aws_config)
+    return kinesis_analytics(
+        "DiscoverInputSchema",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -835,12 +866,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"Limit"`: Maximum number of applications to list.
 """
 function list_applications(; aws_config::AbstractAWSConfig=global_aws_config())
-    return kinesis_analytics("ListApplications"; aws_config=aws_config)
+    return kinesis_analytics(
+        "ListApplications"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_applications(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return kinesis_analytics("ListApplications", params; aws_config=aws_config)
+    return kinesis_analytics(
+        "ListApplications", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -861,6 +896,7 @@ function list_tags_for_resource(
         "ListTagsForResource",
         Dict{String,Any}("ResourceARN" => ResourceARN);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags_for_resource(
@@ -874,6 +910,7 @@ function list_tags_for_resource(
             mergewith(_merge, Dict{String,Any}("ResourceARN" => ResourceARN), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -911,6 +948,7 @@ function start_application(
             "InputConfigurations" => InputConfigurations,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_application(
@@ -932,6 +970,7 @@ function start_application(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -960,6 +999,7 @@ function stop_application(
         "StopApplication",
         Dict{String,Any}("ApplicationName" => ApplicationName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function stop_application(
@@ -975,6 +1015,7 @@ function stop_application(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -996,6 +1037,7 @@ function tag_resource(ResourceARN, Tags; aws_config::AbstractAWSConfig=global_aw
         "TagResource",
         Dict{String,Any}("ResourceARN" => ResourceARN, "Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -1014,6 +1056,7 @@ function tag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1037,6 +1080,7 @@ function untag_resource(
         "UntagResource",
         Dict{String,Any}("ResourceARN" => ResourceARN, "TagKeys" => TagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -1055,6 +1099,7 @@ function untag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1091,6 +1136,7 @@ function update_application(
             "CurrentApplicationVersionId" => CurrentApplicationVersionId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_application(
@@ -1114,5 +1160,6 @@ function update_application(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/kinesis_analytics_v2.jl
+++ b/src/services/kinesis_analytics_v2.jl
@@ -39,6 +39,7 @@ function add_application_cloud_watch_logging_option(
             "CloudWatchLoggingOption" => CloudWatchLoggingOption,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function add_application_cloud_watch_logging_option(
@@ -60,6 +61,7 @@ function add_application_cloud_watch_logging_option(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -97,6 +99,7 @@ function add_application_input(
             "Input" => Input,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function add_application_input(
@@ -120,6 +123,7 @@ function add_application_input(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -161,6 +165,7 @@ function add_application_input_processing_configuration(
             "InputProcessingConfiguration" => InputProcessingConfiguration,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function add_application_input_processing_configuration(
@@ -186,6 +191,7 @@ function add_application_input_processing_configuration(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -232,6 +238,7 @@ function add_application_output(
             "Output" => Output,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function add_application_output(
@@ -255,6 +262,7 @@ function add_application_output(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -295,6 +303,7 @@ function add_application_reference_data_source(
             "ReferenceDataSource" => ReferenceDataSource,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function add_application_reference_data_source(
@@ -318,6 +327,7 @@ function add_application_reference_data_source(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -358,6 +368,7 @@ function add_application_vpc_configuration(
             "ApplicationName" => ApplicationName, "VpcConfiguration" => VpcConfiguration
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function add_application_vpc_configuration(
@@ -379,6 +390,7 @@ function add_application_vpc_configuration(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -424,6 +436,7 @@ function create_application(
             "ServiceExecutionRole" => ServiceExecutionRole,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_application(
@@ -447,6 +460,7 @@ function create_application(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -483,6 +497,7 @@ function create_application_presigned_url(
         "CreateApplicationPresignedUrl",
         Dict{String,Any}("ApplicationName" => ApplicationName, "UrlType" => UrlType);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_application_presigned_url(
@@ -503,6 +518,7 @@ function create_application_presigned_url(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -526,6 +542,7 @@ function create_application_snapshot(
             "ApplicationName" => ApplicationName, "SnapshotName" => SnapshotName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_application_snapshot(
@@ -546,6 +563,7 @@ function create_application_snapshot(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -570,6 +588,7 @@ function delete_application(
             "ApplicationName" => ApplicationName, "CreateTimestamp" => CreateTimestamp
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_application(
@@ -591,6 +610,7 @@ function delete_application(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -630,6 +650,7 @@ function delete_application_cloud_watch_logging_option(
             "CloudWatchLoggingOptionId" => CloudWatchLoggingOptionId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_application_cloud_watch_logging_option(
@@ -651,6 +672,7 @@ function delete_application_cloud_watch_logging_option(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -684,6 +706,7 @@ function delete_application_input_processing_configuration(
             "InputId" => InputId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_application_input_processing_configuration(
@@ -707,6 +730,7 @@ function delete_application_input_processing_configuration(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -744,6 +768,7 @@ function delete_application_output(
             "OutputId" => OutputId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_application_output(
@@ -767,6 +792,7 @@ function delete_application_output(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -803,6 +829,7 @@ function delete_application_reference_data_source(
             "ReferenceId" => ReferenceId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_application_reference_data_source(
@@ -826,6 +853,7 @@ function delete_application_reference_data_source(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -856,6 +884,7 @@ function delete_application_snapshot(
             "SnapshotName" => SnapshotName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_application_snapshot(
@@ -879,6 +908,7 @@ function delete_application_snapshot(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -913,6 +943,7 @@ function delete_application_vpc_configuration(
             "ApplicationName" => ApplicationName, "VpcConfigurationId" => VpcConfigurationId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_application_vpc_configuration(
@@ -934,6 +965,7 @@ function delete_application_vpc_configuration(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -959,6 +991,7 @@ function describe_application(
         "DescribeApplication",
         Dict{String,Any}("ApplicationName" => ApplicationName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_application(
@@ -974,6 +1007,7 @@ function describe_application(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -998,6 +1032,7 @@ function describe_application_snapshot(
             "ApplicationName" => ApplicationName, "SnapshotName" => SnapshotName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_application_snapshot(
@@ -1018,6 +1053,7 @@ function describe_application_snapshot(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1046,6 +1082,7 @@ function describe_application_version(
             "ApplicationVersionId" => ApplicationVersionId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_application_version(
@@ -1067,6 +1104,7 @@ function describe_application_version(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1102,6 +1140,7 @@ function discover_input_schema(
         "DiscoverInputSchema",
         Dict{String,Any}("ServiceExecutionRole" => ServiceExecutionRole);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function discover_input_schema(
@@ -1119,6 +1158,7 @@ function discover_input_schema(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1145,6 +1185,7 @@ function list_application_snapshots(
         "ListApplicationSnapshots",
         Dict{String,Any}("ApplicationName" => ApplicationName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_application_snapshots(
@@ -1160,6 +1201,7 @@ function list_application_snapshots(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1190,6 +1232,7 @@ function list_application_versions(
         "ListApplicationVersions",
         Dict{String,Any}("ApplicationName" => ApplicationName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_application_versions(
@@ -1205,6 +1248,7 @@ function list_application_versions(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1225,12 +1269,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   AWS Command Line Interface's Pagination Options.
 """
 function list_applications(; aws_config::AbstractAWSConfig=global_aws_config())
-    return kinesis_analytics_v2("ListApplications"; aws_config=aws_config)
+    return kinesis_analytics_v2(
+        "ListApplications"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_applications(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return kinesis_analytics_v2("ListApplications", params; aws_config=aws_config)
+    return kinesis_analytics_v2(
+        "ListApplications", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1251,6 +1299,7 @@ function list_tags_for_resource(
         "ListTagsForResource",
         Dict{String,Any}("ResourceARN" => ResourceARN);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags_for_resource(
@@ -1264,6 +1313,7 @@ function list_tags_for_resource(
             mergewith(_merge, Dict{String,Any}("ResourceARN" => ResourceARN), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1296,6 +1346,7 @@ function rollback_application(
             "CurrentApplicationVersionId" => CurrentApplicationVersionId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function rollback_application(
@@ -1317,6 +1368,7 @@ function rollback_application(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1342,6 +1394,7 @@ function start_application(
         "StartApplication",
         Dict{String,Any}("ApplicationName" => ApplicationName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_application(
@@ -1357,6 +1410,7 @@ function start_application(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1389,6 +1443,7 @@ function stop_application(
         "StopApplication",
         Dict{String,Any}("ApplicationName" => ApplicationName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function stop_application(
@@ -1404,6 +1459,7 @@ function stop_application(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1425,6 +1481,7 @@ function tag_resource(ResourceARN, Tags; aws_config::AbstractAWSConfig=global_aw
         "TagResource",
         Dict{String,Any}("ResourceARN" => ResourceARN, "Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -1443,6 +1500,7 @@ function tag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1466,6 +1524,7 @@ function untag_resource(
         "UntagResource",
         Dict{String,Any}("ResourceARN" => ResourceARN, "TagKeys" => TagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -1484,6 +1543,7 @@ function untag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1525,6 +1585,7 @@ function update_application(
         "UpdateApplication",
         Dict{String,Any}("ApplicationName" => ApplicationName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_application(
@@ -1540,6 +1601,7 @@ function update_application(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1581,6 +1643,7 @@ function update_application_maintenance_configuration(
             "ApplicationName" => ApplicationName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_application_maintenance_configuration(
@@ -1603,5 +1666,6 @@ function update_application_maintenance_configuration(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/kinesis_video.jl
+++ b/src/services/kinesis_video.jl
@@ -30,6 +30,7 @@ function create_signaling_channel(
         "/createSignalingChannel",
         Dict{String,Any}("ChannelName" => ChannelName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_signaling_channel(
@@ -44,6 +45,7 @@ function create_signaling_channel(
             mergewith(_merge, Dict{String,Any}("ChannelName" => ChannelName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -89,6 +91,7 @@ function create_stream(StreamName; aws_config::AbstractAWSConfig=global_aws_conf
         "/createStream",
         Dict{String,Any}("StreamName" => StreamName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_stream(
@@ -103,6 +106,7 @@ function create_stream(
             mergewith(_merge, Dict{String,Any}("StreamName" => StreamName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -131,6 +135,7 @@ function delete_signaling_channel(
         "/deleteSignalingChannel",
         Dict{String,Any}("ChannelARN" => ChannelARN);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_signaling_channel(
@@ -145,6 +150,7 @@ function delete_signaling_channel(
             mergewith(_merge, Dict{String,Any}("ChannelARN" => ChannelARN), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -176,6 +182,7 @@ function delete_stream(StreamARN; aws_config::AbstractAWSConfig=global_aws_confi
         "/deleteStream",
         Dict{String,Any}("StreamARN" => StreamARN);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_stream(
@@ -190,6 +197,7 @@ function delete_stream(
             mergewith(_merge, Dict{String,Any}("StreamARN" => StreamARN), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -206,12 +214,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"ChannelName"`: The name of the signaling channel that you want to describe.
 """
 function describe_signaling_channel(; aws_config::AbstractAWSConfig=global_aws_config())
-    return kinesis_video("POST", "/describeSignalingChannel"; aws_config=aws_config)
+    return kinesis_video(
+        "POST",
+        "/describeSignalingChannel";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_signaling_channel(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return kinesis_video("POST", "/describeSignalingChannel", params; aws_config=aws_config)
+    return kinesis_video(
+        "POST",
+        "/describeSignalingChannel",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -227,12 +246,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"StreamName"`: The name of the stream.
 """
 function describe_stream(; aws_config::AbstractAWSConfig=global_aws_config())
-    return kinesis_video("POST", "/describeStream"; aws_config=aws_config)
+    return kinesis_video(
+        "POST", "/describeStream"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_stream(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return kinesis_video("POST", "/describeStream", params; aws_config=aws_config)
+    return kinesis_video(
+        "POST",
+        "/describeStream",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -262,6 +289,7 @@ function get_data_endpoint(APIName; aws_config::AbstractAWSConfig=global_aws_con
         "/getDataEndpoint",
         Dict{String,Any}("APIName" => APIName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_data_endpoint(
@@ -272,6 +300,7 @@ function get_data_endpoint(
         "/getDataEndpoint",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("APIName" => APIName), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -306,6 +335,7 @@ function get_signaling_channel_endpoint(
         "/getSignalingChannelEndpoint",
         Dict{String,Any}("ChannelARN" => ChannelARN);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_signaling_channel_endpoint(
@@ -320,6 +350,7 @@ function get_signaling_channel_endpoint(
             mergewith(_merge, Dict{String,Any}("ChannelARN" => ChannelARN), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -342,12 +373,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   batch of channels, provide this token in your next request.
 """
 function list_signaling_channels(; aws_config::AbstractAWSConfig=global_aws_config())
-    return kinesis_video("POST", "/listSignalingChannels"; aws_config=aws_config)
+    return kinesis_video(
+        "POST",
+        "/listSignalingChannels";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_signaling_channels(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return kinesis_video("POST", "/listSignalingChannels", params; aws_config=aws_config)
+    return kinesis_video(
+        "POST",
+        "/listSignalingChannels",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -368,12 +410,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   condition. Currently, you can specify only the prefix of a stream name as a condition.
 """
 function list_streams(; aws_config::AbstractAWSConfig=global_aws_config())
-    return kinesis_video("POST", "/listStreams"; aws_config=aws_config)
+    return kinesis_video(
+        "POST", "/listStreams"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_streams(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return kinesis_video("POST", "/listStreams", params; aws_config=aws_config)
+    return kinesis_video(
+        "POST",
+        "/listStreams",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -400,6 +450,7 @@ function list_tags_for_resource(
         "/ListTagsForResource",
         Dict{String,Any}("ResourceARN" => ResourceARN);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags_for_resource(
@@ -414,6 +465,7 @@ function list_tags_for_resource(
             mergewith(_merge, Dict{String,Any}("ResourceARN" => ResourceARN), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -434,12 +486,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"StreamName"`: The name of the stream that you want to list tags for.
 """
 function list_tags_for_stream(; aws_config::AbstractAWSConfig=global_aws_config())
-    return kinesis_video("POST", "/listTagsForStream"; aws_config=aws_config)
+    return kinesis_video(
+        "POST", "/listTagsForStream"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_tags_for_stream(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return kinesis_video("POST", "/listTagsForStream", params; aws_config=aws_config)
+    return kinesis_video(
+        "POST",
+        "/listTagsForStream",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -465,6 +525,7 @@ function tag_resource(ResourceARN, Tags; aws_config::AbstractAWSConfig=global_aw
         "/TagResource",
         Dict{String,Any}("ResourceARN" => ResourceARN, "Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -484,6 +545,7 @@ function tag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -510,7 +572,11 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function tag_stream(Tags; aws_config::AbstractAWSConfig=global_aws_config())
     return kinesis_video(
-        "POST", "/tagStream", Dict{String,Any}("Tags" => Tags); aws_config=aws_config
+        "POST",
+        "/tagStream",
+        Dict{String,Any}("Tags" => Tags);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_stream(
@@ -521,6 +587,7 @@ function tag_stream(
         "/tagStream",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Tags" => Tags), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -546,6 +613,7 @@ function untag_resource(
         "/UntagResource",
         Dict{String,Any}("ResourceARN" => ResourceARN, "TagKeyList" => TagKeyList);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -565,6 +633,7 @@ function untag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -591,6 +660,7 @@ function untag_stream(TagKeyList; aws_config::AbstractAWSConfig=global_aws_confi
         "/untagStream",
         Dict{String,Any}("TagKeyList" => TagKeyList);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_stream(
@@ -605,6 +675,7 @@ function untag_stream(
             mergewith(_merge, Dict{String,Any}("TagKeyList" => TagKeyList), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -653,6 +724,7 @@ function update_data_retention(
             "Operation" => Operation,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_data_retention(
@@ -677,6 +749,7 @@ function update_data_retention(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -707,6 +780,7 @@ function update_signaling_channel(
         "/updateSignalingChannel",
         Dict{String,Any}("ChannelARN" => ChannelARN, "CurrentVersion" => CurrentVersion);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_signaling_channel(
@@ -728,6 +802,7 @@ function update_signaling_channel(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -764,6 +839,7 @@ function update_stream(CurrentVersion; aws_config::AbstractAWSConfig=global_aws_
         "/updateStream",
         Dict{String,Any}("CurrentVersion" => CurrentVersion);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_stream(
@@ -778,5 +854,6 @@ function update_stream(
             mergewith(_merge, Dict{String,Any}("CurrentVersion" => CurrentVersion), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/kinesis_video_archived_media.jl
+++ b/src/services/kinesis_video_archived_media.jl
@@ -45,6 +45,7 @@ function get_clip(ClipFragmentSelector; aws_config::AbstractAWSConfig=global_aws
         "/getClip",
         Dict{String,Any}("ClipFragmentSelector" => ClipFragmentSelector);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_clip(
@@ -63,6 +64,7 @@ function get_clip(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -214,14 +216,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function get_dashstreaming_session_url(; aws_config::AbstractAWSConfig=global_aws_config())
     return kinesis_video_archived_media(
-        "POST", "/getDASHStreamingSessionURL"; aws_config=aws_config
+        "POST",
+        "/getDASHStreamingSessionURL";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_dashstreaming_session_url(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return kinesis_video_archived_media(
-        "POST", "/getDASHStreamingSessionURL", params; aws_config=aws_config
+        "POST",
+        "/getDASHStreamingSessionURL",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -407,14 +416,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function get_hlsstreaming_session_url(; aws_config::AbstractAWSConfig=global_aws_config())
     return kinesis_video_archived_media(
-        "POST", "/getHLSStreamingSessionURL"; aws_config=aws_config
+        "POST",
+        "/getHLSStreamingSessionURL";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_hlsstreaming_session_url(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return kinesis_video_archived_media(
-        "POST", "/getHLSStreamingSessionURL", params; aws_config=aws_config
+        "POST",
+        "/getHLSStreamingSessionURL",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -456,6 +472,7 @@ function get_media_for_fragment_list(
         "/getMediaForFragmentList",
         Dict{String,Any}("Fragments" => Fragments);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_media_for_fragment_list(
@@ -470,6 +487,7 @@ function get_media_for_fragment_list(
             mergewith(_merge, Dict{String,Any}("Fragments" => Fragments), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -510,12 +528,18 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   either this parameter or the StreamARN parameter.
 """
 function list_fragments(; aws_config::AbstractAWSConfig=global_aws_config())
-    return kinesis_video_archived_media("POST", "/listFragments"; aws_config=aws_config)
+    return kinesis_video_archived_media(
+        "POST", "/listFragments"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_fragments(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return kinesis_video_archived_media(
-        "POST", "/listFragments", params; aws_config=aws_config
+        "POST",
+        "/listFragments",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/kinesis_video_media.jl
+++ b/src/services/kinesis_video_media.jl
@@ -46,6 +46,7 @@ function get_media(StartSelector; aws_config::AbstractAWSConfig=global_aws_confi
         "/getMedia",
         Dict{String,Any}("StartSelector" => StartSelector);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_media(
@@ -60,5 +61,6 @@ function get_media(
             mergewith(_merge, Dict{String,Any}("StartSelector" => StartSelector), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/kinesis_video_signaling.jl
+++ b/src/services/kinesis_video_signaling.jl
@@ -39,6 +39,7 @@ function get_ice_server_config(
         "/v1/get-ice-server-config",
         Dict{String,Any}("ChannelARN" => ChannelARN);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_ice_server_config(
@@ -53,6 +54,7 @@ function get_ice_server_config(
             mergewith(_merge, Dict{String,Any}("ChannelARN" => ChannelARN), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -88,6 +90,7 @@ function send_alexa_offer_to_master(
             "SenderClientId" => SenderClientId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function send_alexa_offer_to_master(
@@ -112,5 +115,6 @@ function send_alexa_offer_to_master(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/kms.jl
+++ b/src/services/kms.jl
@@ -26,7 +26,10 @@ kms:CancelKeyDeletion (key policy)  Related operations: ScheduleKeyDeletion
 """
 function cancel_key_deletion(KeyId; aws_config::AbstractAWSConfig=global_aws_config())
     return kms(
-        "CancelKeyDeletion", Dict{String,Any}("KeyId" => KeyId); aws_config=aws_config
+        "CancelKeyDeletion",
+        Dict{String,Any}("KeyId" => KeyId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function cancel_key_deletion(
@@ -36,6 +39,7 @@ function cancel_key_deletion(
         "CancelKeyDeletion",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("KeyId" => KeyId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -83,6 +87,7 @@ function connect_custom_key_store(
         "ConnectCustomKeyStore",
         Dict{String,Any}("CustomKeyStoreId" => CustomKeyStoreId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function connect_custom_key_store(
@@ -98,6 +103,7 @@ function connect_custom_key_store(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -149,6 +155,7 @@ function create_alias(
         "CreateAlias",
         Dict{String,Any}("AliasName" => AliasName, "TargetKeyId" => TargetKeyId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_alias(
@@ -167,6 +174,7 @@ function create_alias(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -224,6 +232,7 @@ function create_custom_key_store(
             "TrustAnchorCertificate" => TrustAnchorCertificate,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_custom_key_store(
@@ -249,6 +258,7 @@ function create_custom_key_store(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -348,6 +358,7 @@ function create_grant(
             "Operations" => Operations,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_grant(
@@ -371,6 +382,7 @@ function create_grant(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -542,12 +554,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   can also be used to control access to a KMS key. For details, see Tagging Keys.
 """
 function create_key(; aws_config::AbstractAWSConfig=global_aws_config())
-    return kms("CreateKey"; aws_config=aws_config)
+    return kms("CreateKey"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function create_key(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return kms("CreateKey", params; aws_config=aws_config)
+    return kms("CreateKey", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 
 """
@@ -633,6 +645,7 @@ function decrypt(CiphertextBlob; aws_config::AbstractAWSConfig=global_aws_config
         "Decrypt",
         Dict{String,Any}("CiphertextBlob" => CiphertextBlob);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function decrypt(
@@ -646,6 +659,7 @@ function decrypt(
             mergewith(_merge, Dict{String,Any}("CiphertextBlob" => CiphertextBlob), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -674,7 +688,10 @@ aliases in the Key Management Service Developer Guide.  Related operations:     
 """
 function delete_alias(AliasName; aws_config::AbstractAWSConfig=global_aws_config())
     return kms(
-        "DeleteAlias", Dict{String,Any}("AliasName" => AliasName); aws_config=aws_config
+        "DeleteAlias",
+        Dict{String,Any}("AliasName" => AliasName);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_alias(
@@ -688,6 +705,7 @@ function delete_alias(
             mergewith(_merge, Dict{String,Any}("AliasName" => AliasName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -729,6 +747,7 @@ function delete_custom_key_store(
         "DeleteCustomKeyStore",
         Dict{String,Any}("CustomKeyStoreId" => CustomKeyStoreId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_custom_key_store(
@@ -744,6 +763,7 @@ function delete_custom_key_store(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -778,6 +798,7 @@ function delete_imported_key_material(
         "DeleteImportedKeyMaterial",
         Dict{String,Any}("KeyId" => KeyId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_imported_key_material(
@@ -787,6 +808,7 @@ function delete_imported_key_material(
         "DeleteImportedKeyMaterial",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("KeyId" => KeyId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -834,12 +856,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   received.
 """
 function describe_custom_key_stores(; aws_config::AbstractAWSConfig=global_aws_config())
-    return kms("DescribeCustomKeyStores"; aws_config=aws_config)
+    return kms(
+        "DescribeCustomKeyStores"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_custom_key_stores(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return kms("DescribeCustomKeyStores", params; aws_config=aws_config)
+    return kms(
+        "DescribeCustomKeyStores",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -892,7 +921,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Developer Guide.
 """
 function describe_key(KeyId; aws_config::AbstractAWSConfig=global_aws_config())
-    return kms("DescribeKey", Dict{String,Any}("KeyId" => KeyId); aws_config=aws_config)
+    return kms(
+        "DescribeKey",
+        Dict{String,Any}("KeyId" => KeyId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_key(
     KeyId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -901,6 +935,7 @@ function describe_key(
         "DescribeKey",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("KeyId" => KeyId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -925,7 +960,12 @@ a different Amazon Web Services account.  Required permissions: kms:DisableKey (
 
 """
 function disable_key(KeyId; aws_config::AbstractAWSConfig=global_aws_config())
-    return kms("DisableKey", Dict{String,Any}("KeyId" => KeyId); aws_config=aws_config)
+    return kms(
+        "DisableKey",
+        Dict{String,Any}("KeyId" => KeyId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function disable_key(
     KeyId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -934,6 +974,7 @@ function disable_key(
         "DisableKey",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("KeyId" => KeyId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -962,7 +1003,10 @@ account.  Required permissions: kms:DisableKeyRotation (key policy)  Related ope
 """
 function disable_key_rotation(KeyId; aws_config::AbstractAWSConfig=global_aws_config())
     return kms(
-        "DisableKeyRotation", Dict{String,Any}("KeyId" => KeyId); aws_config=aws_config
+        "DisableKeyRotation",
+        Dict{String,Any}("KeyId" => KeyId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disable_key_rotation(
@@ -972,6 +1016,7 @@ function disable_key_rotation(
         "DisableKeyRotation",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("KeyId" => KeyId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1007,6 +1052,7 @@ function disconnect_custom_key_store(
         "DisconnectCustomKeyStore",
         Dict{String,Any}("CustomKeyStoreId" => CustomKeyStoreId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disconnect_custom_key_store(
@@ -1022,6 +1068,7 @@ function disconnect_custom_key_store(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1044,7 +1091,12 @@ kms:EnableKey (key policy)  Related operations: DisableKey
 
 """
 function enable_key(KeyId; aws_config::AbstractAWSConfig=global_aws_config())
-    return kms("EnableKey", Dict{String,Any}("KeyId" => KeyId); aws_config=aws_config)
+    return kms(
+        "EnableKey",
+        Dict{String,Any}("KeyId" => KeyId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function enable_key(
     KeyId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -1053,6 +1105,7 @@ function enable_key(
         "EnableKey",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("KeyId" => KeyId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1082,7 +1135,10 @@ DisableKeyRotation     GetKeyRotationStatus
 """
 function enable_key_rotation(KeyId; aws_config::AbstractAWSConfig=global_aws_config())
     return kms(
-        "EnableKeyRotation", Dict{String,Any}("KeyId" => KeyId); aws_config=aws_config
+        "EnableKeyRotation",
+        Dict{String,Any}("KeyId" => KeyId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function enable_key_rotation(
@@ -1092,6 +1148,7 @@ function enable_key_rotation(
         "EnableKeyRotation",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("KeyId" => KeyId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1176,6 +1233,7 @@ function encrypt(KeyId, Plaintext; aws_config::AbstractAWSConfig=global_aws_conf
         "Encrypt",
         Dict{String,Any}("KeyId" => KeyId, "Plaintext" => Plaintext);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function encrypt(
@@ -1192,6 +1250,7 @@ function encrypt(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1271,7 +1330,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   or the NumberOfBytes parameter (but not both) in every GenerateDataKey request.
 """
 function generate_data_key(KeyId; aws_config::AbstractAWSConfig=global_aws_config())
-    return kms("GenerateDataKey", Dict{String,Any}("KeyId" => KeyId); aws_config=aws_config)
+    return kms(
+        "GenerateDataKey",
+        Dict{String,Any}("KeyId" => KeyId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function generate_data_key(
     KeyId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -1280,6 +1344,7 @@ function generate_data_key(
         "GenerateDataKey",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("KeyId" => KeyId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1361,6 +1426,7 @@ function generate_data_key_pair(
         "GenerateDataKeyPair",
         Dict{String,Any}("KeyId" => KeyId, "KeyPairSpec" => KeyPairSpec);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function generate_data_key_pair(
@@ -1379,6 +1445,7 @@ function generate_data_key_pair(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1453,6 +1520,7 @@ function generate_data_key_pair_without_plaintext(
         "GenerateDataKeyPairWithoutPlaintext",
         Dict{String,Any}("KeyId" => KeyId, "KeyPairSpec" => KeyPairSpec);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function generate_data_key_pair_without_plaintext(
@@ -1471,6 +1539,7 @@ function generate_data_key_pair_without_plaintext(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1547,6 +1616,7 @@ function generate_data_key_without_plaintext(
         "GenerateDataKeyWithoutPlaintext",
         Dict{String,Any}("KeyId" => KeyId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function generate_data_key_without_plaintext(
@@ -1556,6 +1626,7 @@ function generate_data_key_without_plaintext(
         "GenerateDataKeyWithoutPlaintext",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("KeyId" => KeyId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1580,12 +1651,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NumberOfBytes"`: The length of the byte string.
 """
 function generate_random(; aws_config::AbstractAWSConfig=global_aws_config())
-    return kms("GenerateRandom"; aws_config=aws_config)
+    return kms("GenerateRandom"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function generate_random(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return kms("GenerateRandom", params; aws_config=aws_config)
+    return kms(
+        "GenerateRandom", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1612,6 +1685,7 @@ function get_key_policy(
         "GetKeyPolicy",
         Dict{String,Any}("KeyId" => KeyId, "PolicyName" => PolicyName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_key_policy(
@@ -1630,6 +1704,7 @@ function get_key_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1663,7 +1738,10 @@ DisableKeyRotation     EnableKeyRotation
 """
 function get_key_rotation_status(KeyId; aws_config::AbstractAWSConfig=global_aws_config())
     return kms(
-        "GetKeyRotationStatus", Dict{String,Any}("KeyId" => KeyId); aws_config=aws_config
+        "GetKeyRotationStatus",
+        Dict{String,Any}("KeyId" => KeyId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_key_rotation_status(
@@ -1673,6 +1751,7 @@ function get_key_rotation_status(
         "GetKeyRotationStatus",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("KeyId" => KeyId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1726,6 +1805,7 @@ function get_parameters_for_import(
             "WrappingKeySpec" => WrappingKeySpec,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_parameters_for_import(
@@ -1749,6 +1829,7 @@ function get_parameters_for_import(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1803,7 +1884,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Developer Guide.
 """
 function get_public_key(KeyId; aws_config::AbstractAWSConfig=global_aws_config())
-    return kms("GetPublicKey", Dict{String,Any}("KeyId" => KeyId); aws_config=aws_config)
+    return kms(
+        "GetPublicKey",
+        Dict{String,Any}("KeyId" => KeyId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_public_key(
     KeyId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -1812,6 +1898,7 @@ function get_public_key(
         "GetPublicKey",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("KeyId" => KeyId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1889,6 +1976,7 @@ function import_key_material(
             "KeyId" => KeyId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function import_key_material(
@@ -1912,6 +2000,7 @@ function import_key_material(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1952,12 +2041,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   received.
 """
 function list_aliases(; aws_config::AbstractAWSConfig=global_aws_config())
-    return kms("ListAliases"; aws_config=aws_config)
+    return kms("ListAliases"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_aliases(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return kms("ListAliases", params; aws_config=aws_config)
+    return kms(
+        "ListAliases", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -2000,7 +2091,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   received.
 """
 function list_grants(KeyId; aws_config::AbstractAWSConfig=global_aws_config())
-    return kms("ListGrants", Dict{String,Any}("KeyId" => KeyId); aws_config=aws_config)
+    return kms(
+        "ListGrants",
+        Dict{String,Any}("KeyId" => KeyId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_grants(
     KeyId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -2009,6 +2105,7 @@ function list_grants(
         "ListGrants",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("KeyId" => KeyId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2040,7 +2137,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   received.
 """
 function list_key_policies(KeyId; aws_config::AbstractAWSConfig=global_aws_config())
-    return kms("ListKeyPolicies", Dict{String,Any}("KeyId" => KeyId); aws_config=aws_config)
+    return kms(
+        "ListKeyPolicies",
+        Dict{String,Any}("KeyId" => KeyId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_key_policies(
     KeyId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -2049,6 +2151,7 @@ function list_key_policies(
         "ListKeyPolicies",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("KeyId" => KeyId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2072,12 +2175,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   received.
 """
 function list_keys(; aws_config::AbstractAWSConfig=global_aws_config())
-    return kms("ListKeys"; aws_config=aws_config)
+    return kms("ListKeys"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_keys(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return kms("ListKeys", params; aws_config=aws_config)
+    return kms("ListKeys", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 
 """
@@ -2110,7 +2213,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function list_resource_tags(KeyId; aws_config::AbstractAWSConfig=global_aws_config())
     return kms(
-        "ListResourceTags", Dict{String,Any}("KeyId" => KeyId); aws_config=aws_config
+        "ListResourceTags",
+        Dict{String,Any}("KeyId" => KeyId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_resource_tags(
@@ -2120,6 +2226,7 @@ function list_resource_tags(
         "ListResourceTags",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("KeyId" => KeyId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2168,6 +2275,7 @@ function list_retirable_grants(
         "ListRetirableGrants",
         Dict{String,Any}("RetiringPrincipal" => RetiringPrincipal);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_retirable_grants(
@@ -2183,6 +2291,7 @@ function list_retirable_grants(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2237,6 +2346,7 @@ function put_key_policy(
         "PutKeyPolicy",
         Dict{String,Any}("KeyId" => KeyId, "Policy" => Policy, "PolicyName" => PolicyName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_key_policy(
@@ -2258,6 +2368,7 @@ function put_key_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2383,6 +2494,7 @@ function re_encrypt(
             "CiphertextBlob" => CiphertextBlob, "DestinationKeyId" => DestinationKeyId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function re_encrypt(
@@ -2404,6 +2516,7 @@ function re_encrypt(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2519,6 +2632,7 @@ function replicate_key(
         "ReplicateKey",
         Dict{String,Any}("KeyId" => KeyId, "ReplicaRegion" => ReplicaRegion);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function replicate_key(
@@ -2537,6 +2651,7 @@ function replicate_key(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2574,12 +2689,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   arn:aws:kms:us-east-2:444455556666:key/1234abcd-12ab-34cd-56ef-1234567890ab
 """
 function retire_grant(; aws_config::AbstractAWSConfig=global_aws_config())
-    return kms("RetireGrant"; aws_config=aws_config)
+    return kms("RetireGrant"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function retire_grant(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return kms("RetireGrant", params; aws_config=aws_config)
+    return kms(
+        "RetireGrant", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -2615,6 +2732,7 @@ function revoke_grant(GrantId, KeyId; aws_config::AbstractAWSConfig=global_aws_c
         "RevokeGrant",
         Dict{String,Any}("GrantId" => GrantId, "KeyId" => KeyId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function revoke_grant(
@@ -2631,6 +2749,7 @@ function revoke_grant(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2684,7 +2803,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function schedule_key_deletion(KeyId; aws_config::AbstractAWSConfig=global_aws_config())
     return kms(
-        "ScheduleKeyDeletion", Dict{String,Any}("KeyId" => KeyId); aws_config=aws_config
+        "ScheduleKeyDeletion",
+        Dict{String,Any}("KeyId" => KeyId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function schedule_key_deletion(
@@ -2694,6 +2816,7 @@ function schedule_key_deletion(
         "ScheduleKeyDeletion",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("KeyId" => KeyId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2764,6 +2887,7 @@ function sign(
             "KeyId" => KeyId, "Message" => Message, "SigningAlgorithm" => SigningAlgorithm
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function sign(
@@ -2787,6 +2911,7 @@ function sign(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2827,6 +2952,7 @@ function tag_resource(KeyId, Tags; aws_config::AbstractAWSConfig=global_aws_conf
         "TagResource",
         Dict{String,Any}("KeyId" => KeyId, "Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -2841,6 +2967,7 @@ function tag_resource(
             mergewith(_merge, Dict{String,Any}("KeyId" => KeyId, "Tags" => Tags), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2876,6 +3003,7 @@ function untag_resource(KeyId, TagKeys; aws_config::AbstractAWSConfig=global_aws
         "UntagResource",
         Dict{String,Any}("KeyId" => KeyId, "TagKeys" => TagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -2892,6 +3020,7 @@ function untag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2943,6 +3072,7 @@ function update_alias(
         "UpdateAlias",
         Dict{String,Any}("AliasName" => AliasName, "TargetKeyId" => TargetKeyId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_alias(
@@ -2961,6 +3091,7 @@ function update_alias(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3021,6 +3152,7 @@ function update_custom_key_store(
         "UpdateCustomKeyStore",
         Dict{String,Any}("CustomKeyStoreId" => CustomKeyStoreId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_custom_key_store(
@@ -3036,6 +3168,7 @@ function update_custom_key_store(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3065,6 +3198,7 @@ function update_key_description(
         "UpdateKeyDescription",
         Dict{String,Any}("Description" => Description, "KeyId" => KeyId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_key_description(
@@ -3083,6 +3217,7 @@ function update_key_description(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3147,6 +3282,7 @@ function update_primary_region(
         "UpdatePrimaryRegion",
         Dict{String,Any}("KeyId" => KeyId, "PrimaryRegion" => PrimaryRegion);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_primary_region(
@@ -3165,6 +3301,7 @@ function update_primary_region(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3243,6 +3380,7 @@ function verify(
             "SigningAlgorithm" => SigningAlgorithm,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function verify(
@@ -3268,5 +3406,6 @@ function verify(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/lakeformation.jl
+++ b/src/services/lakeformation.jl
@@ -27,6 +27,7 @@ function add_lftags_to_resource(
         "AddLFTagsToResource",
         Dict{String,Any}("LFTags" => LFTags, "Resource" => Resource);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function add_lftags_to_resource(
@@ -43,6 +44,7 @@ function add_lftags_to_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -67,6 +69,7 @@ function batch_grant_permissions(Entries; aws_config::AbstractAWSConfig=global_a
         "BatchGrantPermissions",
         Dict{String,Any}("Entries" => Entries);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_grant_permissions(
@@ -76,6 +79,7 @@ function batch_grant_permissions(
         "BatchGrantPermissions",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Entries" => Entries), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -102,6 +106,7 @@ function batch_revoke_permissions(
         "BatchRevokePermissions",
         Dict{String,Any}("Entries" => Entries);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_revoke_permissions(
@@ -111,6 +116,7 @@ function batch_revoke_permissions(
         "BatchRevokePermissions",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Entries" => Entries), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -135,6 +141,7 @@ function create_lftag(TagKey, TagValues; aws_config::AbstractAWSConfig=global_aw
         "CreateLFTag",
         Dict{String,Any}("TagKey" => TagKey, "TagValues" => TagValues);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_lftag(
@@ -153,6 +160,7 @@ function create_lftag(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -177,7 +185,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function delete_lftag(TagKey; aws_config::AbstractAWSConfig=global_aws_config())
     return lakeformation(
-        "DeleteLFTag", Dict{String,Any}("TagKey" => TagKey); aws_config=aws_config
+        "DeleteLFTag",
+        Dict{String,Any}("TagKey" => TagKey);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_lftag(
@@ -187,6 +198,7 @@ function delete_lftag(
         "DeleteLFTag",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("TagKey" => TagKey), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -207,6 +219,7 @@ function deregister_resource(ResourceArn; aws_config::AbstractAWSConfig=global_a
         "DeregisterResource",
         Dict{String,Any}("ResourceArn" => ResourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function deregister_resource(
@@ -220,6 +233,7 @@ function deregister_resource(
             mergewith(_merge, Dict{String,Any}("ResourceArn" => ResourceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -239,6 +253,7 @@ function describe_resource(ResourceArn; aws_config::AbstractAWSConfig=global_aws
         "DescribeResource",
         Dict{String,Any}("ResourceArn" => ResourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_resource(
@@ -252,6 +267,7 @@ function describe_resource(
             mergewith(_merge, Dict{String,Any}("ResourceArn" => ResourceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -268,12 +284,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   definitions, and other control information to manage your AWS Lake Formation environment.
 """
 function get_data_lake_settings(; aws_config::AbstractAWSConfig=global_aws_config())
-    return lakeformation("GetDataLakeSettings"; aws_config=aws_config)
+    return lakeformation(
+        "GetDataLakeSettings"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_data_lake_settings(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return lakeformation("GetDataLakeSettings", params; aws_config=aws_config)
+    return lakeformation(
+        "GetDataLakeSettings",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -303,6 +326,7 @@ function get_effective_permissions_for_path(
         "GetEffectivePermissionsForPath",
         Dict{String,Any}("ResourceArn" => ResourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_effective_permissions_for_path(
@@ -316,6 +340,7 @@ function get_effective_permissions_for_path(
             mergewith(_merge, Dict{String,Any}("ResourceArn" => ResourceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -336,7 +361,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function get_lftag(TagKey; aws_config::AbstractAWSConfig=global_aws_config())
     return lakeformation(
-        "GetLFTag", Dict{String,Any}("TagKey" => TagKey); aws_config=aws_config
+        "GetLFTag",
+        Dict{String,Any}("TagKey" => TagKey);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_lftag(
@@ -346,6 +374,7 @@ function get_lftag(
         "GetLFTag",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("TagKey" => TagKey), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -367,7 +396,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function get_resource_lftags(Resource; aws_config::AbstractAWSConfig=global_aws_config())
     return lakeformation(
-        "GetResourceLFTags", Dict{String,Any}("Resource" => Resource); aws_config=aws_config
+        "GetResourceLFTags",
+        Dict{String,Any}("Resource" => Resource);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_resource_lftags(
@@ -381,6 +413,7 @@ function get_resource_lftags(
             mergewith(_merge, Dict{String,Any}("Resource" => Resource), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -424,6 +457,7 @@ function grant_permissions(
             "Permissions" => Permissions, "Principal" => Principal, "Resource" => Resource
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function grant_permissions(
@@ -447,6 +481,7 @@ function grant_permissions(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -469,12 +504,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   lists tags in the given catalog ID that the requester has permission to view.
 """
 function list_lftags(; aws_config::AbstractAWSConfig=global_aws_config())
-    return lakeformation("ListLFTags"; aws_config=aws_config)
+    return lakeformation(
+        "ListLFTags"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_lftags(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return lakeformation("ListLFTags", params; aws_config=aws_config)
+    return lakeformation(
+        "ListLFTags", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -501,12 +540,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"ResourceType"`: Specifies a resource type to filter the permissions returned.
 """
 function list_permissions(; aws_config::AbstractAWSConfig=global_aws_config())
-    return lakeformation("ListPermissions"; aws_config=aws_config)
+    return lakeformation(
+        "ListPermissions"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_permissions(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return lakeformation("ListPermissions", params; aws_config=aws_config)
+    return lakeformation(
+        "ListPermissions", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -524,12 +567,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   resources.
 """
 function list_resources(; aws_config::AbstractAWSConfig=global_aws_config())
-    return lakeformation("ListResources"; aws_config=aws_config)
+    return lakeformation(
+        "ListResources"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_resources(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return lakeformation("ListResources", params; aws_config=aws_config)
+    return lakeformation(
+        "ListResources", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -559,6 +606,7 @@ function put_data_lake_settings(
         "PutDataLakeSettings",
         Dict{String,Any}("DataLakeSettings" => DataLakeSettings);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_data_lake_settings(
@@ -574,6 +622,7 @@ function put_data_lake_settings(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -609,6 +658,7 @@ function register_resource(ResourceArn; aws_config::AbstractAWSConfig=global_aws
         "RegisterResource",
         Dict{String,Any}("ResourceArn" => ResourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function register_resource(
@@ -622,6 +672,7 @@ function register_resource(
             mergewith(_merge, Dict{String,Any}("ResourceArn" => ResourceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -650,6 +701,7 @@ function remove_lftags_from_resource(
         "RemoveLFTagsFromResource",
         Dict{String,Any}("LFTags" => LFTags, "Resource" => Resource);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function remove_lftags_from_resource(
@@ -666,6 +718,7 @@ function remove_lftags_from_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -699,6 +752,7 @@ function revoke_permissions(
             "Permissions" => Permissions, "Principal" => Principal, "Resource" => Resource
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function revoke_permissions(
@@ -722,6 +776,7 @@ function revoke_permissions(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -752,6 +807,7 @@ function search_databases_by_lftags(
         "SearchDatabasesByLFTags",
         Dict{String,Any}("Expression" => Expression);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function search_databases_by_lftags(
@@ -765,6 +821,7 @@ function search_databases_by_lftags(
             mergewith(_merge, Dict{String,Any}("Expression" => Expression), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -795,6 +852,7 @@ function search_tables_by_lftags(
         "SearchTablesByLFTags",
         Dict{String,Any}("Expression" => Expression);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function search_tables_by_lftags(
@@ -808,6 +866,7 @@ function search_tables_by_lftags(
             mergewith(_merge, Dict{String,Any}("Expression" => Expression), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -834,7 +893,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function update_lftag(TagKey; aws_config::AbstractAWSConfig=global_aws_config())
     return lakeformation(
-        "UpdateLFTag", Dict{String,Any}("TagKey" => TagKey); aws_config=aws_config
+        "UpdateLFTag",
+        Dict{String,Any}("TagKey" => TagKey);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_lftag(
@@ -844,6 +906,7 @@ function update_lftag(
         "UpdateLFTag",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("TagKey" => TagKey), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -866,6 +929,7 @@ function update_resource(
         "UpdateResource",
         Dict{String,Any}("ResourceArn" => ResourceArn, "RoleArn" => RoleArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_resource(
@@ -884,5 +948,6 @@ function update_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/lambda.jl
+++ b/src/services/lambda.jl
@@ -48,6 +48,7 @@ function add_layer_version_permission(
             "Action" => Action, "Principal" => Principal, "StatementId" => StatementId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function add_layer_version_permission(
@@ -74,6 +75,7 @@ function add_layer_version_permission(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -139,6 +141,7 @@ function add_permission(
             "Action" => Action, "Principal" => Principal, "StatementId" => StatementId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function add_permission(
@@ -164,6 +167,7 @@ function add_permission(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -197,6 +201,7 @@ function create_alias(
         "/2015-03-31/functions/$(FunctionName)/aliases",
         Dict{String,Any}("FunctionVersion" => FunctionVersion, "Name" => Name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_alias(
@@ -217,6 +222,7 @@ function create_alias(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -245,6 +251,7 @@ function create_code_signing_config(
         "/2020-04-22/code-signing-configs/",
         Dict{String,Any}("AllowedPublishers" => AllowedPublishers);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_code_signing_config(
@@ -261,6 +268,7 @@ function create_code_signing_config(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -341,6 +349,7 @@ function create_event_source_mapping(
         "/2015-03-31/event-source-mappings/",
         Dict{String,Any}("FunctionName" => FunctionName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_event_source_mapping(
@@ -355,6 +364,7 @@ function create_event_source_mapping(
             mergewith(_merge, Dict{String,Any}("FunctionName" => FunctionName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -455,6 +465,7 @@ function create_function(
         "/2015-03-31/functions",
         Dict{String,Any}("Code" => Code, "FunctionName" => FunctionName, "Role" => Role);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_function(
@@ -477,6 +488,7 @@ function create_function(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -499,6 +511,7 @@ function delete_alias(FunctionName, Name; aws_config::AbstractAWSConfig=global_a
         "DELETE",
         "/2015-03-31/functions/$(FunctionName)/aliases/$(Name)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_alias(
@@ -512,6 +525,7 @@ function delete_alias(
         "/2015-03-31/functions/$(FunctionName)/aliases/$(Name)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -534,6 +548,7 @@ function delete_code_signing_config(
         "DELETE",
         "/2020-04-22/code-signing-configs/$(CodeSigningConfigArn)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_code_signing_config(
@@ -546,6 +561,7 @@ function delete_code_signing_config(
         "/2020-04-22/code-signing-configs/$(CodeSigningConfigArn)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -565,14 +581,21 @@ function delete_event_source_mapping(
     UUID; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return lambda(
-        "DELETE", "/2015-03-31/event-source-mappings/$(UUID)"; aws_config=aws_config
+        "DELETE",
+        "/2015-03-31/event-source-mappings/$(UUID)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_event_source_mapping(
     UUID, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return lambda(
-        "DELETE", "/2015-03-31/event-source-mappings/$(UUID)", params; aws_config=aws_config
+        "DELETE",
+        "/2015-03-31/event-source-mappings/$(UUID)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -600,7 +623,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   by an alias.
 """
 function delete_function(FunctionName; aws_config::AbstractAWSConfig=global_aws_config())
-    return lambda("DELETE", "/2015-03-31/functions/$(FunctionName)"; aws_config=aws_config)
+    return lambda(
+        "DELETE",
+        "/2015-03-31/functions/$(FunctionName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_function(
     FunctionName,
@@ -608,7 +636,11 @@ function delete_function(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return lambda(
-        "DELETE", "/2015-03-31/functions/$(FunctionName)", params; aws_config=aws_config
+        "DELETE",
+        "/2015-03-31/functions/$(FunctionName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -632,6 +664,7 @@ function delete_function_code_signing_config(
         "DELETE",
         "/2020-06-30/functions/$(FunctionName)/code-signing-config";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_function_code_signing_config(
@@ -644,6 +677,7 @@ function delete_function_code_signing_config(
         "/2020-06-30/functions/$(FunctionName)/code-signing-config",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -665,7 +699,10 @@ function delete_function_concurrency(
     FunctionName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return lambda(
-        "DELETE", "/2017-10-31/functions/$(FunctionName)/concurrency"; aws_config=aws_config
+        "DELETE",
+        "/2017-10-31/functions/$(FunctionName)/concurrency";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_function_concurrency(
@@ -678,6 +715,7 @@ function delete_function_concurrency(
         "/2017-10-31/functions/$(FunctionName)/concurrency",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -707,6 +745,7 @@ function delete_function_event_invoke_config(
         "DELETE",
         "/2019-09-25/functions/$(FunctionName)/event-invoke-config";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_function_event_invoke_config(
@@ -719,6 +758,7 @@ function delete_function_event_invoke_config(
         "/2019-09-25/functions/$(FunctionName)/event-invoke-config",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -742,6 +782,7 @@ function delete_layer_version(
         "DELETE",
         "/2018-10-31/layers/$(LayerName)/versions/$(VersionNumber)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_layer_version(
@@ -755,6 +796,7 @@ function delete_layer_version(
         "/2018-10-31/layers/$(LayerName)/versions/$(VersionNumber)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -781,6 +823,7 @@ function delete_provisioned_concurrency_config(
         "/2019-09-30/functions/$(FunctionName)/provisioned-concurrency",
         Dict{String,Any}("Qualifier" => Qualifier);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_provisioned_concurrency_config(
@@ -796,6 +839,7 @@ function delete_provisioned_concurrency_config(
             mergewith(_merge, Dict{String,Any}("Qualifier" => Qualifier), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -807,12 +851,23 @@ Retrieves details about your account's limits and usage in an Amazon Web Service
 
 """
 function get_account_settings(; aws_config::AbstractAWSConfig=global_aws_config())
-    return lambda("GET", "/2016-08-19/account-settings/"; aws_config=aws_config)
+    return lambda(
+        "GET",
+        "/2016-08-19/account-settings/";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_account_settings(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return lambda("GET", "/2016-08-19/account-settings/", params; aws_config=aws_config)
+    return lambda(
+        "GET",
+        "/2016-08-19/account-settings/",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -834,6 +889,7 @@ function get_alias(FunctionName, Name; aws_config::AbstractAWSConfig=global_aws_
         "GET",
         "/2015-03-31/functions/$(FunctionName)/aliases/$(Name)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_alias(
@@ -847,6 +903,7 @@ function get_alias(
         "/2015-03-31/functions/$(FunctionName)/aliases/$(Name)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -868,6 +925,7 @@ function get_code_signing_config(
         "GET",
         "/2020-04-22/code-signing-configs/$(CodeSigningConfigArn)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_code_signing_config(
@@ -880,6 +938,7 @@ function get_code_signing_config(
         "/2020-04-22/code-signing-configs/$(CodeSigningConfigArn)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -895,13 +954,22 @@ the output of ListEventSourceMappings.
 
 """
 function get_event_source_mapping(UUID; aws_config::AbstractAWSConfig=global_aws_config())
-    return lambda("GET", "/2015-03-31/event-source-mappings/$(UUID)"; aws_config=aws_config)
+    return lambda(
+        "GET",
+        "/2015-03-31/event-source-mappings/$(UUID)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_event_source_mapping(
     UUID, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return lambda(
-        "GET", "/2015-03-31/event-source-mappings/$(UUID)", params; aws_config=aws_config
+        "GET",
+        "/2015-03-31/event-source-mappings/$(UUID)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -927,7 +995,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   function.
 """
 function get_function(FunctionName; aws_config::AbstractAWSConfig=global_aws_config())
-    return lambda("GET", "/2015-03-31/functions/$(FunctionName)"; aws_config=aws_config)
+    return lambda(
+        "GET",
+        "/2015-03-31/functions/$(FunctionName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_function(
     FunctionName,
@@ -935,7 +1008,11 @@ function get_function(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return lambda(
-        "GET", "/2015-03-31/functions/$(FunctionName)", params; aws_config=aws_config
+        "GET",
+        "/2015-03-31/functions/$(FunctionName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -959,6 +1036,7 @@ function get_function_code_signing_config(
         "GET",
         "/2020-06-30/functions/$(FunctionName)/code-signing-config";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_function_code_signing_config(
@@ -971,6 +1049,7 @@ function get_function_code_signing_config(
         "/2020-06-30/functions/$(FunctionName)/code-signing-config",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -993,7 +1072,10 @@ function get_function_concurrency(
     FunctionName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return lambda(
-        "GET", "/2019-09-30/functions/$(FunctionName)/concurrency"; aws_config=aws_config
+        "GET",
+        "/2019-09-30/functions/$(FunctionName)/concurrency";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_function_concurrency(
@@ -1006,6 +1088,7 @@ function get_function_concurrency(
         "/2019-09-30/functions/$(FunctionName)/concurrency",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1035,7 +1118,10 @@ function get_function_configuration(
     FunctionName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return lambda(
-        "GET", "/2015-03-31/functions/$(FunctionName)/configuration"; aws_config=aws_config
+        "GET",
+        "/2015-03-31/functions/$(FunctionName)/configuration";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_function_configuration(
@@ -1048,6 +1134,7 @@ function get_function_configuration(
         "/2015-03-31/functions/$(FunctionName)/configuration",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1077,6 +1164,7 @@ function get_function_event_invoke_config(
         "GET",
         "/2019-09-25/functions/$(FunctionName)/event-invoke-config";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_function_event_invoke_config(
@@ -1089,6 +1177,7 @@ function get_function_event_invoke_config(
         "/2019-09-25/functions/$(FunctionName)/event-invoke-config",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1111,6 +1200,7 @@ function get_layer_version(
         "GET",
         "/2018-10-31/layers/$(LayerName)/versions/$(VersionNumber)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_layer_version(
@@ -1124,6 +1214,7 @@ function get_layer_version(
         "/2018-10-31/layers/$(LayerName)/versions/$(VersionNumber)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1144,6 +1235,7 @@ function get_layer_version_by_arn(Arn; aws_config::AbstractAWSConfig=global_aws_
         "/2018-10-31/layers?find=LayerVersion",
         Dict{String,Any}("Arn" => Arn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_layer_version_by_arn(
@@ -1154,6 +1246,7 @@ function get_layer_version_by_arn(
         "/2018-10-31/layers?find=LayerVersion",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Arn" => Arn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1176,6 +1269,7 @@ function get_layer_version_policy(
         "GET",
         "/2018-10-31/layers/$(LayerName)/versions/$(VersionNumber)/policy";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_layer_version_policy(
@@ -1189,6 +1283,7 @@ function get_layer_version_policy(
         "/2018-10-31/layers/$(LayerName)/versions/$(VersionNumber)/policy",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1212,7 +1307,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function get_policy(FunctionName; aws_config::AbstractAWSConfig=global_aws_config())
     return lambda(
-        "GET", "/2015-03-31/functions/$(FunctionName)/policy"; aws_config=aws_config
+        "GET",
+        "/2015-03-31/functions/$(FunctionName)/policy";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_policy(
@@ -1221,7 +1319,11 @@ function get_policy(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return lambda(
-        "GET", "/2015-03-31/functions/$(FunctionName)/policy", params; aws_config=aws_config
+        "GET",
+        "/2015-03-31/functions/$(FunctionName)/policy",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1248,6 +1350,7 @@ function get_provisioned_concurrency_config(
         "/2019-09-30/functions/$(FunctionName)/provisioned-concurrency",
         Dict{String,Any}("Qualifier" => Qualifier);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_provisioned_concurrency_config(
@@ -1263,6 +1366,7 @@ function get_provisioned_concurrency_config(
             mergewith(_merge, Dict{String,Any}("Qualifier" => Qualifier), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1319,7 +1423,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function invoke(FunctionName; aws_config::AbstractAWSConfig=global_aws_config())
     return lambda(
-        "POST", "/2015-03-31/functions/$(FunctionName)/invocations"; aws_config=aws_config
+        "POST",
+        "/2015-03-31/functions/$(FunctionName)/invocations";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function invoke(
@@ -1332,6 +1439,7 @@ function invoke(
         "/2015-03-31/functions/$(FunctionName)/invocations",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1358,6 +1466,7 @@ function invoke_async(
         "/2014-11-13/functions/$(FunctionName)/invoke-async/",
         Dict{String,Any}("InvokeArgs" => InvokeArgs);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function invoke_async(
@@ -1373,6 +1482,7 @@ function invoke_async(
             mergewith(_merge, Dict{String,Any}("InvokeArgs" => InvokeArgs), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1398,7 +1508,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function list_aliases(FunctionName; aws_config::AbstractAWSConfig=global_aws_config())
     return lambda(
-        "GET", "/2015-03-31/functions/$(FunctionName)/aliases"; aws_config=aws_config
+        "GET",
+        "/2015-03-31/functions/$(FunctionName)/aliases";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_aliases(
@@ -1411,6 +1524,7 @@ function list_aliases(
         "/2015-03-31/functions/$(FunctionName)/aliases",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1429,12 +1543,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"MaxItems"`: Maximum number of items to return.
 """
 function list_code_signing_configs(; aws_config::AbstractAWSConfig=global_aws_config())
-    return lambda("GET", "/2020-04-22/code-signing-configs/"; aws_config=aws_config)
+    return lambda(
+        "GET",
+        "/2020-04-22/code-signing-configs/";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_code_signing_configs(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return lambda("GET", "/2020-04-22/code-signing-configs/", params; aws_config=aws_config)
+    return lambda(
+        "GET",
+        "/2020-04-22/code-signing-configs/",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1461,13 +1586,22 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   the number higher.
 """
 function list_event_source_mappings(; aws_config::AbstractAWSConfig=global_aws_config())
-    return lambda("GET", "/2015-03-31/event-source-mappings/"; aws_config=aws_config)
+    return lambda(
+        "GET",
+        "/2015-03-31/event-source-mappings/";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_event_source_mappings(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return lambda(
-        "GET", "/2015-03-31/event-source-mappings/", params; aws_config=aws_config
+        "GET",
+        "/2015-03-31/event-source-mappings/",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1498,6 +1632,7 @@ function list_function_event_invoke_configs(
         "GET",
         "/2019-09-25/functions/$(FunctionName)/event-invoke-config/list";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_function_event_invoke_configs(
@@ -1510,6 +1645,7 @@ function list_function_event_invoke_configs(
         "/2019-09-25/functions/$(FunctionName)/event-invoke-config/list",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1539,12 +1675,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   higher.
 """
 function list_functions(; aws_config::AbstractAWSConfig=global_aws_config())
-    return lambda("GET", "/2015-03-31/functions/"; aws_config=aws_config)
+    return lambda(
+        "GET",
+        "/2015-03-31/functions/";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_functions(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return lambda("GET", "/2015-03-31/functions/", params; aws_config=aws_config)
+    return lambda(
+        "GET",
+        "/2015-03-31/functions/",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1572,6 +1719,7 @@ function list_functions_by_code_signing_config(
         "GET",
         "/2020-04-22/code-signing-configs/$(CodeSigningConfigArn)/functions";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_functions_by_code_signing_config(
@@ -1584,6 +1732,7 @@ function list_functions_by_code_signing_config(
         "/2020-04-22/code-signing-configs/$(CodeSigningConfigArn)/functions",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1605,7 +1754,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"MaxItems"`: The maximum number of versions to return.
 """
 function list_layer_versions(LayerName; aws_config::AbstractAWSConfig=global_aws_config())
-    return lambda("GET", "/2018-10-31/layers/$(LayerName)/versions"; aws_config=aws_config)
+    return lambda(
+        "GET",
+        "/2018-10-31/layers/$(LayerName)/versions";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_layer_versions(
     LayerName,
@@ -1613,7 +1767,11 @@ function list_layer_versions(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return lambda(
-        "GET", "/2018-10-31/layers/$(LayerName)/versions", params; aws_config=aws_config
+        "GET",
+        "/2018-10-31/layers/$(LayerName)/versions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1632,12 +1790,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"MaxItems"`: The maximum number of layers to return.
 """
 function list_layers(; aws_config::AbstractAWSConfig=global_aws_config())
-    return lambda("GET", "/2018-10-31/layers"; aws_config=aws_config)
+    return lambda(
+        "GET", "/2018-10-31/layers"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_layers(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return lambda("GET", "/2018-10-31/layers", params; aws_config=aws_config)
+    return lambda(
+        "GET",
+        "/2018-10-31/layers",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1666,6 +1832,7 @@ function list_provisioned_concurrency_configs(
         "GET",
         "/2019-09-30/functions/$(FunctionName)/provisioned-concurrency?List=ALL";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_provisioned_concurrency_configs(
@@ -1678,6 +1845,7 @@ function list_provisioned_concurrency_configs(
         "/2019-09-30/functions/$(FunctionName)/provisioned-concurrency?List=ALL",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1692,12 +1860,23 @@ Returns a function's tags. You can also view tags with GetFunction.
 
 """
 function list_tags(ARN; aws_config::AbstractAWSConfig=global_aws_config())
-    return lambda("GET", "/2017-03-31/tags/$(ARN)"; aws_config=aws_config)
+    return lambda(
+        "GET",
+        "/2017-03-31/tags/$(ARN)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_tags(
     ARN, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return lambda("GET", "/2017-03-31/tags/$(ARN)", params; aws_config=aws_config)
+    return lambda(
+        "GET",
+        "/2017-03-31/tags/$(ARN)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1724,7 +1903,10 @@ function list_versions_by_function(
     FunctionName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return lambda(
-        "GET", "/2015-03-31/functions/$(FunctionName)/versions"; aws_config=aws_config
+        "GET",
+        "/2015-03-31/functions/$(FunctionName)/versions";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_versions_by_function(
@@ -1737,6 +1919,7 @@ function list_versions_by_function(
         "/2015-03-31/functions/$(FunctionName)/versions",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1769,6 +1952,7 @@ function publish_layer_version(
         "/2018-10-31/layers/$(LayerName)/versions",
         Dict{String,Any}("Content" => Content);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function publish_layer_version(
@@ -1782,6 +1966,7 @@ function publish_layer_version(
         "/2018-10-31/layers/$(LayerName)/versions",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Content" => Content), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1816,7 +2001,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function publish_version(FunctionName; aws_config::AbstractAWSConfig=global_aws_config())
     return lambda(
-        "POST", "/2015-03-31/functions/$(FunctionName)/versions"; aws_config=aws_config
+        "POST",
+        "/2015-03-31/functions/$(FunctionName)/versions";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function publish_version(
@@ -1829,6 +2017,7 @@ function publish_version(
         "/2015-03-31/functions/$(FunctionName)/versions",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1857,6 +2046,7 @@ function put_function_code_signing_config(
         "/2020-06-30/functions/$(FunctionName)/code-signing-config",
         Dict{String,Any}("CodeSigningConfigArn" => CodeSigningConfigArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_function_code_signing_config(
@@ -1876,6 +2066,7 @@ function put_function_code_signing_config(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1913,6 +2104,7 @@ function put_function_concurrency(
         "/2017-10-31/functions/$(FunctionName)/concurrency",
         Dict{String,Any}("ReservedConcurrentExecutions" => ReservedConcurrentExecutions);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_function_concurrency(
@@ -1934,6 +2126,7 @@ function put_function_concurrency(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1981,6 +2174,7 @@ function put_function_event_invoke_config(
         "PUT",
         "/2019-09-25/functions/$(FunctionName)/event-invoke-config";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_function_event_invoke_config(
@@ -1993,6 +2187,7 @@ function put_function_event_invoke_config(
         "/2019-09-25/functions/$(FunctionName)/event-invoke-config",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2027,6 +2222,7 @@ function put_provisioned_concurrency_config(
             "Qualifier" => Qualifier,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_provisioned_concurrency_config(
@@ -2050,6 +2246,7 @@ function put_provisioned_concurrency_config(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2077,6 +2274,7 @@ function remove_layer_version_permission(
         "DELETE",
         "/2018-10-31/layers/$(LayerName)/versions/$(VersionNumber)/policy/$(StatementId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function remove_layer_version_permission(
@@ -2091,6 +2289,7 @@ function remove_layer_version_permission(
         "/2018-10-31/layers/$(LayerName)/versions/$(VersionNumber)/policy/$(StatementId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2125,6 +2324,7 @@ function remove_permission(
         "DELETE",
         "/2015-03-31/functions/$(FunctionName)/policy/$(StatementId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function remove_permission(
@@ -2138,6 +2338,7 @@ function remove_permission(
         "/2015-03-31/functions/$(FunctionName)/policy/$(StatementId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2158,6 +2359,7 @@ function tag_resource(ARN, Tags; aws_config::AbstractAWSConfig=global_aws_config
         "/2017-03-31/tags/$(ARN)",
         Dict{String,Any}("Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -2171,6 +2373,7 @@ function tag_resource(
         "/2017-03-31/tags/$(ARN)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Tags" => Tags), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2191,6 +2394,7 @@ function untag_resource(ARN, tagKeys; aws_config::AbstractAWSConfig=global_aws_c
         "/2017-03-31/tags/$(ARN)",
         Dict{String,Any}("tagKeys" => tagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -2204,6 +2408,7 @@ function untag_resource(
         "/2017-03-31/tags/$(ARN)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tagKeys" => tagKeys), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2233,6 +2438,7 @@ function update_alias(FunctionName, Name; aws_config::AbstractAWSConfig=global_a
         "PUT",
         "/2015-03-31/functions/$(FunctionName)/aliases/$(Name)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_alias(
@@ -2246,6 +2452,7 @@ function update_alias(
         "/2015-03-31/functions/$(FunctionName)/aliases/$(Name)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2273,6 +2480,7 @@ function update_code_signing_config(
         "PUT",
         "/2020-04-22/code-signing-configs/$(CodeSigningConfigArn)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_code_signing_config(
@@ -2285,6 +2493,7 @@ function update_code_signing_config(
         "/2020-04-22/code-signing-configs/$(CodeSigningConfigArn)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2344,13 +2553,22 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function update_event_source_mapping(
     UUID; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return lambda("PUT", "/2015-03-31/event-source-mappings/$(UUID)"; aws_config=aws_config)
+    return lambda(
+        "PUT",
+        "/2015-03-31/event-source-mappings/$(UUID)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function update_event_source_mapping(
     UUID, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return lambda(
-        "PUT", "/2015-03-31/event-source-mappings/$(UUID)", params; aws_config=aws_config
+        "PUT",
+        "/2015-03-31/event-source-mappings/$(UUID)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2394,7 +2612,10 @@ function update_function_code(
     FunctionName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return lambda(
-        "PUT", "/2015-03-31/functions/$(FunctionName)/code"; aws_config=aws_config
+        "PUT",
+        "/2015-03-31/functions/$(FunctionName)/code";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_function_code(
@@ -2403,7 +2624,11 @@ function update_function_code(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return lambda(
-        "PUT", "/2015-03-31/functions/$(FunctionName)/code", params; aws_config=aws_config
+        "PUT",
+        "/2015-03-31/functions/$(FunctionName)/code",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2471,7 +2696,10 @@ function update_function_configuration(
     FunctionName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return lambda(
-        "PUT", "/2015-03-31/functions/$(FunctionName)/configuration"; aws_config=aws_config
+        "PUT",
+        "/2015-03-31/functions/$(FunctionName)/configuration";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_function_configuration(
@@ -2484,6 +2712,7 @@ function update_function_configuration(
         "/2015-03-31/functions/$(FunctionName)/configuration",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2521,6 +2750,7 @@ function update_function_event_invoke_config(
         "POST",
         "/2019-09-25/functions/$(FunctionName)/event-invoke-config";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_function_event_invoke_config(
@@ -2533,5 +2763,6 @@ function update_function_event_invoke_config(
         "/2019-09-25/functions/$(FunctionName)/event-invoke-config",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/lex_model_building_service.jl
+++ b/src/services/lex_model_building_service.jl
@@ -29,14 +29,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function create_bot_version(name; aws_config::AbstractAWSConfig=global_aws_config())
     return lex_model_building_service(
-        "POST", "/bots/$(name)/versions"; aws_config=aws_config
+        "POST",
+        "/bots/$(name)/versions";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_bot_version(
     name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return lex_model_building_service(
-        "POST", "/bots/$(name)/versions", params; aws_config=aws_config
+        "POST",
+        "/bots/$(name)/versions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -67,14 +74,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function create_intent_version(name; aws_config::AbstractAWSConfig=global_aws_config())
     return lex_model_building_service(
-        "POST", "/intents/$(name)/versions"; aws_config=aws_config
+        "POST",
+        "/intents/$(name)/versions";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_intent_version(
     name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return lex_model_building_service(
-        "POST", "/intents/$(name)/versions", params; aws_config=aws_config
+        "POST",
+        "/intents/$(name)/versions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -104,14 +118,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function create_slot_type_version(name; aws_config::AbstractAWSConfig=global_aws_config())
     return lex_model_building_service(
-        "POST", "/slottypes/$(name)/versions"; aws_config=aws_config
+        "POST",
+        "/slottypes/$(name)/versions";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_slot_type_version(
     name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return lex_model_building_service(
-        "POST", "/slottypes/$(name)/versions", params; aws_config=aws_config
+        "POST",
+        "/slottypes/$(name)/versions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -136,13 +157,19 @@ lex:DeleteBot action.
 
 """
 function delete_bot(name; aws_config::AbstractAWSConfig=global_aws_config())
-    return lex_model_building_service("DELETE", "/bots/$(name)"; aws_config=aws_config)
+    return lex_model_building_service(
+        "DELETE", "/bots/$(name)"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function delete_bot(
     name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return lex_model_building_service(
-        "DELETE", "/bots/$(name)", params; aws_config=aws_config
+        "DELETE",
+        "/bots/$(name)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -164,7 +191,10 @@ again, delete the referring association until the DeleteBotAlias operation is su
 """
 function delete_bot_alias(botName, name; aws_config::AbstractAWSConfig=global_aws_config())
     return lex_model_building_service(
-        "DELETE", "/bots/$(botName)/aliases/$(name)"; aws_config=aws_config
+        "DELETE",
+        "/bots/$(botName)/aliases/$(name)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_bot_alias(
@@ -174,7 +204,11 @@ function delete_bot_alias(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return lex_model_building_service(
-        "DELETE", "/bots/$(botName)/aliases/$(name)", params; aws_config=aws_config
+        "DELETE",
+        "/bots/$(botName)/aliases/$(name)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -199,6 +233,7 @@ function delete_bot_channel_association(
         "DELETE",
         "/bots/$(botName)/aliases/$(aliasName)/channels/$(name)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_bot_channel_association(
@@ -213,6 +248,7 @@ function delete_bot_channel_association(
         "/bots/$(botName)/aliases/$(aliasName)/channels/$(name)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -233,7 +269,10 @@ function delete_bot_version(
     name, version; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return lex_model_building_service(
-        "DELETE", "/bots/$(name)/versions/$(version)"; aws_config=aws_config
+        "DELETE",
+        "/bots/$(name)/versions/$(version)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_bot_version(
@@ -243,7 +282,11 @@ function delete_bot_version(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return lex_model_building_service(
-        "DELETE", "/bots/$(name)/versions/$(version)", params; aws_config=aws_config
+        "DELETE",
+        "/bots/$(name)/versions/$(version)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -266,13 +309,19 @@ This operation requires permission for the lex:DeleteIntent action.
 
 """
 function delete_intent(name; aws_config::AbstractAWSConfig=global_aws_config())
-    return lex_model_building_service("DELETE", "/intents/$(name)"; aws_config=aws_config)
+    return lex_model_building_service(
+        "DELETE", "/intents/$(name)"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function delete_intent(
     name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return lex_model_building_service(
-        "DELETE", "/intents/$(name)", params; aws_config=aws_config
+        "DELETE",
+        "/intents/$(name)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -294,7 +343,10 @@ function delete_intent_version(
     name, version; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return lex_model_building_service(
-        "DELETE", "/intents/$(name)/versions/$(version)"; aws_config=aws_config
+        "DELETE",
+        "/intents/$(name)/versions/$(version)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_intent_version(
@@ -304,7 +356,11 @@ function delete_intent_version(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return lex_model_building_service(
-        "DELETE", "/intents/$(name)/versions/$(version)", params; aws_config=aws_config
+        "DELETE",
+        "/intents/$(name)/versions/$(version)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -328,13 +384,22 @@ lex:DeleteSlotType action.
 
 """
 function delete_slot_type(name; aws_config::AbstractAWSConfig=global_aws_config())
-    return lex_model_building_service("DELETE", "/slottypes/$(name)"; aws_config=aws_config)
+    return lex_model_building_service(
+        "DELETE",
+        "/slottypes/$(name)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_slot_type(
     name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return lex_model_building_service(
-        "DELETE", "/slottypes/$(name)", params; aws_config=aws_config
+        "DELETE",
+        "/slottypes/$(name)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -356,7 +421,10 @@ function delete_slot_type_version(
     name, version; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return lex_model_building_service(
-        "DELETE", "/slottypes/$(name)/version/$(version)"; aws_config=aws_config
+        "DELETE",
+        "/slottypes/$(name)/version/$(version)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_slot_type_version(
@@ -366,7 +434,11 @@ function delete_slot_type_version(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return lex_model_building_service(
-        "DELETE", "/slottypes/$(name)/version/$(version)", params; aws_config=aws_config
+        "DELETE",
+        "/slottypes/$(name)/version/$(version)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -394,7 +466,10 @@ function delete_utterances(
     botName, userId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return lex_model_building_service(
-        "DELETE", "/bots/$(botName)/utterances/$(userId)"; aws_config=aws_config
+        "DELETE",
+        "/bots/$(botName)/utterances/$(userId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_utterances(
@@ -404,7 +479,11 @@ function delete_utterances(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return lex_model_building_service(
-        "DELETE", "/bots/$(botName)/utterances/$(userId)", params; aws_config=aws_config
+        "DELETE",
+        "/bots/$(botName)/utterances/$(userId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -422,7 +501,10 @@ version or alias.   This operation requires permissions for the lex:GetBot actio
 """
 function get_bot(name, versionoralias; aws_config::AbstractAWSConfig=global_aws_config())
     return lex_model_building_service(
-        "GET", "/bots/$(name)/versions/$(versionoralias)"; aws_config=aws_config
+        "GET",
+        "/bots/$(name)/versions/$(versionoralias)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_bot(
@@ -432,7 +514,11 @@ function get_bot(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return lex_model_building_service(
-        "GET", "/bots/$(name)/versions/$(versionoralias)", params; aws_config=aws_config
+        "GET",
+        "/bots/$(name)/versions/$(versionoralias)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -450,7 +536,10 @@ versioning-aliases. This operation requires permissions for the lex:GetBotAlias 
 """
 function get_bot_alias(botName, name; aws_config::AbstractAWSConfig=global_aws_config())
     return lex_model_building_service(
-        "GET", "/bots/$(botName)/aliases/$(name)"; aws_config=aws_config
+        "GET",
+        "/bots/$(botName)/aliases/$(name)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_bot_alias(
@@ -460,7 +549,11 @@ function get_bot_alias(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return lex_model_building_service(
-        "GET", "/bots/$(botName)/aliases/$(name)", params; aws_config=aws_config
+        "GET",
+        "/bots/$(botName)/aliases/$(name)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -487,14 +580,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function get_bot_aliases(botName; aws_config::AbstractAWSConfig=global_aws_config())
     return lex_model_building_service(
-        "GET", "/bots/$(botName)/aliases/"; aws_config=aws_config
+        "GET",
+        "/bots/$(botName)/aliases/";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_bot_aliases(
     botName, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return lex_model_building_service(
-        "GET", "/bots/$(botName)/aliases/", params; aws_config=aws_config
+        "GET",
+        "/bots/$(botName)/aliases/",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -520,6 +620,7 @@ function get_bot_channel_association(
         "GET",
         "/bots/$(botName)/aliases/$(aliasName)/channels/$(name)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_bot_channel_association(
@@ -534,6 +635,7 @@ function get_bot_channel_association(
         "/bots/$(botName)/aliases/$(aliasName)/channels/$(name)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -566,7 +668,10 @@ function get_bot_channel_associations(
     aliasName, botName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return lex_model_building_service(
-        "GET", "/bots/$(botName)/aliases/$(aliasName)/channels/"; aws_config=aws_config
+        "GET",
+        "/bots/$(botName)/aliases/$(aliasName)/channels/";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_bot_channel_associations(
@@ -580,6 +685,7 @@ function get_bot_channel_associations(
         "/bots/$(botName)/aliases/$(aliasName)/channels/",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -607,14 +713,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function get_bot_versions(name; aws_config::AbstractAWSConfig=global_aws_config())
     return lex_model_building_service(
-        "GET", "/bots/$(name)/versions/"; aws_config=aws_config
+        "GET",
+        "/bots/$(name)/versions/";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_bot_versions(
     name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return lex_model_building_service(
-        "GET", "/bots/$(name)/versions/", params; aws_config=aws_config
+        "GET",
+        "/bots/$(name)/versions/",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -639,12 +752,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   next page of bots, specify the pagination token in the next request.
 """
 function get_bots(; aws_config::AbstractAWSConfig=global_aws_config())
-    return lex_model_building_service("GET", "/bots/"; aws_config=aws_config)
+    return lex_model_building_service(
+        "GET", "/bots/"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_bots(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return lex_model_building_service("GET", "/bots/", params; aws_config=aws_config)
+    return lex_model_building_service(
+        "GET", "/bots/", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -661,7 +778,10 @@ lex:GetBuiltinIntent action.
 """
 function get_builtin_intent(signature; aws_config::AbstractAWSConfig=global_aws_config())
     return lex_model_building_service(
-        "GET", "/builtins/intents/$(signature)"; aws_config=aws_config
+        "GET",
+        "/builtins/intents/$(signature)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_builtin_intent(
@@ -670,7 +790,11 @@ function get_builtin_intent(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return lex_model_building_service(
-        "GET", "/builtins/intents/$(signature)", params; aws_config=aws_config
+        "GET",
+        "/builtins/intents/$(signature)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -695,13 +819,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Built-in Intents in the Alexa Skills Kit.
 """
 function get_builtin_intents(; aws_config::AbstractAWSConfig=global_aws_config())
-    return lex_model_building_service("GET", "/builtins/intents/"; aws_config=aws_config)
+    return lex_model_building_service(
+        "GET", "/builtins/intents/"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_builtin_intents(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return lex_model_building_service(
-        "GET", "/builtins/intents/", params; aws_config=aws_config
+        "GET",
+        "/builtins/intents/",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -727,13 +857,22 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   matches both \"xyzabc\" and \"abcxyz.\"
 """
 function get_builtin_slot_types(; aws_config::AbstractAWSConfig=global_aws_config())
-    return lex_model_building_service("GET", "/builtins/slottypes/"; aws_config=aws_config)
+    return lex_model_building_service(
+        "GET",
+        "/builtins/slottypes/";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_builtin_slot_types(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return lex_model_building_service(
-        "GET", "/builtins/slottypes/", params; aws_config=aws_config
+        "GET",
+        "/builtins/slottypes/",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -767,6 +906,7 @@ function get_export(
             "version" => version,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_export(
@@ -793,6 +933,7 @@ function get_export(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -807,7 +948,12 @@ Gets information about an import job started with the StartImport operation.
 
 """
 function get_import(importId; aws_config::AbstractAWSConfig=global_aws_config())
-    return lex_model_building_service("GET", "/imports/$(importId)"; aws_config=aws_config)
+    return lex_model_building_service(
+        "GET",
+        "/imports/$(importId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_import(
     importId,
@@ -815,7 +961,11 @@ function get_import(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return lex_model_building_service(
-        "GET", "/imports/$(importId)", params; aws_config=aws_config
+        "GET",
+        "/imports/$(importId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -833,7 +983,10 @@ intent version.   This operation requires permissions to perform the lex:GetInte
 """
 function get_intent(name, version; aws_config::AbstractAWSConfig=global_aws_config())
     return lex_model_building_service(
-        "GET", "/intents/$(name)/versions/$(version)"; aws_config=aws_config
+        "GET",
+        "/intents/$(name)/versions/$(version)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_intent(
@@ -843,7 +996,11 @@ function get_intent(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return lex_model_building_service(
-        "GET", "/intents/$(name)/versions/$(version)", params; aws_config=aws_config
+        "GET",
+        "/intents/$(name)/versions/$(version)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -871,14 +1028,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function get_intent_versions(name; aws_config::AbstractAWSConfig=global_aws_config())
     return lex_model_building_service(
-        "GET", "/intents/$(name)/versions/"; aws_config=aws_config
+        "GET",
+        "/intents/$(name)/versions/";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_intent_versions(
     name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return lex_model_building_service(
-        "GET", "/intents/$(name)/versions/", params; aws_config=aws_config
+        "GET",
+        "/intents/$(name)/versions/",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -903,12 +1067,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   fetch the next page of intents, specify the pagination token in the next request.
 """
 function get_intents(; aws_config::AbstractAWSConfig=global_aws_config())
-    return lex_model_building_service("GET", "/intents/"; aws_config=aws_config)
+    return lex_model_building_service(
+        "GET", "/intents/"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_intents(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return lex_model_building_service("GET", "/intents/", params; aws_config=aws_config)
+    return lex_model_building_service(
+        "GET", "/intents/", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -926,7 +1094,10 @@ the migration.
 """
 function get_migration(migrationId; aws_config::AbstractAWSConfig=global_aws_config())
     return lex_model_building_service(
-        "GET", "/migrations/$(migrationId)"; aws_config=aws_config
+        "GET",
+        "/migrations/$(migrationId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_migration(
@@ -935,7 +1106,11 @@ function get_migration(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return lex_model_building_service(
-        "GET", "/migrations/$(migrationId)", params; aws_config=aws_config
+        "GET",
+        "/migrations/$(migrationId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -961,12 +1136,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   specified string. The string is matched anywhere in bot name.
 """
 function get_migrations(; aws_config::AbstractAWSConfig=global_aws_config())
-    return lex_model_building_service("GET", "/migrations"; aws_config=aws_config)
+    return lex_model_building_service(
+        "GET", "/migrations"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_migrations(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return lex_model_building_service("GET", "/migrations", params; aws_config=aws_config)
+    return lex_model_building_service(
+        "GET", "/migrations", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -984,7 +1163,10 @@ for the lex:GetSlotType action.
 """
 function get_slot_type(name, version; aws_config::AbstractAWSConfig=global_aws_config())
     return lex_model_building_service(
-        "GET", "/slottypes/$(name)/versions/$(version)"; aws_config=aws_config
+        "GET",
+        "/slottypes/$(name)/versions/$(version)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_slot_type(
@@ -994,7 +1176,11 @@ function get_slot_type(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return lex_model_building_service(
-        "GET", "/slottypes/$(name)/versions/$(version)", params; aws_config=aws_config
+        "GET",
+        "/slottypes/$(name)/versions/$(version)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1023,14 +1209,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function get_slot_type_versions(name; aws_config::AbstractAWSConfig=global_aws_config())
     return lex_model_building_service(
-        "GET", "/slottypes/$(name)/versions/"; aws_config=aws_config
+        "GET",
+        "/slottypes/$(name)/versions/";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_slot_type_versions(
     name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return lex_model_building_service(
-        "GET", "/slottypes/$(name)/versions/", params; aws_config=aws_config
+        "GET",
+        "/slottypes/$(name)/versions/",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1056,12 +1249,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   request.
 """
 function get_slot_types(; aws_config::AbstractAWSConfig=global_aws_config())
-    return lex_model_building_service("GET", "/slottypes/"; aws_config=aws_config)
+    return lex_model_building_service(
+        "GET", "/slottypes/"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_slot_types(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return lex_model_building_service("GET", "/slottypes/", params; aws_config=aws_config)
+    return lex_model_building_service(
+        "GET", "/slottypes/", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1101,6 +1298,7 @@ function get_utterances_view(
         "/bots/$(botname)/utterances?view=aggregation",
         Dict{String,Any}("bot_versions" => bot_versions, "status_type" => status_type);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_utterances_view(
@@ -1123,6 +1321,7 @@ function get_utterances_view(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1140,7 +1339,12 @@ channels can have tags associated with them.
 function list_tags_for_resource(
     resourceArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return lex_model_building_service("GET", "/tags/$(resourceArn)"; aws_config=aws_config)
+    return lex_model_building_service(
+        "GET",
+        "/tags/$(resourceArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_tags_for_resource(
     resourceArn,
@@ -1148,7 +1352,11 @@ function list_tags_for_resource(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return lex_model_building_service(
-        "GET", "/tags/$(resourceArn)", params; aws_config=aws_config
+        "GET",
+        "/tags/$(resourceArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1292,6 +1500,7 @@ function put_bot(
         "/bots/$(name)/versions/$LATEST",
         Dict{String,Any}("childDirected" => childDirected, "locale" => locale);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_bot(
@@ -1312,6 +1521,7 @@ function put_bot(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1351,6 +1561,7 @@ function put_bot_alias(
         "/bots/$(botName)/aliases/$(name)",
         Dict{String,Any}("botVersion" => botVersion);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_bot_alias(
@@ -1367,6 +1578,7 @@ function put_bot_alias(
             mergewith(_merge, Dict{String,Any}("botVersion" => botVersion), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1471,14 +1683,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function put_intent(name; aws_config::AbstractAWSConfig=global_aws_config())
     return lex_model_building_service(
-        "PUT", "/intents/$(name)/versions/$LATEST"; aws_config=aws_config
+        "PUT",
+        "/intents/$(name)/versions/$LATEST";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_intent(
     name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return lex_model_building_service(
-        "PUT", "/intents/$(name)/versions/$LATEST", params; aws_config=aws_config
+        "PUT",
+        "/intents/$(name)/versions/$LATEST",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1540,14 +1759,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function put_slot_type(name; aws_config::AbstractAWSConfig=global_aws_config())
     return lex_model_building_service(
-        "PUT", "/slottypes/$(name)/versions/$LATEST"; aws_config=aws_config
+        "PUT",
+        "/slottypes/$(name)/versions/$LATEST";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_slot_type(
     name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return lex_model_building_service(
-        "PUT", "/slottypes/$(name)/versions/$LATEST", params; aws_config=aws_config
+        "PUT",
+        "/slottypes/$(name)/versions/$LATEST",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1589,6 +1815,7 @@ function start_import(
             "resourceType" => resourceType,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_import(
@@ -1613,6 +1840,7 @@ function start_import(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1659,6 +1887,7 @@ function start_migration(
             "v2BotRole" => v2BotRole,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_migration(
@@ -1687,6 +1916,7 @@ function start_migration(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1710,6 +1940,7 @@ function tag_resource(resourceArn, tags; aws_config::AbstractAWSConfig=global_aw
         "/tags/$(resourceArn)",
         Dict{String,Any}("tags" => tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -1723,6 +1954,7 @@ function tag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tags" => tags), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1746,6 +1978,7 @@ function untag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}("tagKeys" => tagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -1759,5 +1992,6 @@ function untag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tagKeys" => tagKeys), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/lex_models_v2.jl
+++ b/src/services/lex_models_v2.jl
@@ -28,6 +28,7 @@ function build_bot_locale(
         "POST",
         "/bots/$(botId)/botversions/$(botVersion)/botlocales/$(localeId)/";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function build_bot_locale(
@@ -42,6 +43,7 @@ function build_bot_locale(
         "/bots/$(botId)/botversions/$(botVersion)/botlocales/$(localeId)/",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -92,6 +94,7 @@ function create_bot(
             "roleArn" => roleArn,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_bot(
@@ -118,6 +121,7 @@ function create_bot(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -159,6 +163,7 @@ function create_bot_alias(
         "/bots/$(botId)/botaliases/",
         Dict{String,Any}("botAliasName" => botAliasName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_bot_alias(
@@ -174,6 +179,7 @@ function create_bot_alias(
             mergewith(_merge, Dict{String,Any}("botAliasName" => botAliasName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -223,6 +229,7 @@ function create_bot_locale(
             "nluIntentConfidenceThreshold" => nluIntentConfidenceThreshold,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_bot_locale(
@@ -247,6 +254,7 @@ function create_bot_locale(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -279,6 +287,7 @@ function create_bot_version(
         "/bots/$(botId)/botversions/",
         Dict{String,Any}("botVersionLocaleSpecification" => botVersionLocaleSpecification);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_bot_version(
@@ -300,6 +309,7 @@ function create_bot_version(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -335,6 +345,7 @@ function create_export(
             "fileFormat" => fileFormat, "resourceSpecification" => resourceSpecification
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_export(
@@ -357,6 +368,7 @@ function create_export(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -448,6 +460,7 @@ function create_intent(
         "/bots/$(botId)/botversions/$(botVersion)/botlocales/$(localeId)/intents/",
         Dict{String,Any}("intentName" => intentName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_intent(
@@ -465,6 +478,7 @@ function create_intent(
             mergewith(_merge, Dict{String,Any}("intentName" => intentName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -491,6 +505,7 @@ function create_resource_policy(
         "/policy/$(resourceArn)/",
         Dict{String,Any}("policy" => policy);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_resource_policy(
@@ -504,6 +519,7 @@ function create_resource_policy(
         "/policy/$(resourceArn)/",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("policy" => policy), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -559,6 +575,7 @@ function create_resource_policy_statement(
             "statementId" => statementId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_resource_policy_statement(
@@ -586,6 +603,7 @@ function create_resource_policy_statement(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -642,6 +660,7 @@ function create_slot(
             "valueElicitationSetting" => valueElicitationSetting,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_slot(
@@ -670,6 +689,7 @@ function create_slot(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -722,6 +742,7 @@ function create_slot_type(
             "slotTypeName" => slotTypeName, "valueSelectionSetting" => valueSelectionSetting
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_slot_type(
@@ -747,6 +768,7 @@ function create_slot_type(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -759,12 +781,20 @@ or a bot locale.
 
 """
 function create_upload_url(; aws_config::AbstractAWSConfig=global_aws_config())
-    return lex_models_v2("POST", "/createuploadurl/"; aws_config=aws_config)
+    return lex_models_v2(
+        "POST", "/createuploadurl/"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function create_upload_url(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return lex_models_v2("POST", "/createuploadurl/", params; aws_config=aws_config)
+    return lex_models_v2(
+        "POST",
+        "/createuploadurl/",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -787,12 +817,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   resource, such as an alias, is using the bot before it is deleted.
 """
 function delete_bot(botId; aws_config::AbstractAWSConfig=global_aws_config())
-    return lex_models_v2("DELETE", "/bots/$(botId)/"; aws_config=aws_config)
+    return lex_models_v2(
+        "DELETE", "/bots/$(botId)/"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function delete_bot(
     botId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return lex_models_v2("DELETE", "/bots/$(botId)/", params; aws_config=aws_config)
+    return lex_models_v2(
+        "DELETE",
+        "/bots/$(botId)/",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -814,7 +852,10 @@ function delete_bot_alias(
     botAliasId, botId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return lex_models_v2(
-        "DELETE", "/bots/$(botId)/botaliases/$(botAliasId)/"; aws_config=aws_config
+        "DELETE",
+        "/bots/$(botId)/botaliases/$(botAliasId)/";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_bot_alias(
@@ -824,7 +865,11 @@ function delete_bot_alias(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return lex_models_v2(
-        "DELETE", "/bots/$(botId)/botaliases/$(botAliasId)/", params; aws_config=aws_config
+        "DELETE",
+        "/bots/$(botId)/botaliases/$(botAliasId)/",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -849,6 +894,7 @@ function delete_bot_locale(
         "DELETE",
         "/bots/$(botId)/botversions/$(botVersion)/botlocales/$(localeId)/";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_bot_locale(
@@ -863,6 +909,7 @@ function delete_bot_locale(
         "/bots/$(botId)/botversions/$(botVersion)/botlocales/$(localeId)/",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -888,7 +935,10 @@ function delete_bot_version(
     botId, botVersion; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return lex_models_v2(
-        "DELETE", "/bots/$(botId)/botversions/$(botVersion)/"; aws_config=aws_config
+        "DELETE",
+        "/bots/$(botId)/botversions/$(botVersion)/";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_bot_version(
@@ -898,7 +948,11 @@ function delete_bot_version(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return lex_models_v2(
-        "DELETE", "/bots/$(botId)/botversions/$(botVersion)/", params; aws_config=aws_config
+        "DELETE",
+        "/bots/$(botId)/botversions/$(botVersion)/",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -913,14 +967,25 @@ Removes a previous export and the associated files stored in an S3 bucket.
 
 """
 function delete_export(exportId; aws_config::AbstractAWSConfig=global_aws_config())
-    return lex_models_v2("DELETE", "/exports/$(exportId)/"; aws_config=aws_config)
+    return lex_models_v2(
+        "DELETE",
+        "/exports/$(exportId)/";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_export(
     exportId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return lex_models_v2("DELETE", "/exports/$(exportId)/", params; aws_config=aws_config)
+    return lex_models_v2(
+        "DELETE",
+        "/exports/$(exportId)/",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -934,14 +999,25 @@ Removes a previous import and the associated file stored in an S3 bucket.
 
 """
 function delete_import(importId; aws_config::AbstractAWSConfig=global_aws_config())
-    return lex_models_v2("DELETE", "/imports/$(importId)/"; aws_config=aws_config)
+    return lex_models_v2(
+        "DELETE",
+        "/imports/$(importId)/";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_import(
     importId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return lex_models_v2("DELETE", "/imports/$(importId)/", params; aws_config=aws_config)
+    return lex_models_v2(
+        "DELETE",
+        "/imports/$(importId)/",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -967,6 +1043,7 @@ function delete_intent(
         "DELETE",
         "/bots/$(botId)/botversions/$(botVersion)/botlocales/$(localeId)/intents/$(intentId)/";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_intent(
@@ -982,6 +1059,7 @@ function delete_intent(
         "/bots/$(botId)/botversions/$(botVersion)/botlocales/$(localeId)/intents/$(intentId)/",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1005,14 +1083,25 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function delete_resource_policy(
     resourceArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return lex_models_v2("DELETE", "/policy/$(resourceArn)/"; aws_config=aws_config)
+    return lex_models_v2(
+        "DELETE",
+        "/policy/$(resourceArn)/";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_resource_policy(
     resourceArn,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return lex_models_v2("DELETE", "/policy/$(resourceArn)/", params; aws_config=aws_config)
+    return lex_models_v2(
+        "DELETE",
+        "/policy/$(resourceArn)/",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1040,7 +1129,10 @@ function delete_resource_policy_statement(
     resourceArn, statementId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return lex_models_v2(
-        "DELETE", "/policy/$(resourceArn)/statements/$(statementId)/"; aws_config=aws_config
+        "DELETE",
+        "/policy/$(resourceArn)/statements/$(statementId)/";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_resource_policy_statement(
@@ -1054,6 +1146,7 @@ function delete_resource_policy_statement(
         "/policy/$(resourceArn)/statements/$(statementId)/",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1085,6 +1178,7 @@ function delete_slot(
         "DELETE",
         "/bots/$(botId)/botversions/$(botVersion)/botlocales/$(localeId)/intents/$(intentId)/slots/$(slotId)/";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_slot(
@@ -1101,6 +1195,7 @@ function delete_slot(
         "/bots/$(botId)/botversions/$(botVersion)/botlocales/$(localeId)/intents/$(intentId)/slots/$(slotId)/",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1138,6 +1233,7 @@ function delete_slot_type(
         "DELETE",
         "/bots/$(botId)/botversions/$(botVersion)/botlocales/$(localeId)/slottypes/$(slotTypeId)/";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_slot_type(
@@ -1153,6 +1249,7 @@ function delete_slot_type(
         "/bots/$(botId)/botversions/$(botVersion)/botlocales/$(localeId)/slottypes/$(slotTypeId)/",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1180,13 +1277,22 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   the response from the and operations.
 """
 function delete_utterances(botId; aws_config::AbstractAWSConfig=global_aws_config())
-    return lex_models_v2("DELETE", "/bots/$(botId)/utterances/"; aws_config=aws_config)
+    return lex_models_v2(
+        "DELETE",
+        "/bots/$(botId)/utterances/";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_utterances(
     botId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return lex_models_v2(
-        "DELETE", "/bots/$(botId)/utterances/", params; aws_config=aws_config
+        "DELETE",
+        "/bots/$(botId)/utterances/",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1201,12 +1307,20 @@ Provides metadata information about a bot.
 
 """
 function describe_bot(botId; aws_config::AbstractAWSConfig=global_aws_config())
-    return lex_models_v2("GET", "/bots/$(botId)/"; aws_config=aws_config)
+    return lex_models_v2(
+        "GET", "/bots/$(botId)/"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_bot(
     botId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return lex_models_v2("GET", "/bots/$(botId)/", params; aws_config=aws_config)
+    return lex_models_v2(
+        "GET",
+        "/bots/$(botId)/",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1224,7 +1338,10 @@ function describe_bot_alias(
     botAliasId, botId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return lex_models_v2(
-        "GET", "/bots/$(botId)/botaliases/$(botAliasId)/"; aws_config=aws_config
+        "GET",
+        "/bots/$(botId)/botaliases/$(botAliasId)/";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_bot_alias(
@@ -1234,7 +1351,11 @@ function describe_bot_alias(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return lex_models_v2(
-        "GET", "/bots/$(botId)/botaliases/$(botAliasId)/", params; aws_config=aws_config
+        "GET",
+        "/bots/$(botId)/botaliases/$(botAliasId)/",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1258,6 +1379,7 @@ function describe_bot_locale(
         "GET",
         "/bots/$(botId)/botversions/$(botVersion)/botlocales/$(localeId)/";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_bot_locale(
@@ -1272,6 +1394,7 @@ function describe_bot_locale(
         "/bots/$(botId)/botversions/$(botVersion)/botlocales/$(localeId)/",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1290,7 +1413,10 @@ function describe_bot_version(
     botId, botVersion; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return lex_models_v2(
-        "GET", "/bots/$(botId)/botversions/$(botVersion)/"; aws_config=aws_config
+        "GET",
+        "/bots/$(botId)/botversions/$(botVersion)/";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_bot_version(
@@ -1300,7 +1426,11 @@ function describe_bot_version(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return lex_models_v2(
-        "GET", "/bots/$(botId)/botversions/$(botVersion)/", params; aws_config=aws_config
+        "GET",
+        "/bots/$(botId)/botversions/$(botVersion)/",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1315,14 +1445,25 @@ Gets information about a specific export.
 
 """
 function describe_export(exportId; aws_config::AbstractAWSConfig=global_aws_config())
-    return lex_models_v2("GET", "/exports/$(exportId)/"; aws_config=aws_config)
+    return lex_models_v2(
+        "GET",
+        "/exports/$(exportId)/";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_export(
     exportId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return lex_models_v2("GET", "/exports/$(exportId)/", params; aws_config=aws_config)
+    return lex_models_v2(
+        "GET",
+        "/exports/$(exportId)/",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1336,14 +1477,25 @@ Gets information about a specific import.
 
 """
 function describe_import(importId; aws_config::AbstractAWSConfig=global_aws_config())
-    return lex_models_v2("GET", "/imports/$(importId)/"; aws_config=aws_config)
+    return lex_models_v2(
+        "GET",
+        "/imports/$(importId)/";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_import(
     importId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return lex_models_v2("GET", "/imports/$(importId)/", params; aws_config=aws_config)
+    return lex_models_v2(
+        "GET",
+        "/imports/$(importId)/",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1368,6 +1520,7 @@ function describe_intent(
         "GET",
         "/bots/$(botId)/botversions/$(botVersion)/botlocales/$(localeId)/intents/$(intentId)/";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_intent(
@@ -1383,6 +1536,7 @@ function describe_intent(
         "/bots/$(botId)/botversions/$(botVersion)/botlocales/$(localeId)/intents/$(intentId)/",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1400,14 +1554,25 @@ Gets the resource policy and policy revision for a bot or bot alias.
 function describe_resource_policy(
     resourceArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return lex_models_v2("GET", "/policy/$(resourceArn)/"; aws_config=aws_config)
+    return lex_models_v2(
+        "GET",
+        "/policy/$(resourceArn)/";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_resource_policy(
     resourceArn,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return lex_models_v2("GET", "/policy/$(resourceArn)/", params; aws_config=aws_config)
+    return lex_models_v2(
+        "GET",
+        "/policy/$(resourceArn)/",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1438,6 +1603,7 @@ function describe_slot(
         "GET",
         "/bots/$(botId)/botversions/$(botVersion)/botlocales/$(localeId)/intents/$(intentId)/slots/$(slotId)/";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_slot(
@@ -1454,6 +1620,7 @@ function describe_slot(
         "/bots/$(botId)/botversions/$(botVersion)/botlocales/$(localeId)/intents/$(intentId)/slots/$(slotId)/",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1483,6 +1650,7 @@ function describe_slot_type(
         "GET",
         "/bots/$(botId)/botversions/$(botVersion)/botlocales/$(localeId)/slottypes/$(slotTypeId)/";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_slot_type(
@@ -1498,6 +1666,7 @@ function describe_slot_type(
         "/bots/$(botId)/botversions/$(botVersion)/botlocales/$(localeId)/slottypes/$(slotTypeId)/",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1551,6 +1720,7 @@ function list_aggregated_utterances(
             "aggregationDuration" => aggregationDuration, "localeId" => localeId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_aggregated_utterances(
@@ -1573,6 +1743,7 @@ function list_aggregated_utterances(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1594,13 +1765,22 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   token in the nextToken parameter to return the next page of results.
 """
 function list_bot_aliases(botId; aws_config::AbstractAWSConfig=global_aws_config())
-    return lex_models_v2("POST", "/bots/$(botId)/botaliases/"; aws_config=aws_config)
+    return lex_models_v2(
+        "POST",
+        "/bots/$(botId)/botaliases/";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_bot_aliases(
     botId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return lex_models_v2(
-        "POST", "/bots/$(botId)/botaliases/", params; aws_config=aws_config
+        "POST",
+        "/bots/$(botId)/botaliases/",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1634,6 +1814,7 @@ function list_bot_locales(
         "POST",
         "/bots/$(botId)/botversions/$(botVersion)/botlocales/";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_bot_locales(
@@ -1647,6 +1828,7 @@ function list_bot_locales(
         "/bots/$(botId)/botversions/$(botVersion)/botlocales/",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1675,13 +1857,22 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   the list be sorted by version name in either ascending or descending order.
 """
 function list_bot_versions(botId; aws_config::AbstractAWSConfig=global_aws_config())
-    return lex_models_v2("POST", "/bots/$(botId)/botversions/"; aws_config=aws_config)
+    return lex_models_v2(
+        "POST",
+        "/bots/$(botId)/botversions/";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_bot_versions(
     botId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return lex_models_v2(
-        "POST", "/bots/$(botId)/botversions/", params; aws_config=aws_config
+        "POST",
+        "/bots/$(botId)/botversions/",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1706,12 +1897,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   list be sorted by bot name in ascending or descending order.
 """
 function list_bots(; aws_config::AbstractAWSConfig=global_aws_config())
-    return lex_models_v2("POST", "/bots/"; aws_config=aws_config)
+    return lex_models_v2(
+        "POST", "/bots/"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_bots(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return lex_models_v2("POST", "/bots/", params; aws_config=aws_config)
+    return lex_models_v2(
+        "POST", "/bots/", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1741,7 +1936,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function list_built_in_intents(localeId; aws_config::AbstractAWSConfig=global_aws_config())
     return lex_models_v2(
-        "POST", "/builtins/locales/$(localeId)/intents/"; aws_config=aws_config
+        "POST",
+        "/builtins/locales/$(localeId)/intents/";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_built_in_intents(
@@ -1750,7 +1948,11 @@ function list_built_in_intents(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return lex_models_v2(
-        "POST", "/builtins/locales/$(localeId)/intents/", params; aws_config=aws_config
+        "POST",
+        "/builtins/locales/$(localeId)/intents/",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1781,7 +1983,10 @@ function list_built_in_slot_types(
     localeId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return lex_models_v2(
-        "POST", "/builtins/locales/$(localeId)/slottypes/"; aws_config=aws_config
+        "POST",
+        "/builtins/locales/$(localeId)/slottypes/";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_built_in_slot_types(
@@ -1790,7 +1995,11 @@ function list_built_in_slot_types(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return lex_models_v2(
-        "POST", "/builtins/locales/$(localeId)/slottypes/", params; aws_config=aws_config
+        "POST",
+        "/builtins/locales/$(localeId)/slottypes/",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1816,12 +2025,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   the LastUpdatedDateTime field in ascending or descending order.
 """
 function list_exports(; aws_config::AbstractAWSConfig=global_aws_config())
-    return lex_models_v2("POST", "/exports/"; aws_config=aws_config)
+    return lex_models_v2(
+        "POST", "/exports/"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_exports(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return lex_models_v2("POST", "/exports/", params; aws_config=aws_config)
+    return lex_models_v2(
+        "POST", "/exports/", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1846,12 +2059,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   the LastUpdatedDateTime field in ascending or descending order.
 """
 function list_imports(; aws_config::AbstractAWSConfig=global_aws_config())
-    return lex_models_v2("POST", "/imports/"; aws_config=aws_config)
+    return lex_models_v2(
+        "POST", "/imports/"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_imports(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return lex_models_v2("POST", "/imports/", params; aws_config=aws_config)
+    return lex_models_v2(
+        "POST", "/imports/", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1887,6 +2104,7 @@ function list_intents(
         "POST",
         "/bots/$(botId)/botversions/$(botVersion)/botlocales/$(localeId)/intents/";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_intents(
@@ -1901,6 +2119,7 @@ function list_intents(
         "/bots/$(botId)/botversions/$(botVersion)/botlocales/$(localeId)/intents/",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1939,6 +2158,7 @@ function list_slot_types(
         "POST",
         "/bots/$(botId)/botversions/$(botVersion)/botlocales/$(localeId)/slottypes/";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_slot_types(
@@ -1953,6 +2173,7 @@ function list_slot_types(
         "/bots/$(botId)/botversions/$(botVersion)/botlocales/$(localeId)/slottypes/",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1990,6 +2211,7 @@ function list_slots(
         "POST",
         "/bots/$(botId)/botversions/$(botVersion)/botlocales/$(localeId)/intents/$(intentId)/slots/";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_slots(
@@ -2005,6 +2227,7 @@ function list_slots(
         "/bots/$(botId)/botversions/$(botVersion)/botlocales/$(localeId)/intents/$(intentId)/slots/",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2022,14 +2245,25 @@ can have tags associated with them.
 function list_tags_for_resource(
     resourceARN; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return lex_models_v2("GET", "/tags/$(resourceARN)"; aws_config=aws_config)
+    return lex_models_v2(
+        "GET",
+        "/tags/$(resourceARN)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_tags_for_resource(
     resourceARN,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return lex_models_v2("GET", "/tags/$(resourceARN)", params; aws_config=aws_config)
+    return lex_models_v2(
+        "GET",
+        "/tags/$(resourceARN)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2067,6 +2301,7 @@ function start_import(
             "resourceSpecification" => resourceSpecification,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_import(
@@ -2091,6 +2326,7 @@ function start_import(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2114,6 +2350,7 @@ function tag_resource(resourceARN, tags; aws_config::AbstractAWSConfig=global_aw
         "/tags/$(resourceARN)",
         Dict{String,Any}("tags" => tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -2127,6 +2364,7 @@ function tag_resource(
         "/tags/$(resourceARN)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tags" => tags), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2150,6 +2388,7 @@ function untag_resource(
         "/tags/$(resourceARN)",
         Dict{String,Any}("tagKeys" => tagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -2163,6 +2402,7 @@ function untag_resource(
         "/tags/$(resourceARN)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tagKeys" => tagKeys), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2209,6 +2449,7 @@ function update_bot(
             "roleArn" => roleArn,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_bot(
@@ -2236,6 +2477,7 @@ function update_bot(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2268,6 +2510,7 @@ function update_bot_alias(
         "/bots/$(botId)/botaliases/$(botAliasId)/",
         Dict{String,Any}("botAliasName" => botAliasName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_bot_alias(
@@ -2284,6 +2527,7 @@ function update_bot_alias(
             mergewith(_merge, Dict{String,Any}("botAliasName" => botAliasName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2321,6 +2565,7 @@ function update_bot_locale(
         "/bots/$(botId)/botversions/$(botVersion)/botlocales/$(localeId)/",
         Dict{String,Any}("nluIntentConfidenceThreshold" => nluIntentConfidenceThreshold);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_bot_locale(
@@ -2344,6 +2589,7 @@ function update_bot_locale(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2364,14 +2610,25 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"filePassword"`: The new password to use to encrypt the export zip archive.
 """
 function update_export(exportId; aws_config::AbstractAWSConfig=global_aws_config())
-    return lex_models_v2("PUT", "/exports/$(exportId)/"; aws_config=aws_config)
+    return lex_models_v2(
+        "PUT",
+        "/exports/$(exportId)/";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function update_export(
     exportId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return lex_models_v2("PUT", "/exports/$(exportId)/", params; aws_config=aws_config)
+    return lex_models_v2(
+        "PUT",
+        "/exports/$(exportId)/",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2425,6 +2682,7 @@ function update_intent(
         "/bots/$(botId)/botversions/$(botVersion)/botlocales/$(localeId)/intents/$(intentId)/",
         Dict{String,Any}("intentName" => intentName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_intent(
@@ -2443,6 +2701,7 @@ function update_intent(
             mergewith(_merge, Dict{String,Any}("intentName" => intentName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2476,6 +2735,7 @@ function update_resource_policy(
         "/policy/$(resourceArn)/",
         Dict{String,Any}("policy" => policy);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_resource_policy(
@@ -2489,6 +2749,7 @@ function update_resource_policy(
         "/policy/$(resourceArn)/",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("policy" => policy), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2540,6 +2801,7 @@ function update_slot(
             "valueElicitationSetting" => valueElicitationSetting,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_slot(
@@ -2569,6 +2831,7 @@ function update_slot(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2613,6 +2876,7 @@ function update_slot_type(
             "slotTypeName" => slotTypeName, "valueSelectionSetting" => valueSelectionSetting
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_slot_type(
@@ -2639,5 +2903,6 @@ function update_slot_type(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/lex_runtime_service.jl
+++ b/src/services/lex_runtime_service.jl
@@ -23,6 +23,7 @@ function delete_session(
         "DELETE",
         "/bot/$(botName)/alias/$(botAlias)/user/$(userId)/session";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_session(
@@ -37,6 +38,7 @@ function delete_session(
         "/bot/$(botName)/alias/$(botAlias)/user/$(userId)/session",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -65,6 +67,7 @@ function get_session(
         "GET",
         "/bot/$(botName)/alias/$(botAlias)/user/$(userId)/session/";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_session(
@@ -79,6 +82,7 @@ function get_session(
         "/bot/$(botName)/alias/$(botAlias)/user/$(userId)/session/",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -189,6 +193,7 @@ function post_content(
             "headers" => Dict{String,Any}("Content-Type" => Content_Type),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function post_content(
@@ -214,6 +219,7 @@ function post_content(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -287,6 +293,7 @@ function post_text(
         "/bot/$(botName)/alias/$(botAlias)/user/$(userId)/text",
         Dict{String,Any}("inputText" => inputText);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function post_text(
@@ -304,6 +311,7 @@ function post_text(
             mergewith(_merge, Dict{String,Any}("inputText" => inputText), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -359,6 +367,7 @@ function put_session(
         "POST",
         "/bot/$(botName)/alias/$(botAlias)/user/$(userId)/session";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_session(
@@ -373,5 +382,6 @@ function put_session(
         "/bot/$(botName)/alias/$(botAlias)/user/$(userId)/session",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/lex_runtime_v2.jl
+++ b/src/services/lex_runtime_v2.jl
@@ -35,6 +35,7 @@ function delete_session(
         "DELETE",
         "/bots/$(botId)/botAliases/$(botAliasId)/botLocales/$(localeId)/sessions/$(sessionId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_session(
@@ -50,6 +51,7 @@ function delete_session(
         "/bots/$(botId)/botAliases/$(botAliasId)/botLocales/$(localeId)/sessions/$(sessionId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -81,6 +83,7 @@ function get_session(
         "GET",
         "/bots/$(botId)/botAliases/$(botAliasId)/botLocales/$(localeId)/sessions/$(sessionId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_session(
@@ -96,6 +99,7 @@ function get_session(
         "/bots/$(botId)/botAliases/$(botAliasId)/botLocales/$(localeId)/sessions/$(sessionId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -139,6 +143,7 @@ function put_session(
         "/bots/$(botId)/botAliases/$(botAliasId)/botLocales/$(localeId)/sessions/$(sessionId)",
         Dict{String,Any}("sessionState" => sessionState);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_session(
@@ -157,6 +162,7 @@ function put_session(
             mergewith(_merge, Dict{String,Any}("sessionState" => sessionState), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -196,6 +202,7 @@ function recognize_text(
         "/bots/$(botId)/botAliases/$(botAliasId)/botLocales/$(localeId)/sessions/$(sessionId)/text",
         Dict{String,Any}("text" => text);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function recognize_text(
@@ -212,6 +219,7 @@ function recognize_text(
         "/bots/$(botId)/botAliases/$(botAliasId)/botLocales/$(localeId)/sessions/$(sessionId)/text",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("text" => text), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -280,6 +288,7 @@ function recognize_utterance(
         "/bots/$(botId)/botAliases/$(botAliasId)/botLocales/$(localeId)/sessions/$(sessionId)/utterance",
         Dict{String,Any}("headers" => Dict{String,Any}("Content-Type" => Content_Type));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function recognize_utterance(
@@ -304,5 +313,6 @@ function recognize_utterance(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/license_manager.jl
+++ b/src/services/license_manager.jl
@@ -16,7 +16,10 @@ Accepts the specified grant.
 """
 function accept_grant(GrantArn; aws_config::AbstractAWSConfig=global_aws_config())
     return license_manager(
-        "AcceptGrant", Dict{String,Any}("GrantArn" => GrantArn); aws_config=aws_config
+        "AcceptGrant",
+        Dict{String,Any}("GrantArn" => GrantArn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function accept_grant(
@@ -30,6 +33,7 @@ function accept_grant(
             mergewith(_merge, Dict{String,Any}("GrantArn" => GrantArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -53,6 +57,7 @@ function check_in_license(
         "CheckInLicense",
         Dict{String,Any}("LicenseConsumptionToken" => LicenseConsumptionToken);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function check_in_license(
@@ -70,6 +75,7 @@ function check_in_license(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -110,6 +116,7 @@ function checkout_borrow_license(
             "LicenseArn" => LicenseArn,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function checkout_borrow_license(
@@ -135,6 +142,7 @@ function checkout_borrow_license(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -175,6 +183,7 @@ function checkout_license(
             "ProductSKU" => ProductSKU,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function checkout_license(
@@ -202,6 +211,7 @@ function checkout_license(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -242,6 +252,7 @@ function create_grant(
             "Principals" => Principals,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_grant(
@@ -271,6 +282,7 @@ function create_grant(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -300,6 +312,7 @@ function create_grant_version(
         "CreateGrantVersion",
         Dict{String,Any}("ClientToken" => ClientToken, "GrantArn" => GrantArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_grant_version(
@@ -318,6 +331,7 @@ function create_grant_version(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -374,6 +388,7 @@ function create_license(
             "Validity" => Validity,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_license(
@@ -411,6 +426,7 @@ function create_license(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -457,6 +473,7 @@ function create_license_configuration(
         "CreateLicenseConfiguration",
         Dict{String,Any}("LicenseCountingType" => LicenseCountingType, "Name" => Name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_license_configuration(
@@ -477,6 +494,7 @@ function create_license_configuration(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -511,6 +529,7 @@ function create_license_conversion_task_for_resource(
             "SourceLicenseContext" => SourceLicenseContext,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_license_conversion_task_for_resource(
@@ -534,6 +553,7 @@ function create_license_conversion_task_for_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -578,6 +598,7 @@ function create_license_manager_report_generator(
             "Type" => Type,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_license_manager_report_generator(
@@ -605,6 +626,7 @@ function create_license_manager_report_generator(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -662,6 +684,7 @@ function create_license_version(
             "Validity" => Validity,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_license_version(
@@ -699,6 +722,7 @@ function create_license_version(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -731,6 +755,7 @@ function create_token(
         "CreateToken",
         Dict{String,Any}("ClientToken" => ClientToken, "LicenseArn" => LicenseArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_token(
@@ -749,6 +774,7 @@ function create_token(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -771,6 +797,7 @@ function delete_grant(GrantArn, Version; aws_config::AbstractAWSConfig=global_aw
         "DeleteGrant",
         Dict{String,Any}("GrantArn" => GrantArn, "Version" => Version);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_grant(
@@ -789,6 +816,7 @@ function delete_grant(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -810,6 +838,7 @@ function delete_license(
         "DeleteLicense",
         Dict{String,Any}("LicenseArn" => LicenseArn, "SourceVersion" => SourceVersion);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_license(
@@ -830,6 +859,7 @@ function delete_license(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -851,6 +881,7 @@ function delete_license_configuration(
         "DeleteLicenseConfiguration",
         Dict{String,Any}("LicenseConfigurationArn" => LicenseConfigurationArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_license_configuration(
@@ -868,6 +899,7 @@ function delete_license_configuration(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -893,6 +925,7 @@ function delete_license_manager_report_generator(
             "LicenseManagerReportGeneratorArn" => LicenseManagerReportGeneratorArn
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_license_manager_report_generator(
@@ -912,6 +945,7 @@ function delete_license_manager_report_generator(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -927,7 +961,10 @@ Deletes the specified token. Must be called in the license home Region.
 """
 function delete_token(TokenId; aws_config::AbstractAWSConfig=global_aws_config())
     return license_manager(
-        "DeleteToken", Dict{String,Any}("TokenId" => TokenId); aws_config=aws_config
+        "DeleteToken",
+        Dict{String,Any}("TokenId" => TokenId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_token(
@@ -937,6 +974,7 @@ function delete_token(
         "DeleteToken",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("TokenId" => TokenId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -962,6 +1000,7 @@ function extend_license_consumption(
         "ExtendLicenseConsumption",
         Dict{String,Any}("LicenseConsumptionToken" => LicenseConsumptionToken);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function extend_license_consumption(
@@ -979,6 +1018,7 @@ function extend_license_consumption(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -998,7 +1038,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function get_access_token(Token; aws_config::AbstractAWSConfig=global_aws_config())
     return license_manager(
-        "GetAccessToken", Dict{String,Any}("Token" => Token); aws_config=aws_config
+        "GetAccessToken",
+        Dict{String,Any}("Token" => Token);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_access_token(
@@ -1008,6 +1051,7 @@ function get_access_token(
         "GetAccessToken",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Token" => Token), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1026,7 +1070,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function get_grant(GrantArn; aws_config::AbstractAWSConfig=global_aws_config())
     return license_manager(
-        "GetGrant", Dict{String,Any}("GrantArn" => GrantArn); aws_config=aws_config
+        "GetGrant",
+        Dict{String,Any}("GrantArn" => GrantArn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_grant(
@@ -1040,6 +1087,7 @@ function get_grant(
             mergewith(_merge, Dict{String,Any}("GrantArn" => GrantArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1058,7 +1106,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function get_license(LicenseArn; aws_config::AbstractAWSConfig=global_aws_config())
     return license_manager(
-        "GetLicense", Dict{String,Any}("LicenseArn" => LicenseArn); aws_config=aws_config
+        "GetLicense",
+        Dict{String,Any}("LicenseArn" => LicenseArn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_license(
@@ -1072,6 +1123,7 @@ function get_license(
             mergewith(_merge, Dict{String,Any}("LicenseArn" => LicenseArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1092,6 +1144,7 @@ function get_license_configuration(
         "GetLicenseConfiguration",
         Dict{String,Any}("LicenseConfigurationArn" => LicenseConfigurationArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_license_configuration(
@@ -1109,6 +1162,7 @@ function get_license_configuration(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1130,6 +1184,7 @@ function get_license_conversion_task(
         "GetLicenseConversionTask",
         Dict{String,Any}("LicenseConversionTaskId" => LicenseConversionTaskId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_license_conversion_task(
@@ -1147,6 +1202,7 @@ function get_license_conversion_task(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1170,6 +1226,7 @@ function get_license_manager_report_generator(
             "LicenseManagerReportGeneratorArn" => LicenseManagerReportGeneratorArn
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_license_manager_report_generator(
@@ -1189,6 +1246,7 @@ function get_license_manager_report_generator(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1207,6 +1265,7 @@ function get_license_usage(LicenseArn; aws_config::AbstractAWSConfig=global_aws_
         "GetLicenseUsage",
         Dict{String,Any}("LicenseArn" => LicenseArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_license_usage(
@@ -1220,6 +1279,7 @@ function get_license_usage(
             mergewith(_merge, Dict{String,Any}("LicenseArn" => LicenseArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1231,12 +1291,16 @@ Gets the License Manager settings for the current Region.
 
 """
 function get_service_settings(; aws_config::AbstractAWSConfig=global_aws_config())
-    return license_manager("GetServiceSettings"; aws_config=aws_config)
+    return license_manager(
+        "GetServiceSettings"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_service_settings(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return license_manager("GetServiceSettings", params; aws_config=aws_config)
+    return license_manager(
+        "GetServiceSettings", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1262,6 +1326,7 @@ function list_associations_for_license_configuration(
         "ListAssociationsForLicenseConfiguration",
         Dict{String,Any}("LicenseConfigurationArn" => LicenseConfigurationArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_associations_for_license_configuration(
@@ -1279,6 +1344,7 @@ function list_associations_for_license_configuration(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1297,12 +1363,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`: Token for the next set of results.
 """
 function list_distributed_grants(; aws_config::AbstractAWSConfig=global_aws_config())
-    return license_manager("ListDistributedGrants"; aws_config=aws_config)
+    return license_manager(
+        "ListDistributedGrants"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_distributed_grants(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return license_manager("ListDistributedGrants", params; aws_config=aws_config)
+    return license_manager(
+        "ListDistributedGrants",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1326,6 +1399,7 @@ function list_failures_for_license_configuration_operations(
         "ListFailuresForLicenseConfigurationOperations",
         Dict{String,Any}("LicenseConfigurationArn" => LicenseConfigurationArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_failures_for_license_configuration_operations(
@@ -1343,6 +1417,7 @@ function list_failures_for_license_configuration_operations(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1366,12 +1441,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`: Token for the next set of results.
 """
 function list_license_configurations(; aws_config::AbstractAWSConfig=global_aws_config())
-    return license_manager("ListLicenseConfigurations"; aws_config=aws_config)
+    return license_manager(
+        "ListLicenseConfigurations"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_license_configurations(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return license_manager("ListLicenseConfigurations", params; aws_config=aws_config)
+    return license_manager(
+        "ListLicenseConfigurations",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1387,12 +1469,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`: Token for the next set of results.
 """
 function list_license_conversion_tasks(; aws_config::AbstractAWSConfig=global_aws_config())
-    return license_manager("ListLicenseConversionTasks"; aws_config=aws_config)
+    return license_manager(
+        "ListLicenseConversionTasks"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_license_conversion_tasks(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return license_manager("ListLicenseConversionTasks", params; aws_config=aws_config)
+    return license_manager(
+        "ListLicenseConversionTasks",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1411,13 +1500,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function list_license_manager_report_generators(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return license_manager("ListLicenseManagerReportGenerators"; aws_config=aws_config)
+    return license_manager(
+        "ListLicenseManagerReportGenerators";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_license_manager_report_generators(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return license_manager(
-        "ListLicenseManagerReportGenerators", params; aws_config=aws_config
+        "ListLicenseManagerReportGenerators",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1443,6 +1539,7 @@ function list_license_specifications_for_resource(
         "ListLicenseSpecificationsForResource",
         Dict{String,Any}("ResourceArn" => ResourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_license_specifications_for_resource(
@@ -1456,6 +1553,7 @@ function list_license_specifications_for_resource(
             mergewith(_merge, Dict{String,Any}("ResourceArn" => ResourceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1480,6 +1578,7 @@ function list_license_versions(
         "ListLicenseVersions",
         Dict{String,Any}("LicenseArn" => LicenseArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_license_versions(
@@ -1493,6 +1592,7 @@ function list_license_versions(
             mergewith(_merge, Dict{String,Any}("LicenseArn" => LicenseArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1511,12 +1611,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`: Token for the next set of results.
 """
 function list_licenses(; aws_config::AbstractAWSConfig=global_aws_config())
-    return license_manager("ListLicenses"; aws_config=aws_config)
+    return license_manager(
+        "ListLicenses"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_licenses(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return license_manager("ListLicenses", params; aws_config=aws_config)
+    return license_manager(
+        "ListLicenses", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1534,12 +1638,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`: Token for the next set of results.
 """
 function list_received_grants(; aws_config::AbstractAWSConfig=global_aws_config())
-    return license_manager("ListReceivedGrants"; aws_config=aws_config)
+    return license_manager(
+        "ListReceivedGrants"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_received_grants(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return license_manager("ListReceivedGrants", params; aws_config=aws_config)
+    return license_manager(
+        "ListReceivedGrants", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1557,12 +1665,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`: Token for the next set of results.
 """
 function list_received_licenses(; aws_config::AbstractAWSConfig=global_aws_config())
-    return license_manager("ListReceivedLicenses"; aws_config=aws_config)
+    return license_manager(
+        "ListReceivedLicenses"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_received_licenses(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return license_manager("ListReceivedLicenses", params; aws_config=aws_config)
+    return license_manager(
+        "ListReceivedLicenses",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1587,12 +1702,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`: Token for the next set of results.
 """
 function list_resource_inventory(; aws_config::AbstractAWSConfig=global_aws_config())
-    return license_manager("ListResourceInventory"; aws_config=aws_config)
+    return license_manager(
+        "ListResourceInventory"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_resource_inventory(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return license_manager("ListResourceInventory", params; aws_config=aws_config)
+    return license_manager(
+        "ListResourceInventory",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1612,6 +1734,7 @@ function list_tags_for_resource(
         "ListTagsForResource",
         Dict{String,Any}("ResourceArn" => ResourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags_for_resource(
@@ -1625,6 +1748,7 @@ function list_tags_for_resource(
             mergewith(_merge, Dict{String,Any}("ResourceArn" => ResourceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1643,12 +1767,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"TokenIds"`: Token IDs.
 """
 function list_tokens(; aws_config::AbstractAWSConfig=global_aws_config())
-    return license_manager("ListTokens"; aws_config=aws_config)
+    return license_manager(
+        "ListTokens"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_tokens(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return license_manager("ListTokens", params; aws_config=aws_config)
+    return license_manager(
+        "ListTokens", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1680,6 +1808,7 @@ function list_usage_for_license_configuration(
         "ListUsageForLicenseConfiguration",
         Dict{String,Any}("LicenseConfigurationArn" => LicenseConfigurationArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_usage_for_license_configuration(
@@ -1697,6 +1826,7 @@ function list_usage_for_license_configuration(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1712,7 +1842,10 @@ Rejects the specified grant.
 """
 function reject_grant(GrantArn; aws_config::AbstractAWSConfig=global_aws_config())
     return license_manager(
-        "RejectGrant", Dict{String,Any}("GrantArn" => GrantArn); aws_config=aws_config
+        "RejectGrant",
+        Dict{String,Any}("GrantArn" => GrantArn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function reject_grant(
@@ -1726,6 +1859,7 @@ function reject_grant(
             mergewith(_merge, Dict{String,Any}("GrantArn" => GrantArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1745,6 +1879,7 @@ function tag_resource(ResourceArn, Tags; aws_config::AbstractAWSConfig=global_aw
         "TagResource",
         Dict{String,Any}("ResourceArn" => ResourceArn, "Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -1763,6 +1898,7 @@ function tag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1784,6 +1920,7 @@ function untag_resource(
         "UntagResource",
         Dict{String,Any}("ResourceArn" => ResourceArn, "TagKeys" => TagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -1802,6 +1939,7 @@ function untag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1834,6 +1972,7 @@ function update_license_configuration(
         "UpdateLicenseConfiguration",
         Dict{String,Any}("LicenseConfigurationArn" => LicenseConfigurationArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_license_configuration(
@@ -1851,6 +1990,7 @@ function update_license_configuration(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1898,6 +2038,7 @@ function update_license_manager_report_generator(
             "Type" => Type,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_license_manager_report_generator(
@@ -1927,6 +2068,7 @@ function update_license_manager_report_generator(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1954,6 +2096,7 @@ function update_license_specifications_for_resource(
         "UpdateLicenseSpecificationsForResource",
         Dict{String,Any}("ResourceArn" => ResourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_license_specifications_for_resource(
@@ -1967,6 +2110,7 @@ function update_license_specifications_for_resource(
             mergewith(_merge, Dict{String,Any}("ResourceArn" => ResourceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1987,10 +2131,17 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Manager alerts.
 """
 function update_service_settings(; aws_config::AbstractAWSConfig=global_aws_config())
-    return license_manager("UpdateServiceSettings"; aws_config=aws_config)
+    return license_manager(
+        "UpdateServiceSettings"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function update_service_settings(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return license_manager("UpdateServiceSettings", params; aws_config=aws_config)
+    return license_manager(
+        "UpdateServiceSettings",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end

--- a/src/services/lightsail.jl
+++ b/src/services/lightsail.jl
@@ -19,6 +19,7 @@ function allocate_static_ip(staticIpName; aws_config::AbstractAWSConfig=global_a
         "AllocateStaticIp",
         Dict{String,Any}("staticIpName" => staticIpName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function allocate_static_ip(
@@ -32,6 +33,7 @@ function allocate_static_ip(
             mergewith(_merge, Dict{String,Any}("staticIpName" => staticIpName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -70,6 +72,7 @@ function attach_certificate_to_distribution(
             "certificateName" => certificateName, "distributionName" => distributionName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function attach_certificate_to_distribution(
@@ -91,6 +94,7 @@ function attach_certificate_to_distribution(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -119,6 +123,7 @@ function attach_disk(
             "diskName" => diskName, "diskPath" => diskPath, "instanceName" => instanceName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function attach_disk(
@@ -142,6 +147,7 @@ function attach_disk(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -173,6 +179,7 @@ function attach_instances_to_load_balancer(
             "instanceNames" => instanceNames, "loadBalancerName" => loadBalancerName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function attach_instances_to_load_balancer(
@@ -193,6 +200,7 @@ function attach_instances_to_load_balancer(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -224,6 +232,7 @@ function attach_load_balancer_tls_certificate(
             "certificateName" => certificateName, "loadBalancerName" => loadBalancerName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function attach_load_balancer_tls_certificate(
@@ -245,6 +254,7 @@ function attach_load_balancer_tls_certificate(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -266,6 +276,7 @@ function attach_static_ip(
         "AttachStaticIp",
         Dict{String,Any}("instanceName" => instanceName, "staticIpName" => staticIpName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function attach_static_ip(
@@ -286,6 +297,7 @@ function attach_static_ip(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -309,6 +321,7 @@ function close_instance_public_ports(
         "CloseInstancePublicPorts",
         Dict{String,Any}("instanceName" => instanceName, "portInfo" => portInfo);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function close_instance_public_ports(
@@ -327,6 +340,7 @@ function close_instance_public_ports(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -378,6 +392,7 @@ function copy_snapshot(
             "sourceRegion" => sourceRegion, "targetSnapshotName" => targetSnapshotName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function copy_snapshot(
@@ -399,6 +414,7 @@ function copy_snapshot(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -435,6 +451,7 @@ function create_bucket(
         "CreateBucket",
         Dict{String,Any}("bucketName" => bucketName, "bundleId" => bundleId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_bucket(
@@ -453,6 +470,7 @@ function create_bucket(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -482,6 +500,7 @@ function create_bucket_access_key(
         "CreateBucketAccessKey",
         Dict{String,Any}("bucketName" => bucketName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_bucket_access_key(
@@ -495,6 +514,7 @@ function create_bucket_access_key(
             mergewith(_merge, Dict{String,Any}("bucketName" => bucketName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -531,6 +551,7 @@ function create_certificate(
         "CreateCertificate",
         Dict{String,Any}("certificateName" => certificateName, "domainName" => domainName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_certificate(
@@ -551,6 +572,7 @@ function create_certificate(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -578,6 +600,7 @@ function create_cloud_formation_stack(
         "CreateCloudFormationStack",
         Dict{String,Any}("instances" => instances);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_cloud_formation_stack(
@@ -591,6 +614,7 @@ function create_cloud_formation_stack(
             mergewith(_merge, Dict{String,Any}("instances" => instances), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -628,6 +652,7 @@ function create_contact_method(
         "CreateContactMethod",
         Dict{String,Any}("contactEndpoint" => contactEndpoint, "protocol" => protocol);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_contact_method(
@@ -648,6 +673,7 @@ function create_contact_method(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -713,6 +739,7 @@ function create_container_service(
         "CreateContainerService",
         Dict{String,Any}("power" => power, "scale" => scale, "serviceName" => serviceName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_container_service(
@@ -734,6 +761,7 @@ function create_container_service(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -768,6 +796,7 @@ function create_container_service_deployment(
         "CreateContainerServiceDeployment",
         Dict{String,Any}("serviceName" => serviceName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_container_service_deployment(
@@ -781,6 +810,7 @@ function create_container_service_deployment(
             mergewith(_merge, Dict{String,Any}("serviceName" => serviceName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -807,12 +837,21 @@ Amazon Lightsail container services in the Amazon Lightsail Developer Guide.
 function create_container_service_registry_login(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return lightsail("CreateContainerServiceRegistryLogin"; aws_config=aws_config)
+    return lightsail(
+        "CreateContainerServiceRegistryLogin";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function create_container_service_registry_login(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return lightsail("CreateContainerServiceRegistryLogin", params; aws_config=aws_config)
+    return lightsail(
+        "CreateContainerServiceRegistryLogin",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -849,6 +888,7 @@ function create_disk(
             "sizeInGb" => sizeInGb,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_disk(
@@ -872,6 +912,7 @@ function create_disk(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -932,6 +973,7 @@ function create_disk_from_snapshot(
             "sizeInGb" => sizeInGb,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_disk_from_snapshot(
@@ -955,6 +997,7 @@ function create_disk_from_snapshot(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1005,6 +1048,7 @@ function create_disk_snapshot(
         "CreateDiskSnapshot",
         Dict{String,Any}("diskSnapshotName" => diskSnapshotName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_disk_snapshot(
@@ -1020,6 +1064,7 @@ function create_disk_snapshot(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1071,6 +1116,7 @@ function create_distribution(
             "origin" => origin,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_distribution(
@@ -1096,6 +1142,7 @@ function create_distribution(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1120,7 +1167,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function create_domain(domainName; aws_config::AbstractAWSConfig=global_aws_config())
     return lightsail(
-        "CreateDomain", Dict{String,Any}("domainName" => domainName); aws_config=aws_config
+        "CreateDomain",
+        Dict{String,Any}("domainName" => domainName);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_domain(
@@ -1134,6 +1184,7 @@ function create_domain(
             mergewith(_merge, Dict{String,Any}("domainName" => domainName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1161,6 +1212,7 @@ function create_domain_entry(
         "CreateDomainEntry",
         Dict{String,Any}("domainEntry" => domainEntry, "domainName" => domainName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_domain_entry(
@@ -1179,6 +1231,7 @@ function create_domain_entry(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1209,6 +1262,7 @@ function create_instance_snapshot(
             "instanceName" => instanceName, "instanceSnapshotName" => instanceSnapshotName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_instance_snapshot(
@@ -1230,6 +1284,7 @@ function create_instance_snapshot(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1290,6 +1345,7 @@ function create_instances(
             "instanceNames" => instanceNames,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_instances(
@@ -1315,6 +1371,7 @@ function create_instances(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1389,6 +1446,7 @@ function create_instances_from_snapshot(
             "instanceNames" => instanceNames,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_instances_from_snapshot(
@@ -1412,6 +1470,7 @@ function create_instances_from_snapshot(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1435,6 +1494,7 @@ function create_key_pair(keyPairName; aws_config::AbstractAWSConfig=global_aws_c
         "CreateKeyPair",
         Dict{String,Any}("keyPairName" => keyPairName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_key_pair(
@@ -1448,6 +1508,7 @@ function create_key_pair(
             mergewith(_merge, Dict{String,Any}("keyPairName" => keyPairName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1495,6 +1556,7 @@ function create_load_balancer(
             "instancePort" => instancePort, "loadBalancerName" => loadBalancerName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_load_balancer(
@@ -1515,6 +1577,7 @@ function create_load_balancer(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1561,6 +1624,7 @@ function create_load_balancer_tls_certificate(
             "loadBalancerName" => loadBalancerName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_load_balancer_tls_certificate(
@@ -1584,6 +1648,7 @@ function create_load_balancer_tls_certificate(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1678,6 +1743,7 @@ function create_relational_database(
             "relationalDatabaseName" => relationalDatabaseName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_relational_database(
@@ -1705,6 +1771,7 @@ function create_relational_database(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1760,6 +1827,7 @@ function create_relational_database_from_snapshot(
         "CreateRelationalDatabaseFromSnapshot",
         Dict{String,Any}("relationalDatabaseName" => relationalDatabaseName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_relational_database_from_snapshot(
@@ -1777,6 +1845,7 @@ function create_relational_database_from_snapshot(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1812,6 +1881,7 @@ function create_relational_database_snapshot(
             "relationalDatabaseSnapshotName" => relationalDatabaseSnapshotName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_relational_database_snapshot(
@@ -1833,6 +1903,7 @@ function create_relational_database_snapshot(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1851,7 +1922,10 @@ Amazon Lightsail.
 """
 function delete_alarm(alarmName; aws_config::AbstractAWSConfig=global_aws_config())
     return lightsail(
-        "DeleteAlarm", Dict{String,Any}("alarmName" => alarmName); aws_config=aws_config
+        "DeleteAlarm",
+        Dict{String,Any}("alarmName" => alarmName);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_alarm(
@@ -1865,6 +1939,7 @@ function delete_alarm(
             mergewith(_merge, Dict{String,Any}("alarmName" => alarmName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1889,6 +1964,7 @@ function delete_auto_snapshot(
         "DeleteAutoSnapshot",
         Dict{String,Any}("date" => date, "resourceName" => resourceName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_auto_snapshot(
@@ -1907,6 +1983,7 @@ function delete_auto_snapshot(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1932,7 +2009,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function delete_bucket(bucketName; aws_config::AbstractAWSConfig=global_aws_config())
     return lightsail(
-        "DeleteBucket", Dict{String,Any}("bucketName" => bucketName); aws_config=aws_config
+        "DeleteBucket",
+        Dict{String,Any}("bucketName" => bucketName);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_bucket(
@@ -1946,6 +2026,7 @@ function delete_bucket(
             mergewith(_merge, Dict{String,Any}("bucketName" => bucketName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1971,6 +2052,7 @@ function delete_bucket_access_key(
         "DeleteBucketAccessKey",
         Dict{String,Any}("accessKeyId" => accessKeyId, "bucketName" => bucketName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_bucket_access_key(
@@ -1989,6 +2071,7 @@ function delete_bucket_access_key(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2013,6 +2096,7 @@ function delete_certificate(
         "DeleteCertificate",
         Dict{String,Any}("certificateName" => certificateName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_certificate(
@@ -2028,6 +2112,7 @@ function delete_certificate(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2052,6 +2137,7 @@ function delete_contact_method(protocol; aws_config::AbstractAWSConfig=global_aw
         "DeleteContactMethod",
         Dict{String,Any}("protocol" => protocol);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_contact_method(
@@ -2065,6 +2151,7 @@ function delete_contact_method(
             mergewith(_merge, Dict{String,Any}("protocol" => protocol), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2092,6 +2179,7 @@ function delete_container_image(
         "DeleteContainerImage",
         Dict{String,Any}("image" => image, "serviceName" => serviceName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_container_image(
@@ -2110,6 +2198,7 @@ function delete_container_image(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2130,6 +2219,7 @@ function delete_container_service(
         "DeleteContainerService",
         Dict{String,Any}("serviceName" => serviceName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_container_service(
@@ -2143,6 +2233,7 @@ function delete_container_service(
             mergewith(_merge, Dict{String,Any}("serviceName" => serviceName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2166,7 +2257,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function delete_disk(diskName; aws_config::AbstractAWSConfig=global_aws_config())
     return lightsail(
-        "DeleteDisk", Dict{String,Any}("diskName" => diskName); aws_config=aws_config
+        "DeleteDisk",
+        Dict{String,Any}("diskName" => diskName);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_disk(
@@ -2180,6 +2274,7 @@ function delete_disk(
             mergewith(_merge, Dict{String,Any}("diskName" => diskName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2208,6 +2303,7 @@ function delete_disk_snapshot(
         "DeleteDiskSnapshot",
         Dict{String,Any}("diskSnapshotName" => diskSnapshotName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_disk_snapshot(
@@ -2223,6 +2319,7 @@ function delete_disk_snapshot(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2238,12 +2335,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   action to get a list of distribution names that you can specify.
 """
 function delete_distribution(; aws_config::AbstractAWSConfig=global_aws_config())
-    return lightsail("DeleteDistribution"; aws_config=aws_config)
+    return lightsail(
+        "DeleteDistribution"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function delete_distribution(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return lightsail("DeleteDistribution", params; aws_config=aws_config)
+    return lightsail(
+        "DeleteDistribution", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -2260,7 +2361,10 @@ identified by domain name. For more information, see the Amazon Lightsail Develo
 """
 function delete_domain(domainName; aws_config::AbstractAWSConfig=global_aws_config())
     return lightsail(
-        "DeleteDomain", Dict{String,Any}("domainName" => domainName); aws_config=aws_config
+        "DeleteDomain",
+        Dict{String,Any}("domainName" => domainName);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_domain(
@@ -2274,6 +2378,7 @@ function delete_domain(
             mergewith(_merge, Dict{String,Any}("domainName" => domainName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2298,6 +2403,7 @@ function delete_domain_entry(
         "DeleteDomainEntry",
         Dict{String,Any}("domainEntry" => domainEntry, "domainName" => domainName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_domain_entry(
@@ -2316,6 +2422,7 @@ function delete_domain_entry(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2340,6 +2447,7 @@ function delete_instance(instanceName; aws_config::AbstractAWSConfig=global_aws_
         "DeleteInstance",
         Dict{String,Any}("instanceName" => instanceName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_instance(
@@ -2353,6 +2461,7 @@ function delete_instance(
             mergewith(_merge, Dict{String,Any}("instanceName" => instanceName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2376,6 +2485,7 @@ function delete_instance_snapshot(
         "DeleteInstanceSnapshot",
         Dict{String,Any}("instanceSnapshotName" => instanceSnapshotName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_instance_snapshot(
@@ -2393,6 +2503,7 @@ function delete_instance_snapshot(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2413,6 +2524,7 @@ function delete_key_pair(keyPairName; aws_config::AbstractAWSConfig=global_aws_c
         "DeleteKeyPair",
         Dict{String,Any}("keyPairName" => keyPairName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_key_pair(
@@ -2426,6 +2538,7 @@ function delete_key_pair(
             mergewith(_merge, Dict{String,Any}("keyPairName" => keyPairName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2453,6 +2566,7 @@ function delete_known_host_keys(
         "DeleteKnownHostKeys",
         Dict{String,Any}("instanceName" => instanceName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_known_host_keys(
@@ -2466,6 +2580,7 @@ function delete_known_host_keys(
             mergewith(_merge, Dict{String,Any}("instanceName" => instanceName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2490,6 +2605,7 @@ function delete_load_balancer(
         "DeleteLoadBalancer",
         Dict{String,Any}("loadBalancerName" => loadBalancerName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_load_balancer(
@@ -2505,6 +2621,7 @@ function delete_load_balancer(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2537,6 +2654,7 @@ function delete_load_balancer_tls_certificate(
             "certificateName" => certificateName, "loadBalancerName" => loadBalancerName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_load_balancer_tls_certificate(
@@ -2558,6 +2676,7 @@ function delete_load_balancer_tls_certificate(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2592,6 +2711,7 @@ function delete_relational_database(
         "DeleteRelationalDatabase",
         Dict{String,Any}("relationalDatabaseName" => relationalDatabaseName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_relational_database(
@@ -2609,6 +2729,7 @@ function delete_relational_database(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2635,6 +2756,7 @@ function delete_relational_database_snapshot(
             "relationalDatabaseSnapshotName" => relationalDatabaseSnapshotName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_relational_database_snapshot(
@@ -2654,6 +2776,7 @@ function delete_relational_database_snapshot(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2677,6 +2800,7 @@ function detach_certificate_from_distribution(
         "DetachCertificateFromDistribution",
         Dict{String,Any}("distributionName" => distributionName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function detach_certificate_from_distribution(
@@ -2692,6 +2816,7 @@ function detach_certificate_from_distribution(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2712,7 +2837,10 @@ the Amazon Lightsail Developer Guide.
 """
 function detach_disk(diskName; aws_config::AbstractAWSConfig=global_aws_config())
     return lightsail(
-        "DetachDisk", Dict{String,Any}("diskName" => diskName); aws_config=aws_config
+        "DetachDisk",
+        Dict{String,Any}("diskName" => diskName);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function detach_disk(
@@ -2726,6 +2854,7 @@ function detach_disk(
             mergewith(_merge, Dict{String,Any}("diskName" => diskName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2754,6 +2883,7 @@ function detach_instances_from_load_balancer(
             "instanceNames" => instanceNames, "loadBalancerName" => loadBalancerName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function detach_instances_from_load_balancer(
@@ -2774,6 +2904,7 @@ function detach_instances_from_load_balancer(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2792,6 +2923,7 @@ function detach_static_ip(staticIpName; aws_config::AbstractAWSConfig=global_aws
         "DetachStaticIp",
         Dict{String,Any}("staticIpName" => staticIpName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function detach_static_ip(
@@ -2805,6 +2937,7 @@ function detach_static_ip(
             mergewith(_merge, Dict{String,Any}("staticIpName" => staticIpName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2827,6 +2960,7 @@ function disable_add_on(
         "DisableAddOn",
         Dict{String,Any}("addOnType" => addOnType, "resourceName" => resourceName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disable_add_on(
@@ -2845,6 +2979,7 @@ function disable_add_on(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2856,12 +2991,19 @@ Downloads the default SSH key pair from the user's account.
 
 """
 function download_default_key_pair(; aws_config::AbstractAWSConfig=global_aws_config())
-    return lightsail("DownloadDefaultKeyPair"; aws_config=aws_config)
+    return lightsail(
+        "DownloadDefaultKeyPair"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function download_default_key_pair(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return lightsail("DownloadDefaultKeyPair", params; aws_config=aws_config)
+    return lightsail(
+        "DownloadDefaultKeyPair",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2883,6 +3025,7 @@ function enable_add_on(
         "EnableAddOn",
         Dict{String,Any}("addOnRequest" => addOnRequest, "resourceName" => resourceName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function enable_add_on(
@@ -2903,6 +3046,7 @@ function enable_add_on(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2934,6 +3078,7 @@ function export_snapshot(
         "ExportSnapshot",
         Dict{String,Any}("sourceSnapshotName" => sourceSnapshotName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function export_snapshot(
@@ -2949,6 +3094,7 @@ function export_snapshot(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2966,12 +3112,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   subsequent request.
 """
 function get_active_names(; aws_config::AbstractAWSConfig=global_aws_config())
-    return lightsail("GetActiveNames"; aws_config=aws_config)
+    return lightsail(
+        "GetActiveNames"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_active_names(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return lightsail("GetActiveNames", params; aws_config=aws_config)
+    return lightsail(
+        "GetActiveNames", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -2998,12 +3148,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   subsequent request.
 """
 function get_alarms(; aws_config::AbstractAWSConfig=global_aws_config())
-    return lightsail("GetAlarms"; aws_config=aws_config)
+    return lightsail("GetAlarms"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function get_alarms(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return lightsail("GetAlarms", params; aws_config=aws_config)
+    return lightsail(
+        "GetAlarms", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -3023,6 +3175,7 @@ function get_auto_snapshots(resourceName; aws_config::AbstractAWSConfig=global_a
         "GetAutoSnapshots",
         Dict{String,Any}("resourceName" => resourceName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_auto_snapshots(
@@ -3036,6 +3189,7 @@ function get_auto_snapshots(
             mergewith(_merge, Dict{String,Any}("resourceName" => resourceName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3061,12 +3215,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   subsequent request.
 """
 function get_blueprints(; aws_config::AbstractAWSConfig=global_aws_config())
-    return lightsail("GetBlueprints"; aws_config=aws_config)
+    return lightsail(
+        "GetBlueprints"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_blueprints(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return lightsail("GetBlueprints", params; aws_config=aws_config)
+    return lightsail(
+        "GetBlueprints", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -3089,6 +3247,7 @@ function get_bucket_access_keys(
         "GetBucketAccessKeys",
         Dict{String,Any}("bucketName" => bucketName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_bucket_access_keys(
@@ -3102,6 +3261,7 @@ function get_bucket_access_keys(
             mergewith(_merge, Dict{String,Any}("bucketName" => bucketName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3119,12 +3279,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   (unavailable) bundles in the response.
 """
 function get_bucket_bundles(; aws_config::AbstractAWSConfig=global_aws_config())
-    return lightsail("GetBucketBundles"; aws_config=aws_config)
+    return lightsail(
+        "GetBucketBundles"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_bucket_bundles(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return lightsail("GetBucketBundles", params; aws_config=aws_config)
+    return lightsail(
+        "GetBucketBundles", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -3191,6 +3355,7 @@ function get_bucket_metric_data(
             "unit" => unit,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_bucket_metric_data(
@@ -3222,6 +3387,7 @@ function get_bucket_metric_data(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3245,12 +3411,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   subsequent request.
 """
 function get_buckets(; aws_config::AbstractAWSConfig=global_aws_config())
-    return lightsail("GetBuckets"; aws_config=aws_config)
+    return lightsail("GetBuckets"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function get_buckets(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return lightsail("GetBuckets", params; aws_config=aws_config)
+    return lightsail(
+        "GetBuckets", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -3270,12 +3438,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   subsequent request.
 """
 function get_bundles(; aws_config::AbstractAWSConfig=global_aws_config())
-    return lightsail("GetBundles"; aws_config=aws_config)
+    return lightsail("GetBundles"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function get_bundles(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return lightsail("GetBundles", params; aws_config=aws_config)
+    return lightsail(
+        "GetBundles", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -3301,12 +3471,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   names, Amazon Resource Names (ARNs), domain names, and tags.
 """
 function get_certificates(; aws_config::AbstractAWSConfig=global_aws_config())
-    return lightsail("GetCertificates"; aws_config=aws_config)
+    return lightsail(
+        "GetCertificates"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_certificates(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return lightsail("GetCertificates", params; aws_config=aws_config)
+    return lightsail(
+        "GetCertificates", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -3327,12 +3501,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function get_cloud_formation_stack_records(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return lightsail("GetCloudFormationStackRecords"; aws_config=aws_config)
+    return lightsail(
+        "GetCloudFormationStackRecords";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_cloud_formation_stack_records(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return lightsail("GetCloudFormationStackRecords", params; aws_config=aws_config)
+    return lightsail(
+        "GetCloudFormationStackRecords",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -3353,12 +3536,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   contact method protocol.
 """
 function get_contact_methods(; aws_config::AbstractAWSConfig=global_aws_config())
-    return lightsail("GetContactMethods"; aws_config=aws_config)
+    return lightsail(
+        "GetContactMethods"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_contact_methods(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return lightsail("GetContactMethods", params; aws_config=aws_config)
+    return lightsail(
+        "GetContactMethods", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -3370,12 +3557,19 @@ Lightsail Control (lightsailctl) plugin.
 
 """
 function get_container_apimetadata(; aws_config::AbstractAWSConfig=global_aws_config())
-    return lightsail("GetContainerAPIMetadata"; aws_config=aws_config)
+    return lightsail(
+        "GetContainerAPIMetadata"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_container_apimetadata(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return lightsail("GetContainerAPIMetadata", params; aws_config=aws_config)
+    return lightsail(
+        "GetContainerAPIMetadata",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -3399,6 +3593,7 @@ function get_container_images(
         "GetContainerImages",
         Dict{String,Any}("serviceName" => serviceName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_container_images(
@@ -3412,6 +3607,7 @@ function get_container_images(
             mergewith(_merge, Dict{String,Any}("serviceName" => serviceName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3462,6 +3658,7 @@ function get_container_log(
         "GetContainerLog",
         Dict{String,Any}("containerName" => containerName, "serviceName" => serviceName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_container_log(
@@ -3482,6 +3679,7 @@ function get_container_log(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3507,6 +3705,7 @@ function get_container_service_deployments(
         "GetContainerServiceDeployments",
         Dict{String,Any}("serviceName" => serviceName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_container_service_deployments(
@@ -3520,6 +3719,7 @@ function get_container_service_deployments(
             mergewith(_merge, Dict{String,Any}("serviceName" => serviceName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3581,6 +3781,7 @@ function get_container_service_metric_data(
             "statistics" => statistics,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_container_service_metric_data(
@@ -3610,6 +3811,7 @@ function get_container_service_metric_data(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3623,12 +3825,19 @@ of the container service.
 
 """
 function get_container_service_powers(; aws_config::AbstractAWSConfig=global_aws_config())
-    return lightsail("GetContainerServicePowers"; aws_config=aws_config)
+    return lightsail(
+        "GetContainerServicePowers"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_container_service_powers(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return lightsail("GetContainerServicePowers", params; aws_config=aws_config)
+    return lightsail(
+        "GetContainerServicePowers",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -3644,12 +3853,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   request is made.
 """
 function get_container_services(; aws_config::AbstractAWSConfig=global_aws_config())
-    return lightsail("GetContainerServices"; aws_config=aws_config)
+    return lightsail(
+        "GetContainerServices"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_container_services(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return lightsail("GetContainerServices", params; aws_config=aws_config)
+    return lightsail(
+        "GetContainerServices",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -3664,7 +3880,10 @@ Returns information about a specific block storage disk.
 """
 function get_disk(diskName; aws_config::AbstractAWSConfig=global_aws_config())
     return lightsail(
-        "GetDisk", Dict{String,Any}("diskName" => diskName); aws_config=aws_config
+        "GetDisk",
+        Dict{String,Any}("diskName" => diskName);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_disk(
@@ -3678,6 +3897,7 @@ function get_disk(
             mergewith(_merge, Dict{String,Any}("diskName" => diskName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3698,6 +3918,7 @@ function get_disk_snapshot(
         "GetDiskSnapshot",
         Dict{String,Any}("diskSnapshotName" => diskSnapshotName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_disk_snapshot(
@@ -3713,6 +3934,7 @@ function get_disk_snapshot(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3730,12 +3952,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   subsequent request.
 """
 function get_disk_snapshots(; aws_config::AbstractAWSConfig=global_aws_config())
-    return lightsail("GetDiskSnapshots"; aws_config=aws_config)
+    return lightsail(
+        "GetDiskSnapshots"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_disk_snapshots(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return lightsail("GetDiskSnapshots", params; aws_config=aws_config)
+    return lightsail(
+        "GetDiskSnapshots", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -3752,12 +3978,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   subsequent request.
 """
 function get_disks(; aws_config::AbstractAWSConfig=global_aws_config())
-    return lightsail("GetDisks"; aws_config=aws_config)
+    return lightsail("GetDisks"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function get_disks(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return lightsail("GetDisks", params; aws_config=aws_config)
+    return lightsail(
+        "GetDisks", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -3770,12 +3998,19 @@ monthly cost of your dsitribution.
 
 """
 function get_distribution_bundles(; aws_config::AbstractAWSConfig=global_aws_config())
-    return lightsail("GetDistributionBundles"; aws_config=aws_config)
+    return lightsail(
+        "GetDistributionBundles"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_distribution_bundles(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return lightsail("GetDistributionBundles", params; aws_config=aws_config)
+    return lightsail(
+        "GetDistributionBundles",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -3795,12 +4030,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function get_distribution_latest_cache_reset(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return lightsail("GetDistributionLatestCacheReset"; aws_config=aws_config)
+    return lightsail(
+        "GetDistributionLatestCacheReset";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_distribution_latest_cache_reset(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return lightsail("GetDistributionLatestCacheReset", params; aws_config=aws_config)
+    return lightsail(
+        "GetDistributionLatestCacheReset",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -3884,6 +4128,7 @@ function get_distribution_metric_data(
             "unit" => unit,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_distribution_metric_data(
@@ -3915,6 +4160,7 @@ function get_distribution_metric_data(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3936,12 +4182,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   subsequent request.
 """
 function get_distributions(; aws_config::AbstractAWSConfig=global_aws_config())
-    return lightsail("GetDistributions"; aws_config=aws_config)
+    return lightsail(
+        "GetDistributions"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_distributions(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return lightsail("GetDistributions", params; aws_config=aws_config)
+    return lightsail(
+        "GetDistributions", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -3956,7 +4206,10 @@ Returns information about a specific domain recordset.
 """
 function get_domain(domainName; aws_config::AbstractAWSConfig=global_aws_config())
     return lightsail(
-        "GetDomain", Dict{String,Any}("domainName" => domainName); aws_config=aws_config
+        "GetDomain",
+        Dict{String,Any}("domainName" => domainName);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_domain(
@@ -3970,6 +4223,7 @@ function get_domain(
             mergewith(_merge, Dict{String,Any}("domainName" => domainName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3987,12 +4241,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   subsequent request.
 """
 function get_domains(; aws_config::AbstractAWSConfig=global_aws_config())
-    return lightsail("GetDomains"; aws_config=aws_config)
+    return lightsail("GetDomains"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function get_domains(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return lightsail("GetDomains", params; aws_config=aws_config)
+    return lightsail(
+        "GetDomains", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -4011,12 +4267,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   token in a subsequent request.
 """
 function get_export_snapshot_records(; aws_config::AbstractAWSConfig=global_aws_config())
-    return lightsail("GetExportSnapshotRecords"; aws_config=aws_config)
+    return lightsail(
+        "GetExportSnapshotRecords"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_export_snapshot_records(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return lightsail("GetExportSnapshotRecords", params; aws_config=aws_config)
+    return lightsail(
+        "GetExportSnapshotRecords",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -4035,6 +4298,7 @@ function get_instance(instanceName; aws_config::AbstractAWSConfig=global_aws_con
         "GetInstance",
         Dict{String,Any}("instanceName" => instanceName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_instance(
@@ -4048,6 +4312,7 @@ function get_instance(
             mergewith(_merge, Dict{String,Any}("instanceName" => instanceName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4074,6 +4339,7 @@ function get_instance_access_details(
         "GetInstanceAccessDetails",
         Dict{String,Any}("instanceName" => instanceName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_instance_access_details(
@@ -4087,6 +4353,7 @@ function get_instance_access_details(
             mergewith(_merge, Dict{String,Any}("instanceName" => instanceName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4188,6 +4455,7 @@ function get_instance_metric_data(
             "unit" => unit,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_instance_metric_data(
@@ -4219,6 +4487,7 @@ function get_instance_metric_data(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4240,6 +4509,7 @@ function get_instance_port_states(
         "GetInstancePortStates",
         Dict{String,Any}("instanceName" => instanceName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_instance_port_states(
@@ -4253,6 +4523,7 @@ function get_instance_port_states(
             mergewith(_merge, Dict{String,Any}("instanceName" => instanceName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4274,6 +4545,7 @@ function get_instance_snapshot(
         "GetInstanceSnapshot",
         Dict{String,Any}("instanceSnapshotName" => instanceSnapshotName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_instance_snapshot(
@@ -4291,6 +4563,7 @@ function get_instance_snapshot(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4308,12 +4581,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   token in a subsequent request.
 """
 function get_instance_snapshots(; aws_config::AbstractAWSConfig=global_aws_config())
-    return lightsail("GetInstanceSnapshots"; aws_config=aws_config)
+    return lightsail(
+        "GetInstanceSnapshots"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_instance_snapshots(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return lightsail("GetInstanceSnapshots", params; aws_config=aws_config)
+    return lightsail(
+        "GetInstanceSnapshots",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -4331,6 +4611,7 @@ function get_instance_state(instanceName; aws_config::AbstractAWSConfig=global_a
         "GetInstanceState",
         Dict{String,Any}("instanceName" => instanceName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_instance_state(
@@ -4344,6 +4625,7 @@ function get_instance_state(
             mergewith(_merge, Dict{String,Any}("instanceName" => instanceName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4361,12 +4643,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   subsequent request.
 """
 function get_instances(; aws_config::AbstractAWSConfig=global_aws_config())
-    return lightsail("GetInstances"; aws_config=aws_config)
+    return lightsail("GetInstances"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function get_instances(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return lightsail("GetInstances", params; aws_config=aws_config)
+    return lightsail(
+        "GetInstances", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -4381,7 +4665,10 @@ Returns information about a specific key pair.
 """
 function get_key_pair(keyPairName; aws_config::AbstractAWSConfig=global_aws_config())
     return lightsail(
-        "GetKeyPair", Dict{String,Any}("keyPairName" => keyPairName); aws_config=aws_config
+        "GetKeyPair",
+        Dict{String,Any}("keyPairName" => keyPairName);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_key_pair(
@@ -4395,6 +4682,7 @@ function get_key_pair(
             mergewith(_merge, Dict{String,Any}("keyPairName" => keyPairName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4412,12 +4700,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   subsequent request.
 """
 function get_key_pairs(; aws_config::AbstractAWSConfig=global_aws_config())
-    return lightsail("GetKeyPairs"; aws_config=aws_config)
+    return lightsail("GetKeyPairs"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function get_key_pairs(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return lightsail("GetKeyPairs", params; aws_config=aws_config)
+    return lightsail(
+        "GetKeyPairs", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -4437,6 +4727,7 @@ function get_load_balancer(
         "GetLoadBalancer",
         Dict{String,Any}("loadBalancerName" => loadBalancerName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_load_balancer(
@@ -4452,6 +4743,7 @@ function get_load_balancer(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4551,6 +4843,7 @@ function get_load_balancer_metric_data(
             "unit" => unit,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_load_balancer_metric_data(
@@ -4582,6 +4875,7 @@ function get_load_balancer_metric_data(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4606,6 +4900,7 @@ function get_load_balancer_tls_certificates(
         "GetLoadBalancerTlsCertificates",
         Dict{String,Any}("loadBalancerName" => loadBalancerName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_load_balancer_tls_certificates(
@@ -4621,6 +4916,7 @@ function get_load_balancer_tls_certificates(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4638,12 +4934,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   subsequent request.
 """
 function get_load_balancers(; aws_config::AbstractAWSConfig=global_aws_config())
-    return lightsail("GetLoadBalancers"; aws_config=aws_config)
+    return lightsail(
+        "GetLoadBalancers"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_load_balancers(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return lightsail("GetLoadBalancers", params; aws_config=aws_config)
+    return lightsail(
+        "GetLoadBalancers", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -4662,6 +4962,7 @@ function get_operation(operationId; aws_config::AbstractAWSConfig=global_aws_con
         "GetOperation",
         Dict{String,Any}("operationId" => operationId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_operation(
@@ -4675,6 +4976,7 @@ function get_operation(
             mergewith(_merge, Dict{String,Any}("operationId" => operationId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4694,12 +4996,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   subsequent request.
 """
 function get_operations(; aws_config::AbstractAWSConfig=global_aws_config())
-    return lightsail("GetOperations"; aws_config=aws_config)
+    return lightsail(
+        "GetOperations"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_operations(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return lightsail("GetOperations", params; aws_config=aws_config)
+    return lightsail(
+        "GetOperations", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -4725,6 +5031,7 @@ function get_operations_for_resource(
         "GetOperationsForResource",
         Dict{String,Any}("resourceName" => resourceName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_operations_for_resource(
@@ -4738,6 +5045,7 @@ function get_operations_for_resource(
             mergewith(_merge, Dict{String,Any}("resourceName" => resourceName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4758,12 +5066,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Zones are indicated with a letter (e.g., us-east-2a).
 """
 function get_regions(; aws_config::AbstractAWSConfig=global_aws_config())
-    return lightsail("GetRegions"; aws_config=aws_config)
+    return lightsail("GetRegions"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function get_regions(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return lightsail("GetRegions", params; aws_config=aws_config)
+    return lightsail(
+        "GetRegions", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -4783,6 +5093,7 @@ function get_relational_database(
         "GetRelationalDatabase",
         Dict{String,Any}("relationalDatabaseName" => relationalDatabaseName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_relational_database(
@@ -4800,6 +5111,7 @@ function get_relational_database(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4821,12 +5133,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function get_relational_database_blueprints(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return lightsail("GetRelationalDatabaseBlueprints"; aws_config=aws_config)
+    return lightsail(
+        "GetRelationalDatabaseBlueprints";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_relational_database_blueprints(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return lightsail("GetRelationalDatabaseBlueprints", params; aws_config=aws_config)
+    return lightsail(
+        "GetRelationalDatabaseBlueprints",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -4847,12 +5168,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function get_relational_database_bundles(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return lightsail("GetRelationalDatabaseBundles"; aws_config=aws_config)
+    return lightsail(
+        "GetRelationalDatabaseBundles";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_relational_database_bundles(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return lightsail("GetRelationalDatabaseBundles", params; aws_config=aws_config)
+    return lightsail(
+        "GetRelationalDatabaseBundles",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -4881,6 +5211,7 @@ function get_relational_database_events(
         "GetRelationalDatabaseEvents",
         Dict{String,Any}("relationalDatabaseName" => relationalDatabaseName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_relational_database_events(
@@ -4898,6 +5229,7 @@ function get_relational_database_events(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4941,6 +5273,7 @@ function get_relational_database_log_events(
             "relationalDatabaseName" => relationalDatabaseName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_relational_database_log_events(
@@ -4962,6 +5295,7 @@ function get_relational_database_log_events(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4982,6 +5316,7 @@ function get_relational_database_log_streams(
         "GetRelationalDatabaseLogStreams",
         Dict{String,Any}("relationalDatabaseName" => relationalDatabaseName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_relational_database_log_streams(
@@ -4999,6 +5334,7 @@ function get_relational_database_log_streams(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5029,6 +5365,7 @@ function get_relational_database_master_user_password(
         "GetRelationalDatabaseMasterUserPassword",
         Dict{String,Any}("relationalDatabaseName" => relationalDatabaseName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_relational_database_master_user_password(
@@ -5046,6 +5383,7 @@ function get_relational_database_master_user_password(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5125,6 +5463,7 @@ function get_relational_database_metric_data(
             "unit" => unit,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_relational_database_metric_data(
@@ -5156,6 +5495,7 @@ function get_relational_database_metric_data(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5186,6 +5526,7 @@ function get_relational_database_parameters(
         "GetRelationalDatabaseParameters",
         Dict{String,Any}("relationalDatabaseName" => relationalDatabaseName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_relational_database_parameters(
@@ -5203,6 +5544,7 @@ function get_relational_database_parameters(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5226,6 +5568,7 @@ function get_relational_database_snapshot(
             "relationalDatabaseSnapshotName" => relationalDatabaseSnapshotName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_relational_database_snapshot(
@@ -5245,6 +5588,7 @@ function get_relational_database_snapshot(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5264,12 +5608,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function get_relational_database_snapshots(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return lightsail("GetRelationalDatabaseSnapshots"; aws_config=aws_config)
+    return lightsail(
+        "GetRelationalDatabaseSnapshots";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_relational_database_snapshots(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return lightsail("GetRelationalDatabaseSnapshots", params; aws_config=aws_config)
+    return lightsail(
+        "GetRelationalDatabaseSnapshots",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -5286,12 +5639,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   token in a subsequent request.
 """
 function get_relational_databases(; aws_config::AbstractAWSConfig=global_aws_config())
-    return lightsail("GetRelationalDatabases"; aws_config=aws_config)
+    return lightsail(
+        "GetRelationalDatabases"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_relational_databases(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return lightsail("GetRelationalDatabases", params; aws_config=aws_config)
+    return lightsail(
+        "GetRelationalDatabases",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -5309,6 +5669,7 @@ function get_static_ip(staticIpName; aws_config::AbstractAWSConfig=global_aws_co
         "GetStaticIp",
         Dict{String,Any}("staticIpName" => staticIpName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_static_ip(
@@ -5322,6 +5683,7 @@ function get_static_ip(
             mergewith(_merge, Dict{String,Any}("staticIpName" => staticIpName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5339,12 +5701,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   subsequent request.
 """
 function get_static_ips(; aws_config::AbstractAWSConfig=global_aws_config())
-    return lightsail("GetStaticIps"; aws_config=aws_config)
+    return lightsail("GetStaticIps"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function get_static_ips(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return lightsail("GetStaticIps", params; aws_config=aws_config)
+    return lightsail(
+        "GetStaticIps", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -5367,6 +5731,7 @@ function import_key_pair(
             "keyPairName" => keyPairName, "publicKeyBase64" => publicKeyBase64
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function import_key_pair(
@@ -5387,6 +5752,7 @@ function import_key_pair(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5398,12 +5764,14 @@ Returns a Boolean value indicating whether your Lightsail VPC is peered.
 
 """
 function is_vpc_peered(; aws_config::AbstractAWSConfig=global_aws_config())
-    return lightsail("IsVpcPeered"; aws_config=aws_config)
+    return lightsail("IsVpcPeered"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function is_vpc_peered(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return lightsail("IsVpcPeered", params; aws_config=aws_config)
+    return lightsail(
+        "IsVpcPeered", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -5428,6 +5796,7 @@ function open_instance_public_ports(
         "OpenInstancePublicPorts",
         Dict{String,Any}("instanceName" => instanceName, "portInfo" => portInfo);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function open_instance_public_ports(
@@ -5446,6 +5815,7 @@ function open_instance_public_ports(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5457,12 +5827,14 @@ Peers the Lightsail VPC with the user's default VPC.
 
 """
 function peer_vpc(; aws_config::AbstractAWSConfig=global_aws_config())
-    return lightsail("PeerVpc"; aws_config=aws_config)
+    return lightsail("PeerVpc"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function peer_vpc(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return lightsail("PeerVpc", params; aws_config=aws_config)
+    return lightsail(
+        "PeerVpc", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -5563,6 +5935,7 @@ function put_alarm(
             "threshold" => threshold,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_alarm(
@@ -5592,6 +5965,7 @@ function put_alarm(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5621,6 +5995,7 @@ function put_instance_public_ports(
         "PutInstancePublicPorts",
         Dict{String,Any}("instanceName" => instanceName, "portInfos" => portInfos);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_instance_public_ports(
@@ -5639,6 +6014,7 @@ function put_instance_public_ports(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5659,6 +6035,7 @@ function reboot_instance(instanceName; aws_config::AbstractAWSConfig=global_aws_
         "RebootInstance",
         Dict{String,Any}("instanceName" => instanceName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function reboot_instance(
@@ -5672,6 +6049,7 @@ function reboot_instance(
             mergewith(_merge, Dict{String,Any}("instanceName" => instanceName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5694,6 +6072,7 @@ function reboot_relational_database(
         "RebootRelationalDatabase",
         Dict{String,Any}("relationalDatabaseName" => relationalDatabaseName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function reboot_relational_database(
@@ -5711,6 +6090,7 @@ function reboot_relational_database(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5750,6 +6130,7 @@ function register_container_image(
             "digest" => digest, "label" => label, "serviceName" => serviceName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function register_container_image(
@@ -5771,6 +6152,7 @@ function register_container_image(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5789,6 +6171,7 @@ function release_static_ip(staticIpName; aws_config::AbstractAWSConfig=global_aw
         "ReleaseStaticIp",
         Dict{String,Any}("staticIpName" => staticIpName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function release_static_ip(
@@ -5802,6 +6185,7 @@ function release_static_ip(
             mergewith(_merge, Dict{String,Any}("staticIpName" => staticIpName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5819,12 +6203,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   GetDistributions action to get a list of distribution names that you can specify.
 """
 function reset_distribution_cache(; aws_config::AbstractAWSConfig=global_aws_config())
-    return lightsail("ResetDistributionCache"; aws_config=aws_config)
+    return lightsail(
+        "ResetDistributionCache"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function reset_distribution_cache(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return lightsail("ResetDistributionCache", params; aws_config=aws_config)
+    return lightsail(
+        "ResetDistributionCache",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -5853,6 +6244,7 @@ function send_contact_method_verification(
         "SendContactMethodVerification",
         Dict{String,Any}("protocol" => protocol);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function send_contact_method_verification(
@@ -5866,6 +6258,7 @@ function send_contact_method_verification(
             mergewith(_merge, Dict{String,Any}("protocol" => protocol), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5901,6 +6294,7 @@ function set_ip_address_type(
             "resourceType" => resourceType,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function set_ip_address_type(
@@ -5924,6 +6318,7 @@ function set_ip_address_type(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5954,6 +6349,7 @@ function set_resource_access_for_bucket(
             "access" => access, "bucketName" => bucketName, "resourceName" => resourceName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function set_resource_access_for_bucket(
@@ -5977,6 +6373,7 @@ function set_resource_access_for_bucket(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6001,6 +6398,7 @@ function start_instance(instanceName; aws_config::AbstractAWSConfig=global_aws_c
         "StartInstance",
         Dict{String,Any}("instanceName" => instanceName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_instance(
@@ -6014,6 +6412,7 @@ function start_instance(
             mergewith(_merge, Dict{String,Any}("instanceName" => instanceName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6037,6 +6436,7 @@ function start_relational_database(
         "StartRelationalDatabase",
         Dict{String,Any}("relationalDatabaseName" => relationalDatabaseName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_relational_database(
@@ -6054,6 +6454,7 @@ function start_relational_database(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6084,6 +6485,7 @@ function stop_instance(instanceName; aws_config::AbstractAWSConfig=global_aws_co
         "StopInstance",
         Dict{String,Any}("instanceName" => instanceName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function stop_instance(
@@ -6097,6 +6499,7 @@ function stop_instance(
             mergewith(_merge, Dict{String,Any}("instanceName" => instanceName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6124,6 +6527,7 @@ function stop_relational_database(
         "StopRelationalDatabase",
         Dict{String,Any}("relationalDatabaseName" => relationalDatabaseName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function stop_relational_database(
@@ -6141,6 +6545,7 @@ function stop_relational_database(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6169,6 +6574,7 @@ function tag_resource(resourceName, tags; aws_config::AbstractAWSConfig=global_a
         "TagResource",
         Dict{String,Any}("resourceName" => resourceName, "tags" => tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -6187,6 +6593,7 @@ function tag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6215,6 +6622,7 @@ function test_alarm(alarmName, state; aws_config::AbstractAWSConfig=global_aws_c
         "TestAlarm",
         Dict{String,Any}("alarmName" => alarmName, "state" => state);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function test_alarm(
@@ -6231,6 +6639,7 @@ function test_alarm(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6242,12 +6651,14 @@ Unpeers the Lightsail VPC from the user's default VPC.
 
 """
 function unpeer_vpc(; aws_config::AbstractAWSConfig=global_aws_config())
-    return lightsail("UnpeerVpc"; aws_config=aws_config)
+    return lightsail("UnpeerVpc"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function unpeer_vpc(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return lightsail("UnpeerVpc", params; aws_config=aws_config)
+    return lightsail(
+        "UnpeerVpc", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -6275,6 +6686,7 @@ function untag_resource(
         "UntagResource",
         Dict{String,Any}("resourceName" => resourceName, "tagKeys" => tagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -6293,6 +6705,7 @@ function untag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6320,7 +6733,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function update_bucket(bucketName; aws_config::AbstractAWSConfig=global_aws_config())
     return lightsail(
-        "UpdateBucket", Dict{String,Any}("bucketName" => bucketName); aws_config=aws_config
+        "UpdateBucket",
+        Dict{String,Any}("bucketName" => bucketName);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_bucket(
@@ -6334,6 +6750,7 @@ function update_bucket(
             mergewith(_merge, Dict{String,Any}("bucketName" => bucketName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6367,6 +6784,7 @@ function update_bucket_bundle(
         "UpdateBucketBundle",
         Dict{String,Any}("bucketName" => bucketName, "bundleId" => bundleId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_bucket_bundle(
@@ -6385,6 +6803,7 @@ function update_bucket_bundle(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6428,6 +6847,7 @@ function update_container_service(
         "UpdateContainerService",
         Dict{String,Any}("serviceName" => serviceName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_container_service(
@@ -6441,6 +6861,7 @@ function update_container_service(
             mergewith(_merge, Dict{String,Any}("serviceName" => serviceName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6476,6 +6897,7 @@ function update_distribution(
         "UpdateDistribution",
         Dict{String,Any}("distributionName" => distributionName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_distribution(
@@ -6491,6 +6913,7 @@ function update_distribution(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6515,12 +6938,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   the GetDistributions action to get a list of distribution names that you can specify.
 """
 function update_distribution_bundle(; aws_config::AbstractAWSConfig=global_aws_config())
-    return lightsail("UpdateDistributionBundle"; aws_config=aws_config)
+    return lightsail(
+        "UpdateDistributionBundle"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function update_distribution_bundle(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return lightsail("UpdateDistributionBundle", params; aws_config=aws_config)
+    return lightsail(
+        "UpdateDistributionBundle",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -6543,6 +6973,7 @@ function update_domain_entry(
         "UpdateDomainEntry",
         Dict{String,Any}("domainEntry" => domainEntry, "domainName" => domainName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_domain_entry(
@@ -6561,6 +6992,7 @@ function update_domain_entry(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6594,6 +7026,7 @@ function update_load_balancer_attribute(
             "loadBalancerName" => loadBalancerName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_load_balancer_attribute(
@@ -6617,6 +7050,7 @@ function update_load_balancer_attribute(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6677,6 +7111,7 @@ function update_relational_database(
         "UpdateRelationalDatabase",
         Dict{String,Any}("relationalDatabaseName" => relationalDatabaseName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_relational_database(
@@ -6694,6 +7129,7 @@ function update_relational_database(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6725,6 +7161,7 @@ function update_relational_database_parameters(
             "parameters" => parameters, "relationalDatabaseName" => relationalDatabaseName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_relational_database_parameters(
@@ -6746,5 +7183,6 @@ function update_relational_database_parameters(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/location.jl
+++ b/src/services/location.jl
@@ -31,6 +31,7 @@ function associate_tracker_consumer(
         "/tracking/v0/trackers/$(TrackerName)/consumers",
         Dict{String,Any}("ConsumerArn" => ConsumerArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_tracker_consumer(
@@ -46,6 +47,7 @@ function associate_tracker_consumer(
             mergewith(_merge, Dict{String,Any}("ConsumerArn" => ConsumerArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -70,6 +72,7 @@ function batch_delete_device_position_history(
         "/tracking/v0/trackers/$(TrackerName)/delete-positions",
         Dict{String,Any}("DeviceIds" => DeviceIds);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_delete_device_position_history(
@@ -85,6 +88,7 @@ function batch_delete_device_position_history(
             mergewith(_merge, Dict{String,Any}("DeviceIds" => DeviceIds), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -108,6 +112,7 @@ function batch_delete_geofence(
         "/geofencing/v0/collections/$(CollectionName)/delete-geofences",
         Dict{String,Any}("GeofenceIds" => GeofenceIds);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_delete_geofence(
@@ -123,6 +128,7 @@ function batch_delete_geofence(
             mergewith(_merge, Dict{String,Any}("GeofenceIds" => GeofenceIds), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -154,6 +160,7 @@ function batch_evaluate_geofences(
         "/geofencing/v0/collections/$(CollectionName)/positions",
         Dict{String,Any}("DevicePositionUpdates" => DevicePositionUpdates);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_evaluate_geofences(
@@ -173,6 +180,7 @@ function batch_evaluate_geofences(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -196,6 +204,7 @@ function batch_get_device_position(
         "/tracking/v0/trackers/$(TrackerName)/get-positions",
         Dict{String,Any}("DeviceIds" => DeviceIds);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_get_device_position(
@@ -211,6 +220,7 @@ function batch_get_device_position(
             mergewith(_merge, Dict{String,Any}("DeviceIds" => DeviceIds), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -234,6 +244,7 @@ function batch_put_geofence(
         "/geofencing/v0/collections/$(CollectionName)/put-geofences",
         Dict{String,Any}("Entries" => Entries);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_put_geofence(
@@ -247,6 +258,7 @@ function batch_put_geofence(
         "/geofencing/v0/collections/$(CollectionName)/put-geofences",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Entries" => Entries), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -272,6 +284,7 @@ function batch_update_device_position(
         "/tracking/v0/trackers/$(TrackerName)/positions",
         Dict{String,Any}("Updates" => Updates);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_update_device_position(
@@ -285,6 +298,7 @@ function batch_update_device_position(
         "/tracking/v0/trackers/$(TrackerName)/positions",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Updates" => Updates), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -359,6 +373,7 @@ function calculate_route(
             "DestinationPosition" => DestinationPosition,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function calculate_route(
@@ -382,6 +397,7 @@ function calculate_route(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -426,6 +442,7 @@ function create_geofence_collection(
         "/geofencing/v0/collections",
         Dict{String,Any}("CollectionName" => CollectionName, "PricingPlan" => PricingPlan);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_geofence_collection(
@@ -447,6 +464,7 @@ function create_geofence_collection(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -487,6 +505,7 @@ function create_map(
             "PricingPlan" => PricingPlan,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_map(
@@ -511,6 +530,7 @@ function create_map(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -562,6 +582,7 @@ function create_place_index(
             "PricingPlan" => PricingPlan,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_place_index(
@@ -586,6 +607,7 @@ function create_place_index(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -639,6 +661,7 @@ function create_route_calculator(
             "PricingPlan" => PricingPlan,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_route_calculator(
@@ -663,6 +686,7 @@ function create_route_calculator(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -707,6 +731,7 @@ function create_tracker(
         "/tracking/v0/trackers",
         Dict{String,Any}("PricingPlan" => PricingPlan, "TrackerName" => TrackerName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_tracker(
@@ -728,6 +753,7 @@ function create_tracker(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -747,7 +773,10 @@ function delete_geofence_collection(
     CollectionName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return location(
-        "DELETE", "/geofencing/v0/collections/$(CollectionName)"; aws_config=aws_config
+        "DELETE",
+        "/geofencing/v0/collections/$(CollectionName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_geofence_collection(
@@ -760,6 +789,7 @@ function delete_geofence_collection(
         "/geofencing/v0/collections/$(CollectionName)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -775,12 +805,23 @@ permanently. If the map is being used in an application, the map may not render.
 
 """
 function delete_map(MapName; aws_config::AbstractAWSConfig=global_aws_config())
-    return location("DELETE", "/maps/v0/maps/$(MapName)"; aws_config=aws_config)
+    return location(
+        "DELETE",
+        "/maps/v0/maps/$(MapName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_map(
     MapName, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return location("DELETE", "/maps/v0/maps/$(MapName)", params; aws_config=aws_config)
+    return location(
+        "DELETE",
+        "/maps/v0/maps/$(MapName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -795,7 +836,12 @@ permanently.
 
 """
 function delete_place_index(IndexName; aws_config::AbstractAWSConfig=global_aws_config())
-    return location("DELETE", "/places/v0/indexes/$(IndexName)"; aws_config=aws_config)
+    return location(
+        "DELETE",
+        "/places/v0/indexes/$(IndexName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_place_index(
     IndexName,
@@ -803,7 +849,11 @@ function delete_place_index(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return location(
-        "DELETE", "/places/v0/indexes/$(IndexName)", params; aws_config=aws_config
+        "DELETE",
+        "/places/v0/indexes/$(IndexName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -822,7 +872,10 @@ function delete_route_calculator(
     CalculatorName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return location(
-        "DELETE", "/routes/v0/calculators/$(CalculatorName)"; aws_config=aws_config
+        "DELETE",
+        "/routes/v0/calculators/$(CalculatorName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_route_calculator(
@@ -831,7 +884,11 @@ function delete_route_calculator(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return location(
-        "DELETE", "/routes/v0/calculators/$(CalculatorName)", params; aws_config=aws_config
+        "DELETE",
+        "/routes/v0/calculators/$(CalculatorName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -848,7 +905,12 @@ the target resource isn't a dependency for your applications.
 
 """
 function delete_tracker(TrackerName; aws_config::AbstractAWSConfig=global_aws_config())
-    return location("DELETE", "/tracking/v0/trackers/$(TrackerName)"; aws_config=aws_config)
+    return location(
+        "DELETE",
+        "/tracking/v0/trackers/$(TrackerName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_tracker(
     TrackerName,
@@ -856,7 +918,11 @@ function delete_tracker(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return location(
-        "DELETE", "/tracking/v0/trackers/$(TrackerName)", params; aws_config=aws_config
+        "DELETE",
+        "/tracking/v0/trackers/$(TrackerName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -874,7 +940,10 @@ function describe_geofence_collection(
     CollectionName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return location(
-        "GET", "/geofencing/v0/collections/$(CollectionName)"; aws_config=aws_config
+        "GET",
+        "/geofencing/v0/collections/$(CollectionName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_geofence_collection(
@@ -883,7 +952,11 @@ function describe_geofence_collection(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return location(
-        "GET", "/geofencing/v0/collections/$(CollectionName)", params; aws_config=aws_config
+        "GET",
+        "/geofencing/v0/collections/$(CollectionName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -898,12 +971,23 @@ Retrieves the map resource details.
 
 """
 function describe_map(MapName; aws_config::AbstractAWSConfig=global_aws_config())
-    return location("GET", "/maps/v0/maps/$(MapName)"; aws_config=aws_config)
+    return location(
+        "GET",
+        "/maps/v0/maps/$(MapName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_map(
     MapName, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return location("GET", "/maps/v0/maps/$(MapName)", params; aws_config=aws_config)
+    return location(
+        "GET",
+        "/maps/v0/maps/$(MapName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -917,14 +1001,25 @@ Retrieves the place index resource details.
 
 """
 function describe_place_index(IndexName; aws_config::AbstractAWSConfig=global_aws_config())
-    return location("GET", "/places/v0/indexes/$(IndexName)"; aws_config=aws_config)
+    return location(
+        "GET",
+        "/places/v0/indexes/$(IndexName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_place_index(
     IndexName,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return location("GET", "/places/v0/indexes/$(IndexName)", params; aws_config=aws_config)
+    return location(
+        "GET",
+        "/places/v0/indexes/$(IndexName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -941,7 +1036,10 @@ function describe_route_calculator(
     CalculatorName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return location(
-        "GET", "/routes/v0/calculators/$(CalculatorName)"; aws_config=aws_config
+        "GET",
+        "/routes/v0/calculators/$(CalculatorName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_route_calculator(
@@ -950,7 +1048,11 @@ function describe_route_calculator(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return location(
-        "GET", "/routes/v0/calculators/$(CalculatorName)", params; aws_config=aws_config
+        "GET",
+        "/routes/v0/calculators/$(CalculatorName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -965,7 +1067,12 @@ Retrieves the tracker resource details.
 
 """
 function describe_tracker(TrackerName; aws_config::AbstractAWSConfig=global_aws_config())
-    return location("GET", "/tracking/v0/trackers/$(TrackerName)"; aws_config=aws_config)
+    return location(
+        "GET",
+        "/tracking/v0/trackers/$(TrackerName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_tracker(
     TrackerName,
@@ -973,7 +1080,11 @@ function describe_tracker(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return location(
-        "GET", "/tracking/v0/trackers/$(TrackerName)", params; aws_config=aws_config
+        "GET",
+        "/tracking/v0/trackers/$(TrackerName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1000,6 +1111,7 @@ function disassociate_tracker_consumer(
         "DELETE",
         "/tracking/v0/trackers/$(TrackerName)/consumers/$(ConsumerArn)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disassociate_tracker_consumer(
@@ -1013,6 +1125,7 @@ function disassociate_tracker_consumer(
         "/tracking/v0/trackers/$(TrackerName)/consumers/$(ConsumerArn)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1035,6 +1148,7 @@ function get_device_position(
         "GET",
         "/tracking/v0/trackers/$(TrackerName)/devices/$(DeviceId)/positions/latest";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_device_position(
@@ -1048,6 +1162,7 @@ function get_device_position(
         "/tracking/v0/trackers/$(TrackerName)/devices/$(DeviceId)/positions/latest",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1083,6 +1198,7 @@ function get_device_position_history(
         "POST",
         "/tracking/v0/trackers/$(TrackerName)/devices/$(DeviceId)/list-positions";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_device_position_history(
@@ -1096,6 +1212,7 @@ function get_device_position_history(
         "/tracking/v0/trackers/$(TrackerName)/devices/$(DeviceId)/list-positions",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1117,6 +1234,7 @@ function get_geofence(
         "GET",
         "/geofencing/v0/collections/$(CollectionName)/geofences/$(GeofenceId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_geofence(
@@ -1130,6 +1248,7 @@ function get_geofence(
         "/geofencing/v0/collections/$(CollectionName)/geofences/$(GeofenceId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1162,6 +1281,7 @@ function get_map_glyphs(
         "GET",
         "/maps/v0/maps/$(MapName)/glyphs/$(FontStack)/$(FontUnicodeRange)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_map_glyphs(
@@ -1176,6 +1296,7 @@ function get_map_glyphs(
         "/maps/v0/maps/$(MapName)/glyphs/$(FontStack)/$(FontUnicodeRange)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1199,7 +1320,10 @@ function get_map_sprites(
     FileName, MapName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return location(
-        "GET", "/maps/v0/maps/$(MapName)/sprites/$(FileName)"; aws_config=aws_config
+        "GET",
+        "/maps/v0/maps/$(MapName)/sprites/$(FileName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_map_sprites(
@@ -1209,7 +1333,11 @@ function get_map_sprites(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return location(
-        "GET", "/maps/v0/maps/$(MapName)/sprites/$(FileName)", params; aws_config=aws_config
+        "GET",
+        "/maps/v0/maps/$(MapName)/sprites/$(FileName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1230,14 +1358,21 @@ function get_map_style_descriptor(
     MapName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return location(
-        "GET", "/maps/v0/maps/$(MapName)/style-descriptor"; aws_config=aws_config
+        "GET",
+        "/maps/v0/maps/$(MapName)/style-descriptor";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_map_style_descriptor(
     MapName, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return location(
-        "GET", "/maps/v0/maps/$(MapName)/style-descriptor", params; aws_config=aws_config
+        "GET",
+        "/maps/v0/maps/$(MapName)/style-descriptor",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1260,7 +1395,10 @@ doubles both the X and Y dimensions, so a tile containing data for the entire wo
 """
 function get_map_tile(MapName, X, Y, Z; aws_config::AbstractAWSConfig=global_aws_config())
     return location(
-        "GET", "/maps/v0/maps/$(MapName)/tiles/$(Z)/$(X)/$(Y)"; aws_config=aws_config
+        "GET",
+        "/maps/v0/maps/$(MapName)/tiles/$(Z)/$(X)/$(Y)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_map_tile(
@@ -1276,6 +1414,7 @@ function get_map_tile(
         "/maps/v0/maps/$(MapName)/tiles/$(Z)/$(X)/$(Y)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1299,7 +1438,10 @@ function list_device_positions(
     TrackerName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return location(
-        "POST", "/tracking/v0/trackers/$(TrackerName)/list-positions"; aws_config=aws_config
+        "POST",
+        "/tracking/v0/trackers/$(TrackerName)/list-positions";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_device_positions(
@@ -1312,6 +1454,7 @@ function list_device_positions(
         "/tracking/v0/trackers/$(TrackerName)/list-positions",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1329,13 +1472,22 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   response. If no token is provided, the default page is the first page.  Default value: null
 """
 function list_geofence_collections(; aws_config::AbstractAWSConfig=global_aws_config())
-    return location("POST", "/geofencing/v0/list-collections"; aws_config=aws_config)
+    return location(
+        "POST",
+        "/geofencing/v0/list-collections";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_geofence_collections(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return location(
-        "POST", "/geofencing/v0/list-collections", params; aws_config=aws_config
+        "POST",
+        "/geofencing/v0/list-collections",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1358,6 +1510,7 @@ function list_geofences(CollectionName; aws_config::AbstractAWSConfig=global_aws
         "POST",
         "/geofencing/v0/collections/$(CollectionName)/list-geofences";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_geofences(
@@ -1370,6 +1523,7 @@ function list_geofences(
         "/geofencing/v0/collections/$(CollectionName)/list-geofences",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1387,12 +1541,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   response. If no token is provided, the default page is the first page. Default value: null
 """
 function list_maps(; aws_config::AbstractAWSConfig=global_aws_config())
-    return location("POST", "/maps/v0/list-maps"; aws_config=aws_config)
+    return location(
+        "POST", "/maps/v0/list-maps"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_maps(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return location("POST", "/maps/v0/list-maps", params; aws_config=aws_config)
+    return location(
+        "POST",
+        "/maps/v0/list-maps",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1409,12 +1571,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   response. If no token is provided, the default page is the first page. Default value: null
 """
 function list_place_indexes(; aws_config::AbstractAWSConfig=global_aws_config())
-    return location("POST", "/places/v0/list-indexes"; aws_config=aws_config)
+    return location(
+        "POST",
+        "/places/v0/list-indexes";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_place_indexes(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return location("POST", "/places/v0/list-indexes", params; aws_config=aws_config)
+    return location(
+        "POST",
+        "/places/v0/list-indexes",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1431,12 +1604,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   response. If no token is provided, the default page is the first page. Default Value: null
 """
 function list_route_calculators(; aws_config::AbstractAWSConfig=global_aws_config())
-    return location("POST", "/routes/v0/list-calculators"; aws_config=aws_config)
+    return location(
+        "POST",
+        "/routes/v0/list-calculators";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_route_calculators(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return location("POST", "/routes/v0/list-calculators", params; aws_config=aws_config)
+    return location(
+        "POST",
+        "/routes/v0/list-calculators",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1453,14 +1637,25 @@ Returns a list of tags that are applied to the specified Amazon Location resourc
 function list_tags_for_resource(
     ResourceArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return location("GET", "/tags/$(ResourceArn)"; aws_config=aws_config)
+    return location(
+        "GET",
+        "/tags/$(ResourceArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_tags_for_resource(
     ResourceArn,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return location("GET", "/tags/$(ResourceArn)", params; aws_config=aws_config)
+    return location(
+        "GET",
+        "/tags/$(ResourceArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1484,7 +1679,10 @@ function list_tracker_consumers(
     TrackerName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return location(
-        "POST", "/tracking/v0/trackers/$(TrackerName)/list-consumers"; aws_config=aws_config
+        "POST",
+        "/tracking/v0/trackers/$(TrackerName)/list-consumers";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tracker_consumers(
@@ -1497,6 +1695,7 @@ function list_tracker_consumers(
         "/tracking/v0/trackers/$(TrackerName)/list-consumers",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1514,12 +1713,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   response. If no token is provided, the default page is the first page.  Default value: null
 """
 function list_trackers(; aws_config::AbstractAWSConfig=global_aws_config())
-    return location("POST", "/tracking/v0/list-trackers"; aws_config=aws_config)
+    return location(
+        "POST",
+        "/tracking/v0/list-trackers";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_trackers(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return location("POST", "/tracking/v0/list-trackers", params; aws_config=aws_config)
+    return location(
+        "POST",
+        "/tracking/v0/list-trackers",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1544,6 +1754,7 @@ function put_geofence(
         "/geofencing/v0/collections/$(CollectionName)/geofences/$(GeofenceId)",
         Dict{String,Any}("Geometry" => Geometry);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_geofence(
@@ -1560,6 +1771,7 @@ function put_geofence(
             mergewith(_merge, Dict{String,Any}("Geometry" => Geometry), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1589,6 +1801,7 @@ function search_place_index_for_position(
         "/places/v0/indexes/$(IndexName)/search/position",
         Dict{String,Any}("Position" => Position);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function search_place_index_for_position(
@@ -1604,6 +1817,7 @@ function search_place_index_for_position(
             mergewith(_merge, Dict{String,Any}("Position" => Position), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1651,6 +1865,7 @@ function search_place_index_for_text(
         "/places/v0/indexes/$(IndexName)/search/text",
         Dict{String,Any}("Text" => Text);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function search_place_index_for_text(
@@ -1664,6 +1879,7 @@ function search_place_index_for_text(
         "/places/v0/indexes/$(IndexName)/search/text",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Text" => Text), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1696,6 +1912,7 @@ function tag_resource(ResourceArn, Tags; aws_config::AbstractAWSConfig=global_aw
         "/tags/$(ResourceArn)",
         Dict{String,Any}("Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -1709,6 +1926,7 @@ function tag_resource(
         "/tags/$(ResourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Tags" => Tags), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1732,6 +1950,7 @@ function untag_resource(
         "/tags/$(ResourceArn)",
         Dict{String,Any}("tagKeys" => tagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -1745,6 +1964,7 @@ function untag_resource(
         "/tags/$(ResourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tagKeys" => tagKeys), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1775,7 +1995,10 @@ function update_geofence_collection(
     CollectionName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return location(
-        "PATCH", "/geofencing/v0/collections/$(CollectionName)"; aws_config=aws_config
+        "PATCH",
+        "/geofencing/v0/collections/$(CollectionName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_geofence_collection(
@@ -1788,6 +2011,7 @@ function update_geofence_collection(
         "/geofencing/v0/collections/$(CollectionName)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1807,12 +2031,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   about each pricing plan option restrictions, see Amazon Location Service pricing.
 """
 function update_map(MapName; aws_config::AbstractAWSConfig=global_aws_config())
-    return location("PATCH", "/maps/v0/maps/$(MapName)"; aws_config=aws_config)
+    return location(
+        "PATCH",
+        "/maps/v0/maps/$(MapName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function update_map(
     MapName, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return location("PATCH", "/maps/v0/maps/$(MapName)", params; aws_config=aws_config)
+    return location(
+        "PATCH",
+        "/maps/v0/maps/$(MapName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1833,7 +2068,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   pricing.
 """
 function update_place_index(IndexName; aws_config::AbstractAWSConfig=global_aws_config())
-    return location("PATCH", "/places/v0/indexes/$(IndexName)"; aws_config=aws_config)
+    return location(
+        "PATCH",
+        "/places/v0/indexes/$(IndexName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function update_place_index(
     IndexName,
@@ -1841,7 +2081,11 @@ function update_place_index(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return location(
-        "PATCH", "/places/v0/indexes/$(IndexName)", params; aws_config=aws_config
+        "PATCH",
+        "/places/v0/indexes/$(IndexName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1865,7 +2109,10 @@ function update_route_calculator(
     CalculatorName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return location(
-        "PATCH", "/routes/v0/calculators/$(CalculatorName)"; aws_config=aws_config
+        "PATCH",
+        "/routes/v0/calculators/$(CalculatorName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_route_calculator(
@@ -1874,7 +2121,11 @@ function update_route_calculator(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return location(
-        "PATCH", "/routes/v0/calculators/$(CalculatorName)", params; aws_config=aws_config
+        "PATCH",
+        "/routes/v0/calculators/$(CalculatorName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1901,7 +2152,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   AWS account and Region unless you move it.
 """
 function update_tracker(TrackerName; aws_config::AbstractAWSConfig=global_aws_config())
-    return location("PATCH", "/tracking/v0/trackers/$(TrackerName)"; aws_config=aws_config)
+    return location(
+        "PATCH",
+        "/tracking/v0/trackers/$(TrackerName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function update_tracker(
     TrackerName,
@@ -1909,6 +2165,10 @@ function update_tracker(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return location(
-        "PATCH", "/tracking/v0/trackers/$(TrackerName)", params; aws_config=aws_config
+        "PATCH",
+        "/tracking/v0/trackers/$(TrackerName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/lookoutequipment.jl
+++ b/src/services/lookoutequipment.jl
@@ -40,6 +40,7 @@ function create_dataset(
             "DatasetSchema" => DatasetSchema,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_dataset(
@@ -63,6 +64,7 @@ function create_dataset(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -130,6 +132,7 @@ function create_inference_scheduler(
             "RoleArn" => RoleArn,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_inference_scheduler(
@@ -161,6 +164,7 @@ function create_inference_scheduler(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -223,6 +227,7 @@ function create_model(
             "ModelName" => ModelName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_model(
@@ -246,6 +251,7 @@ function create_model(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -268,6 +274,7 @@ function delete_dataset(DatasetName; aws_config::AbstractAWSConfig=global_aws_co
         "DeleteDataset",
         Dict{String,Any}("DatasetName" => DatasetName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_dataset(
@@ -281,6 +288,7 @@ function delete_dataset(
             mergewith(_merge, Dict{String,Any}("DatasetName" => DatasetName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -302,6 +310,7 @@ function delete_inference_scheduler(
         "DeleteInferenceScheduler",
         Dict{String,Any}("InferenceSchedulerName" => InferenceSchedulerName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_inference_scheduler(
@@ -319,6 +328,7 @@ function delete_inference_scheduler(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -335,7 +345,10 @@ it from being used with an inference scheduler, even one that is already set up.
 """
 function delete_model(ModelName; aws_config::AbstractAWSConfig=global_aws_config())
     return lookoutequipment(
-        "DeleteModel", Dict{String,Any}("ModelName" => ModelName); aws_config=aws_config
+        "DeleteModel",
+        Dict{String,Any}("ModelName" => ModelName);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_model(
@@ -349,6 +362,7 @@ function delete_model(
             mergewith(_merge, Dict{String,Any}("ModelName" => ModelName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -370,6 +384,7 @@ function describe_data_ingestion_job(
         "DescribeDataIngestionJob",
         Dict{String,Any}("JobId" => JobId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_data_ingestion_job(
@@ -379,6 +394,7 @@ function describe_data_ingestion_job(
         "DescribeDataIngestionJob",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("JobId" => JobId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -398,6 +414,7 @@ function describe_dataset(DatasetName; aws_config::AbstractAWSConfig=global_aws_
         "DescribeDataset",
         Dict{String,Any}("DatasetName" => DatasetName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_dataset(
@@ -411,6 +428,7 @@ function describe_dataset(
             mergewith(_merge, Dict{String,Any}("DatasetName" => DatasetName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -432,6 +450,7 @@ function describe_inference_scheduler(
         "DescribeInferenceScheduler",
         Dict{String,Any}("InferenceSchedulerName" => InferenceSchedulerName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_inference_scheduler(
@@ -449,6 +468,7 @@ function describe_inference_scheduler(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -465,7 +485,10 @@ model name and ARN, dataset, training and evaluation information, status, and so
 """
 function describe_model(ModelName; aws_config::AbstractAWSConfig=global_aws_config())
     return lookoutequipment(
-        "DescribeModel", Dict{String,Any}("ModelName" => ModelName); aws_config=aws_config
+        "DescribeModel",
+        Dict{String,Any}("ModelName" => ModelName);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_model(
@@ -479,6 +502,7 @@ function describe_model(
             mergewith(_merge, Dict{String,Any}("ModelName" => ModelName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -498,12 +522,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"Status"`: Indicates the status of the data ingestion job.
 """
 function list_data_ingestion_jobs(; aws_config::AbstractAWSConfig=global_aws_config())
-    return lookoutequipment("ListDataIngestionJobs"; aws_config=aws_config)
+    return lookoutequipment(
+        "ListDataIngestionJobs"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_data_ingestion_jobs(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return lookoutequipment("ListDataIngestionJobs", params; aws_config=aws_config)
+    return lookoutequipment(
+        "ListDataIngestionJobs",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -520,12 +551,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   datasets.
 """
 function list_datasets(; aws_config::AbstractAWSConfig=global_aws_config())
-    return lookoutequipment("ListDatasets"; aws_config=aws_config)
+    return lookoutequipment(
+        "ListDatasets"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_datasets(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return lookoutequipment("ListDatasets", params; aws_config=aws_config)
+    return lookoutequipment(
+        "ListDatasets", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -557,6 +592,7 @@ function list_inference_executions(
         "ListInferenceExecutions",
         Dict{String,Any}("InferenceSchedulerName" => InferenceSchedulerName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_inference_executions(
@@ -574,6 +610,7 @@ function list_inference_executions(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -593,12 +630,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   inference schedulers.
 """
 function list_inference_schedulers(; aws_config::AbstractAWSConfig=global_aws_config())
-    return lookoutequipment("ListInferenceSchedulers"; aws_config=aws_config)
+    return lookoutequipment(
+        "ListInferenceSchedulers"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_inference_schedulers(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return lookoutequipment("ListInferenceSchedulers", params; aws_config=aws_config)
+    return lookoutequipment(
+        "ListInferenceSchedulers",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -619,12 +663,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"Status"`: The status of the ML model.
 """
 function list_models(; aws_config::AbstractAWSConfig=global_aws_config())
-    return lookoutequipment("ListModels"; aws_config=aws_config)
+    return lookoutequipment(
+        "ListModels"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_models(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return lookoutequipment("ListModels", params; aws_config=aws_config)
+    return lookoutequipment(
+        "ListModels", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -645,6 +693,7 @@ function list_tags_for_resource(
         "ListTagsForResource",
         Dict{String,Any}("ResourceArn" => ResourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags_for_resource(
@@ -658,6 +707,7 @@ function list_tags_for_resource(
             mergewith(_merge, Dict{String,Any}("ResourceArn" => ResourceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -693,6 +743,7 @@ function start_data_ingestion_job(
             "RoleArn" => RoleArn,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_data_ingestion_job(
@@ -718,6 +769,7 @@ function start_data_ingestion_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -738,6 +790,7 @@ function start_inference_scheduler(
         "StartInferenceScheduler",
         Dict{String,Any}("InferenceSchedulerName" => InferenceSchedulerName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_inference_scheduler(
@@ -755,6 +808,7 @@ function start_inference_scheduler(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -775,6 +829,7 @@ function stop_inference_scheduler(
         "StopInferenceScheduler",
         Dict{String,Any}("InferenceSchedulerName" => InferenceSchedulerName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function stop_inference_scheduler(
@@ -792,6 +847,7 @@ function stop_inference_scheduler(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -817,6 +873,7 @@ function tag_resource(ResourceArn, Tags; aws_config::AbstractAWSConfig=global_aw
         "TagResource",
         Dict{String,Any}("ResourceArn" => ResourceArn, "Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -835,6 +892,7 @@ function tag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -857,6 +915,7 @@ function untag_resource(
         "UntagResource",
         Dict{String,Any}("ResourceArn" => ResourceArn, "TagKeys" => TagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -875,6 +934,7 @@ function untag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -916,6 +976,7 @@ function update_inference_scheduler(
         "UpdateInferenceScheduler",
         Dict{String,Any}("InferenceSchedulerName" => InferenceSchedulerName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_inference_scheduler(
@@ -933,5 +994,6 @@ function update_inference_scheduler(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/lookoutmetrics.jl
+++ b/src/services/lookoutmetrics.jl
@@ -22,6 +22,7 @@ function activate_anomaly_detector(
         "/ActivateAnomalyDetector",
         Dict{String,Any}("AnomalyDetectorArn" => AnomalyDetectorArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function activate_anomaly_detector(
@@ -38,6 +39,7 @@ function activate_anomaly_detector(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -59,6 +61,7 @@ function back_test_anomaly_detector(
         "/BackTestAnomalyDetector",
         Dict{String,Any}("AnomalyDetectorArn" => AnomalyDetectorArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function back_test_anomaly_detector(
@@ -75,6 +78,7 @@ function back_test_anomaly_detector(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -113,6 +117,7 @@ function create_alert(
             "AnomalyDetectorArn" => AnomalyDetectorArn,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_alert(
@@ -139,6 +144,7 @@ function create_alert(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -172,6 +178,7 @@ function create_anomaly_detector(
             "AnomalyDetectorName" => AnomalyDetectorName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_anomaly_detector(
@@ -194,6 +201,7 @@ function create_anomaly_detector(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -239,6 +247,7 @@ function create_metric_set(
             "MetricSource" => MetricSource,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_metric_set(
@@ -265,6 +274,7 @@ function create_metric_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -284,6 +294,7 @@ function delete_alert(AlertArn; aws_config::AbstractAWSConfig=global_aws_config(
         "/DeleteAlert",
         Dict{String,Any}("AlertArn" => AlertArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_alert(
@@ -298,6 +309,7 @@ function delete_alert(
             mergewith(_merge, Dict{String,Any}("AlertArn" => AlertArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -320,6 +332,7 @@ function delete_anomaly_detector(
         "/DeleteAnomalyDetector",
         Dict{String,Any}("AnomalyDetectorArn" => AnomalyDetectorArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_anomaly_detector(
@@ -336,6 +349,7 @@ function delete_anomaly_detector(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -357,6 +371,7 @@ function describe_alert(AlertArn; aws_config::AbstractAWSConfig=global_aws_confi
         "/DescribeAlert",
         Dict{String,Any}("AlertArn" => AlertArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_alert(
@@ -371,6 +386,7 @@ function describe_alert(
             mergewith(_merge, Dict{String,Any}("AlertArn" => AlertArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -398,6 +414,7 @@ function describe_anomaly_detection_executions(
         "/DescribeAnomalyDetectionExecutions",
         Dict{String,Any}("AnomalyDetectorArn" => AnomalyDetectorArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_anomaly_detection_executions(
@@ -414,6 +431,7 @@ function describe_anomaly_detection_executions(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -437,6 +455,7 @@ function describe_anomaly_detector(
         "/DescribeAnomalyDetector",
         Dict{String,Any}("AnomalyDetectorArn" => AnomalyDetectorArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_anomaly_detector(
@@ -453,6 +472,7 @@ function describe_anomaly_detector(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -476,6 +496,7 @@ function describe_metric_set(
         "/DescribeMetricSet",
         Dict{String,Any}("MetricSetArn" => MetricSetArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_metric_set(
@@ -490,6 +511,7 @@ function describe_metric_set(
             mergewith(_merge, Dict{String,Any}("MetricSetArn" => MetricSetArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -514,6 +536,7 @@ function get_anomaly_group(
             "AnomalyDetectorArn" => AnomalyDetectorArn, "AnomalyGroupId" => AnomalyGroupId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_anomaly_group(
@@ -536,6 +559,7 @@ function get_anomaly_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -568,6 +592,7 @@ function get_feedback(
             "AnomalyGroupTimeSeriesFeedback" => AnomalyGroupTimeSeriesFeedback,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_feedback(
@@ -590,6 +615,7 @@ function get_feedback(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -604,12 +630,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"S3SourceConfig"`: A datasource bucket in Amazon S3.
 """
 function get_sample_data(; aws_config::AbstractAWSConfig=global_aws_config())
-    return lookoutmetrics("POST", "/GetSampleData"; aws_config=aws_config)
+    return lookoutmetrics(
+        "POST", "/GetSampleData"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_sample_data(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return lookoutmetrics("POST", "/GetSampleData", params; aws_config=aws_config)
+    return lookoutmetrics(
+        "POST",
+        "/GetSampleData",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -629,12 +663,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   expire after 24 hours.
 """
 function list_alerts(; aws_config::AbstractAWSConfig=global_aws_config())
-    return lookoutmetrics("POST", "/ListAlerts"; aws_config=aws_config)
+    return lookoutmetrics(
+        "POST", "/ListAlerts"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_alerts(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return lookoutmetrics("POST", "/ListAlerts", params; aws_config=aws_config)
+    return lookoutmetrics(
+        "POST",
+        "/ListAlerts",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -653,12 +695,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   expire after 24 hours.
 """
 function list_anomaly_detectors(; aws_config::AbstractAWSConfig=global_aws_config())
-    return lookoutmetrics("POST", "/ListAnomalyDetectors"; aws_config=aws_config)
+    return lookoutmetrics(
+        "POST",
+        "/ListAnomalyDetectors";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_anomaly_detectors(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return lookoutmetrics("POST", "/ListAnomalyDetectors", params; aws_config=aws_config)
+    return lookoutmetrics(
+        "POST",
+        "/ListAnomalyDetectors",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -690,6 +743,7 @@ function list_anomaly_group_summaries(
             "SensitivityThreshold" => SensitivityThreshold,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_anomaly_group_summaries(
@@ -712,6 +766,7 @@ function list_anomaly_group_summaries(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -747,6 +802,7 @@ function list_anomaly_group_time_series(
             "MetricName" => MetricName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_anomaly_group_time_series(
@@ -771,6 +827,7 @@ function list_anomaly_group_time_series(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -792,12 +849,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   expire after 24 hours.
 """
 function list_metric_sets(; aws_config::AbstractAWSConfig=global_aws_config())
-    return lookoutmetrics("POST", "/ListMetricSets"; aws_config=aws_config)
+    return lookoutmetrics(
+        "POST", "/ListMetricSets"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_metric_sets(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return lookoutmetrics("POST", "/ListMetricSets", params; aws_config=aws_config)
+    return lookoutmetrics(
+        "POST",
+        "/ListMetricSets",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -813,14 +878,25 @@ Gets a list of tags for a detector, dataset, or alert.
 function list_tags_for_resource(
     resourceArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return lookoutmetrics("GET", "/tags/$(resourceArn)"; aws_config=aws_config)
+    return lookoutmetrics(
+        "GET",
+        "/tags/$(resourceArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_tags_for_resource(
     resourceArn,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return lookoutmetrics("GET", "/tags/$(resourceArn)", params; aws_config=aws_config)
+    return lookoutmetrics(
+        "GET",
+        "/tags/$(resourceArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -847,6 +923,7 @@ function put_feedback(
             "AnomalyGroupTimeSeriesFeedback" => AnomalyGroupTimeSeriesFeedback,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_feedback(
@@ -869,6 +946,7 @@ function put_feedback(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -890,6 +968,7 @@ function tag_resource(resourceArn, tags; aws_config::AbstractAWSConfig=global_aw
         "/tags/$(resourceArn)",
         Dict{String,Any}("tags" => tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -903,6 +982,7 @@ function tag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tags" => tags), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -925,6 +1005,7 @@ function untag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}("tagKeys" => tagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -938,6 +1019,7 @@ function untag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tagKeys" => tagKeys), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -966,6 +1048,7 @@ function update_anomaly_detector(
         "/UpdateAnomalyDetector",
         Dict{String,Any}("AnomalyDetectorArn" => AnomalyDetectorArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_anomaly_detector(
@@ -982,6 +1065,7 @@ function update_anomaly_detector(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1011,6 +1095,7 @@ function update_metric_set(MetricSetArn; aws_config::AbstractAWSConfig=global_aw
         "/UpdateMetricSet",
         Dict{String,Any}("MetricSetArn" => MetricSetArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_metric_set(
@@ -1025,5 +1110,6 @@ function update_metric_set(
             mergewith(_merge, Dict{String,Any}("MetricSetArn" => MetricSetArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/lookoutvision.jl
+++ b/src/services/lookoutvision.jl
@@ -48,6 +48,7 @@ function create_dataset(
             "DatasetType" => DatasetType, "X-Amzn-Client-Token" => string(uuid4())
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_dataset(
@@ -69,6 +70,7 @@ function create_dataset(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -117,6 +119,7 @@ function create_model(
             "OutputConfig" => OutputConfig, "X-Amzn-Client-Token" => string(uuid4())
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_model(
@@ -138,6 +141,7 @@ function create_model(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -170,6 +174,7 @@ function create_project(ProjectName; aws_config::AbstractAWSConfig=global_aws_co
             "ProjectName" => ProjectName, "X-Amzn-Client-Token" => string(uuid4())
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_project(
@@ -190,6 +195,7 @@ function create_project(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -230,6 +236,7 @@ function delete_dataset(
         "/2020-11-20/projects/$(projectName)/datasets/$(datasetType)",
         Dict{String,Any}("X-Amzn-Client-Token" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_dataset(
@@ -247,6 +254,7 @@ function delete_dataset(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -282,6 +290,7 @@ function delete_model(
         "/2020-11-20/projects/$(projectName)/models/$(modelVersion)",
         Dict{String,Any}("X-Amzn-Client-Token" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_model(
@@ -299,6 +308,7 @@ function delete_model(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -332,6 +342,7 @@ function delete_project(projectName; aws_config::AbstractAWSConfig=global_aws_co
         "/2020-11-20/projects/$(projectName)",
         Dict{String,Any}("X-Amzn-Client-Token" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_project(
@@ -348,6 +359,7 @@ function delete_project(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -373,6 +385,7 @@ function describe_dataset(
         "GET",
         "/2020-11-20/projects/$(projectName)/datasets/$(datasetType)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_dataset(
@@ -386,6 +399,7 @@ function describe_dataset(
         "/2020-11-20/projects/$(projectName)/datasets/$(datasetType)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -409,6 +423,7 @@ function describe_model(
         "GET",
         "/2020-11-20/projects/$(projectName)/models/$(modelVersion)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_model(
@@ -422,6 +437,7 @@ function describe_model(
         "/2020-11-20/projects/$(projectName)/models/$(modelVersion)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -438,7 +454,10 @@ perform the lookoutvision:DescribeProject operation.
 """
 function describe_project(projectName; aws_config::AbstractAWSConfig=global_aws_config())
     return lookoutvision(
-        "GET", "/2020-11-20/projects/$(projectName)"; aws_config=aws_config
+        "GET",
+        "/2020-11-20/projects/$(projectName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_project(
@@ -447,7 +466,11 @@ function describe_project(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return lookoutvision(
-        "GET", "/2020-11-20/projects/$(projectName)", params; aws_config=aws_config
+        "GET",
+        "/2020-11-20/projects/$(projectName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -486,6 +509,7 @@ function detect_anomalies(
             "Body" => Body, "headers" => Dict{String,Any}("Content-Type" => Content_Type)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function detect_anomalies(
@@ -510,6 +534,7 @@ function detect_anomalies(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -556,6 +581,7 @@ function list_dataset_entries(
         "GET",
         "/2020-11-20/projects/$(projectName)/datasets/$(datasetType)/entries";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_dataset_entries(
@@ -569,6 +595,7 @@ function list_dataset_entries(
         "/2020-11-20/projects/$(projectName)/datasets/$(datasetType)/entries",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -594,7 +621,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function list_models(projectName; aws_config::AbstractAWSConfig=global_aws_config())
     return lookoutvision(
-        "GET", "/2020-11-20/projects/$(projectName)/models"; aws_config=aws_config
+        "GET",
+        "/2020-11-20/projects/$(projectName)/models";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_models(
@@ -603,7 +633,11 @@ function list_models(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return lookoutvision(
-        "GET", "/2020-11-20/projects/$(projectName)/models", params; aws_config=aws_config
+        "GET",
+        "/2020-11-20/projects/$(projectName)/models",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -624,12 +658,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   use this pagination token to retrieve the next set of projects.
 """
 function list_projects(; aws_config::AbstractAWSConfig=global_aws_config())
-    return lookoutvision("GET", "/2020-11-20/projects"; aws_config=aws_config)
+    return lookoutvision(
+        "GET",
+        "/2020-11-20/projects";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_projects(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return lookoutvision("GET", "/2020-11-20/projects", params; aws_config=aws_config)
+    return lookoutvision(
+        "GET",
+        "/2020-11-20/projects",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -647,7 +692,12 @@ operation requires permissions to perform the lookoutvision:ListTagsForResource 
 function list_tags_for_resource(
     resourceArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return lookoutvision("GET", "/2020-11-20/tags/$(resourceArn)"; aws_config=aws_config)
+    return lookoutvision(
+        "GET",
+        "/2020-11-20/tags/$(resourceArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_tags_for_resource(
     resourceArn,
@@ -655,7 +705,11 @@ function list_tags_for_resource(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return lookoutvision(
-        "GET", "/2020-11-20/tags/$(resourceArn)", params; aws_config=aws_config
+        "GET",
+        "/2020-11-20/tags/$(resourceArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -702,6 +756,7 @@ function start_model(
             "X-Amzn-Client-Token" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_model(
@@ -725,6 +780,7 @@ function start_model(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -759,6 +815,7 @@ function stop_model(
         "/2020-11-20/projects/$(projectName)/models/$(modelVersion)/stop",
         Dict{String,Any}("X-Amzn-Client-Token" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function stop_model(
@@ -776,6 +833,7 @@ function stop_model(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -798,6 +856,7 @@ function tag_resource(Tags, resourceArn; aws_config::AbstractAWSConfig=global_aw
         "/2020-11-20/tags/$(resourceArn)",
         Dict{String,Any}("Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -811,6 +870,7 @@ function tag_resource(
         "/2020-11-20/tags/$(resourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Tags" => Tags), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -836,6 +896,7 @@ function untag_resource(
         "/2020-11-20/tags/$(resourceArn)",
         Dict{String,Any}("tagKeys" => tagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -849,6 +910,7 @@ function untag_resource(
         "/2020-11-20/tags/$(resourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tagKeys" => tagKeys), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -887,6 +949,7 @@ function update_dataset_entries(
         "/2020-11-20/projects/$(projectName)/datasets/$(datasetType)/entries",
         Dict{String,Any}("Changes" => Changes, "X-Amzn-Client-Token" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_dataset_entries(
@@ -909,5 +972,6 @@ function update_dataset_entries(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/machine_learning.jl
+++ b/src/services/machine_learning.jl
@@ -28,6 +28,7 @@ function add_tags(
             "ResourceId" => ResourceId, "ResourceType" => ResourceType, "Tags" => Tags
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function add_tags(
@@ -51,6 +52,7 @@ function add_tags(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -101,6 +103,7 @@ function create_batch_prediction(
             "OutputUri" => OutputUri,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_batch_prediction(
@@ -126,6 +129,7 @@ function create_batch_prediction(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -188,6 +192,7 @@ function create_data_source_from_rds(
             "DataSourceId" => DataSourceId, "RDSData" => RDSData, "RoleARN" => RoleARN
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_data_source_from_rds(
@@ -211,6 +216,7 @@ function create_data_source_from_rds(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -278,6 +284,7 @@ function create_data_source_from_redshift(
             "DataSourceId" => DataSourceId, "DataSpec" => DataSpec, "RoleARN" => RoleARN
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_data_source_from_redshift(
@@ -301,6 +308,7 @@ function create_data_source_from_redshift(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -353,6 +361,7 @@ function create_data_source_from_s3(
         "CreateDataSourceFromS3",
         Dict{String,Any}("DataSourceId" => DataSourceId, "DataSpec" => DataSpec);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_data_source_from_s3(
@@ -371,6 +380,7 @@ function create_data_source_from_s3(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -415,6 +425,7 @@ function create_evaluation(
             "MLModelId" => MLModelId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_evaluation(
@@ -438,6 +449,7 @@ function create_evaluation(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -509,6 +521,7 @@ function create_mlmodel(
             "TrainingDataSourceId" => TrainingDataSourceId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_mlmodel(
@@ -532,6 +545,7 @@ function create_mlmodel(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -553,6 +567,7 @@ function create_realtime_endpoint(
         "CreateRealtimeEndpoint",
         Dict{String,Any}("MLModelId" => MLModelId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_realtime_endpoint(
@@ -566,6 +581,7 @@ function create_realtime_endpoint(
             mergewith(_merge, Dict{String,Any}("MLModelId" => MLModelId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -589,6 +605,7 @@ function delete_batch_prediction(
         "DeleteBatchPrediction",
         Dict{String,Any}("BatchPredictionId" => BatchPredictionId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_batch_prediction(
@@ -604,6 +621,7 @@ function delete_batch_prediction(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -625,6 +643,7 @@ function delete_data_source(DataSourceId; aws_config::AbstractAWSConfig=global_a
         "DeleteDataSource",
         Dict{String,Any}("DataSourceId" => DataSourceId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_data_source(
@@ -638,6 +657,7 @@ function delete_data_source(
             mergewith(_merge, Dict{String,Any}("DataSourceId" => DataSourceId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -659,6 +679,7 @@ function delete_evaluation(EvaluationId; aws_config::AbstractAWSConfig=global_aw
         "DeleteEvaluation",
         Dict{String,Any}("EvaluationId" => EvaluationId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_evaluation(
@@ -672,6 +693,7 @@ function delete_evaluation(
             mergewith(_merge, Dict{String,Any}("EvaluationId" => EvaluationId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -690,7 +712,10 @@ irreversible.
 """
 function delete_mlmodel(MLModelId; aws_config::AbstractAWSConfig=global_aws_config())
     return machine_learning(
-        "DeleteMLModel", Dict{String,Any}("MLModelId" => MLModelId); aws_config=aws_config
+        "DeleteMLModel",
+        Dict{String,Any}("MLModelId" => MLModelId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_mlmodel(
@@ -704,6 +729,7 @@ function delete_mlmodel(
             mergewith(_merge, Dict{String,Any}("MLModelId" => MLModelId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -724,6 +750,7 @@ function delete_realtime_endpoint(
         "DeleteRealtimeEndpoint",
         Dict{String,Any}("MLModelId" => MLModelId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_realtime_endpoint(
@@ -737,6 +764,7 @@ function delete_realtime_endpoint(
             mergewith(_merge, Dict{String,Any}("MLModelId" => MLModelId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -763,6 +791,7 @@ function delete_tags(
             "ResourceId" => ResourceId, "ResourceType" => ResourceType, "TagKeys" => TagKeys
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_tags(
@@ -786,6 +815,7 @@ function delete_tags(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -830,12 +860,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   the list in descending order (Z-A, 9-0).   Results are sorted by FilterVariable.
 """
 function describe_batch_predictions(; aws_config::AbstractAWSConfig=global_aws_config())
-    return machine_learning("DescribeBatchPredictions"; aws_config=aws_config)
+    return machine_learning(
+        "DescribeBatchPredictions"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_batch_predictions(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return machine_learning("DescribeBatchPredictions", params; aws_config=aws_config)
+    return machine_learning(
+        "DescribeBatchPredictions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -876,12 +913,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   the list in descending order (Z-A, 9-0).   Results are sorted by FilterVariable.
 """
 function describe_data_sources(; aws_config::AbstractAWSConfig=global_aws_config())
-    return machine_learning("DescribeDataSources"; aws_config=aws_config)
+    return machine_learning(
+        "DescribeDataSources"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_data_sources(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return machine_learning("DescribeDataSources", params; aws_config=aws_config)
+    return machine_learning(
+        "DescribeDataSources",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -924,12 +968,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   the list in descending order (Z-A, 9-0).   Results are sorted by FilterVariable.
 """
 function describe_evaluations(; aws_config::AbstractAWSConfig=global_aws_config())
-    return machine_learning("DescribeEvaluations"; aws_config=aws_config)
+    return machine_learning(
+        "DescribeEvaluations"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_evaluations(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return machine_learning("DescribeEvaluations", params; aws_config=aws_config)
+    return machine_learning(
+        "DescribeEvaluations",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -975,12 +1026,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   list in descending order (Z-A, 9-0).   Results are sorted by FilterVariable.
 """
 function describe_mlmodels(; aws_config::AbstractAWSConfig=global_aws_config())
-    return machine_learning("DescribeMLModels"; aws_config=aws_config)
+    return machine_learning(
+        "DescribeMLModels"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_mlmodels(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return machine_learning("DescribeMLModels", params; aws_config=aws_config)
+    return machine_learning(
+        "DescribeMLModels", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1001,6 +1056,7 @@ function describe_tags(
         "DescribeTags",
         Dict{String,Any}("ResourceId" => ResourceId, "ResourceType" => ResourceType);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_tags(
@@ -1021,6 +1077,7 @@ function describe_tags(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1042,6 +1099,7 @@ function get_batch_prediction(
         "GetBatchPrediction",
         Dict{String,Any}("BatchPredictionId" => BatchPredictionId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_batch_prediction(
@@ -1057,6 +1115,7 @@ function get_batch_prediction(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1083,6 +1142,7 @@ function get_data_source(DataSourceId; aws_config::AbstractAWSConfig=global_aws_
         "GetDataSource",
         Dict{String,Any}("DataSourceId" => DataSourceId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_data_source(
@@ -1096,6 +1156,7 @@ function get_data_source(
             mergewith(_merge, Dict{String,Any}("DataSourceId" => DataSourceId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1116,6 +1177,7 @@ function get_evaluation(EvaluationId; aws_config::AbstractAWSConfig=global_aws_c
         "GetEvaluation",
         Dict{String,Any}("EvaluationId" => EvaluationId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_evaluation(
@@ -1129,6 +1191,7 @@ function get_evaluation(
             mergewith(_merge, Dict{String,Any}("EvaluationId" => EvaluationId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1149,7 +1212,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function get_mlmodel(MLModelId; aws_config::AbstractAWSConfig=global_aws_config())
     return machine_learning(
-        "GetMLModel", Dict{String,Any}("MLModelId" => MLModelId); aws_config=aws_config
+        "GetMLModel",
+        Dict{String,Any}("MLModelId" => MLModelId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_mlmodel(
@@ -1163,6 +1229,7 @@ function get_mlmodel(
             mergewith(_merge, Dict{String,Any}("MLModelId" => MLModelId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1191,6 +1258,7 @@ function predict(
             "Record" => Record,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function predict(
@@ -1214,6 +1282,7 @@ function predict(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1241,6 +1310,7 @@ function update_batch_prediction(
             "BatchPredictionName" => BatchPredictionName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_batch_prediction(
@@ -1262,6 +1332,7 @@ function update_batch_prediction(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1287,6 +1358,7 @@ function update_data_source(
             "DataSourceId" => DataSourceId, "DataSourceName" => DataSourceName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_data_source(
@@ -1307,6 +1379,7 @@ function update_data_source(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1332,6 +1405,7 @@ function update_evaluation(
             "EvaluationId" => EvaluationId, "EvaluationName" => EvaluationName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_evaluation(
@@ -1352,6 +1426,7 @@ function update_evaluation(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1376,7 +1451,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function update_mlmodel(MLModelId; aws_config::AbstractAWSConfig=global_aws_config())
     return machine_learning(
-        "UpdateMLModel", Dict{String,Any}("MLModelId" => MLModelId); aws_config=aws_config
+        "UpdateMLModel",
+        Dict{String,Any}("MLModelId" => MLModelId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_mlmodel(
@@ -1390,5 +1468,6 @@ function update_mlmodel(
             mergewith(_merge, Dict{String,Any}("MLModelId" => MLModelId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/macie.jl
+++ b/src/services/macie.jl
@@ -22,6 +22,7 @@ function associate_member_account(
         "AssociateMemberAccount",
         Dict{String,Any}("memberAccountId" => memberAccountId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_member_account(
@@ -37,6 +38,7 @@ function associate_member_account(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -66,6 +68,7 @@ function associate_s3_resources(
         "AssociateS3Resources",
         Dict{String,Any}("s3Resources" => s3Resources);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_s3_resources(
@@ -79,6 +82,7 @@ function associate_s3_resources(
             mergewith(_merge, Dict{String,Any}("s3Resources" => s3Resources), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -100,6 +104,7 @@ function disassociate_member_account(
         "DisassociateMemberAccount",
         Dict{String,Any}("memberAccountId" => memberAccountId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disassociate_member_account(
@@ -115,6 +120,7 @@ function disassociate_member_account(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -144,6 +150,7 @@ function disassociate_s3_resources(
         "DisassociateS3Resources",
         Dict{String,Any}("associatedS3Resources" => associatedS3Resources);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disassociate_s3_resources(
@@ -161,6 +168,7 @@ function disassociate_s3_resources(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -181,12 +189,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   response to continue listing data.
 """
 function list_member_accounts(; aws_config::AbstractAWSConfig=global_aws_config())
-    return macie("ListMemberAccounts"; aws_config=aws_config)
+    return macie(
+        "ListMemberAccounts"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_member_accounts(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return macie("ListMemberAccounts", params; aws_config=aws_config)
+    return macie(
+        "ListMemberAccounts", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -210,12 +222,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   data.
 """
 function list_s3_resources(; aws_config::AbstractAWSConfig=global_aws_config())
-    return macie("ListS3Resources"; aws_config=aws_config)
+    return macie("ListS3Resources"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_s3_resources(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return macie("ListS3Resources", params; aws_config=aws_config)
+    return macie(
+        "ListS3Resources", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -243,6 +257,7 @@ function update_s3_resources(
         "UpdateS3Resources",
         Dict{String,Any}("s3ResourcesUpdate" => s3ResourcesUpdate);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_s3_resources(
@@ -258,5 +273,6 @@ function update_s3_resources(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/macie2.jl
+++ b/src/services/macie2.jl
@@ -27,6 +27,7 @@ function accept_invitation(invitationId; aws_config::AbstractAWSConfig=global_aw
         "/invitations/accept",
         Dict{String,Any}("invitationId" => invitationId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function accept_invitation(
@@ -41,6 +42,7 @@ function accept_invitation(
             mergewith(_merge, Dict{String,Any}("invitationId" => invitationId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -58,12 +60,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function batch_get_custom_data_identifiers(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return macie2("POST", "/custom-data-identifiers/get"; aws_config=aws_config)
+    return macie2(
+        "POST",
+        "/custom-data-identifiers/get";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function batch_get_custom_data_identifiers(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return macie2("POST", "/custom-data-identifiers/get", params; aws_config=aws_config)
+    return macie2(
+        "POST",
+        "/custom-data-identifiers/get",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -142,6 +155,7 @@ function create_classification_job(
             "s3JobDefinition" => s3JobDefinition,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_classification_job(
@@ -168,6 +182,7 @@ function create_classification_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -215,6 +230,7 @@ function create_custom_data_identifier(; aws_config::AbstractAWSConfig=global_aw
         "/custom-data-identifiers",
         Dict{String,Any}("clientToken" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_custom_data_identifier(
@@ -227,6 +243,7 @@ function create_custom_data_identifier(
             mergewith(_merge, Dict{String,Any}("clientToken" => string(uuid4())), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -275,6 +292,7 @@ function create_findings_filter(
             "clientToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_findings_filter(
@@ -300,6 +318,7 @@ function create_findings_filter(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -328,6 +347,7 @@ function create_invitations(accountIds; aws_config::AbstractAWSConfig=global_aws
         "/invitations",
         Dict{String,Any}("accountIds" => accountIds);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_invitations(
@@ -342,6 +362,7 @@ function create_invitations(
             mergewith(_merge, Dict{String,Any}("accountIds" => accountIds), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -363,7 +384,11 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function create_member(account; aws_config::AbstractAWSConfig=global_aws_config())
     return macie2(
-        "POST", "/members", Dict{String,Any}("account" => account); aws_config=aws_config
+        "POST",
+        "/members",
+        Dict{String,Any}("account" => account);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_member(
@@ -374,6 +399,7 @@ function create_member(
         "/members",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("account" => account), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -390,12 +416,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Policy:IAMUser/S3BucketEncryptionDisabled.
 """
 function create_sample_findings(; aws_config::AbstractAWSConfig=global_aws_config())
-    return macie2("POST", "/findings/sample"; aws_config=aws_config)
+    return macie2(
+        "POST", "/findings/sample"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function create_sample_findings(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return macie2("POST", "/findings/sample", params; aws_config=aws_config)
+    return macie2(
+        "POST",
+        "/findings/sample",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -415,6 +449,7 @@ function decline_invitations(accountIds; aws_config::AbstractAWSConfig=global_aw
         "/invitations/decline",
         Dict{String,Any}("accountIds" => accountIds);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function decline_invitations(
@@ -429,6 +464,7 @@ function decline_invitations(
             mergewith(_merge, Dict{String,Any}("accountIds" => accountIds), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -446,12 +482,23 @@ Soft deletes a custom data identifier.
 function delete_custom_data_identifier(
     id; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return macie2("DELETE", "/custom-data-identifiers/$(id)"; aws_config=aws_config)
+    return macie2(
+        "DELETE",
+        "/custom-data-identifiers/$(id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_custom_data_identifier(
     id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return macie2("DELETE", "/custom-data-identifiers/$(id)", params; aws_config=aws_config)
+    return macie2(
+        "DELETE",
+        "/custom-data-identifiers/$(id)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -466,12 +513,23 @@ Deletes a findings filter.
 
 """
 function delete_findings_filter(id; aws_config::AbstractAWSConfig=global_aws_config())
-    return macie2("DELETE", "/findingsfilters/$(id)"; aws_config=aws_config)
+    return macie2(
+        "DELETE",
+        "/findingsfilters/$(id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_findings_filter(
     id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return macie2("DELETE", "/findingsfilters/$(id)", params; aws_config=aws_config)
+    return macie2(
+        "DELETE",
+        "/findingsfilters/$(id)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -491,6 +549,7 @@ function delete_invitations(accountIds; aws_config::AbstractAWSConfig=global_aws
         "/invitations/delete",
         Dict{String,Any}("accountIds" => accountIds);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_invitations(
@@ -505,6 +564,7 @@ function delete_invitations(
             mergewith(_merge, Dict{String,Any}("accountIds" => accountIds), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -520,12 +580,20 @@ Deletes the association between an Amazon Macie administrator account and an acc
 
 """
 function delete_member(id; aws_config::AbstractAWSConfig=global_aws_config())
-    return macie2("DELETE", "/members/$(id)"; aws_config=aws_config)
+    return macie2(
+        "DELETE", "/members/$(id)"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function delete_member(
     id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return macie2("DELETE", "/members/$(id)", params; aws_config=aws_config)
+    return macie2(
+        "DELETE",
+        "/members/$(id)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -545,12 +613,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"sortCriteria"`: The criteria to use to sort the query results.
 """
 function describe_buckets(; aws_config::AbstractAWSConfig=global_aws_config())
-    return macie2("POST", "/datasources/s3"; aws_config=aws_config)
+    return macie2(
+        "POST", "/datasources/s3"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_buckets(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return macie2("POST", "/datasources/s3", params; aws_config=aws_config)
+    return macie2(
+        "POST",
+        "/datasources/s3",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -566,12 +642,20 @@ Retrieves the status and settings for a classification job.
 function describe_classification_job(
     jobId; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return macie2("GET", "/jobs/$(jobId)"; aws_config=aws_config)
+    return macie2(
+        "GET", "/jobs/$(jobId)"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_classification_job(
     jobId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return macie2("GET", "/jobs/$(jobId)", params; aws_config=aws_config)
+    return macie2(
+        "GET",
+        "/jobs/$(jobId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -584,12 +668,23 @@ Retrieves the Amazon Macie configuration settings for an Amazon Web Services org
 function describe_organization_configuration(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return macie2("GET", "/admin/configuration"; aws_config=aws_config)
+    return macie2(
+        "GET",
+        "/admin/configuration";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_organization_configuration(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return macie2("GET", "/admin/configuration", params; aws_config=aws_config)
+    return macie2(
+        "GET",
+        "/admin/configuration",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -600,12 +695,16 @@ Disables an Amazon Macie account and deletes Macie resources for the account.
 
 """
 function disable_macie(; aws_config::AbstractAWSConfig=global_aws_config())
-    return macie2("DELETE", "/macie"; aws_config=aws_config)
+    return macie2(
+        "DELETE", "/macie"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function disable_macie(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return macie2("DELETE", "/macie", params; aws_config=aws_config)
+    return macie2(
+        "DELETE", "/macie", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -628,6 +727,7 @@ function disable_organization_admin_account(
         "/admin",
         Dict{String,Any}("adminAccountId" => adminAccountId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disable_organization_admin_account(
@@ -642,6 +742,7 @@ function disable_organization_admin_account(
             mergewith(_merge, Dict{String,Any}("adminAccountId" => adminAccountId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -655,12 +756,23 @@ Disassociates a member account from its Amazon Macie administrator account.
 function disassociate_from_administrator_account(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return macie2("POST", "/administrator/disassociate"; aws_config=aws_config)
+    return macie2(
+        "POST",
+        "/administrator/disassociate";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function disassociate_from_administrator_account(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return macie2("POST", "/administrator/disassociate", params; aws_config=aws_config)
+    return macie2(
+        "POST",
+        "/administrator/disassociate",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -674,12 +786,23 @@ This operation has been replaced by the DisassociateFromAdministratorAccount ope
 function disassociate_from_master_account(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return macie2("POST", "/master/disassociate"; aws_config=aws_config)
+    return macie2(
+        "POST",
+        "/master/disassociate";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function disassociate_from_master_account(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return macie2("POST", "/master/disassociate", params; aws_config=aws_config)
+    return macie2(
+        "POST",
+        "/master/disassociate",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -694,12 +817,23 @@ Disassociates an Amazon Macie administrator account from a member account.
 
 """
 function disassociate_member(id; aws_config::AbstractAWSConfig=global_aws_config())
-    return macie2("POST", "/members/disassociate/$(id)"; aws_config=aws_config)
+    return macie2(
+        "POST",
+        "/members/disassociate/$(id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function disassociate_member(
     id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return macie2("POST", "/members/disassociate/$(id)", params; aws_config=aws_config)
+    return macie2(
+        "POST",
+        "/members/disassociate/$(id)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -724,6 +858,7 @@ function enable_macie(; aws_config::AbstractAWSConfig=global_aws_config())
         "/macie",
         Dict{String,Any}("clientToken" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function enable_macie(
@@ -736,6 +871,7 @@ function enable_macie(
             mergewith(_merge, Dict{String,Any}("clientToken" => string(uuid4())), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -765,6 +901,7 @@ function enable_organization_admin_account(
             "adminAccountId" => adminAccountId, "clientToken" => string(uuid4())
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function enable_organization_admin_account(
@@ -785,6 +922,7 @@ function enable_organization_admin_account(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -796,12 +934,20 @@ Retrieves information about the Amazon Macie administrator account for an accoun
 
 """
 function get_administrator_account(; aws_config::AbstractAWSConfig=global_aws_config())
-    return macie2("GET", "/administrator"; aws_config=aws_config)
+    return macie2(
+        "GET", "/administrator"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_administrator_account(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return macie2("GET", "/administrator", params; aws_config=aws_config)
+    return macie2(
+        "GET",
+        "/administrator",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -816,12 +962,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"accountId"`: The unique identifier for the Amazon Web Services account.
 """
 function get_bucket_statistics(; aws_config::AbstractAWSConfig=global_aws_config())
-    return macie2("POST", "/datasources/s3/statistics"; aws_config=aws_config)
+    return macie2(
+        "POST",
+        "/datasources/s3/statistics";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_bucket_statistics(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return macie2("POST", "/datasources/s3/statistics", params; aws_config=aws_config)
+    return macie2(
+        "POST",
+        "/datasources/s3/statistics",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -834,13 +991,22 @@ Retrieves the configuration settings for storing data classification results.
 function get_classification_export_configuration(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return macie2("GET", "/classification-export-configuration"; aws_config=aws_config)
+    return macie2(
+        "GET",
+        "/classification-export-configuration";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_classification_export_configuration(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return macie2(
-        "GET", "/classification-export-configuration", params; aws_config=aws_config
+        "GET",
+        "/classification-export-configuration",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -856,12 +1022,23 @@ Retrieves the criteria and other settings for a custom data identifier.
 
 """
 function get_custom_data_identifier(id; aws_config::AbstractAWSConfig=global_aws_config())
-    return macie2("GET", "/custom-data-identifiers/$(id)"; aws_config=aws_config)
+    return macie2(
+        "GET",
+        "/custom-data-identifiers/$(id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_custom_data_identifier(
     id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return macie2("GET", "/custom-data-identifiers/$(id)", params; aws_config=aws_config)
+    return macie2(
+        "GET",
+        "/custom-data-identifiers/$(id)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -890,6 +1067,7 @@ function get_finding_statistics(groupBy; aws_config::AbstractAWSConfig=global_aw
         "/findings/statistics",
         Dict{String,Any}("groupBy" => groupBy);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_finding_statistics(
@@ -900,6 +1078,7 @@ function get_finding_statistics(
         "/findings/statistics",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("groupBy" => groupBy), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -923,6 +1102,7 @@ function get_findings(findingIds; aws_config::AbstractAWSConfig=global_aws_confi
         "/findings/describe",
         Dict{String,Any}("findingIds" => findingIds);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_findings(
@@ -937,6 +1117,7 @@ function get_findings(
             mergewith(_merge, Dict{String,Any}("findingIds" => findingIds), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -952,12 +1133,23 @@ Retrieves the criteria and other settings for a findings filter.
 
 """
 function get_findings_filter(id; aws_config::AbstractAWSConfig=global_aws_config())
-    return macie2("GET", "/findingsfilters/$(id)"; aws_config=aws_config)
+    return macie2(
+        "GET",
+        "/findingsfilters/$(id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_findings_filter(
     id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return macie2("GET", "/findingsfilters/$(id)", params; aws_config=aws_config)
+    return macie2(
+        "GET",
+        "/findingsfilters/$(id)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -970,13 +1162,22 @@ Retrieves the configuration settings for publishing findings to Security Hub.
 function get_findings_publication_configuration(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return macie2("GET", "/findings-publication-configuration"; aws_config=aws_config)
+    return macie2(
+        "GET",
+        "/findings-publication-configuration";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_findings_publication_configuration(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return macie2(
-        "GET", "/findings-publication-configuration", params; aws_config=aws_config
+        "GET",
+        "/findings-publication-configuration",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -988,12 +1189,20 @@ Retrieves the count of Amazon Macie membership invitations that were received by
 
 """
 function get_invitations_count(; aws_config::AbstractAWSConfig=global_aws_config())
-    return macie2("GET", "/invitations/count"; aws_config=aws_config)
+    return macie2(
+        "GET", "/invitations/count"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_invitations_count(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return macie2("GET", "/invitations/count", params; aws_config=aws_config)
+    return macie2(
+        "GET",
+        "/invitations/count",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1004,12 +1213,14 @@ Retrieves the current status and configuration settings for an Amazon Macie acco
 
 """
 function get_macie_session(; aws_config::AbstractAWSConfig=global_aws_config())
-    return macie2("GET", "/macie"; aws_config=aws_config)
+    return macie2("GET", "/macie"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function get_macie_session(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return macie2("GET", "/macie", params; aws_config=aws_config)
+    return macie2(
+        "GET", "/macie", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1021,12 +1232,14 @@ account. This operation has been replaced by the GetAdministratorAccount operati
 
 """
 function get_master_account(; aws_config::AbstractAWSConfig=global_aws_config())
-    return macie2("GET", "/master"; aws_config=aws_config)
+    return macie2("GET", "/master"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function get_master_account(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return macie2("GET", "/master", params; aws_config=aws_config)
+    return macie2(
+        "GET", "/master", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1042,12 +1255,20 @@ account.
 
 """
 function get_member(id; aws_config::AbstractAWSConfig=global_aws_config())
-    return macie2("GET", "/members/$(id)"; aws_config=aws_config)
+    return macie2(
+        "GET", "/members/$(id)"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_member(
     id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return macie2("GET", "/members/$(id)", params; aws_config=aws_config)
+    return macie2(
+        "GET",
+        "/members/$(id)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1071,12 +1292,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   30 days.
 """
 function get_usage_statistics(; aws_config::AbstractAWSConfig=global_aws_config())
-    return macie2("POST", "/usage/statistics"; aws_config=aws_config)
+    return macie2(
+        "POST", "/usage/statistics"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_usage_statistics(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return macie2("POST", "/usage/statistics", params; aws_config=aws_config)
+    return macie2(
+        "POST",
+        "/usage/statistics",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1093,12 +1322,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   usage data for the preceding 30 days.
 """
 function get_usage_totals(; aws_config::AbstractAWSConfig=global_aws_config())
-    return macie2("GET", "/usage"; aws_config=aws_config)
+    return macie2("GET", "/usage"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function get_usage_totals(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return macie2("GET", "/usage", params; aws_config=aws_config)
+    return macie2(
+        "GET", "/usage", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1116,12 +1347,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"sortCriteria"`: The criteria to use to sort the results.
 """
 function list_classification_jobs(; aws_config::AbstractAWSConfig=global_aws_config())
-    return macie2("POST", "/jobs/list"; aws_config=aws_config)
+    return macie2(
+        "POST", "/jobs/list"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_classification_jobs(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return macie2("POST", "/jobs/list", params; aws_config=aws_config)
+    return macie2(
+        "POST", "/jobs/list", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1137,12 +1372,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   paginated response.
 """
 function list_custom_data_identifiers(; aws_config::AbstractAWSConfig=global_aws_config())
-    return macie2("POST", "/custom-data-identifiers/list"; aws_config=aws_config)
+    return macie2(
+        "POST",
+        "/custom-data-identifiers/list";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_custom_data_identifiers(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return macie2("POST", "/custom-data-identifiers/list", params; aws_config=aws_config)
+    return macie2(
+        "POST",
+        "/custom-data-identifiers/list",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1160,12 +1406,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"sortCriteria"`: The criteria to use to sort the results.
 """
 function list_findings(; aws_config::AbstractAWSConfig=global_aws_config())
-    return macie2("POST", "/findings"; aws_config=aws_config)
+    return macie2(
+        "POST", "/findings"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_findings(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return macie2("POST", "/findings", params; aws_config=aws_config)
+    return macie2(
+        "POST", "/findings", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1182,12 +1432,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   paginated response.
 """
 function list_findings_filters(; aws_config::AbstractAWSConfig=global_aws_config())
-    return macie2("GET", "/findingsfilters"; aws_config=aws_config)
+    return macie2(
+        "GET", "/findingsfilters"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_findings_filters(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return macie2("GET", "/findingsfilters", params; aws_config=aws_config)
+    return macie2(
+        "GET",
+        "/findingsfilters",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1205,12 +1463,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   paginated response.
 """
 function list_invitations(; aws_config::AbstractAWSConfig=global_aws_config())
-    return macie2("GET", "/invitations"; aws_config=aws_config)
+    return macie2(
+        "GET", "/invitations"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_invitations(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return macie2("GET", "/invitations", params; aws_config=aws_config)
+    return macie2(
+        "GET",
+        "/invitations",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1226,12 +1492,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   paginated response.
 """
 function list_managed_data_identifiers(; aws_config::AbstractAWSConfig=global_aws_config())
-    return macie2("POST", "/managed-data-identifiers/list"; aws_config=aws_config)
+    return macie2(
+        "POST",
+        "/managed-data-identifiers/list";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_managed_data_identifiers(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return macie2("POST", "/managed-data-identifiers/list", params; aws_config=aws_config)
+    return macie2(
+        "POST",
+        "/managed-data-identifiers/list",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1253,12 +1530,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   false.
 """
 function list_members(; aws_config::AbstractAWSConfig=global_aws_config())
-    return macie2("GET", "/members"; aws_config=aws_config)
+    return macie2("GET", "/members"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_members(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return macie2("GET", "/members", params; aws_config=aws_config)
+    return macie2(
+        "GET", "/members", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1278,12 +1557,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function list_organization_admin_accounts(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return macie2("GET", "/admin"; aws_config=aws_config)
+    return macie2("GET", "/admin"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_organization_admin_accounts(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return macie2("GET", "/admin", params; aws_config=aws_config)
+    return macie2(
+        "GET", "/admin", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1301,14 +1582,25 @@ data identifier, findings filter, or member account.
 function list_tags_for_resource(
     resourceArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return macie2("GET", "/tags/$(resourceArn)"; aws_config=aws_config)
+    return macie2(
+        "GET",
+        "/tags/$(resourceArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_tags_for_resource(
     resourceArn,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return macie2("GET", "/tags/$(resourceArn)", params; aws_config=aws_config)
+    return macie2(
+        "GET",
+        "/tags/$(resourceArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1330,6 +1622,7 @@ function put_classification_export_configuration(
         "/classification-export-configuration",
         Dict{String,Any}("configuration" => configuration);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_classification_export_configuration(
@@ -1344,6 +1637,7 @@ function put_classification_export_configuration(
             mergewith(_merge, Dict{String,Any}("configuration" => configuration), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1368,6 +1662,7 @@ function put_findings_publication_configuration(;
         "/findings-publication-configuration",
         Dict{String,Any}("clientToken" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_findings_publication_configuration(
@@ -1380,6 +1675,7 @@ function put_findings_publication_configuration(
             mergewith(_merge, Dict{String,Any}("clientToken" => string(uuid4())), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1401,12 +1697,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"sortCriteria"`: The criteria to use to sort the results.
 """
 function search_resources(; aws_config::AbstractAWSConfig=global_aws_config())
-    return macie2("POST", "/datasources/search-resources"; aws_config=aws_config)
+    return macie2(
+        "POST",
+        "/datasources/search-resources";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function search_resources(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return macie2("POST", "/datasources/search-resources", params; aws_config=aws_config)
+    return macie2(
+        "POST",
+        "/datasources/search-resources",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1431,6 +1738,7 @@ function tag_resource(resourceArn, tags; aws_config::AbstractAWSConfig=global_aw
         "/tags/$(resourceArn)",
         Dict{String,Any}("tags" => tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -1444,6 +1752,7 @@ function tag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tags" => tags), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1482,6 +1791,7 @@ function test_custom_data_identifier(
         "/custom-data-identifiers/test",
         Dict{String,Any}("regex" => regex, "sampleText" => sampleText);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function test_custom_data_identifier(
@@ -1501,6 +1811,7 @@ function test_custom_data_identifier(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1527,6 +1838,7 @@ function untag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}("tagKeys" => tagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -1540,6 +1852,7 @@ function untag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tagKeys" => tagKeys), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1577,6 +1890,7 @@ function update_classification_job(
         "/jobs/$(jobId)",
         Dict{String,Any}("jobStatus" => jobStatus);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_classification_job(
@@ -1592,6 +1906,7 @@ function update_classification_job(
             mergewith(_merge, Dict{String,Any}("jobStatus" => jobStatus), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1631,6 +1946,7 @@ function update_findings_filter(id; aws_config::AbstractAWSConfig=global_aws_con
         "/findingsfilters/$(id)",
         Dict{String,Any}("clientToken" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_findings_filter(
@@ -1643,6 +1959,7 @@ function update_findings_filter(
             mergewith(_merge, Dict{String,Any}("clientToken" => string(uuid4())), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1663,12 +1980,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   account.
 """
 function update_macie_session(; aws_config::AbstractAWSConfig=global_aws_config())
-    return macie2("PATCH", "/macie"; aws_config=aws_config)
+    return macie2("PATCH", "/macie"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function update_macie_session(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return macie2("PATCH", "/macie", params; aws_config=aws_config)
+    return macie2(
+        "PATCH", "/macie", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1693,6 +2012,7 @@ function update_member_session(
         "/macie/members/$(id)",
         Dict{String,Any}("status" => status);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_member_session(
@@ -1706,6 +2026,7 @@ function update_member_session(
         "/macie/members/$(id)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("status" => status), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1728,6 +2049,7 @@ function update_organization_configuration(
         "/admin/configuration",
         Dict{String,Any}("autoEnable" => autoEnable);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_organization_configuration(
@@ -1742,5 +2064,6 @@ function update_organization_configuration(
             mergewith(_merge, Dict{String,Any}("autoEnable" => autoEnable), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/managedblockchain.jl
+++ b/src/services/managedblockchain.jl
@@ -37,6 +37,7 @@ function create_member(
             "MemberConfiguration" => MemberConfiguration,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_member(
@@ -62,6 +63,7 @@ function create_member(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -117,6 +119,7 @@ function create_network(
             "VotingPolicy" => VotingPolicy,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_network(
@@ -147,6 +150,7 @@ function create_network(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -192,6 +196,7 @@ function create_node(
             "NodeConfiguration" => NodeConfiguration,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_node(
@@ -215,6 +220,7 @@ function create_node(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -267,6 +273,7 @@ function create_proposal(
             "MemberId" => MemberId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_proposal(
@@ -292,6 +299,7 @@ function create_proposal(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -315,7 +323,10 @@ function delete_member(
     memberId, networkId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return managedblockchain(
-        "DELETE", "/networks/$(networkId)/members/$(memberId)"; aws_config=aws_config
+        "DELETE",
+        "/networks/$(networkId)/members/$(memberId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_member(
@@ -329,6 +340,7 @@ function delete_member(
         "/networks/$(networkId)/members/$(memberId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -352,7 +364,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function delete_node(networkId, nodeId; aws_config::AbstractAWSConfig=global_aws_config())
     return managedblockchain(
-        "DELETE", "/networks/$(networkId)/nodes/$(nodeId)"; aws_config=aws_config
+        "DELETE",
+        "/networks/$(networkId)/nodes/$(nodeId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_node(
@@ -362,7 +377,11 @@ function delete_node(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return managedblockchain(
-        "DELETE", "/networks/$(networkId)/nodes/$(nodeId)", params; aws_config=aws_config
+        "DELETE",
+        "/networks/$(networkId)/nodes/$(nodeId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -379,7 +398,10 @@ Returns detailed information about a member. Applies only to Hyperledger Fabric.
 """
 function get_member(memberId, networkId; aws_config::AbstractAWSConfig=global_aws_config())
     return managedblockchain(
-        "GET", "/networks/$(networkId)/members/$(memberId)"; aws_config=aws_config
+        "GET",
+        "/networks/$(networkId)/members/$(memberId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_member(
@@ -389,7 +411,11 @@ function get_member(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return managedblockchain(
-        "GET", "/networks/$(networkId)/members/$(memberId)", params; aws_config=aws_config
+        "GET",
+        "/networks/$(networkId)/members/$(memberId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -404,14 +430,25 @@ Returns detailed information about a network. Applies to Hyperledger Fabric and 
 
 """
 function get_network(networkId; aws_config::AbstractAWSConfig=global_aws_config())
-    return managedblockchain("GET", "/networks/$(networkId)"; aws_config=aws_config)
+    return managedblockchain(
+        "GET",
+        "/networks/$(networkId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_network(
     networkId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return managedblockchain("GET", "/networks/$(networkId)", params; aws_config=aws_config)
+    return managedblockchain(
+        "GET",
+        "/networks/$(networkId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -431,7 +468,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function get_node(networkId, nodeId; aws_config::AbstractAWSConfig=global_aws_config())
     return managedblockchain(
-        "GET", "/networks/$(networkId)/nodes/$(nodeId)"; aws_config=aws_config
+        "GET",
+        "/networks/$(networkId)/nodes/$(nodeId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_node(
@@ -441,7 +481,11 @@ function get_node(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return managedblockchain(
-        "GET", "/networks/$(networkId)/nodes/$(nodeId)", params; aws_config=aws_config
+        "GET",
+        "/networks/$(networkId)/nodes/$(nodeId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -460,7 +504,10 @@ function get_proposal(
     networkId, proposalId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return managedblockchain(
-        "GET", "/networks/$(networkId)/proposals/$(proposalId)"; aws_config=aws_config
+        "GET",
+        "/networks/$(networkId)/proposals/$(proposalId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_proposal(
@@ -474,6 +521,7 @@ function get_proposal(
         "/networks/$(networkId)/proposals/$(proposalId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -490,12 +538,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: The pagination token that indicates the next set of results to retrieve.
 """
 function list_invitations(; aws_config::AbstractAWSConfig=global_aws_config())
-    return managedblockchain("GET", "/invitations"; aws_config=aws_config)
+    return managedblockchain(
+        "GET", "/invitations"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_invitations(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return managedblockchain("GET", "/invitations", params; aws_config=aws_config)
+    return managedblockchain(
+        "GET",
+        "/invitations",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -520,7 +576,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   status are listed.
 """
 function list_members(networkId; aws_config::AbstractAWSConfig=global_aws_config())
-    return managedblockchain("GET", "/networks/$(networkId)/members"; aws_config=aws_config)
+    return managedblockchain(
+        "GET",
+        "/networks/$(networkId)/members";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_members(
     networkId,
@@ -528,7 +589,11 @@ function list_members(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return managedblockchain(
-        "GET", "/networks/$(networkId)/members", params; aws_config=aws_config
+        "GET",
+        "/networks/$(networkId)/members",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -550,12 +615,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   status are listed. Applies only to Hyperledger Fabric.
 """
 function list_networks(; aws_config::AbstractAWSConfig=global_aws_config())
-    return managedblockchain("GET", "/networks"; aws_config=aws_config)
+    return managedblockchain(
+        "GET", "/networks"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_networks(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return managedblockchain("GET", "/networks", params; aws_config=aws_config)
+    return managedblockchain(
+        "GET", "/networks", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -578,7 +647,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   status are listed.
 """
 function list_nodes(networkId; aws_config::AbstractAWSConfig=global_aws_config())
-    return managedblockchain("GET", "/networks/$(networkId)/nodes"; aws_config=aws_config)
+    return managedblockchain(
+        "GET",
+        "/networks/$(networkId)/nodes";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_nodes(
     networkId,
@@ -586,7 +660,11 @@ function list_nodes(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return managedblockchain(
-        "GET", "/networks/$(networkId)/nodes", params; aws_config=aws_config
+        "GET",
+        "/networks/$(networkId)/nodes",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -610,7 +688,10 @@ function list_proposal_votes(
     networkId, proposalId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return managedblockchain(
-        "GET", "/networks/$(networkId)/proposals/$(proposalId)/votes"; aws_config=aws_config
+        "GET",
+        "/networks/$(networkId)/proposals/$(proposalId)/votes";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_proposal_votes(
@@ -624,6 +705,7 @@ function list_proposal_votes(
         "/networks/$(networkId)/proposals/$(proposalId)/votes",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -643,7 +725,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function list_proposals(networkId; aws_config::AbstractAWSConfig=global_aws_config())
     return managedblockchain(
-        "GET", "/networks/$(networkId)/proposals"; aws_config=aws_config
+        "GET",
+        "/networks/$(networkId)/proposals";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_proposals(
@@ -652,7 +737,11 @@ function list_proposals(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return managedblockchain(
-        "GET", "/networks/$(networkId)/proposals", params; aws_config=aws_config
+        "GET",
+        "/networks/$(networkId)/proposals",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -673,14 +762,25 @@ Hyperledger Fabric Developer Guide.
 function list_tags_for_resource(
     resourceArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return managedblockchain("GET", "/tags/$(resourceArn)"; aws_config=aws_config)
+    return managedblockchain(
+        "GET",
+        "/tags/$(resourceArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_tags_for_resource(
     resourceArn,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return managedblockchain("GET", "/tags/$(resourceArn)", params; aws_config=aws_config)
+    return managedblockchain(
+        "GET",
+        "/tags/$(resourceArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -697,7 +797,10 @@ to Hyperledger Fabric.
 """
 function reject_invitation(invitationId; aws_config::AbstractAWSConfig=global_aws_config())
     return managedblockchain(
-        "DELETE", "/invitations/$(invitationId)"; aws_config=aws_config
+        "DELETE",
+        "/invitations/$(invitationId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function reject_invitation(
@@ -706,7 +809,11 @@ function reject_invitation(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return managedblockchain(
-        "DELETE", "/invitations/$(invitationId)", params; aws_config=aws_config
+        "DELETE",
+        "/invitations/$(invitationId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -736,6 +843,7 @@ function tag_resource(Tags, resourceArn; aws_config::AbstractAWSConfig=global_aw
         "/tags/$(resourceArn)",
         Dict{String,Any}("Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -749,6 +857,7 @@ function tag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Tags" => Tags), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -775,6 +884,7 @@ function untag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}("tagKeys" => tagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -788,6 +898,7 @@ function untag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tagKeys" => tagKeys), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -811,7 +922,10 @@ function update_member(
     memberId, networkId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return managedblockchain(
-        "PATCH", "/networks/$(networkId)/members/$(memberId)"; aws_config=aws_config
+        "PATCH",
+        "/networks/$(networkId)/members/$(memberId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_member(
@@ -821,7 +935,11 @@ function update_member(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return managedblockchain(
-        "PATCH", "/networks/$(networkId)/members/$(memberId)", params; aws_config=aws_config
+        "PATCH",
+        "/networks/$(networkId)/members/$(memberId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -844,7 +962,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function update_node(networkId, nodeId; aws_config::AbstractAWSConfig=global_aws_config())
     return managedblockchain(
-        "PATCH", "/networks/$(networkId)/nodes/$(nodeId)"; aws_config=aws_config
+        "PATCH",
+        "/networks/$(networkId)/nodes/$(nodeId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_node(
@@ -854,7 +975,11 @@ function update_node(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return managedblockchain(
-        "PATCH", "/networks/$(networkId)/nodes/$(nodeId)", params; aws_config=aws_config
+        "PATCH",
+        "/networks/$(networkId)/nodes/$(nodeId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -885,6 +1010,7 @@ function vote_on_proposal(
         "/networks/$(networkId)/proposals/$(proposalId)/votes",
         Dict{String,Any}("Vote" => Vote, "VoterMemberId" => VoterMemberId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function vote_on_proposal(
@@ -906,5 +1032,6 @@ function vote_on_proposal(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/marketplace_catalog.jl
+++ b/src/services/marketplace_catalog.jl
@@ -26,6 +26,7 @@ function cancel_change_set(
         "/CancelChangeSet",
         Dict{String,Any}("catalog" => catalog, "changeSetId" => changeSetId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function cancel_change_set(
@@ -45,6 +46,7 @@ function cancel_change_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -68,6 +70,7 @@ function describe_change_set(
         "/DescribeChangeSet",
         Dict{String,Any}("catalog" => catalog, "changeSetId" => changeSetId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_change_set(
@@ -87,6 +90,7 @@ function describe_change_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -109,6 +113,7 @@ function describe_entity(
         "/DescribeEntity",
         Dict{String,Any}("catalog" => catalog, "entityId" => entityId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_entity(
@@ -128,6 +133,7 @@ function describe_entity(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -160,6 +166,7 @@ function list_change_sets(Catalog; aws_config::AbstractAWSConfig=global_aws_conf
         "/ListChangeSets",
         Dict{String,Any}("Catalog" => Catalog);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_change_sets(
@@ -170,6 +177,7 @@ function list_change_sets(
         "/ListChangeSets",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Catalog" => Catalog), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -201,6 +209,7 @@ function list_entities(
         "/ListEntities",
         Dict{String,Any}("Catalog" => Catalog, "EntityType" => EntityType);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_entities(
@@ -220,6 +229,7 @@ function list_entities(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -255,6 +265,7 @@ function start_change_set(
         "/StartChangeSet",
         Dict{String,Any}("Catalog" => Catalog, "ChangeSet" => ChangeSet);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_change_set(
@@ -274,5 +285,6 @@ function start_change_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/marketplace_commerce_analytics.jl
+++ b/src/services/marketplace_commerce_analytics.jl
@@ -100,6 +100,7 @@ function generate_data_set(
             "snsTopicArn" => snsTopicArn,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function generate_data_set(
@@ -127,6 +128,7 @@ function generate_data_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -193,6 +195,7 @@ function start_support_data_export(
             "snsTopicArn" => snsTopicArn,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_support_data_export(
@@ -220,5 +223,6 @@ function start_support_data_export(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/marketplace_entitlement_service.jl
+++ b/src/services/marketplace_entitlement_service.jl
@@ -31,6 +31,7 @@ function get_entitlements(ProductCode; aws_config::AbstractAWSConfig=global_aws_
         "GetEntitlements",
         Dict{String,Any}("ProductCode" => ProductCode);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_entitlements(
@@ -44,5 +45,6 @@ function get_entitlements(
             mergewith(_merge, Dict{String,Any}("ProductCode" => ProductCode), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/marketplace_metering.jl
+++ b/src/services/marketplace_metering.jl
@@ -31,6 +31,7 @@ function batch_meter_usage(
         "BatchMeterUsage",
         Dict{String,Any}("ProductCode" => ProductCode, "UsageRecords" => UsageRecords);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_meter_usage(
@@ -51,6 +52,7 @@ function batch_meter_usage(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -97,6 +99,7 @@ function meter_usage(
             "UsageDimension" => UsageDimension,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function meter_usage(
@@ -120,6 +123,7 @@ function meter_usage(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -172,6 +176,7 @@ function register_usage(
             "ProductCode" => ProductCode, "PublicKeyVersion" => PublicKeyVersion
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function register_usage(
@@ -192,6 +197,7 @@ function register_usage(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -217,6 +223,7 @@ function resolve_customer(
         "ResolveCustomer",
         Dict{String,Any}("RegistrationToken" => RegistrationToken);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function resolve_customer(
@@ -232,5 +239,6 @@ function resolve_customer(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/mediaconnect.jl
+++ b/src/services/mediaconnect.jl
@@ -24,6 +24,7 @@ function add_flow_media_streams(
         "/v1/flows/$(flowArn)/mediaStreams",
         Dict{String,Any}("mediaStreams" => mediaStreams);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function add_flow_media_streams(
@@ -39,6 +40,7 @@ function add_flow_media_streams(
             mergewith(_merge, Dict{String,Any}("mediaStreams" => mediaStreams), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -61,6 +63,7 @@ function add_flow_outputs(
         "/v1/flows/$(flowArn)/outputs",
         Dict{String,Any}("outputs" => outputs);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function add_flow_outputs(
@@ -74,6 +77,7 @@ function add_flow_outputs(
         "/v1/flows/$(flowArn)/outputs",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("outputs" => outputs), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -96,6 +100,7 @@ function add_flow_sources(
         "/v1/flows/$(flowArn)/source",
         Dict{String,Any}("sources" => sources);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function add_flow_sources(
@@ -109,6 +114,7 @@ function add_flow_sources(
         "/v1/flows/$(flowArn)/source",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("sources" => sources), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -131,6 +137,7 @@ function add_flow_vpc_interfaces(
         "/v1/flows/$(flowArn)/vpcInterfaces",
         Dict{String,Any}("vpcInterfaces" => vpcInterfaces);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function add_flow_vpc_interfaces(
@@ -146,6 +153,7 @@ function add_flow_vpc_interfaces(
             mergewith(_merge, Dict{String,Any}("vpcInterfaces" => vpcInterfaces), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -174,7 +182,11 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function create_flow(name; aws_config::AbstractAWSConfig=global_aws_config())
     return mediaconnect(
-        "POST", "/v1/flows", Dict{String,Any}("name" => name); aws_config=aws_config
+        "POST",
+        "/v1/flows",
+        Dict{String,Any}("name" => name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_flow(
@@ -185,6 +197,7 @@ function create_flow(
         "/v1/flows",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("name" => name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -199,12 +212,23 @@ Deletes a flow. Before you can delete a flow, you must stop the flow.
 
 """
 function delete_flow(flowArn; aws_config::AbstractAWSConfig=global_aws_config())
-    return mediaconnect("DELETE", "/v1/flows/$(flowArn)"; aws_config=aws_config)
+    return mediaconnect(
+        "DELETE",
+        "/v1/flows/$(flowArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_flow(
     flowArn, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return mediaconnect("DELETE", "/v1/flows/$(flowArn)", params; aws_config=aws_config)
+    return mediaconnect(
+        "DELETE",
+        "/v1/flows/$(flowArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -219,12 +243,23 @@ Zone, as well as details about the source, outputs, and entitlements.
 
 """
 function describe_flow(flowArn; aws_config::AbstractAWSConfig=global_aws_config())
-    return mediaconnect("GET", "/v1/flows/$(flowArn)"; aws_config=aws_config)
+    return mediaconnect(
+        "GET",
+        "/v1/flows/$(flowArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_flow(
     flowArn, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return mediaconnect("GET", "/v1/flows/$(flowArn)", params; aws_config=aws_config)
+    return mediaconnect(
+        "GET",
+        "/v1/flows/$(flowArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -239,7 +274,12 @@ duration, outbound bandwidth, price, and Amazon Resource Name (ARN).
 
 """
 function describe_offering(offeringArn; aws_config::AbstractAWSConfig=global_aws_config())
-    return mediaconnect("GET", "/v1/offerings/$(offeringArn)"; aws_config=aws_config)
+    return mediaconnect(
+        "GET",
+        "/v1/offerings/$(offeringArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_offering(
     offeringArn,
@@ -247,7 +287,11 @@ function describe_offering(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return mediaconnect(
-        "GET", "/v1/offerings/$(offeringArn)", params; aws_config=aws_config
+        "GET",
+        "/v1/offerings/$(offeringArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -266,7 +310,12 @@ reservation (such as price, duration, and outbound bandwidth).
 function describe_reservation(
     reservationArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return mediaconnect("GET", "/v1/reservations/$(reservationArn)"; aws_config=aws_config)
+    return mediaconnect(
+        "GET",
+        "/v1/reservations/$(reservationArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_reservation(
     reservationArn,
@@ -274,7 +323,11 @@ function describe_reservation(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return mediaconnect(
-        "GET", "/v1/reservations/$(reservationArn)", params; aws_config=aws_config
+        "GET",
+        "/v1/reservations/$(reservationArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -297,6 +350,7 @@ function grant_flow_entitlements(
         "/v1/flows/$(flowArn)/entitlements",
         Dict{String,Any}("entitlements" => entitlements);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function grant_flow_entitlements(
@@ -312,6 +366,7 @@ function grant_flow_entitlements(
             mergewith(_merge, Dict{String,Any}("entitlements" => entitlements), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -337,12 +392,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   NextToken value.
 """
 function list_entitlements(; aws_config::AbstractAWSConfig=global_aws_config())
-    return mediaconnect("GET", "/v1/entitlements"; aws_config=aws_config)
+    return mediaconnect(
+        "GET", "/v1/entitlements"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_entitlements(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return mediaconnect("GET", "/v1/entitlements", params; aws_config=aws_config)
+    return mediaconnect(
+        "GET",
+        "/v1/entitlements",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -366,12 +429,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   you can submit the ListFlows request a second time and specify the NextToken value.
 """
 function list_flows(; aws_config::AbstractAWSConfig=global_aws_config())
-    return mediaconnect("GET", "/v1/flows"; aws_config=aws_config)
+    return mediaconnect(
+        "GET", "/v1/flows"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_flows(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return mediaconnect("GET", "/v1/flows", params; aws_config=aws_config)
+    return mediaconnect(
+        "GET", "/v1/flows", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -398,12 +465,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   value.
 """
 function list_offerings(; aws_config::AbstractAWSConfig=global_aws_config())
-    return mediaconnect("GET", "/v1/offerings"; aws_config=aws_config)
+    return mediaconnect(
+        "GET", "/v1/offerings"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_offerings(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return mediaconnect("GET", "/v1/offerings", params; aws_config=aws_config)
+    return mediaconnect(
+        "GET",
+        "/v1/offerings",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -428,12 +503,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   NextToken value.
 """
 function list_reservations(; aws_config::AbstractAWSConfig=global_aws_config())
-    return mediaconnect("GET", "/v1/reservations"; aws_config=aws_config)
+    return mediaconnect(
+        "GET", "/v1/reservations"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_reservations(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return mediaconnect("GET", "/v1/reservations", params; aws_config=aws_config)
+    return mediaconnect(
+        "GET",
+        "/v1/reservations",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -450,14 +533,25 @@ List all tags on an AWS Elemental MediaConnect resource
 function list_tags_for_resource(
     resourceArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return mediaconnect("GET", "/tags/$(resourceArn)"; aws_config=aws_config)
+    return mediaconnect(
+        "GET",
+        "/tags/$(resourceArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_tags_for_resource(
     resourceArn,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return mediaconnect("GET", "/tags/$(resourceArn)", params; aws_config=aws_config)
+    return mediaconnect(
+        "GET",
+        "/tags/$(resourceArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -485,6 +579,7 @@ function purchase_offering(
         "/v1/offerings/$(offeringArn)",
         Dict{String,Any}("reservationName" => reservationName, "start" => start);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function purchase_offering(
@@ -505,6 +600,7 @@ function purchase_offering(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -527,6 +623,7 @@ function remove_flow_media_stream(
         "DELETE",
         "/v1/flows/$(flowArn)/mediaStreams/$(mediaStreamName)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function remove_flow_media_stream(
@@ -540,6 +637,7 @@ function remove_flow_media_stream(
         "/v1/flows/$(flowArn)/mediaStreams/$(mediaStreamName)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -561,7 +659,10 @@ function remove_flow_output(
     flowArn, outputArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return mediaconnect(
-        "DELETE", "/v1/flows/$(flowArn)/outputs/$(outputArn)"; aws_config=aws_config
+        "DELETE",
+        "/v1/flows/$(flowArn)/outputs/$(outputArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function remove_flow_output(
@@ -571,7 +672,11 @@ function remove_flow_output(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return mediaconnect(
-        "DELETE", "/v1/flows/$(flowArn)/outputs/$(outputArn)", params; aws_config=aws_config
+        "DELETE",
+        "/v1/flows/$(flowArn)/outputs/$(outputArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -591,7 +696,10 @@ function remove_flow_source(
     flowArn, sourceArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return mediaconnect(
-        "DELETE", "/v1/flows/$(flowArn)/source/$(sourceArn)"; aws_config=aws_config
+        "DELETE",
+        "/v1/flows/$(flowArn)/source/$(sourceArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function remove_flow_source(
@@ -601,7 +709,11 @@ function remove_flow_source(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return mediaconnect(
-        "DELETE", "/v1/flows/$(flowArn)/source/$(sourceArn)", params; aws_config=aws_config
+        "DELETE",
+        "/v1/flows/$(flowArn)/source/$(sourceArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -626,6 +738,7 @@ function remove_flow_vpc_interface(
         "DELETE",
         "/v1/flows/$(flowArn)/vpcInterfaces/$(vpcInterfaceName)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function remove_flow_vpc_interface(
@@ -639,6 +752,7 @@ function remove_flow_vpc_interface(
         "/v1/flows/$(flowArn)/vpcInterfaces/$(vpcInterfaceName)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -661,6 +775,7 @@ function revoke_flow_entitlement(
         "DELETE",
         "/v1/flows/$(flowArn)/entitlements/$(entitlementArn)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function revoke_flow_entitlement(
@@ -674,6 +789,7 @@ function revoke_flow_entitlement(
         "/v1/flows/$(flowArn)/entitlements/$(entitlementArn)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -688,12 +804,23 @@ Starts a flow.
 
 """
 function start_flow(flowArn; aws_config::AbstractAWSConfig=global_aws_config())
-    return mediaconnect("POST", "/v1/flows/start/$(flowArn)"; aws_config=aws_config)
+    return mediaconnect(
+        "POST",
+        "/v1/flows/start/$(flowArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function start_flow(
     flowArn, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return mediaconnect("POST", "/v1/flows/start/$(flowArn)", params; aws_config=aws_config)
+    return mediaconnect(
+        "POST",
+        "/v1/flows/start/$(flowArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -707,12 +834,23 @@ Stops a flow.
 
 """
 function stop_flow(flowArn; aws_config::AbstractAWSConfig=global_aws_config())
-    return mediaconnect("POST", "/v1/flows/stop/$(flowArn)"; aws_config=aws_config)
+    return mediaconnect(
+        "POST",
+        "/v1/flows/stop/$(flowArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function stop_flow(
     flowArn, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return mediaconnect("POST", "/v1/flows/stop/$(flowArn)", params; aws_config=aws_config)
+    return mediaconnect(
+        "POST",
+        "/v1/flows/stop/$(flowArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -736,6 +874,7 @@ function tag_resource(resourceArn, tags; aws_config::AbstractAWSConfig=global_aw
         "/tags/$(resourceArn)",
         Dict{String,Any}("tags" => tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -749,6 +888,7 @@ function tag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tags" => tags), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -772,6 +912,7 @@ function untag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}("tagKeys" => tagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -785,6 +926,7 @@ function untag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tagKeys" => tagKeys), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -802,12 +944,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"sourceFailoverConfig"`:
 """
 function update_flow(flowArn; aws_config::AbstractAWSConfig=global_aws_config())
-    return mediaconnect("PUT", "/v1/flows/$(flowArn)"; aws_config=aws_config)
+    return mediaconnect(
+        "PUT",
+        "/v1/flows/$(flowArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function update_flow(
     flowArn, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return mediaconnect("PUT", "/v1/flows/$(flowArn)", params; aws_config=aws_config)
+    return mediaconnect(
+        "PUT",
+        "/v1/flows/$(flowArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -840,7 +993,10 @@ function update_flow_entitlement(
     entitlementArn, flowArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return mediaconnect(
-        "PUT", "/v1/flows/$(flowArn)/entitlements/$(entitlementArn)"; aws_config=aws_config
+        "PUT",
+        "/v1/flows/$(flowArn)/entitlements/$(entitlementArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_flow_entitlement(
@@ -854,6 +1010,7 @@ function update_flow_entitlement(
         "/v1/flows/$(flowArn)/entitlements/$(entitlementArn)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -881,7 +1038,10 @@ function update_flow_media_stream(
     flowArn, mediaStreamName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return mediaconnect(
-        "PUT", "/v1/flows/$(flowArn)/mediaStreams/$(mediaStreamName)"; aws_config=aws_config
+        "PUT",
+        "/v1/flows/$(flowArn)/mediaStreams/$(mediaStreamName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_flow_media_stream(
@@ -895,6 +1055,7 @@ function update_flow_media_stream(
         "/v1/flows/$(flowArn)/mediaStreams/$(mediaStreamName)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -940,7 +1101,10 @@ function update_flow_output(
     flowArn, outputArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return mediaconnect(
-        "PUT", "/v1/flows/$(flowArn)/outputs/$(outputArn)"; aws_config=aws_config
+        "PUT",
+        "/v1/flows/$(flowArn)/outputs/$(outputArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_flow_output(
@@ -950,7 +1114,11 @@ function update_flow_output(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return mediaconnect(
-        "PUT", "/v1/flows/$(flowArn)/outputs/$(outputArn)", params; aws_config=aws_config
+        "PUT",
+        "/v1/flows/$(flowArn)/outputs/$(outputArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -997,7 +1165,10 @@ function update_flow_source(
     flowArn, sourceArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return mediaconnect(
-        "PUT", "/v1/flows/$(flowArn)/source/$(sourceArn)"; aws_config=aws_config
+        "PUT",
+        "/v1/flows/$(flowArn)/source/$(sourceArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_flow_source(
@@ -1007,6 +1178,10 @@ function update_flow_source(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return mediaconnect(
-        "PUT", "/v1/flows/$(flowArn)/source/$(sourceArn)", params; aws_config=aws_config
+        "PUT",
+        "/v1/flows/$(flowArn)/source/$(sourceArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/mediaconvert.jl
+++ b/src/services/mediaconvert.jl
@@ -22,6 +22,7 @@ function associate_certificate(arn; aws_config::AbstractAWSConfig=global_aws_con
         "/2017-08-29/certificates",
         Dict{String,Any}("arn" => arn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_certificate(
@@ -32,6 +33,7 @@ function associate_certificate(
         "/2017-08-29/certificates",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("arn" => arn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -46,12 +48,23 @@ Permanently cancel a job. Once you have canceled a job, you can't start it again
 
 """
 function cancel_job(id; aws_config::AbstractAWSConfig=global_aws_config())
-    return mediaconvert("DELETE", "/2017-08-29/jobs/$(id)"; aws_config=aws_config)
+    return mediaconvert(
+        "DELETE",
+        "/2017-08-29/jobs/$(id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function cancel_job(
     id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return mediaconvert("DELETE", "/2017-08-29/jobs/$(id)", params; aws_config=aws_config)
+    return mediaconvert(
+        "DELETE",
+        "/2017-08-29/jobs/$(id)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -116,6 +129,7 @@ function create_job(role, settings; aws_config::AbstractAWSConfig=global_aws_con
             "role" => role, "settings" => settings, "clientRequestToken" => string(uuid4())
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_job(
@@ -139,6 +153,7 @@ function create_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -186,6 +201,7 @@ function create_job_template(
         "/2017-08-29/jobTemplates",
         Dict{String,Any}("name" => name, "settings" => settings);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_job_template(
@@ -203,6 +219,7 @@ function create_job_template(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -230,6 +247,7 @@ function create_preset(name, settings; aws_config::AbstractAWSConfig=global_aws_
         "/2017-08-29/presets",
         Dict{String,Any}("name" => name, "settings" => settings);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_preset(
@@ -247,6 +265,7 @@ function create_preset(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -282,6 +301,7 @@ function create_queue(name; aws_config::AbstractAWSConfig=global_aws_config())
         "/2017-08-29/queues",
         Dict{String,Any}("name" => name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_queue(
@@ -292,6 +312,7 @@ function create_queue(
         "/2017-08-29/queues",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("name" => name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -306,13 +327,22 @@ Permanently delete a job template you have created.
 
 """
 function delete_job_template(name; aws_config::AbstractAWSConfig=global_aws_config())
-    return mediaconvert("DELETE", "/2017-08-29/jobTemplates/$(name)"; aws_config=aws_config)
+    return mediaconvert(
+        "DELETE",
+        "/2017-08-29/jobTemplates/$(name)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_job_template(
     name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return mediaconvert(
-        "DELETE", "/2017-08-29/jobTemplates/$(name)", params; aws_config=aws_config
+        "DELETE",
+        "/2017-08-29/jobTemplates/$(name)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -327,13 +357,22 @@ Permanently delete a preset you have created.
 
 """
 function delete_preset(name; aws_config::AbstractAWSConfig=global_aws_config())
-    return mediaconvert("DELETE", "/2017-08-29/presets/$(name)"; aws_config=aws_config)
+    return mediaconvert(
+        "DELETE",
+        "/2017-08-29/presets/$(name)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_preset(
     name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return mediaconvert(
-        "DELETE", "/2017-08-29/presets/$(name)", params; aws_config=aws_config
+        "DELETE",
+        "/2017-08-29/presets/$(name)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -348,13 +387,22 @@ Permanently delete a queue you have created.
 
 """
 function delete_queue(name; aws_config::AbstractAWSConfig=global_aws_config())
-    return mediaconvert("DELETE", "/2017-08-29/queues/$(name)"; aws_config=aws_config)
+    return mediaconvert(
+        "DELETE",
+        "/2017-08-29/queues/$(name)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_queue(
     name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return mediaconvert(
-        "DELETE", "/2017-08-29/queues/$(name)", params; aws_config=aws_config
+        "DELETE",
+        "/2017-08-29/queues/$(name)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -377,12 +425,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   request the next batch of endpoints.
 """
 function describe_endpoints(; aws_config::AbstractAWSConfig=global_aws_config())
-    return mediaconvert("POST", "/2017-08-29/endpoints"; aws_config=aws_config)
+    return mediaconvert(
+        "POST",
+        "/2017-08-29/endpoints";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_endpoints(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return mediaconvert("POST", "/2017-08-29/endpoints", params; aws_config=aws_config)
+    return mediaconvert(
+        "POST",
+        "/2017-08-29/endpoints",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -398,13 +457,22 @@ Removes an association between the Amazon Resource Name (ARN) of an AWS Certific
 
 """
 function disassociate_certificate(arn; aws_config::AbstractAWSConfig=global_aws_config())
-    return mediaconvert("DELETE", "/2017-08-29/certificates/$(arn)"; aws_config=aws_config)
+    return mediaconvert(
+        "DELETE",
+        "/2017-08-29/certificates/$(arn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function disassociate_certificate(
     arn, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return mediaconvert(
-        "DELETE", "/2017-08-29/certificates/$(arn)", params; aws_config=aws_config
+        "DELETE",
+        "/2017-08-29/certificates/$(arn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -419,12 +487,23 @@ Retrieve the JSON for a specific completed transcoding job.
 
 """
 function get_job(id; aws_config::AbstractAWSConfig=global_aws_config())
-    return mediaconvert("GET", "/2017-08-29/jobs/$(id)"; aws_config=aws_config)
+    return mediaconvert(
+        "GET",
+        "/2017-08-29/jobs/$(id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_job(
     id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return mediaconvert("GET", "/2017-08-29/jobs/$(id)", params; aws_config=aws_config)
+    return mediaconvert(
+        "GET",
+        "/2017-08-29/jobs/$(id)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -438,13 +517,22 @@ Retrieve the JSON for a specific job template.
 
 """
 function get_job_template(name; aws_config::AbstractAWSConfig=global_aws_config())
-    return mediaconvert("GET", "/2017-08-29/jobTemplates/$(name)"; aws_config=aws_config)
+    return mediaconvert(
+        "GET",
+        "/2017-08-29/jobTemplates/$(name)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_job_template(
     name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return mediaconvert(
-        "GET", "/2017-08-29/jobTemplates/$(name)", params; aws_config=aws_config
+        "GET",
+        "/2017-08-29/jobTemplates/$(name)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -459,12 +547,23 @@ Retrieve the JSON for a specific preset.
 
 """
 function get_preset(name; aws_config::AbstractAWSConfig=global_aws_config())
-    return mediaconvert("GET", "/2017-08-29/presets/$(name)"; aws_config=aws_config)
+    return mediaconvert(
+        "GET",
+        "/2017-08-29/presets/$(name)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_preset(
     name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return mediaconvert("GET", "/2017-08-29/presets/$(name)", params; aws_config=aws_config)
+    return mediaconvert(
+        "GET",
+        "/2017-08-29/presets/$(name)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -478,12 +577,23 @@ Retrieve the JSON for a specific queue.
 
 """
 function get_queue(name; aws_config::AbstractAWSConfig=global_aws_config())
-    return mediaconvert("GET", "/2017-08-29/queues/$(name)"; aws_config=aws_config)
+    return mediaconvert(
+        "GET",
+        "/2017-08-29/queues/$(name)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_queue(
     name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return mediaconvert("GET", "/2017-08-29/queues/$(name)", params; aws_config=aws_config)
+    return mediaconvert(
+        "GET",
+        "/2017-08-29/queues/$(name)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -509,12 +619,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   are sorted in ASCENDING or DESCENDING order. Default varies by resource.
 """
 function list_job_templates(; aws_config::AbstractAWSConfig=global_aws_config())
-    return mediaconvert("GET", "/2017-08-29/jobTemplates"; aws_config=aws_config)
+    return mediaconvert(
+        "GET",
+        "/2017-08-29/jobTemplates";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_job_templates(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return mediaconvert("GET", "/2017-08-29/jobTemplates", params; aws_config=aws_config)
+    return mediaconvert(
+        "GET",
+        "/2017-08-29/jobTemplates",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -538,12 +659,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   or ERROR.
 """
 function list_jobs(; aws_config::AbstractAWSConfig=global_aws_config())
-    return mediaconvert("GET", "/2017-08-29/jobs"; aws_config=aws_config)
+    return mediaconvert(
+        "GET", "/2017-08-29/jobs"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_jobs(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return mediaconvert("GET", "/2017-08-29/jobs", params; aws_config=aws_config)
+    return mediaconvert(
+        "GET",
+        "/2017-08-29/jobs",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -569,12 +698,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   are sorted in ASCENDING or DESCENDING order. Default varies by resource.
 """
 function list_presets(; aws_config::AbstractAWSConfig=global_aws_config())
-    return mediaconvert("GET", "/2017-08-29/presets"; aws_config=aws_config)
+    return mediaconvert(
+        "GET", "/2017-08-29/presets"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_presets(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return mediaconvert("GET", "/2017-08-29/presets", params; aws_config=aws_config)
+    return mediaconvert(
+        "GET",
+        "/2017-08-29/presets",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -598,12 +735,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   are sorted in ASCENDING or DESCENDING order. Default varies by resource.
 """
 function list_queues(; aws_config::AbstractAWSConfig=global_aws_config())
-    return mediaconvert("GET", "/2017-08-29/queues"; aws_config=aws_config)
+    return mediaconvert(
+        "GET", "/2017-08-29/queues"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_queues(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return mediaconvert("GET", "/2017-08-29/queues", params; aws_config=aws_config)
+    return mediaconvert(
+        "GET",
+        "/2017-08-29/queues",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -618,12 +763,23 @@ Retrieve the tags for a MediaConvert resource.
 
 """
 function list_tags_for_resource(arn; aws_config::AbstractAWSConfig=global_aws_config())
-    return mediaconvert("GET", "/2017-08-29/tags/$(arn)"; aws_config=aws_config)
+    return mediaconvert(
+        "GET",
+        "/2017-08-29/tags/$(arn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_tags_for_resource(
     arn, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return mediaconvert("GET", "/2017-08-29/tags/$(arn)", params; aws_config=aws_config)
+    return mediaconvert(
+        "GET",
+        "/2017-08-29/tags/$(arn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -647,6 +803,7 @@ function tag_resource(arn, tags; aws_config::AbstractAWSConfig=global_aws_config
         "/2017-08-29/tags",
         Dict{String,Any}("arn" => arn, "tags" => tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -662,6 +819,7 @@ function tag_resource(
             mergewith(_merge, Dict{String,Any}("arn" => arn, "tags" => tags), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -682,12 +840,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"tagKeys"`: The keys of the tags that you want to remove from the resource.
 """
 function untag_resource(arn; aws_config::AbstractAWSConfig=global_aws_config())
-    return mediaconvert("PUT", "/2017-08-29/tags/$(arn)"; aws_config=aws_config)
+    return mediaconvert(
+        "PUT",
+        "/2017-08-29/tags/$(arn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function untag_resource(
     arn, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return mediaconvert("PUT", "/2017-08-29/tags/$(arn)", params; aws_config=aws_config)
+    return mediaconvert(
+        "PUT",
+        "/2017-08-29/tags/$(arn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -720,13 +889,22 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   your job to the time it completes the transcode or encounters an error.
 """
 function update_job_template(name; aws_config::AbstractAWSConfig=global_aws_config())
-    return mediaconvert("PUT", "/2017-08-29/jobTemplates/$(name)"; aws_config=aws_config)
+    return mediaconvert(
+        "PUT",
+        "/2017-08-29/jobTemplates/$(name)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function update_job_template(
     name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return mediaconvert(
-        "PUT", "/2017-08-29/jobTemplates/$(name)", params; aws_config=aws_config
+        "PUT",
+        "/2017-08-29/jobTemplates/$(name)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -746,12 +924,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"settings"`: Settings for preset
 """
 function update_preset(name; aws_config::AbstractAWSConfig=global_aws_config())
-    return mediaconvert("PUT", "/2017-08-29/presets/$(name)"; aws_config=aws_config)
+    return mediaconvert(
+        "PUT",
+        "/2017-08-29/presets/$(name)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function update_preset(
     name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return mediaconvert("PUT", "/2017-08-29/presets/$(name)", params; aws_config=aws_config)
+    return mediaconvert(
+        "PUT",
+        "/2017-08-29/presets/$(name)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -776,10 +965,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   the queue continue to run until they finish or result in an error.
 """
 function update_queue(name; aws_config::AbstractAWSConfig=global_aws_config())
-    return mediaconvert("PUT", "/2017-08-29/queues/$(name)"; aws_config=aws_config)
+    return mediaconvert(
+        "PUT",
+        "/2017-08-29/queues/$(name)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function update_queue(
     name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return mediaconvert("PUT", "/2017-08-29/queues/$(name)", params; aws_config=aws_config)
+    return mediaconvert(
+        "PUT",
+        "/2017-08-29/queues/$(name)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end

--- a/src/services/medialive.jl
+++ b/src/services/medialive.jl
@@ -20,7 +20,10 @@ function accept_input_device_transfer(
     inputDeviceId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return medialive(
-        "POST", "/prod/inputDevices/$(inputDeviceId)/accept"; aws_config=aws_config
+        "POST",
+        "/prod/inputDevices/$(inputDeviceId)/accept";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function accept_input_device_transfer(
@@ -29,7 +32,11 @@ function accept_input_device_transfer(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return medialive(
-        "POST", "/prod/inputDevices/$(inputDeviceId)/accept", params; aws_config=aws_config
+        "POST",
+        "/prod/inputDevices/$(inputDeviceId)/accept",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -47,12 +54,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"multiplexIds"`: List of multiplex IDs
 """
 function batch_delete(; aws_config::AbstractAWSConfig=global_aws_config())
-    return medialive("POST", "/prod/batch/delete"; aws_config=aws_config)
+    return medialive(
+        "POST", "/prod/batch/delete"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function batch_delete(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return medialive("POST", "/prod/batch/delete", params; aws_config=aws_config)
+    return medialive(
+        "POST",
+        "/prod/batch/delete",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -67,12 +82,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"multiplexIds"`: List of multiplex IDs
 """
 function batch_start(; aws_config::AbstractAWSConfig=global_aws_config())
-    return medialive("POST", "/prod/batch/start"; aws_config=aws_config)
+    return medialive(
+        "POST", "/prod/batch/start"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function batch_start(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return medialive("POST", "/prod/batch/start", params; aws_config=aws_config)
+    return medialive(
+        "POST",
+        "/prod/batch/start",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -87,12 +110,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"multiplexIds"`: List of multiplex IDs
 """
 function batch_stop(; aws_config::AbstractAWSConfig=global_aws_config())
-    return medialive("POST", "/prod/batch/stop"; aws_config=aws_config)
+    return medialive(
+        "POST", "/prod/batch/stop"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function batch_stop(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return medialive("POST", "/prod/batch/stop", params; aws_config=aws_config)
+    return medialive(
+        "POST",
+        "/prod/batch/stop",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -110,7 +141,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"deletes"`: Schedule actions to delete from the schedule.
 """
 function batch_update_schedule(channelId; aws_config::AbstractAWSConfig=global_aws_config())
-    return medialive("PUT", "/prod/channels/$(channelId)/schedule"; aws_config=aws_config)
+    return medialive(
+        "PUT",
+        "/prod/channels/$(channelId)/schedule";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function batch_update_schedule(
     channelId,
@@ -118,7 +154,11 @@ function batch_update_schedule(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return medialive(
-        "PUT", "/prod/channels/$(channelId)/schedule", params; aws_config=aws_config
+        "PUT",
+        "/prod/channels/$(channelId)/schedule",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -137,7 +177,10 @@ function cancel_input_device_transfer(
     inputDeviceId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return medialive(
-        "POST", "/prod/inputDevices/$(inputDeviceId)/cancel"; aws_config=aws_config
+        "POST",
+        "/prod/inputDevices/$(inputDeviceId)/cancel";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function cancel_input_device_transfer(
@@ -146,7 +189,11 @@ function cancel_input_device_transfer(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return medialive(
-        "POST", "/prod/inputDevices/$(inputDeviceId)/cancel", params; aws_config=aws_config
+        "POST",
+        "/prod/inputDevices/$(inputDeviceId)/cancel",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -182,6 +229,7 @@ function create_channel(; aws_config::AbstractAWSConfig=global_aws_config())
         "/prod/channels",
         Dict{String,Any}("requestId" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_channel(
@@ -194,6 +242,7 @@ function create_channel(
             mergewith(_merge, Dict{String,Any}("requestId" => string(uuid4())), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -236,6 +285,7 @@ function create_input(; aws_config::AbstractAWSConfig=global_aws_config())
         "/prod/inputs",
         Dict{String,Any}("requestId" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_input(
@@ -248,6 +298,7 @@ function create_input(
             mergewith(_merge, Dict{String,Any}("requestId" => string(uuid4())), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -263,12 +314,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"whitelistRules"`: List of IPv4 CIDR addresses to whitelist
 """
 function create_input_security_group(; aws_config::AbstractAWSConfig=global_aws_config())
-    return medialive("POST", "/prod/inputSecurityGroups"; aws_config=aws_config)
+    return medialive(
+        "POST",
+        "/prod/inputSecurityGroups";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function create_input_security_group(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return medialive("POST", "/prod/inputSecurityGroups", params; aws_config=aws_config)
+    return medialive(
+        "POST",
+        "/prod/inputSecurityGroups",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -306,6 +368,7 @@ function create_multiplex(
             "requestId" => requestId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_multiplex(
@@ -332,6 +395,7 @@ function create_multiplex(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -365,6 +429,7 @@ function create_multiplex_program(
             "requestId" => requestId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_multiplex_program(
@@ -390,6 +455,7 @@ function create_multiplex_program(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -415,6 +481,7 @@ function create_partner_input(inputId; aws_config::AbstractAWSConfig=global_aws_
         "/prod/inputs/$(inputId)/partners",
         Dict{String,Any}("requestId" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_partner_input(
@@ -427,6 +494,7 @@ function create_partner_input(
             mergewith(_merge, Dict{String,Any}("requestId" => string(uuid4())), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -444,14 +512,25 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"tags"`:
 """
 function create_tags(resource_arn; aws_config::AbstractAWSConfig=global_aws_config())
-    return medialive("POST", "/prod/tags/$(resource-arn)"; aws_config=aws_config)
+    return medialive(
+        "POST",
+        "/prod/tags/$(resource-arn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function create_tags(
     resource_arn,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return medialive("POST", "/prod/tags/$(resource-arn)", params; aws_config=aws_config)
+    return medialive(
+        "POST",
+        "/prod/tags/$(resource-arn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -465,14 +544,25 @@ Starts deletion of channel. The associated outputs are also deleted.
 
 """
 function delete_channel(channelId; aws_config::AbstractAWSConfig=global_aws_config())
-    return medialive("DELETE", "/prod/channels/$(channelId)"; aws_config=aws_config)
+    return medialive(
+        "DELETE",
+        "/prod/channels/$(channelId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_channel(
     channelId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return medialive("DELETE", "/prod/channels/$(channelId)", params; aws_config=aws_config)
+    return medialive(
+        "DELETE",
+        "/prod/channels/$(channelId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -486,12 +576,23 @@ Deletes the input end point
 
 """
 function delete_input(inputId; aws_config::AbstractAWSConfig=global_aws_config())
-    return medialive("DELETE", "/prod/inputs/$(inputId)"; aws_config=aws_config)
+    return medialive(
+        "DELETE",
+        "/prod/inputs/$(inputId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_input(
     inputId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return medialive("DELETE", "/prod/inputs/$(inputId)", params; aws_config=aws_config)
+    return medialive(
+        "DELETE",
+        "/prod/inputs/$(inputId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -508,7 +609,10 @@ function delete_input_security_group(
     inputSecurityGroupId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return medialive(
-        "DELETE", "/prod/inputSecurityGroups/$(inputSecurityGroupId)"; aws_config=aws_config
+        "DELETE",
+        "/prod/inputSecurityGroups/$(inputSecurityGroupId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_input_security_group(
@@ -521,6 +625,7 @@ function delete_input_security_group(
         "/prod/inputSecurityGroups/$(inputSecurityGroupId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -535,7 +640,12 @@ Delete a multiplex. The multiplex must be idle.
 
 """
 function delete_multiplex(multiplexId; aws_config::AbstractAWSConfig=global_aws_config())
-    return medialive("DELETE", "/prod/multiplexes/$(multiplexId)"; aws_config=aws_config)
+    return medialive(
+        "DELETE",
+        "/prod/multiplexes/$(multiplexId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_multiplex(
     multiplexId,
@@ -543,7 +653,11 @@ function delete_multiplex(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return medialive(
-        "DELETE", "/prod/multiplexes/$(multiplexId)", params; aws_config=aws_config
+        "DELETE",
+        "/prod/multiplexes/$(multiplexId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -565,6 +679,7 @@ function delete_multiplex_program(
         "DELETE",
         "/prod/multiplexes/$(multiplexId)/programs/$(programName)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_multiplex_program(
@@ -578,6 +693,7 @@ function delete_multiplex_program(
         "/prod/multiplexes/$(multiplexId)/programs/$(programName)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -594,7 +710,12 @@ Delete an expired reservation.
 function delete_reservation(
     reservationId; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return medialive("DELETE", "/prod/reservations/$(reservationId)"; aws_config=aws_config)
+    return medialive(
+        "DELETE",
+        "/prod/reservations/$(reservationId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_reservation(
     reservationId,
@@ -602,7 +723,11 @@ function delete_reservation(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return medialive(
-        "DELETE", "/prod/reservations/$(reservationId)", params; aws_config=aws_config
+        "DELETE",
+        "/prod/reservations/$(reservationId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -618,7 +743,10 @@ Delete all schedule actions on a channel.
 """
 function delete_schedule(channelId; aws_config::AbstractAWSConfig=global_aws_config())
     return medialive(
-        "DELETE", "/prod/channels/$(channelId)/schedule"; aws_config=aws_config
+        "DELETE",
+        "/prod/channels/$(channelId)/schedule";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_schedule(
@@ -627,7 +755,11 @@ function delete_schedule(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return medialive(
-        "DELETE", "/prod/channels/$(channelId)/schedule", params; aws_config=aws_config
+        "DELETE",
+        "/prod/channels/$(channelId)/schedule",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -650,6 +782,7 @@ function delete_tags(
         "/prod/tags/$(resource-arn)",
         Dict{String,Any}("tagKeys" => tagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_tags(
@@ -663,6 +796,7 @@ function delete_tags(
         "/prod/tags/$(resource-arn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tagKeys" => tagKeys), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -677,14 +811,25 @@ Gets details about a channel
 
 """
 function describe_channel(channelId; aws_config::AbstractAWSConfig=global_aws_config())
-    return medialive("GET", "/prod/channels/$(channelId)"; aws_config=aws_config)
+    return medialive(
+        "GET",
+        "/prod/channels/$(channelId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_channel(
     channelId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return medialive("GET", "/prod/channels/$(channelId)", params; aws_config=aws_config)
+    return medialive(
+        "GET",
+        "/prod/channels/$(channelId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -698,12 +843,23 @@ Produces details about an input
 
 """
 function describe_input(inputId; aws_config::AbstractAWSConfig=global_aws_config())
-    return medialive("GET", "/prod/inputs/$(inputId)"; aws_config=aws_config)
+    return medialive(
+        "GET",
+        "/prod/inputs/$(inputId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_input(
     inputId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return medialive("GET", "/prod/inputs/$(inputId)", params; aws_config=aws_config)
+    return medialive(
+        "GET",
+        "/prod/inputs/$(inputId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -719,7 +875,12 @@ Gets the details for the input device
 function describe_input_device(
     inputDeviceId; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return medialive("GET", "/prod/inputDevices/$(inputDeviceId)"; aws_config=aws_config)
+    return medialive(
+        "GET",
+        "/prod/inputDevices/$(inputDeviceId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_input_device(
     inputDeviceId,
@@ -727,7 +888,11 @@ function describe_input_device(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return medialive(
-        "GET", "/prod/inputDevices/$(inputDeviceId)", params; aws_config=aws_config
+        "GET",
+        "/prod/inputDevices/$(inputDeviceId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -750,6 +915,7 @@ function describe_input_device_thumbnail(
         "/prod/inputDevices/$(inputDeviceId)/thumbnailData",
         Dict{String,Any}("headers" => Dict{String,Any}("accept" => accept));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_input_device_thumbnail(
@@ -769,6 +935,7 @@ function describe_input_device_thumbnail(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -786,7 +953,10 @@ function describe_input_security_group(
     inputSecurityGroupId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return medialive(
-        "GET", "/prod/inputSecurityGroups/$(inputSecurityGroupId)"; aws_config=aws_config
+        "GET",
+        "/prod/inputSecurityGroups/$(inputSecurityGroupId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_input_security_group(
@@ -799,6 +969,7 @@ function describe_input_security_group(
         "/prod/inputSecurityGroups/$(inputSecurityGroupId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -813,7 +984,12 @@ Gets details about a multiplex.
 
 """
 function describe_multiplex(multiplexId; aws_config::AbstractAWSConfig=global_aws_config())
-    return medialive("GET", "/prod/multiplexes/$(multiplexId)"; aws_config=aws_config)
+    return medialive(
+        "GET",
+        "/prod/multiplexes/$(multiplexId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_multiplex(
     multiplexId,
@@ -821,7 +997,11 @@ function describe_multiplex(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return medialive(
-        "GET", "/prod/multiplexes/$(multiplexId)", params; aws_config=aws_config
+        "GET",
+        "/prod/multiplexes/$(multiplexId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -843,6 +1023,7 @@ function describe_multiplex_program(
         "GET",
         "/prod/multiplexes/$(multiplexId)/programs/$(programName)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_multiplex_program(
@@ -856,6 +1037,7 @@ function describe_multiplex_program(
         "/prod/multiplexes/$(multiplexId)/programs/$(programName)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -870,14 +1052,25 @@ Get details for an offering.
 
 """
 function describe_offering(offeringId; aws_config::AbstractAWSConfig=global_aws_config())
-    return medialive("GET", "/prod/offerings/$(offeringId)"; aws_config=aws_config)
+    return medialive(
+        "GET",
+        "/prod/offerings/$(offeringId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_offering(
     offeringId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return medialive("GET", "/prod/offerings/$(offeringId)", params; aws_config=aws_config)
+    return medialive(
+        "GET",
+        "/prod/offerings/$(offeringId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -893,7 +1086,12 @@ Get details for a reservation.
 function describe_reservation(
     reservationId; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return medialive("GET", "/prod/reservations/$(reservationId)"; aws_config=aws_config)
+    return medialive(
+        "GET",
+        "/prod/reservations/$(reservationId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_reservation(
     reservationId,
@@ -901,7 +1099,11 @@ function describe_reservation(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return medialive(
-        "GET", "/prod/reservations/$(reservationId)", params; aws_config=aws_config
+        "GET",
+        "/prod/reservations/$(reservationId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -920,7 +1122,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`:
 """
 function describe_schedule(channelId; aws_config::AbstractAWSConfig=global_aws_config())
-    return medialive("GET", "/prod/channels/$(channelId)/schedule"; aws_config=aws_config)
+    return medialive(
+        "GET",
+        "/prod/channels/$(channelId)/schedule";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_schedule(
     channelId,
@@ -928,7 +1135,11 @@ function describe_schedule(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return medialive(
-        "GET", "/prod/channels/$(channelId)/schedule", params; aws_config=aws_config
+        "GET",
+        "/prod/channels/$(channelId)/schedule",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -944,12 +1155,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`:
 """
 function list_channels(; aws_config::AbstractAWSConfig=global_aws_config())
-    return medialive("GET", "/prod/channels"; aws_config=aws_config)
+    return medialive(
+        "GET", "/prod/channels"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_channels(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return medialive("GET", "/prod/channels", params; aws_config=aws_config)
+    return medialive(
+        "GET",
+        "/prod/channels",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -976,6 +1195,7 @@ function list_input_device_transfers(
         "/prod/inputDeviceTransfers",
         Dict{String,Any}("transferType" => transferType);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_input_device_transfers(
@@ -990,6 +1210,7 @@ function list_input_device_transfers(
             mergewith(_merge, Dict{String,Any}("transferType" => transferType), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1005,12 +1226,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`:
 """
 function list_input_devices(; aws_config::AbstractAWSConfig=global_aws_config())
-    return medialive("GET", "/prod/inputDevices"; aws_config=aws_config)
+    return medialive(
+        "GET", "/prod/inputDevices"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_input_devices(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return medialive("GET", "/prod/inputDevices", params; aws_config=aws_config)
+    return medialive(
+        "GET",
+        "/prod/inputDevices",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1025,12 +1254,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`:
 """
 function list_input_security_groups(; aws_config::AbstractAWSConfig=global_aws_config())
-    return medialive("GET", "/prod/inputSecurityGroups"; aws_config=aws_config)
+    return medialive(
+        "GET",
+        "/prod/inputSecurityGroups";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_input_security_groups(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return medialive("GET", "/prod/inputSecurityGroups", params; aws_config=aws_config)
+    return medialive(
+        "GET",
+        "/prod/inputSecurityGroups",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1045,12 +1285,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`:
 """
 function list_inputs(; aws_config::AbstractAWSConfig=global_aws_config())
-    return medialive("GET", "/prod/inputs"; aws_config=aws_config)
+    return medialive(
+        "GET", "/prod/inputs"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_inputs(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return medialive("GET", "/prod/inputs", params; aws_config=aws_config)
+    return medialive(
+        "GET",
+        "/prod/inputs",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1071,7 +1319,10 @@ function list_multiplex_programs(
     multiplexId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return medialive(
-        "GET", "/prod/multiplexes/$(multiplexId)/programs"; aws_config=aws_config
+        "GET",
+        "/prod/multiplexes/$(multiplexId)/programs";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_multiplex_programs(
@@ -1080,7 +1331,11 @@ function list_multiplex_programs(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return medialive(
-        "GET", "/prod/multiplexes/$(multiplexId)/programs", params; aws_config=aws_config
+        "GET",
+        "/prod/multiplexes/$(multiplexId)/programs",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1096,12 +1351,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: The token to retrieve the next page of results.
 """
 function list_multiplexes(; aws_config::AbstractAWSConfig=global_aws_config())
-    return medialive("GET", "/prod/multiplexes"; aws_config=aws_config)
+    return medialive(
+        "GET", "/prod/multiplexes"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_multiplexes(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return medialive("GET", "/prod/multiplexes", params; aws_config=aws_config)
+    return medialive(
+        "GET",
+        "/prod/multiplexes",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1127,12 +1390,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"videoQuality"`: Filter by video quality, 'STANDARD', 'ENHANCED', or 'PREMIUM'
 """
 function list_offerings(; aws_config::AbstractAWSConfig=global_aws_config())
-    return medialive("GET", "/prod/offerings"; aws_config=aws_config)
+    return medialive(
+        "GET", "/prod/offerings"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_offerings(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return medialive("GET", "/prod/offerings", params; aws_config=aws_config)
+    return medialive(
+        "GET",
+        "/prod/offerings",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1155,12 +1426,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"videoQuality"`: Filter by video quality, 'STANDARD', 'ENHANCED', or 'PREMIUM'
 """
 function list_reservations(; aws_config::AbstractAWSConfig=global_aws_config())
-    return medialive("GET", "/prod/reservations"; aws_config=aws_config)
+    return medialive(
+        "GET", "/prod/reservations"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_reservations(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return medialive("GET", "/prod/reservations", params; aws_config=aws_config)
+    return medialive(
+        "GET",
+        "/prod/reservations",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1176,14 +1455,25 @@ Produces list of tags that have been created for a resource
 function list_tags_for_resource(
     resource_arn; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return medialive("GET", "/prod/tags/$(resource-arn)"; aws_config=aws_config)
+    return medialive(
+        "GET",
+        "/prod/tags/$(resource-arn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_tags_for_resource(
     resource_arn,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return medialive("GET", "/prod/tags/$(resource-arn)", params; aws_config=aws_config)
+    return medialive(
+        "GET",
+        "/prod/tags/$(resource-arn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1214,6 +1504,7 @@ function purchase_offering(
         "/prod/offerings/$(offeringId)/purchase",
         Dict{String,Any}("count" => count, "requestId" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function purchase_offering(
@@ -1233,6 +1524,7 @@ function purchase_offering(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1251,7 +1543,10 @@ function reject_input_device_transfer(
     inputDeviceId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return medialive(
-        "POST", "/prod/inputDevices/$(inputDeviceId)/reject"; aws_config=aws_config
+        "POST",
+        "/prod/inputDevices/$(inputDeviceId)/reject";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function reject_input_device_transfer(
@@ -1260,7 +1555,11 @@ function reject_input_device_transfer(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return medialive(
-        "POST", "/prod/inputDevices/$(inputDeviceId)/reject", params; aws_config=aws_config
+        "POST",
+        "/prod/inputDevices/$(inputDeviceId)/reject",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1275,7 +1574,12 @@ Starts an existing channel
 
 """
 function start_channel(channelId; aws_config::AbstractAWSConfig=global_aws_config())
-    return medialive("POST", "/prod/channels/$(channelId)/start"; aws_config=aws_config)
+    return medialive(
+        "POST",
+        "/prod/channels/$(channelId)/start";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function start_channel(
     channelId,
@@ -1283,7 +1587,11 @@ function start_channel(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return medialive(
-        "POST", "/prod/channels/$(channelId)/start", params; aws_config=aws_config
+        "POST",
+        "/prod/channels/$(channelId)/start",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1300,7 +1608,10 @@ explicitly start each channel.
 """
 function start_multiplex(multiplexId; aws_config::AbstractAWSConfig=global_aws_config())
     return medialive(
-        "POST", "/prod/multiplexes/$(multiplexId)/start"; aws_config=aws_config
+        "POST",
+        "/prod/multiplexes/$(multiplexId)/start";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_multiplex(
@@ -1309,7 +1620,11 @@ function start_multiplex(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return medialive(
-        "POST", "/prod/multiplexes/$(multiplexId)/start", params; aws_config=aws_config
+        "POST",
+        "/prod/multiplexes/$(multiplexId)/start",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1324,7 +1639,12 @@ Stops a running channel
 
 """
 function stop_channel(channelId; aws_config::AbstractAWSConfig=global_aws_config())
-    return medialive("POST", "/prod/channels/$(channelId)/stop"; aws_config=aws_config)
+    return medialive(
+        "POST",
+        "/prod/channels/$(channelId)/stop";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function stop_channel(
     channelId,
@@ -1332,7 +1652,11 @@ function stop_channel(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return medialive(
-        "POST", "/prod/channels/$(channelId)/stop", params; aws_config=aws_config
+        "POST",
+        "/prod/channels/$(channelId)/stop",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1347,7 +1671,12 @@ Stops a running multiplex. If the multiplex isn't running, this action has no ef
 
 """
 function stop_multiplex(multiplexId; aws_config::AbstractAWSConfig=global_aws_config())
-    return medialive("POST", "/prod/multiplexes/$(multiplexId)/stop"; aws_config=aws_config)
+    return medialive(
+        "POST",
+        "/prod/multiplexes/$(multiplexId)/stop";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function stop_multiplex(
     multiplexId,
@@ -1355,7 +1684,11 @@ function stop_multiplex(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return medialive(
-        "POST", "/prod/multiplexes/$(multiplexId)/stop", params; aws_config=aws_config
+        "POST",
+        "/prod/multiplexes/$(multiplexId)/stop",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1380,7 +1713,10 @@ function transfer_input_device(
     inputDeviceId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return medialive(
-        "POST", "/prod/inputDevices/$(inputDeviceId)/transfer"; aws_config=aws_config
+        "POST",
+        "/prod/inputDevices/$(inputDeviceId)/transfer";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function transfer_input_device(
@@ -1393,6 +1729,7 @@ function transfer_input_device(
         "/prod/inputDevices/$(inputDeviceId)/transfer",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1419,14 +1756,25 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   that role will be removed.
 """
 function update_channel(channelId; aws_config::AbstractAWSConfig=global_aws_config())
-    return medialive("PUT", "/prod/channels/$(channelId)"; aws_config=aws_config)
+    return medialive(
+        "PUT",
+        "/prod/channels/$(channelId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function update_channel(
     channelId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return medialive("PUT", "/prod/channels/$(channelId)", params; aws_config=aws_config)
+    return medialive(
+        "PUT",
+        "/prod/channels/$(channelId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1451,6 +1799,7 @@ function update_channel_class(
         "/prod/channels/$(channelId)/channelClass",
         Dict{String,Any}("channelClass" => channelClass);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_channel_class(
@@ -1466,6 +1815,7 @@ function update_channel_class(
             mergewith(_merge, Dict{String,Any}("channelClass" => channelClass), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1500,12 +1850,23 @@ Only specify sources for PULL type Inputs. Leave
   Destinations empty.
 """
 function update_input(inputId; aws_config::AbstractAWSConfig=global_aws_config())
-    return medialive("PUT", "/prod/inputs/$(inputId)"; aws_config=aws_config)
+    return medialive(
+        "PUT",
+        "/prod/inputs/$(inputId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function update_input(
     inputId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return medialive("PUT", "/prod/inputs/$(inputId)", params; aws_config=aws_config)
+    return medialive(
+        "PUT",
+        "/prod/inputs/$(inputId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1526,7 +1887,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function update_input_device(
     inputDeviceId; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return medialive("PUT", "/prod/inputDevices/$(inputDeviceId)"; aws_config=aws_config)
+    return medialive(
+        "PUT",
+        "/prod/inputDevices/$(inputDeviceId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function update_input_device(
     inputDeviceId,
@@ -1534,7 +1900,11 @@ function update_input_device(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return medialive(
-        "PUT", "/prod/inputDevices/$(inputDeviceId)", params; aws_config=aws_config
+        "PUT",
+        "/prod/inputDevices/$(inputDeviceId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1556,7 +1926,10 @@ function update_input_security_group(
     inputSecurityGroupId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return medialive(
-        "PUT", "/prod/inputSecurityGroups/$(inputSecurityGroupId)"; aws_config=aws_config
+        "PUT",
+        "/prod/inputSecurityGroups/$(inputSecurityGroupId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_input_security_group(
@@ -1569,6 +1942,7 @@ function update_input_security_group(
         "/prod/inputSecurityGroups/$(inputSecurityGroupId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1587,7 +1961,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"name"`: Name of the multiplex.
 """
 function update_multiplex(multiplexId; aws_config::AbstractAWSConfig=global_aws_config())
-    return medialive("PUT", "/prod/multiplexes/$(multiplexId)"; aws_config=aws_config)
+    return medialive(
+        "PUT",
+        "/prod/multiplexes/$(multiplexId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function update_multiplex(
     multiplexId,
@@ -1595,7 +1974,11 @@ function update_multiplex(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return medialive(
-        "PUT", "/prod/multiplexes/$(multiplexId)", params; aws_config=aws_config
+        "PUT",
+        "/prod/multiplexes/$(multiplexId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1620,6 +2003,7 @@ function update_multiplex_program(
         "PUT",
         "/prod/multiplexes/$(multiplexId)/programs/$(programName)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_multiplex_program(
@@ -1633,6 +2017,7 @@ function update_multiplex_program(
         "/prod/multiplexes/$(multiplexId)/programs/$(programName)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1652,7 +2037,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function update_reservation(
     reservationId; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return medialive("PUT", "/prod/reservations/$(reservationId)"; aws_config=aws_config)
+    return medialive(
+        "PUT",
+        "/prod/reservations/$(reservationId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function update_reservation(
     reservationId,
@@ -1660,6 +2050,10 @@ function update_reservation(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return medialive(
-        "PUT", "/prod/reservations/$(reservationId)", params; aws_config=aws_config
+        "PUT",
+        "/prod/reservations/$(reservationId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/mediapackage.jl
+++ b/src/services/mediapackage.jl
@@ -19,13 +19,22 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"ingressAccessLogs"`:
 """
 function configure_logs(id; aws_config::AbstractAWSConfig=global_aws_config())
-    return mediapackage("PUT", "/channels/$(id)/configure_logs"; aws_config=aws_config)
+    return mediapackage(
+        "PUT",
+        "/channels/$(id)/configure_logs";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function configure_logs(
     id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return mediapackage(
-        "PUT", "/channels/$(id)/configure_logs", params; aws_config=aws_config
+        "PUT",
+        "/channels/$(id)/configure_logs",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -47,7 +56,11 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function create_channel(id; aws_config::AbstractAWSConfig=global_aws_config())
     return mediapackage(
-        "POST", "/channels", Dict{String,Any}("id" => id); aws_config=aws_config
+        "POST",
+        "/channels",
+        Dict{String,Any}("id" => id);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_channel(
@@ -58,6 +71,7 @@ function create_channel(
         "/channels",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("id" => id), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -98,6 +112,7 @@ function create_harvest_job(
             "startTime" => startTime,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_harvest_job(
@@ -126,6 +141,7 @@ function create_harvest_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -177,6 +193,7 @@ function create_origin_endpoint(
         "/origin_endpoints",
         Dict{String,Any}("channelId" => channelId, "id" => id);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_origin_endpoint(
@@ -194,6 +211,7 @@ function create_origin_endpoint(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -208,12 +226,20 @@ Deletes an existing Channel.
 
 """
 function delete_channel(id; aws_config::AbstractAWSConfig=global_aws_config())
-    return mediapackage("DELETE", "/channels/$(id)"; aws_config=aws_config)
+    return mediapackage(
+        "DELETE", "/channels/$(id)"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function delete_channel(
     id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return mediapackage("DELETE", "/channels/$(id)", params; aws_config=aws_config)
+    return mediapackage(
+        "DELETE",
+        "/channels/$(id)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -227,12 +253,23 @@ Deletes an existing OriginEndpoint.
 
 """
 function delete_origin_endpoint(id; aws_config::AbstractAWSConfig=global_aws_config())
-    return mediapackage("DELETE", "/origin_endpoints/$(id)"; aws_config=aws_config)
+    return mediapackage(
+        "DELETE",
+        "/origin_endpoints/$(id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_origin_endpoint(
     id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return mediapackage("DELETE", "/origin_endpoints/$(id)", params; aws_config=aws_config)
+    return mediapackage(
+        "DELETE",
+        "/origin_endpoints/$(id)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -246,12 +283,20 @@ Gets details about a Channel.
 
 """
 function describe_channel(id; aws_config::AbstractAWSConfig=global_aws_config())
-    return mediapackage("GET", "/channels/$(id)"; aws_config=aws_config)
+    return mediapackage(
+        "GET", "/channels/$(id)"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_channel(
     id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return mediapackage("GET", "/channels/$(id)", params; aws_config=aws_config)
+    return mediapackage(
+        "GET",
+        "/channels/$(id)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -265,12 +310,20 @@ Gets details about an existing HarvestJob.
 
 """
 function describe_harvest_job(id; aws_config::AbstractAWSConfig=global_aws_config())
-    return mediapackage("GET", "/harvest_jobs/$(id)"; aws_config=aws_config)
+    return mediapackage(
+        "GET", "/harvest_jobs/$(id)"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_harvest_job(
     id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return mediapackage("GET", "/harvest_jobs/$(id)", params; aws_config=aws_config)
+    return mediapackage(
+        "GET",
+        "/harvest_jobs/$(id)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -284,12 +337,23 @@ Gets details about an existing OriginEndpoint.
 
 """
 function describe_origin_endpoint(id; aws_config::AbstractAWSConfig=global_aws_config())
-    return mediapackage("GET", "/origin_endpoints/$(id)"; aws_config=aws_config)
+    return mediapackage(
+        "GET",
+        "/origin_endpoints/$(id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_origin_endpoint(
     id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return mediapackage("GET", "/origin_endpoints/$(id)", params; aws_config=aws_config)
+    return mediapackage(
+        "GET",
+        "/origin_endpoints/$(id)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -304,12 +368,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: A token used to resume pagination from the end of a previous request.
 """
 function list_channels(; aws_config::AbstractAWSConfig=global_aws_config())
-    return mediapackage("GET", "/channels"; aws_config=aws_config)
+    return mediapackage(
+        "GET", "/channels"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_channels(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return mediapackage("GET", "/channels", params; aws_config=aws_config)
+    return mediapackage(
+        "GET", "/channels", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -328,12 +396,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: A token used to resume pagination from the end of a previous request.
 """
 function list_harvest_jobs(; aws_config::AbstractAWSConfig=global_aws_config())
-    return mediapackage("GET", "/harvest_jobs"; aws_config=aws_config)
+    return mediapackage(
+        "GET", "/harvest_jobs"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_harvest_jobs(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return mediapackage("GET", "/harvest_jobs", params; aws_config=aws_config)
+    return mediapackage(
+        "GET",
+        "/harvest_jobs",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -350,12 +426,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: A token used to resume pagination from the end of a previous request.
 """
 function list_origin_endpoints(; aws_config::AbstractAWSConfig=global_aws_config())
-    return mediapackage("GET", "/origin_endpoints"; aws_config=aws_config)
+    return mediapackage(
+        "GET", "/origin_endpoints"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_origin_endpoints(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return mediapackage("GET", "/origin_endpoints", params; aws_config=aws_config)
+    return mediapackage(
+        "GET",
+        "/origin_endpoints",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -371,14 +455,25 @@ end
 function list_tags_for_resource(
     resource_arn; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return mediapackage("GET", "/tags/$(resource-arn)"; aws_config=aws_config)
+    return mediapackage(
+        "GET",
+        "/tags/$(resource-arn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_tags_for_resource(
     resource_arn,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return mediapackage("GET", "/tags/$(resource-arn)", params; aws_config=aws_config)
+    return mediapackage(
+        "GET",
+        "/tags/$(resource-arn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -393,12 +488,23 @@ deprecated. Please use RotateIngestEndpointCredentials instead
 
 """
 function rotate_channel_credentials(id; aws_config::AbstractAWSConfig=global_aws_config())
-    return mediapackage("PUT", "/channels/$(id)/credentials"; aws_config=aws_config)
+    return mediapackage(
+        "PUT",
+        "/channels/$(id)/credentials";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function rotate_channel_credentials(
     id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return mediapackage("PUT", "/channels/$(id)/credentials", params; aws_config=aws_config)
+    return mediapackage(
+        "PUT",
+        "/channels/$(id)/credentials",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -419,6 +525,7 @@ function rotate_ingest_endpoint_credentials(
         "PUT",
         "/channels/$(id)/ingest_endpoints/$(ingest_endpoint_id)/credentials";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function rotate_ingest_endpoint_credentials(
@@ -432,6 +539,7 @@ function rotate_ingest_endpoint_credentials(
         "/channels/$(id)/ingest_endpoints/$(ingest_endpoint_id)/credentials",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -452,6 +560,7 @@ function tag_resource(resource_arn, tags; aws_config::AbstractAWSConfig=global_a
         "/tags/$(resource-arn)",
         Dict{String,Any}("tags" => tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -465,6 +574,7 @@ function tag_resource(
         "/tags/$(resource-arn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tags" => tags), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -487,6 +597,7 @@ function untag_resource(
         "/tags/$(resource-arn)",
         Dict{String,Any}("tagKeys" => tagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -500,6 +611,7 @@ function untag_resource(
         "/tags/$(resource-arn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tagKeys" => tagKeys), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -517,12 +629,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"description"`: A short text description of the Channel.
 """
 function update_channel(id; aws_config::AbstractAWSConfig=global_aws_config())
-    return mediapackage("PUT", "/channels/$(id)"; aws_config=aws_config)
+    return mediapackage(
+        "PUT", "/channels/$(id)"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function update_channel(
     id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return mediapackage("PUT", "/channels/$(id)", params; aws_config=aws_config)
+    return mediapackage(
+        "PUT",
+        "/channels/$(id)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -560,10 +680,21 @@ If not specified, there will be no time delay in effect for the OriginEndpoint.
   OriginEndpoint.
 """
 function update_origin_endpoint(id; aws_config::AbstractAWSConfig=global_aws_config())
-    return mediapackage("PUT", "/origin_endpoints/$(id)"; aws_config=aws_config)
+    return mediapackage(
+        "PUT",
+        "/origin_endpoints/$(id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function update_origin_endpoint(
     id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return mediapackage("PUT", "/origin_endpoints/$(id)", params; aws_config=aws_config)
+    return mediapackage(
+        "PUT",
+        "/origin_endpoints/$(id)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end

--- a/src/services/mediapackage_vod.jl
+++ b/src/services/mediapackage_vod.jl
@@ -19,14 +19,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function configure_logs(id; aws_config::AbstractAWSConfig=global_aws_config())
     return mediapackage_vod(
-        "PUT", "/packaging_groups/$(id)/configure_logs"; aws_config=aws_config
+        "PUT",
+        "/packaging_groups/$(id)/configure_logs";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function configure_logs(
     id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return mediapackage_vod(
-        "PUT", "/packaging_groups/$(id)/configure_logs", params; aws_config=aws_config
+        "PUT",
+        "/packaging_groups/$(id)/configure_logs",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -64,6 +71,7 @@ function create_asset(
             "sourceRoleArn" => sourceRoleArn,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_asset(
@@ -90,6 +98,7 @@ function create_asset(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -119,6 +128,7 @@ function create_packaging_configuration(
         "/packaging_configurations",
         Dict{String,Any}("id" => id, "packagingGroupId" => packagingGroupId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_packaging_configuration(
@@ -138,6 +148,7 @@ function create_packaging_configuration(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -158,7 +169,11 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function create_packaging_group(id; aws_config::AbstractAWSConfig=global_aws_config())
     return mediapackage_vod(
-        "POST", "/packaging_groups", Dict{String,Any}("id" => id); aws_config=aws_config
+        "POST",
+        "/packaging_groups",
+        Dict{String,Any}("id" => id);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_packaging_group(
@@ -169,6 +184,7 @@ function create_packaging_group(
         "/packaging_groups",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("id" => id), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -183,12 +199,20 @@ Deletes an existing MediaPackage VOD Asset resource.
 
 """
 function delete_asset(id; aws_config::AbstractAWSConfig=global_aws_config())
-    return mediapackage_vod("DELETE", "/assets/$(id)"; aws_config=aws_config)
+    return mediapackage_vod(
+        "DELETE", "/assets/$(id)"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function delete_asset(
     id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return mediapackage_vod("DELETE", "/assets/$(id)", params; aws_config=aws_config)
+    return mediapackage_vod(
+        "DELETE",
+        "/assets/$(id)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -205,14 +229,21 @@ function delete_packaging_configuration(
     id; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return mediapackage_vod(
-        "DELETE", "/packaging_configurations/$(id)"; aws_config=aws_config
+        "DELETE",
+        "/packaging_configurations/$(id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_packaging_configuration(
     id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return mediapackage_vod(
-        "DELETE", "/packaging_configurations/$(id)", params; aws_config=aws_config
+        "DELETE",
+        "/packaging_configurations/$(id)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -227,13 +258,22 @@ Deletes a MediaPackage VOD PackagingGroup resource.
 
 """
 function delete_packaging_group(id; aws_config::AbstractAWSConfig=global_aws_config())
-    return mediapackage_vod("DELETE", "/packaging_groups/$(id)"; aws_config=aws_config)
+    return mediapackage_vod(
+        "DELETE",
+        "/packaging_groups/$(id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_packaging_group(
     id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return mediapackage_vod(
-        "DELETE", "/packaging_groups/$(id)", params; aws_config=aws_config
+        "DELETE",
+        "/packaging_groups/$(id)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -248,12 +288,20 @@ Returns a description of a MediaPackage VOD Asset resource.
 
 """
 function describe_asset(id; aws_config::AbstractAWSConfig=global_aws_config())
-    return mediapackage_vod("GET", "/assets/$(id)"; aws_config=aws_config)
+    return mediapackage_vod(
+        "GET", "/assets/$(id)"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_asset(
     id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return mediapackage_vod("GET", "/assets/$(id)", params; aws_config=aws_config)
+    return mediapackage_vod(
+        "GET",
+        "/assets/$(id)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -269,13 +317,22 @@ Returns a description of a MediaPackage VOD PackagingConfiguration resource.
 function describe_packaging_configuration(
     id; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return mediapackage_vod("GET", "/packaging_configurations/$(id)"; aws_config=aws_config)
+    return mediapackage_vod(
+        "GET",
+        "/packaging_configurations/$(id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_packaging_configuration(
     id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return mediapackage_vod(
-        "GET", "/packaging_configurations/$(id)", params; aws_config=aws_config
+        "GET",
+        "/packaging_configurations/$(id)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -290,12 +347,23 @@ Returns a description of a MediaPackage VOD PackagingGroup resource.
 
 """
 function describe_packaging_group(id; aws_config::AbstractAWSConfig=global_aws_config())
-    return mediapackage_vod("GET", "/packaging_groups/$(id)"; aws_config=aws_config)
+    return mediapackage_vod(
+        "GET",
+        "/packaging_groups/$(id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_packaging_group(
     id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return mediapackage_vod("GET", "/packaging_groups/$(id)", params; aws_config=aws_config)
+    return mediapackage_vod(
+        "GET",
+        "/packaging_groups/$(id)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -311,12 +379,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"packagingGroupId"`: Returns Assets associated with the specified PackagingGroup.
 """
 function list_assets(; aws_config::AbstractAWSConfig=global_aws_config())
-    return mediapackage_vod("GET", "/assets"; aws_config=aws_config)
+    return mediapackage_vod(
+        "GET", "/assets"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_assets(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return mediapackage_vod("GET", "/assets", params; aws_config=aws_config)
+    return mediapackage_vod(
+        "GET", "/assets", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -333,13 +405,22 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   the specified PackagingGroup.
 """
 function list_packaging_configurations(; aws_config::AbstractAWSConfig=global_aws_config())
-    return mediapackage_vod("GET", "/packaging_configurations"; aws_config=aws_config)
+    return mediapackage_vod(
+        "GET",
+        "/packaging_configurations";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_packaging_configurations(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return mediapackage_vod(
-        "GET", "/packaging_configurations", params; aws_config=aws_config
+        "GET",
+        "/packaging_configurations",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -355,12 +436,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: A token used to resume pagination from the end of a previous request.
 """
 function list_packaging_groups(; aws_config::AbstractAWSConfig=global_aws_config())
-    return mediapackage_vod("GET", "/packaging_groups"; aws_config=aws_config)
+    return mediapackage_vod(
+        "GET", "/packaging_groups"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_packaging_groups(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return mediapackage_vod("GET", "/packaging_groups", params; aws_config=aws_config)
+    return mediapackage_vod(
+        "GET",
+        "/packaging_groups",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -377,14 +466,25 @@ Returns a list of the tags assigned to the specified resource.
 function list_tags_for_resource(
     resource_arn; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return mediapackage_vod("GET", "/tags/$(resource-arn)"; aws_config=aws_config)
+    return mediapackage_vod(
+        "GET",
+        "/tags/$(resource-arn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_tags_for_resource(
     resource_arn,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return mediapackage_vod("GET", "/tags/$(resource-arn)", params; aws_config=aws_config)
+    return mediapackage_vod(
+        "GET",
+        "/tags/$(resource-arn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -405,6 +505,7 @@ function tag_resource(resource_arn, tags; aws_config::AbstractAWSConfig=global_a
         "/tags/$(resource-arn)",
         Dict{String,Any}("tags" => tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -418,6 +519,7 @@ function tag_resource(
         "/tags/$(resource-arn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tags" => tags), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -441,6 +543,7 @@ function untag_resource(
         "/tags/$(resource-arn)",
         Dict{String,Any}("tagKeys" => tagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -454,6 +557,7 @@ function untag_resource(
         "/tags/$(resource-arn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tagKeys" => tagKeys), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -472,10 +576,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"authorization"`:
 """
 function update_packaging_group(id; aws_config::AbstractAWSConfig=global_aws_config())
-    return mediapackage_vod("PUT", "/packaging_groups/$(id)"; aws_config=aws_config)
+    return mediapackage_vod(
+        "PUT",
+        "/packaging_groups/$(id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function update_packaging_group(
     id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return mediapackage_vod("PUT", "/packaging_groups/$(id)", params; aws_config=aws_config)
+    return mediapackage_vod(
+        "PUT",
+        "/packaging_groups/$(id)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end

--- a/src/services/mediastore.jl
+++ b/src/services/mediastore.jl
@@ -31,6 +31,7 @@ function create_container(ContainerName; aws_config::AbstractAWSConfig=global_aw
         "CreateContainer",
         Dict{String,Any}("ContainerName" => ContainerName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_container(
@@ -44,6 +45,7 @@ function create_container(
             mergewith(_merge, Dict{String,Any}("ContainerName" => ContainerName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -64,6 +66,7 @@ function delete_container(ContainerName; aws_config::AbstractAWSConfig=global_aw
         "DeleteContainer",
         Dict{String,Any}("ContainerName" => ContainerName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_container(
@@ -77,6 +80,7 @@ function delete_container(
             mergewith(_merge, Dict{String,Any}("ContainerName" => ContainerName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -97,6 +101,7 @@ function delete_container_policy(
         "DeleteContainerPolicy",
         Dict{String,Any}("ContainerName" => ContainerName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_container_policy(
@@ -110,6 +115,7 @@ function delete_container_policy(
             mergewith(_merge, Dict{String,Any}("ContainerName" => ContainerName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -133,6 +139,7 @@ function delete_cors_policy(
         "DeleteCorsPolicy",
         Dict{String,Any}("ContainerName" => ContainerName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_cors_policy(
@@ -146,6 +153,7 @@ function delete_cors_policy(
             mergewith(_merge, Dict{String,Any}("ContainerName" => ContainerName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -167,6 +175,7 @@ function delete_lifecycle_policy(
         "DeleteLifecyclePolicy",
         Dict{String,Any}("ContainerName" => ContainerName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_lifecycle_policy(
@@ -180,6 +189,7 @@ function delete_lifecycle_policy(
             mergewith(_merge, Dict{String,Any}("ContainerName" => ContainerName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -202,6 +212,7 @@ function delete_metric_policy(
         "DeleteMetricPolicy",
         Dict{String,Any}("ContainerName" => ContainerName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_metric_policy(
@@ -215,6 +226,7 @@ function delete_metric_policy(
             mergewith(_merge, Dict{String,Any}("ContainerName" => ContainerName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -234,12 +246,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"ContainerName"`: The name of the container to query.
 """
 function describe_container(; aws_config::AbstractAWSConfig=global_aws_config())
-    return mediastore("DescribeContainer"; aws_config=aws_config)
+    return mediastore(
+        "DescribeContainer"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_container(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return mediastore("DescribeContainer", params; aws_config=aws_config)
+    return mediastore(
+        "DescribeContainer", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -260,6 +276,7 @@ function get_container_policy(
         "GetContainerPolicy",
         Dict{String,Any}("ContainerName" => ContainerName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_container_policy(
@@ -273,6 +290,7 @@ function get_container_policy(
             mergewith(_merge, Dict{String,Any}("ContainerName" => ContainerName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -294,6 +312,7 @@ function get_cors_policy(ContainerName; aws_config::AbstractAWSConfig=global_aws
         "GetCorsPolicy",
         Dict{String,Any}("ContainerName" => ContainerName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_cors_policy(
@@ -307,6 +326,7 @@ function get_cors_policy(
             mergewith(_merge, Dict{String,Any}("ContainerName" => ContainerName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -328,6 +348,7 @@ function get_lifecycle_policy(
         "GetLifecyclePolicy",
         Dict{String,Any}("ContainerName" => ContainerName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_lifecycle_policy(
@@ -341,6 +362,7 @@ function get_lifecycle_policy(
             mergewith(_merge, Dict{String,Any}("ContainerName" => ContainerName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -359,6 +381,7 @@ function get_metric_policy(ContainerName; aws_config::AbstractAWSConfig=global_a
         "GetMetricPolicy",
         Dict{String,Any}("ContainerName" => ContainerName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_metric_policy(
@@ -372,6 +395,7 @@ function get_metric_policy(
             mergewith(_merge, Dict{String,Any}("ContainerName" => ContainerName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -396,12 +420,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   included in a response only if there actually are more containers to list.
 """
 function list_containers(; aws_config::AbstractAWSConfig=global_aws_config())
-    return mediastore("ListContainers"; aws_config=aws_config)
+    return mediastore(
+        "ListContainers"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_containers(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return mediastore("ListContainers", params; aws_config=aws_config)
+    return mediastore(
+        "ListContainers", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -419,6 +447,7 @@ function list_tags_for_resource(Resource; aws_config::AbstractAWSConfig=global_a
         "ListTagsForResource",
         Dict{String,Any}("Resource" => Resource);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags_for_resource(
@@ -432,6 +461,7 @@ function list_tags_for_resource(
             mergewith(_merge, Dict{String,Any}("Resource" => Resource), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -458,6 +488,7 @@ function put_container_policy(
         "PutContainerPolicy",
         Dict{String,Any}("ContainerName" => ContainerName, "Policy" => Policy);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_container_policy(
@@ -476,6 +507,7 @@ function put_container_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -506,6 +538,7 @@ function put_cors_policy(
         "PutCorsPolicy",
         Dict{String,Any}("ContainerName" => ContainerName, "CorsPolicy" => CorsPolicy);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_cors_policy(
@@ -526,6 +559,7 @@ function put_cors_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -553,6 +587,7 @@ function put_lifecycle_policy(
             "ContainerName" => ContainerName, "LifecyclePolicy" => LifecyclePolicy
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_lifecycle_policy(
@@ -573,6 +608,7 @@ function put_lifecycle_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -606,6 +642,7 @@ function put_metric_policy(
         "PutMetricPolicy",
         Dict{String,Any}("ContainerName" => ContainerName, "MetricPolicy" => MetricPolicy);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_metric_policy(
@@ -626,6 +663,7 @@ function put_metric_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -648,6 +686,7 @@ function start_access_logging(
         "StartAccessLogging",
         Dict{String,Any}("ContainerName" => ContainerName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_access_logging(
@@ -661,6 +700,7 @@ function start_access_logging(
             mergewith(_merge, Dict{String,Any}("ContainerName" => ContainerName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -683,6 +723,7 @@ function stop_access_logging(
         "StopAccessLogging",
         Dict{String,Any}("ContainerName" => ContainerName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function stop_access_logging(
@@ -696,6 +737,7 @@ function stop_access_logging(
             mergewith(_merge, Dict{String,Any}("ContainerName" => ContainerName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -724,6 +766,7 @@ function tag_resource(Resource, Tags; aws_config::AbstractAWSConfig=global_aws_c
         "TagResource",
         Dict{String,Any}("Resource" => Resource, "Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -740,6 +783,7 @@ function tag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -764,6 +808,7 @@ function untag_resource(
         "UntagResource",
         Dict{String,Any}("Resource" => Resource, "TagKeys" => TagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -782,5 +827,6 @@ function untag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/mediastore_data.jl
+++ b/src/services/mediastore_data.jl
@@ -16,12 +16,16 @@ Deletes an object at the specified path.
 
 """
 function delete_object(Path; aws_config::AbstractAWSConfig=global_aws_config())
-    return mediastore_data("DELETE", "/$(Path)"; aws_config=aws_config)
+    return mediastore_data(
+        "DELETE", "/$(Path)"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function delete_object(
     Path, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return mediastore_data("DELETE", "/$(Path)", params; aws_config=aws_config)
+    return mediastore_data(
+        "DELETE", "/$(Path)", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -36,12 +40,16 @@ Gets the headers for an object at the specified path.
 
 """
 function describe_object(Path; aws_config::AbstractAWSConfig=global_aws_config())
-    return mediastore_data("HEAD", "/$(Path)"; aws_config=aws_config)
+    return mediastore_data(
+        "HEAD", "/$(Path)"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_object(
     Path, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return mediastore_data("HEAD", "/$(Path)", params; aws_config=aws_config)
+    return mediastore_data(
+        "HEAD", "/$(Path)", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -75,12 +83,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   availability.
 """
 function get_object(Path; aws_config::AbstractAWSConfig=global_aws_config())
-    return mediastore_data("GET", "/$(Path)"; aws_config=aws_config)
+    return mediastore_data(
+        "GET", "/$(Path)"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_object(
     Path, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return mediastore_data("GET", "/$(Path)", params; aws_config=aws_config)
+    return mediastore_data(
+        "GET", "/$(Path)", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -106,12 +118,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   name&gt;/&lt;folder name&gt;/&lt;file name&gt;
 """
 function list_items(; aws_config::AbstractAWSConfig=global_aws_config())
-    return mediastore_data("GET", "/"; aws_config=aws_config)
+    return mediastore_data(
+        "GET", "/"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_items(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return mediastore_data("GET", "/", params; aws_config=aws_config)
+    return mediastore_data(
+        "GET", "/", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -156,7 +172,11 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function put_object(Body, Path; aws_config::AbstractAWSConfig=global_aws_config())
     return mediastore_data(
-        "PUT", "/$(Path)", Dict{String,Any}("Body" => Body); aws_config=aws_config
+        "PUT",
+        "/$(Path)",
+        Dict{String,Any}("Body" => Body);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_object(
@@ -170,5 +190,6 @@ function put_object(
         "/$(Path)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Body" => Body), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/mediatailor.jl
+++ b/src/services/mediatailor.jl
@@ -33,6 +33,7 @@ function configure_logs_for_playback_configuration(
             "PlaybackConfigurationName" => PlaybackConfigurationName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function configure_logs_for_playback_configuration(
@@ -55,6 +56,7 @@ function configure_logs_for_playback_configuration(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -86,6 +88,7 @@ function create_channel(
         "/channel/$(channelName)",
         Dict{String,Any}("Outputs" => Outputs, "PlaybackMode" => PlaybackMode);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_channel(
@@ -106,6 +109,7 @@ function create_channel(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -143,6 +147,7 @@ function create_program(
             "VodSourceName" => VodSourceName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_program(
@@ -169,6 +174,7 @@ function create_program(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -198,6 +204,7 @@ function create_source_location(
         "/sourceLocation/$(sourceLocationName)",
         Dict{String,Any}("HttpConfiguration" => HttpConfiguration);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_source_location(
@@ -215,6 +222,7 @@ function create_source_location(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -245,6 +253,7 @@ function create_vod_source(
         "/sourceLocation/$(sourceLocationName)/vodSource/$(vodSourceName)",
         Dict{String,Any}("HttpPackageConfigurations" => HttpPackageConfigurations);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_vod_source(
@@ -265,6 +274,7 @@ function create_vod_source(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -279,14 +289,25 @@ Deletes a channel. You must stop the channel before it can be deleted.
 
 """
 function delete_channel(channelName; aws_config::AbstractAWSConfig=global_aws_config())
-    return mediatailor("DELETE", "/channel/$(channelName)"; aws_config=aws_config)
+    return mediatailor(
+        "DELETE",
+        "/channel/$(channelName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_channel(
     channelName,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return mediatailor("DELETE", "/channel/$(channelName)", params; aws_config=aws_config)
+    return mediatailor(
+        "DELETE",
+        "/channel/$(channelName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -302,7 +323,12 @@ Deletes a channel's IAM policy.
 function delete_channel_policy(
     channelName; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return mediatailor("DELETE", "/channel/$(channelName)/policy"; aws_config=aws_config)
+    return mediatailor(
+        "DELETE",
+        "/channel/$(channelName)/policy";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_channel_policy(
     channelName,
@@ -310,7 +336,11 @@ function delete_channel_policy(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return mediatailor(
-        "DELETE", "/channel/$(channelName)/policy", params; aws_config=aws_config
+        "DELETE",
+        "/channel/$(channelName)/policy",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -327,13 +357,22 @@ Deletes the playback configuration for the specified name.
 function delete_playback_configuration(
     Name; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return mediatailor("DELETE", "/playbackConfiguration/$(Name)"; aws_config=aws_config)
+    return mediatailor(
+        "DELETE",
+        "/playbackConfiguration/$(Name)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_playback_configuration(
     Name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return mediatailor(
-        "DELETE", "/playbackConfiguration/$(Name)", params; aws_config=aws_config
+        "DELETE",
+        "/playbackConfiguration/$(Name)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -352,7 +391,10 @@ function delete_program(
     channelName, programName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return mediatailor(
-        "DELETE", "/channel/$(channelName)/program/$(programName)"; aws_config=aws_config
+        "DELETE",
+        "/channel/$(channelName)/program/$(programName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_program(
@@ -366,6 +408,7 @@ function delete_program(
         "/channel/$(channelName)/program/$(programName)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -383,7 +426,10 @@ function delete_source_location(
     sourceLocationName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return mediatailor(
-        "DELETE", "/sourceLocation/$(sourceLocationName)"; aws_config=aws_config
+        "DELETE",
+        "/sourceLocation/$(sourceLocationName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_source_location(
@@ -392,7 +438,11 @@ function delete_source_location(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return mediatailor(
-        "DELETE", "/sourceLocation/$(sourceLocationName)", params; aws_config=aws_config
+        "DELETE",
+        "/sourceLocation/$(sourceLocationName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -414,6 +464,7 @@ function delete_vod_source(
         "DELETE",
         "/sourceLocation/$(sourceLocationName)/vodSource/$(vodSourceName)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_vod_source(
@@ -427,6 +478,7 @@ function delete_vod_source(
         "/sourceLocation/$(sourceLocationName)/vodSource/$(vodSourceName)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -441,14 +493,25 @@ Describes the properties of a specific channel.
 
 """
 function describe_channel(channelName; aws_config::AbstractAWSConfig=global_aws_config())
-    return mediatailor("GET", "/channel/$(channelName)"; aws_config=aws_config)
+    return mediatailor(
+        "GET",
+        "/channel/$(channelName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_channel(
     channelName,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return mediatailor("GET", "/channel/$(channelName)", params; aws_config=aws_config)
+    return mediatailor(
+        "GET",
+        "/channel/$(channelName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -466,7 +529,10 @@ function describe_program(
     channelName, programName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return mediatailor(
-        "GET", "/channel/$(channelName)/program/$(programName)"; aws_config=aws_config
+        "GET",
+        "/channel/$(channelName)/program/$(programName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_program(
@@ -480,6 +546,7 @@ function describe_program(
         "/channel/$(channelName)/program/$(programName)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -497,7 +564,10 @@ function describe_source_location(
     sourceLocationName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return mediatailor(
-        "GET", "/sourceLocation/$(sourceLocationName)"; aws_config=aws_config
+        "GET",
+        "/sourceLocation/$(sourceLocationName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_source_location(
@@ -506,7 +576,11 @@ function describe_source_location(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return mediatailor(
-        "GET", "/sourceLocation/$(sourceLocationName)", params; aws_config=aws_config
+        "GET",
+        "/sourceLocation/$(sourceLocationName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -528,6 +602,7 @@ function describe_vod_source(
         "GET",
         "/sourceLocation/$(sourceLocationName)/vodSource/$(vodSourceName)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_vod_source(
@@ -541,6 +616,7 @@ function describe_vod_source(
         "/sourceLocation/$(sourceLocationName)/vodSource/$(vodSourceName)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -555,7 +631,12 @@ Retrieves information about a channel's IAM policy.
 
 """
 function get_channel_policy(channelName; aws_config::AbstractAWSConfig=global_aws_config())
-    return mediatailor("GET", "/channel/$(channelName)/policy"; aws_config=aws_config)
+    return mediatailor(
+        "GET",
+        "/channel/$(channelName)/policy";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_channel_policy(
     channelName,
@@ -563,7 +644,11 @@ function get_channel_policy(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return mediatailor(
-        "GET", "/channel/$(channelName)/policy", params; aws_config=aws_config
+        "GET",
+        "/channel/$(channelName)/policy",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -588,7 +673,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function get_channel_schedule(
     channelName; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return mediatailor("GET", "/channel/$(channelName)/schedule"; aws_config=aws_config)
+    return mediatailor(
+        "GET",
+        "/channel/$(channelName)/schedule";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_channel_schedule(
     channelName,
@@ -596,7 +686,11 @@ function get_channel_schedule(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return mediatailor(
-        "GET", "/channel/$(channelName)/schedule", params; aws_config=aws_config
+        "GET",
+        "/channel/$(channelName)/schedule",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -611,13 +705,22 @@ Returns the playback configuration for the specified name.
 
 """
 function get_playback_configuration(Name; aws_config::AbstractAWSConfig=global_aws_config())
-    return mediatailor("GET", "/playbackConfiguration/$(Name)"; aws_config=aws_config)
+    return mediatailor(
+        "GET",
+        "/playbackConfiguration/$(Name)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_playback_configuration(
     Name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return mediatailor(
-        "GET", "/playbackConfiguration/$(Name)", params; aws_config=aws_config
+        "GET",
+        "/playbackConfiguration/$(Name)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -643,6 +746,7 @@ function list_alerts(resourceArn; aws_config::AbstractAWSConfig=global_aws_confi
         "/alerts",
         Dict{String,Any}("resourceArn" => resourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_alerts(
@@ -657,6 +761,7 @@ function list_alerts(
             mergewith(_merge, Dict{String,Any}("resourceArn" => resourceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -674,12 +779,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   next page of results.
 """
 function list_channels(; aws_config::AbstractAWSConfig=global_aws_config())
-    return mediatailor("GET", "/channels"; aws_config=aws_config)
+    return mediatailor(
+        "GET", "/channels"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_channels(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return mediatailor("GET", "/channels", params; aws_config=aws_config)
+    return mediatailor(
+        "GET", "/channels", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -699,12 +808,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   maximum allowed. Use the token to fetch the next page of results.
 """
 function list_playback_configurations(; aws_config::AbstractAWSConfig=global_aws_config())
-    return mediatailor("GET", "/playbackConfigurations"; aws_config=aws_config)
+    return mediatailor(
+        "GET",
+        "/playbackConfigurations";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_playback_configurations(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return mediatailor("GET", "/playbackConfigurations", params; aws_config=aws_config)
+    return mediatailor(
+        "GET",
+        "/playbackConfigurations",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -721,12 +841,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   next page of results.
 """
 function list_source_locations(; aws_config::AbstractAWSConfig=global_aws_config())
-    return mediatailor("GET", "/sourceLocations"; aws_config=aws_config)
+    return mediatailor(
+        "GET", "/sourceLocations"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_source_locations(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return mediatailor("GET", "/sourceLocations", params; aws_config=aws_config)
+    return mediatailor(
+        "GET",
+        "/sourceLocations",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -743,14 +871,25 @@ Returns a list of the tags assigned to the specified playback configuration reso
 function list_tags_for_resource(
     ResourceArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return mediatailor("GET", "/tags/$(ResourceArn)"; aws_config=aws_config)
+    return mediatailor(
+        "GET",
+        "/tags/$(ResourceArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_tags_for_resource(
     ResourceArn,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return mediatailor("GET", "/tags/$(ResourceArn)", params; aws_config=aws_config)
+    return mediatailor(
+        "GET",
+        "/tags/$(ResourceArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -773,7 +912,10 @@ function list_vod_sources(
     sourceLocationName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return mediatailor(
-        "GET", "/sourceLocation/$(sourceLocationName)/vodSources"; aws_config=aws_config
+        "GET",
+        "/sourceLocation/$(sourceLocationName)/vodSources";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_vod_sources(
@@ -786,6 +928,7 @@ function list_vod_sources(
         "/sourceLocation/$(sourceLocationName)/vodSources",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -808,6 +951,7 @@ function put_channel_policy(
         "/channel/$(channelName)/policy",
         Dict{String,Any}("Policy" => Policy);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_channel_policy(
@@ -821,6 +965,7 @@ function put_channel_policy(
         "/channel/$(channelName)/policy",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Policy" => Policy), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -873,12 +1018,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"tags"`: The tags to assign to the playback configuration.
 """
 function put_playback_configuration(; aws_config::AbstractAWSConfig=global_aws_config())
-    return mediatailor("PUT", "/playbackConfiguration"; aws_config=aws_config)
+    return mediatailor(
+        "PUT",
+        "/playbackConfiguration";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function put_playback_configuration(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return mediatailor("PUT", "/playbackConfiguration", params; aws_config=aws_config)
+    return mediatailor(
+        "PUT",
+        "/playbackConfiguration",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -892,7 +1048,12 @@ Starts a specific channel.
 
 """
 function start_channel(channelName; aws_config::AbstractAWSConfig=global_aws_config())
-    return mediatailor("PUT", "/channel/$(channelName)/start"; aws_config=aws_config)
+    return mediatailor(
+        "PUT",
+        "/channel/$(channelName)/start";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function start_channel(
     channelName,
@@ -900,7 +1061,11 @@ function start_channel(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return mediatailor(
-        "PUT", "/channel/$(channelName)/start", params; aws_config=aws_config
+        "PUT",
+        "/channel/$(channelName)/start",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -915,14 +1080,25 @@ Stops a specific channel.
 
 """
 function stop_channel(channelName; aws_config::AbstractAWSConfig=global_aws_config())
-    return mediatailor("PUT", "/channel/$(channelName)/stop"; aws_config=aws_config)
+    return mediatailor(
+        "PUT",
+        "/channel/$(channelName)/stop";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function stop_channel(
     channelName,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return mediatailor("PUT", "/channel/$(channelName)/stop", params; aws_config=aws_config)
+    return mediatailor(
+        "PUT",
+        "/channel/$(channelName)/stop",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -944,6 +1120,7 @@ function tag_resource(ResourceArn, tags; aws_config::AbstractAWSConfig=global_aw
         "/tags/$(ResourceArn)",
         Dict{String,Any}("tags" => tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -957,6 +1134,7 @@ function tag_resource(
         "/tags/$(ResourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tags" => tags), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -982,6 +1160,7 @@ function untag_resource(
         "/tags/$(ResourceArn)",
         Dict{String,Any}("tagKeys" => tagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -995,6 +1174,7 @@ function untag_resource(
         "/tags/$(ResourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tagKeys" => tagKeys), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1017,6 +1197,7 @@ function update_channel(
         "/channel/$(channelName)",
         Dict{String,Any}("Outputs" => Outputs);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_channel(
@@ -1030,6 +1211,7 @@ function update_channel(
         "/channel/$(channelName)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Outputs" => Outputs), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1058,6 +1240,7 @@ function update_source_location(
         "/sourceLocation/$(sourceLocationName)",
         Dict{String,Any}("HttpConfiguration" => HttpConfiguration);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_source_location(
@@ -1075,6 +1258,7 @@ function update_source_location(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1102,6 +1286,7 @@ function update_vod_source(
         "/sourceLocation/$(sourceLocationName)/vodSource/$(vodSourceName)",
         Dict{String,Any}("HttpPackageConfigurations" => HttpPackageConfigurations);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_vod_source(
@@ -1122,5 +1307,6 @@ function update_vod_source(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/memorydb.jl
+++ b/src/services/memorydb.jl
@@ -25,6 +25,7 @@ function batch_update_cluster(
         "BatchUpdateCluster",
         Dict{String,Any}("ClusterNames" => ClusterNames);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_update_cluster(
@@ -38,6 +39,7 @@ function batch_update_cluster(
             mergewith(_merge, Dict{String,Any}("ClusterNames" => ClusterNames), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -75,6 +77,7 @@ function copy_snapshot(
             "TargetSnapshotName" => TargetSnapshotName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function copy_snapshot(
@@ -96,6 +99,7 @@ function copy_snapshot(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -117,7 +121,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function create_acl(ACLName; aws_config::AbstractAWSConfig=global_aws_config())
     return memorydb(
-        "CreateACL", Dict{String,Any}("ACLName" => ACLName); aws_config=aws_config
+        "CreateACL",
+        Dict{String,Any}("ACLName" => ACLName);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_acl(
@@ -127,6 +134,7 @@ function create_acl(
         "CreateACL",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("ACLName" => ACLName), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -186,6 +194,7 @@ function create_cluster(
             "ACLName" => ACLName, "ClusterName" => ClusterName, "NodeType" => NodeType
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_cluster(
@@ -209,6 +218,7 @@ function create_cluster(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -238,6 +248,7 @@ function create_parameter_group(
         "CreateParameterGroup",
         Dict{String,Any}("Family" => Family, "ParameterGroupName" => ParameterGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_parameter_group(
@@ -258,6 +269,7 @@ function create_parameter_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -284,6 +296,7 @@ function create_snapshot(
         "CreateSnapshot",
         Dict{String,Any}("ClusterName" => ClusterName, "SnapshotName" => SnapshotName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_snapshot(
@@ -304,6 +317,7 @@ function create_snapshot(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -334,6 +348,7 @@ function create_subnet_group(
         "CreateSubnetGroup",
         Dict{String,Any}("SubnetGroupName" => SubnetGroupName, "SubnetIds" => SubnetIds);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_subnet_group(
@@ -354,6 +369,7 @@ function create_subnet_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -390,6 +406,7 @@ function create_user(
             "UserName" => UserName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_user(
@@ -413,6 +430,7 @@ function create_user(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -430,7 +448,10 @@ it can be deleted. For more information, see Authenticating users with Access Co
 """
 function delete_acl(ACLName; aws_config::AbstractAWSConfig=global_aws_config())
     return memorydb(
-        "DeleteACL", Dict{String,Any}("ACLName" => ACLName); aws_config=aws_config
+        "DeleteACL",
+        Dict{String,Any}("ACLName" => ACLName);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_acl(
@@ -440,6 +461,7 @@ function delete_acl(
         "DeleteACL",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("ACLName" => ACLName), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -463,6 +485,7 @@ function delete_cluster(ClusterName; aws_config::AbstractAWSConfig=global_aws_co
         "DeleteCluster",
         Dict{String,Any}("ClusterName" => ClusterName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_cluster(
@@ -476,6 +499,7 @@ function delete_cluster(
             mergewith(_merge, Dict{String,Any}("ClusterName" => ClusterName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -498,6 +522,7 @@ function delete_parameter_group(
         "DeleteParameterGroup",
         Dict{String,Any}("ParameterGroupName" => ParameterGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_parameter_group(
@@ -513,6 +538,7 @@ function delete_parameter_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -533,6 +559,7 @@ function delete_snapshot(SnapshotName; aws_config::AbstractAWSConfig=global_aws_
         "DeleteSnapshot",
         Dict{String,Any}("SnapshotName" => SnapshotName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_snapshot(
@@ -546,6 +573,7 @@ function delete_snapshot(
             mergewith(_merge, Dict{String,Any}("SnapshotName" => SnapshotName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -567,6 +595,7 @@ function delete_subnet_group(
         "DeleteSubnetGroup",
         Dict{String,Any}("SubnetGroupName" => SubnetGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_subnet_group(
@@ -582,6 +611,7 @@ function delete_subnet_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -598,7 +628,10 @@ clusters.
 """
 function delete_user(UserName; aws_config::AbstractAWSConfig=global_aws_config())
     return memorydb(
-        "DeleteUser", Dict{String,Any}("UserName" => UserName); aws_config=aws_config
+        "DeleteUser",
+        Dict{String,Any}("UserName" => UserName);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_user(
@@ -612,6 +645,7 @@ function delete_user(
             mergewith(_merge, Dict{String,Any}("UserName" => UserName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -633,12 +667,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   the returned token to retrieve the next page. Keep all other arguments unchanged.
 """
 function describe_acls(; aws_config::AbstractAWSConfig=global_aws_config())
-    return memorydb("DescribeACLs"; aws_config=aws_config)
+    return memorydb("DescribeACLs"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function describe_acls(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return memorydb("DescribeACLs", params; aws_config=aws_config)
+    return memorydb(
+        "DescribeACLs", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -662,12 +698,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   information about the individual shard(s).
 """
 function describe_clusters(; aws_config::AbstractAWSConfig=global_aws_config())
-    return memorydb("DescribeClusters"; aws_config=aws_config)
+    return memorydb(
+        "DescribeClusters"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_clusters(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return memorydb("DescribeClusters", params; aws_config=aws_config)
+    return memorydb(
+        "DescribeClusters", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -692,12 +732,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   for.
 """
 function describe_engine_versions(; aws_config::AbstractAWSConfig=global_aws_config())
-    return memorydb("DescribeEngineVersions"; aws_config=aws_config)
+    return memorydb(
+        "DescribeEngineVersions"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_engine_versions(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return memorydb("DescribeEngineVersions", params; aws_config=aws_config)
+    return memorydb(
+        "DescribeEngineVersions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -729,12 +776,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   ISO 8601 format. Example: 2017-03-30T07:03:49.555Z
 """
 function describe_events(; aws_config::AbstractAWSConfig=global_aws_config())
-    return memorydb("DescribeEvents"; aws_config=aws_config)
+    return memorydb(
+        "DescribeEvents"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_events(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return memorydb("DescribeEvents", params; aws_config=aws_config)
+    return memorydb(
+        "DescribeEvents", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -756,12 +807,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"ParameterGroupName"`: The name of a specific parameter group to return details for.
 """
 function describe_parameter_groups(; aws_config::AbstractAWSConfig=global_aws_config())
-    return memorydb("DescribeParameterGroups"; aws_config=aws_config)
+    return memorydb(
+        "DescribeParameterGroups"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_parameter_groups(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return memorydb("DescribeParameterGroups", params; aws_config=aws_config)
+    return memorydb(
+        "DescribeParameterGroups",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -790,6 +848,7 @@ function describe_parameters(
         "DescribeParameters",
         Dict{String,Any}("ParameterGroupName" => ParameterGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_parameters(
@@ -805,6 +864,7 @@ function describe_parameters(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -828,12 +888,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"Status"`: The status(es) of the service updates to filter on
 """
 function describe_service_updates(; aws_config::AbstractAWSConfig=global_aws_config())
-    return memorydb("DescribeServiceUpdates"; aws_config=aws_config)
+    return memorydb(
+        "DescribeServiceUpdates"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_service_updates(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return memorydb("DescribeServiceUpdates", params; aws_config=aws_config)
+    return memorydb(
+        "DescribeServiceUpdates",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -864,12 +931,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   omitted, the output shows both automatically and manually created snapshots.
 """
 function describe_snapshots(; aws_config::AbstractAWSConfig=global_aws_config())
-    return memorydb("DescribeSnapshots"; aws_config=aws_config)
+    return memorydb(
+        "DescribeSnapshots"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_snapshots(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return memorydb("DescribeSnapshots", params; aws_config=aws_config)
+    return memorydb(
+        "DescribeSnapshots", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -891,12 +962,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"SubnetGroupName"`: The name of the subnet group to return details for.
 """
 function describe_subnet_groups(; aws_config::AbstractAWSConfig=global_aws_config())
-    return memorydb("DescribeSubnetGroups"; aws_config=aws_config)
+    return memorydb(
+        "DescribeSubnetGroups"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_subnet_groups(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return memorydb("DescribeSubnetGroups", params; aws_config=aws_config)
+    return memorydb(
+        "DescribeSubnetGroups",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -918,12 +996,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"UserName"`: The name of the user
 """
 function describe_users(; aws_config::AbstractAWSConfig=global_aws_config())
-    return memorydb("DescribeUsers"; aws_config=aws_config)
+    return memorydb("DescribeUsers"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function describe_users(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return memorydb("DescribeUsers", params; aws_config=aws_config)
+    return memorydb(
+        "DescribeUsers", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -944,6 +1024,7 @@ function failover_shard(
         "FailoverShard",
         Dict{String,Any}("ClusterName" => ClusterName, "ShardName" => ShardName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function failover_shard(
@@ -962,6 +1043,7 @@ function failover_shard(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -986,6 +1068,7 @@ function list_allowed_node_type_updates(
         "ListAllowedNodeTypeUpdates",
         Dict{String,Any}("ClusterName" => ClusterName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_allowed_node_type_updates(
@@ -999,6 +1082,7 @@ function list_allowed_node_type_updates(
             mergewith(_merge, Dict{String,Any}("ClusterName" => ClusterName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1017,7 +1101,10 @@ For more information, see Tagging your MemoryDB resources
 """
 function list_tags(ResourceArn; aws_config::AbstractAWSConfig=global_aws_config())
     return memorydb(
-        "ListTags", Dict{String,Any}("ResourceArn" => ResourceArn); aws_config=aws_config
+        "ListTags",
+        Dict{String,Any}("ResourceArn" => ResourceArn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags(
@@ -1031,6 +1118,7 @@ function list_tags(
             mergewith(_merge, Dict{String,Any}("ResourceArn" => ResourceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1061,6 +1149,7 @@ function reset_parameter_group(
         "ResetParameterGroup",
         Dict{String,Any}("ParameterGroupName" => ParameterGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function reset_parameter_group(
@@ -1076,6 +1165,7 @@ function reset_parameter_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1104,6 +1194,7 @@ function tag_resource(ResourceArn, Tags; aws_config::AbstractAWSConfig=global_aw
         "TagResource",
         Dict{String,Any}("ResourceArn" => ResourceArn, "Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -1122,6 +1213,7 @@ function tag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1144,6 +1236,7 @@ function untag_resource(
         "UntagResource",
         Dict{String,Any}("ResourceArn" => ResourceArn, "TagKeys" => TagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -1162,6 +1255,7 @@ function untag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1181,7 +1275,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function update_acl(ACLName; aws_config::AbstractAWSConfig=global_aws_config())
     return memorydb(
-        "UpdateACL", Dict{String,Any}("ACLName" => ACLName); aws_config=aws_config
+        "UpdateACL",
+        Dict{String,Any}("ACLName" => ACLName);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_acl(
@@ -1191,6 +1288,7 @@ function update_acl(
         "UpdateACL",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("ACLName" => ACLName), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1232,6 +1330,7 @@ function update_cluster(ClusterName; aws_config::AbstractAWSConfig=global_aws_co
         "UpdateCluster",
         Dict{String,Any}("ClusterName" => ClusterName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_cluster(
@@ -1245,6 +1344,7 @@ function update_cluster(
             mergewith(_merge, Dict{String,Any}("ClusterName" => ClusterName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1274,6 +1374,7 @@ function update_parameter_group(
             "ParameterNameValues" => ParameterNameValues,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_parameter_group(
@@ -1295,6 +1396,7 @@ function update_parameter_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1319,6 +1421,7 @@ function update_subnet_group(
         "UpdateSubnetGroup",
         Dict{String,Any}("SubnetGroupName" => SubnetGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_subnet_group(
@@ -1334,6 +1437,7 @@ function update_subnet_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1354,7 +1458,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function update_user(UserName; aws_config::AbstractAWSConfig=global_aws_config())
     return memorydb(
-        "UpdateUser", Dict{String,Any}("UserName" => UserName); aws_config=aws_config
+        "UpdateUser",
+        Dict{String,Any}("UserName" => UserName);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_user(
@@ -1368,5 +1475,6 @@ function update_user(
             mergewith(_merge, Dict{String,Any}("UserName" => UserName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/mgn.jl
+++ b/src/services/mgn.jl
@@ -26,6 +26,7 @@ function change_server_life_cycle_state(
         "/ChangeServerLifeCycleState",
         Dict{String,Any}("lifeCycle" => lifeCycle, "sourceServerID" => sourceServerID);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function change_server_life_cycle_state(
@@ -47,6 +48,7 @@ function change_server_life_cycle_state(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -117,6 +119,7 @@ function create_replication_configuration_template(
             "useDedicatedReplicationServer" => useDedicatedReplicationServer,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_replication_configuration_template(
@@ -158,6 +161,7 @@ function create_replication_configuration_template(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -173,7 +177,11 @@ Deletes a single Job by ID.
 """
 function delete_job(jobID; aws_config::AbstractAWSConfig=global_aws_config())
     return mgn(
-        "POST", "/DeleteJob", Dict{String,Any}("jobID" => jobID); aws_config=aws_config
+        "POST",
+        "/DeleteJob",
+        Dict{String,Any}("jobID" => jobID);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_job(
@@ -184,6 +192,7 @@ function delete_job(
         "/DeleteJob",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("jobID" => jobID), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -208,6 +217,7 @@ function delete_replication_configuration_template(
             "replicationConfigurationTemplateID" => replicationConfigurationTemplateID
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_replication_configuration_template(
@@ -229,6 +239,7 @@ function delete_replication_configuration_template(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -250,6 +261,7 @@ function delete_source_server(
         "/DeleteSourceServer",
         Dict{String,Any}("sourceServerID" => sourceServerID);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_source_server(
@@ -264,6 +276,7 @@ function delete_source_server(
             mergewith(_merge, Dict{String,Any}("sourceServerID" => sourceServerID), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -287,6 +300,7 @@ function describe_job_log_items(jobID; aws_config::AbstractAWSConfig=global_aws_
         "/DescribeJobLogItems",
         Dict{String,Any}("jobID" => jobID);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_job_log_items(
@@ -297,6 +311,7 @@ function describe_job_log_items(
         "/DescribeJobLogItems",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("jobID" => jobID), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -324,6 +339,7 @@ function describe_jobs(filters; aws_config::AbstractAWSConfig=global_aws_config(
         "/DescribeJobs",
         Dict{String,Any}("filters" => filters);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_jobs(
@@ -334,6 +350,7 @@ function describe_jobs(
         "/DescribeJobs",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("filters" => filters), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -362,6 +379,7 @@ function describe_replication_configuration_templates(
             "replicationConfigurationTemplateIDs" => replicationConfigurationTemplateIDs
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_replication_configuration_templates(
@@ -383,6 +401,7 @@ function describe_replication_configuration_templates(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -406,6 +425,7 @@ function describe_source_servers(filters; aws_config::AbstractAWSConfig=global_a
         "/DescribeSourceServers",
         Dict{String,Any}("filters" => filters);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_source_servers(
@@ -416,6 +436,7 @@ function describe_source_servers(
         "/DescribeSourceServers",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("filters" => filters), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -446,6 +467,7 @@ function disconnect_from_service(
         "/DisconnectFromService",
         Dict{String,Any}("sourceServerID" => sourceServerID);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disconnect_from_service(
@@ -460,6 +482,7 @@ function disconnect_from_service(
             mergewith(_merge, Dict{String,Any}("sourceServerID" => sourceServerID), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -487,6 +510,7 @@ function finalize_cutover(sourceServerID; aws_config::AbstractAWSConfig=global_a
         "/FinalizeCutover",
         Dict{String,Any}("sourceServerID" => sourceServerID);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function finalize_cutover(
@@ -501,6 +525,7 @@ function finalize_cutover(
             mergewith(_merge, Dict{String,Any}("sourceServerID" => sourceServerID), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -522,6 +547,7 @@ function get_launch_configuration(
         "/GetLaunchConfiguration",
         Dict{String,Any}("sourceServerID" => sourceServerID);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_launch_configuration(
@@ -536,6 +562,7 @@ function get_launch_configuration(
             mergewith(_merge, Dict{String,Any}("sourceServerID" => sourceServerID), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -557,6 +584,7 @@ function get_replication_configuration(
         "/GetReplicationConfiguration",
         Dict{String,Any}("sourceServerID" => sourceServerID);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_replication_configuration(
@@ -571,6 +599,7 @@ function get_replication_configuration(
             mergewith(_merge, Dict{String,Any}("sourceServerID" => sourceServerID), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -582,12 +611,20 @@ Initialize Application Migration Service.
 
 """
 function initialize_service(; aws_config::AbstractAWSConfig=global_aws_config())
-    return mgn("POST", "/InitializeService"; aws_config=aws_config)
+    return mgn(
+        "POST", "/InitializeService"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function initialize_service(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return mgn("POST", "/InitializeService", params; aws_config=aws_config)
+    return mgn(
+        "POST",
+        "/InitializeService",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -603,14 +640,25 @@ List all tags for your Application Migration Service resources.
 function list_tags_for_resource(
     resourceArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return mgn("GET", "/tags/$(resourceArn)"; aws_config=aws_config)
+    return mgn(
+        "GET",
+        "/tags/$(resourceArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_tags_for_resource(
     resourceArn,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return mgn("GET", "/tags/$(resourceArn)", params; aws_config=aws_config)
+    return mgn(
+        "GET",
+        "/tags/$(resourceArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -631,6 +679,7 @@ function mark_as_archived(sourceServerID; aws_config::AbstractAWSConfig=global_a
         "/MarkAsArchived",
         Dict{String,Any}("sourceServerID" => sourceServerID);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function mark_as_archived(
@@ -645,6 +694,7 @@ function mark_as_archived(
             mergewith(_merge, Dict{String,Any}("sourceServerID" => sourceServerID), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -669,6 +719,7 @@ function retry_data_replication(
         "/RetryDataReplication",
         Dict{String,Any}("sourceServerID" => sourceServerID);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function retry_data_replication(
@@ -683,6 +734,7 @@ function retry_data_replication(
             mergewith(_merge, Dict{String,Any}("sourceServerID" => sourceServerID), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -707,6 +759,7 @@ function start_cutover(sourceServerIDs; aws_config::AbstractAWSConfig=global_aws
         "/StartCutover",
         Dict{String,Any}("sourceServerIDs" => sourceServerIDs);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_cutover(
@@ -723,6 +776,7 @@ function start_cutover(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -747,6 +801,7 @@ function start_test(sourceServerIDs; aws_config::AbstractAWSConfig=global_aws_co
         "/StartTest",
         Dict{String,Any}("sourceServerIDs" => sourceServerIDs);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_test(
@@ -763,6 +818,7 @@ function start_test(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -786,6 +842,7 @@ function tag_resource(resourceArn, tags; aws_config::AbstractAWSConfig=global_aw
         "/tags/$(resourceArn)",
         Dict{String,Any}("tags" => tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -799,6 +856,7 @@ function tag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tags" => tags), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -825,6 +883,7 @@ function terminate_target_instances(
         "/TerminateTargetInstances",
         Dict{String,Any}("sourceServerIDs" => sourceServerIDs);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function terminate_target_instances(
@@ -841,6 +900,7 @@ function terminate_target_instances(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -864,6 +924,7 @@ function untag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}("tagKeys" => tagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -877,6 +938,7 @@ function untag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tagKeys" => tagKeys), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -907,6 +969,7 @@ function update_launch_configuration(
         "/UpdateLaunchConfiguration",
         Dict{String,Any}("sourceServerID" => sourceServerID);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_launch_configuration(
@@ -921,6 +984,7 @@ function update_launch_configuration(
             mergewith(_merge, Dict{String,Any}("sourceServerID" => sourceServerID), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -963,6 +1027,7 @@ function update_replication_configuration(
         "/UpdateReplicationConfiguration",
         Dict{String,Any}("sourceServerID" => sourceServerID);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_replication_configuration(
@@ -977,6 +1042,7 @@ function update_replication_configuration(
             mergewith(_merge, Dict{String,Any}("sourceServerID" => sourceServerID), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1025,6 +1091,7 @@ function update_replication_configuration_template(
             "replicationConfigurationTemplateID" => replicationConfigurationTemplateID
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_replication_configuration_template(
@@ -1046,5 +1113,6 @@ function update_replication_configuration_template(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/migration_hub.jl
+++ b/src/services/migration_hub.jl
@@ -42,6 +42,7 @@ function associate_created_artifact(
             "ProgressUpdateStream" => ProgressUpdateStream,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_created_artifact(
@@ -65,6 +66,7 @@ function associate_created_artifact(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -100,6 +102,7 @@ function associate_discovered_resource(
             "ProgressUpdateStream" => ProgressUpdateStream,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_discovered_resource(
@@ -123,6 +126,7 @@ function associate_discovered_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -152,6 +156,7 @@ function create_progress_update_stream(
         "CreateProgressUpdateStream",
         Dict{String,Any}("ProgressUpdateStreamName" => ProgressUpdateStreamName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_progress_update_stream(
@@ -169,6 +174,7 @@ function create_progress_update_stream(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -206,6 +212,7 @@ function delete_progress_update_stream(
         "DeleteProgressUpdateStream",
         Dict{String,Any}("ProgressUpdateStreamName" => ProgressUpdateStreamName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_progress_update_stream(
@@ -223,6 +230,7 @@ function delete_progress_update_stream(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -244,6 +252,7 @@ function describe_application_state(
         "DescribeApplicationState",
         Dict{String,Any}("ApplicationId" => ApplicationId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_application_state(
@@ -257,6 +266,7 @@ function describe_application_state(
             mergewith(_merge, Dict{String,Any}("ApplicationId" => ApplicationId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -284,6 +294,7 @@ function describe_migration_task(
             "ProgressUpdateStream" => ProgressUpdateStream,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_migration_task(
@@ -305,6 +316,7 @@ function describe_migration_task(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -346,6 +358,7 @@ function disassociate_created_artifact(
             "ProgressUpdateStream" => ProgressUpdateStream,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disassociate_created_artifact(
@@ -369,6 +382,7 @@ function disassociate_created_artifact(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -404,6 +418,7 @@ function disassociate_discovered_resource(
             "ProgressUpdateStream" => ProgressUpdateStream,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disassociate_discovered_resource(
@@ -427,6 +442,7 @@ function disassociate_discovered_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -460,6 +476,7 @@ function import_migration_task(
             "ProgressUpdateStream" => ProgressUpdateStream,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function import_migration_task(
@@ -481,6 +498,7 @@ function import_migration_task(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -502,12 +520,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   token in NextToken.
 """
 function list_application_states(; aws_config::AbstractAWSConfig=global_aws_config())
-    return migration_hub("ListApplicationStates"; aws_config=aws_config)
+    return migration_hub(
+        "ListApplicationStates"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_application_states(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return migration_hub("ListApplicationStates", params; aws_config=aws_config)
+    return migration_hub(
+        "ListApplicationStates",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -543,6 +568,7 @@ function list_created_artifacts(
             "ProgressUpdateStream" => ProgressUpdateStream,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_created_artifacts(
@@ -564,6 +590,7 @@ function list_created_artifacts(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -597,6 +624,7 @@ function list_discovered_resources(
             "ProgressUpdateStream" => ProgressUpdateStream,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_discovered_resources(
@@ -618,6 +646,7 @@ function list_discovered_resources(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -639,12 +668,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"ResourceName"`: Filter migration tasks by discovered resource name.
 """
 function list_migration_tasks(; aws_config::AbstractAWSConfig=global_aws_config())
-    return migration_hub("ListMigrationTasks"; aws_config=aws_config)
+    return migration_hub(
+        "ListMigrationTasks"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_migration_tasks(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return migration_hub("ListMigrationTasks", params; aws_config=aws_config)
+    return migration_hub(
+        "ListMigrationTasks", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -661,12 +694,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   token in NextToken.
 """
 function list_progress_update_streams(; aws_config::AbstractAWSConfig=global_aws_config())
-    return migration_hub("ListProgressUpdateStreams"; aws_config=aws_config)
+    return migration_hub(
+        "ListProgressUpdateStreams"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_progress_update_streams(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return migration_hub("ListProgressUpdateStreams", params; aws_config=aws_config)
+    return migration_hub(
+        "ListProgressUpdateStreams",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -695,6 +735,7 @@ function notify_application_state(
         "NotifyApplicationState",
         Dict{String,Any}("ApplicationId" => ApplicationId, "Status" => Status);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function notify_application_state(
@@ -713,6 +754,7 @@ function notify_application_state(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -759,6 +801,7 @@ function notify_migration_task_state(
             "UpdateDateTime" => UpdateDateTime,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function notify_migration_task_state(
@@ -786,6 +829,7 @@ function notify_migration_task_state(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -842,6 +886,7 @@ function put_resource_attributes(
             "ResourceAttributeList" => ResourceAttributeList,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_resource_attributes(
@@ -865,5 +910,6 @@ function put_resource_attributes(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/migrationhub_config.jl
+++ b/src/services/migrationhub_config.jl
@@ -27,6 +27,7 @@ function create_home_region_control(
         "CreateHomeRegionControl",
         Dict{String,Any}("HomeRegion" => HomeRegion, "Target" => Target);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_home_region_control(
@@ -45,6 +46,7 @@ function create_home_region_control(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -67,12 +69,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   applied, which is always of type ACCOUNT. It applies the home region to the current ACCOUNT.
 """
 function describe_home_region_controls(; aws_config::AbstractAWSConfig=global_aws_config())
-    return migrationhub_config("DescribeHomeRegionControls"; aws_config=aws_config)
+    return migrationhub_config(
+        "DescribeHomeRegionControls"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_home_region_controls(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return migrationhub_config("DescribeHomeRegionControls", params; aws_config=aws_config)
+    return migrationhub_config(
+        "DescribeHomeRegionControls",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -87,10 +96,14 @@ Hub home region.
 
 """
 function get_home_region(; aws_config::AbstractAWSConfig=global_aws_config())
-    return migrationhub_config("GetHomeRegion"; aws_config=aws_config)
+    return migrationhub_config(
+        "GetHomeRegion"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_home_region(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return migrationhub_config("GetHomeRegion", params; aws_config=aws_config)
+    return migrationhub_config(
+        "GetHomeRegion", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end

--- a/src/services/mobile.jl
+++ b/src/services/mobile.jl
@@ -21,12 +21,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   This snapshot identifier is included in the share URL when a project is exported.
 """
 function create_project(; aws_config::AbstractAWSConfig=global_aws_config())
-    return mobile("POST", "/projects"; aws_config=aws_config)
+    return mobile(
+        "POST", "/projects"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function create_project(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return mobile("POST", "/projects", params; aws_config=aws_config)
+    return mobile(
+        "POST", "/projects", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -40,14 +44,25 @@ end
 
 """
 function delete_project(projectId; aws_config::AbstractAWSConfig=global_aws_config())
-    return mobile("DELETE", "/projects/$(projectId)"; aws_config=aws_config)
+    return mobile(
+        "DELETE",
+        "/projects/$(projectId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_project(
     projectId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return mobile("DELETE", "/projects/$(projectId)", params; aws_config=aws_config)
+    return mobile(
+        "DELETE",
+        "/projects/$(projectId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -61,14 +76,25 @@ end
 
 """
 function describe_bundle(bundleId; aws_config::AbstractAWSConfig=global_aws_config())
-    return mobile("GET", "/bundles/$(bundleId)"; aws_config=aws_config)
+    return mobile(
+        "GET",
+        "/bundles/$(bundleId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_bundle(
     bundleId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return mobile("GET", "/bundles/$(bundleId)", params; aws_config=aws_config)
+    return mobile(
+        "GET",
+        "/bundles/$(bundleId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -88,7 +114,11 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function describe_project(projectId; aws_config::AbstractAWSConfig=global_aws_config())
     return mobile(
-        "GET", "/project", Dict{String,Any}("projectId" => projectId); aws_config=aws_config
+        "GET",
+        "/project",
+        Dict{String,Any}("projectId" => projectId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_project(
@@ -103,6 +133,7 @@ function describe_project(
             mergewith(_merge, Dict{String,Any}("projectId" => projectId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -122,14 +153,25 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"projectId"`:  Unique project identifier.
 """
 function export_bundle(bundleId; aws_config::AbstractAWSConfig=global_aws_config())
-    return mobile("POST", "/bundles/$(bundleId)"; aws_config=aws_config)
+    return mobile(
+        "POST",
+        "/bundles/$(bundleId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function export_bundle(
     bundleId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return mobile("POST", "/bundles/$(bundleId)", params; aws_config=aws_config)
+    return mobile(
+        "POST",
+        "/bundles/$(bundleId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -145,14 +187,25 @@ successfully within the same AWS account.
 
 """
 function export_project(projectId; aws_config::AbstractAWSConfig=global_aws_config())
-    return mobile("POST", "/exports/$(projectId)"; aws_config=aws_config)
+    return mobile(
+        "POST",
+        "/exports/$(projectId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function export_project(
     projectId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return mobile("POST", "/exports/$(projectId)", params; aws_config=aws_config)
+    return mobile(
+        "POST",
+        "/exports/$(projectId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -169,12 +222,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   request to list more bundles.
 """
 function list_bundles(; aws_config::AbstractAWSConfig=global_aws_config())
-    return mobile("GET", "/bundles"; aws_config=aws_config)
+    return mobile("GET", "/bundles"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_bundles(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return mobile("GET", "/bundles", params; aws_config=aws_config)
+    return mobile(
+        "GET", "/bundles", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -191,12 +246,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   request to list more projects.
 """
 function list_projects(; aws_config::AbstractAWSConfig=global_aws_config())
-    return mobile("GET", "/projects"; aws_config=aws_config)
+    return mobile(
+        "GET", "/projects"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_projects(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return mobile("GET", "/projects", params; aws_config=aws_config)
+    return mobile(
+        "GET", "/projects", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -216,7 +275,11 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function update_project(projectId; aws_config::AbstractAWSConfig=global_aws_config())
     return mobile(
-        "POST", "/update", Dict{String,Any}("projectId" => projectId); aws_config=aws_config
+        "POST",
+        "/update",
+        Dict{String,Any}("projectId" => projectId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_project(
@@ -231,5 +294,6 @@ function update_project(
             mergewith(_merge, Dict{String,Any}("projectId" => projectId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/mobile_analytics.jl
+++ b/src/services/mobile_analytics.jl
@@ -32,6 +32,7 @@ function put_events(
             "headers" => Dict{String,Any}("x-amz-Client-Context" => x_amz_Client_Context),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_events(
@@ -55,5 +56,6 @@ function put_events(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/mq.jl
+++ b/src/services/mq.jl
@@ -101,6 +101,7 @@ function create_broker(
             "creatorRequestId" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_broker(
@@ -136,6 +137,7 @@ function create_broker(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -171,6 +173,7 @@ function create_configuration(
             "engineType" => engineType, "engineVersion" => engineVersion, "name" => name
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_configuration(
@@ -195,6 +198,7 @@ function create_configuration(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -212,14 +216,25 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"tags"`: The key-value pair for the resource tag.
 """
 function create_tags(resource_arn; aws_config::AbstractAWSConfig=global_aws_config())
-    return mq("POST", "/v1/tags/$(resource-arn)"; aws_config=aws_config)
+    return mq(
+        "POST",
+        "/v1/tags/$(resource-arn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function create_tags(
     resource_arn,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return mq("POST", "/v1/tags/$(resource-arn)", params; aws_config=aws_config)
+    return mq(
+        "POST",
+        "/v1/tags/$(resource-arn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -252,6 +267,7 @@ function create_user(
         "/v1/brokers/$(broker-id)/users/$(username)",
         Dict{String,Any}("password" => password);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_user(
@@ -268,6 +284,7 @@ function create_user(
             mergewith(_merge, Dict{String,Any}("password" => password), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -282,14 +299,25 @@ Deletes a broker. Note: This API is asynchronous.
 
 """
 function delete_broker(broker_id; aws_config::AbstractAWSConfig=global_aws_config())
-    return mq("DELETE", "/v1/brokers/$(broker-id)"; aws_config=aws_config)
+    return mq(
+        "DELETE",
+        "/v1/brokers/$(broker-id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_broker(
     broker_id,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return mq("DELETE", "/v1/brokers/$(broker-id)", params; aws_config=aws_config)
+    return mq(
+        "DELETE",
+        "/v1/brokers/$(broker-id)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -311,6 +339,7 @@ function delete_tags(
         "/v1/tags/$(resource-arn)",
         Dict{String,Any}("tagKeys" => tagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_tags(
@@ -324,6 +353,7 @@ function delete_tags(
         "/v1/tags/$(resource-arn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tagKeys" => tagKeys), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -341,7 +371,12 @@ Deletes an ActiveMQ user.
 
 """
 function delete_user(broker_id, username; aws_config::AbstractAWSConfig=global_aws_config())
-    return mq("DELETE", "/v1/brokers/$(broker-id)/users/$(username)"; aws_config=aws_config)
+    return mq(
+        "DELETE",
+        "/v1/brokers/$(broker-id)/users/$(username)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_user(
     broker_id,
@@ -354,6 +389,7 @@ function delete_user(
         "/v1/brokers/$(broker-id)/users/$(username)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -368,14 +404,25 @@ Returns information about the specified broker.
 
 """
 function describe_broker(broker_id; aws_config::AbstractAWSConfig=global_aws_config())
-    return mq("GET", "/v1/brokers/$(broker-id)"; aws_config=aws_config)
+    return mq(
+        "GET",
+        "/v1/brokers/$(broker-id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_broker(
     broker_id,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return mq("GET", "/v1/brokers/$(broker-id)", params; aws_config=aws_config)
+    return mq(
+        "GET",
+        "/v1/brokers/$(broker-id)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -393,12 +440,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   To request the first page, leave nextToken empty.
 """
 function describe_broker_engine_types(; aws_config::AbstractAWSConfig=global_aws_config())
-    return mq("GET", "/v1/broker-engine-types"; aws_config=aws_config)
+    return mq(
+        "GET",
+        "/v1/broker-engine-types";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_broker_engine_types(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return mq("GET", "/v1/broker-engine-types", params; aws_config=aws_config)
+    return mq(
+        "GET",
+        "/v1/broker-engine-types",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -420,12 +478,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_broker_instance_options(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return mq("GET", "/v1/broker-instance-options"; aws_config=aws_config)
+    return mq(
+        "GET",
+        "/v1/broker-instance-options";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_broker_instance_options(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return mq("GET", "/v1/broker-instance-options", params; aws_config=aws_config)
+    return mq(
+        "GET",
+        "/v1/broker-instance-options",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -441,7 +510,12 @@ Returns information about the specified configuration.
 function describe_configuration(
     configuration_id; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return mq("GET", "/v1/configurations/$(configuration-id)"; aws_config=aws_config)
+    return mq(
+        "GET",
+        "/v1/configurations/$(configuration-id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_configuration(
     configuration_id,
@@ -449,7 +523,11 @@ function describe_configuration(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return mq(
-        "GET", "/v1/configurations/$(configuration-id)", params; aws_config=aws_config
+        "GET",
+        "/v1/configurations/$(configuration-id)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -473,6 +551,7 @@ function describe_configuration_revision(
         "GET",
         "/v1/configurations/$(configuration-id)/revisions/$(configuration-revision)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_configuration_revision(
@@ -486,6 +565,7 @@ function describe_configuration_revision(
         "/v1/configurations/$(configuration-id)/revisions/$(configuration-revision)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -505,7 +585,12 @@ Returns information about an ActiveMQ user.
 function describe_user(
     broker_id, username; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return mq("GET", "/v1/brokers/$(broker-id)/users/$(username)"; aws_config=aws_config)
+    return mq(
+        "GET",
+        "/v1/brokers/$(broker-id)/users/$(username)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_user(
     broker_id,
@@ -514,7 +599,11 @@ function describe_user(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return mq(
-        "GET", "/v1/brokers/$(broker-id)/users/$(username)", params; aws_config=aws_config
+        "GET",
+        "/v1/brokers/$(broker-id)/users/$(username)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -532,12 +621,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   To request the first page, leave nextToken empty.
 """
 function list_brokers(; aws_config::AbstractAWSConfig=global_aws_config())
-    return mq("GET", "/v1/brokers"; aws_config=aws_config)
+    return mq("GET", "/v1/brokers"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_brokers(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return mq("GET", "/v1/brokers", params; aws_config=aws_config)
+    return mq(
+        "GET", "/v1/brokers", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -560,7 +651,10 @@ function list_configuration_revisions(
     configuration_id; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return mq(
-        "GET", "/v1/configurations/$(configuration-id)/revisions"; aws_config=aws_config
+        "GET",
+        "/v1/configurations/$(configuration-id)/revisions";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_configuration_revisions(
@@ -573,6 +667,7 @@ function list_configuration_revisions(
         "/v1/configurations/$(configuration-id)/revisions",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -590,12 +685,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   To request the first page, leave nextToken empty.
 """
 function list_configurations(; aws_config::AbstractAWSConfig=global_aws_config())
-    return mq("GET", "/v1/configurations"; aws_config=aws_config)
+    return mq(
+        "GET", "/v1/configurations"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_configurations(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return mq("GET", "/v1/configurations", params; aws_config=aws_config)
+    return mq(
+        "GET",
+        "/v1/configurations",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -609,14 +712,25 @@ Lists tags for a resource.
 
 """
 function list_tags(resource_arn; aws_config::AbstractAWSConfig=global_aws_config())
-    return mq("GET", "/v1/tags/$(resource-arn)"; aws_config=aws_config)
+    return mq(
+        "GET",
+        "/v1/tags/$(resource-arn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_tags(
     resource_arn,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return mq("GET", "/v1/tags/$(resource-arn)", params; aws_config=aws_config)
+    return mq(
+        "GET",
+        "/v1/tags/$(resource-arn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -636,14 +750,25 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   To request the first page, leave nextToken empty.
 """
 function list_users(broker_id; aws_config::AbstractAWSConfig=global_aws_config())
-    return mq("GET", "/v1/brokers/$(broker-id)/users"; aws_config=aws_config)
+    return mq(
+        "GET",
+        "/v1/brokers/$(broker-id)/users";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_users(
     broker_id,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return mq("GET", "/v1/brokers/$(broker-id)/users", params; aws_config=aws_config)
+    return mq(
+        "GET",
+        "/v1/brokers/$(broker-id)/users",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -657,14 +782,25 @@ Reboots a broker. Note: This API is asynchronous.
 
 """
 function reboot_broker(broker_id; aws_config::AbstractAWSConfig=global_aws_config())
-    return mq("POST", "/v1/brokers/$(broker-id)/reboot"; aws_config=aws_config)
+    return mq(
+        "POST",
+        "/v1/brokers/$(broker-id)/reboot";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function reboot_broker(
     broker_id,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return mq("POST", "/v1/brokers/$(broker-id)/reboot", params; aws_config=aws_config)
+    return mq(
+        "POST",
+        "/v1/brokers/$(broker-id)/reboot",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -696,14 +832,25 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   connections to brokers.
 """
 function update_broker(broker_id; aws_config::AbstractAWSConfig=global_aws_config())
-    return mq("PUT", "/v1/brokers/$(broker-id)"; aws_config=aws_config)
+    return mq(
+        "PUT",
+        "/v1/brokers/$(broker-id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function update_broker(
     broker_id,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return mq("PUT", "/v1/brokers/$(broker-id)", params; aws_config=aws_config)
+    return mq(
+        "PUT",
+        "/v1/brokers/$(broker-id)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -728,6 +875,7 @@ function update_configuration(
         "/v1/configurations/$(configuration-id)",
         Dict{String,Any}("data" => data);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_configuration(
@@ -741,6 +889,7 @@ function update_configuration(
         "/v1/configurations/$(configuration-id)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("data" => data), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -767,7 +916,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   signs (,:=).
 """
 function update_user(broker_id, username; aws_config::AbstractAWSConfig=global_aws_config())
-    return mq("PUT", "/v1/brokers/$(broker-id)/users/$(username)"; aws_config=aws_config)
+    return mq(
+        "PUT",
+        "/v1/brokers/$(broker-id)/users/$(username)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function update_user(
     broker_id,
@@ -776,6 +930,10 @@ function update_user(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return mq(
-        "PUT", "/v1/brokers/$(broker-id)/users/$(username)", params; aws_config=aws_config
+        "PUT",
+        "/v1/brokers/$(broker-id)/users/$(username)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/mturk.jl
+++ b/src/services/mturk.jl
@@ -29,6 +29,7 @@ function accept_qualification_request(
         "AcceptQualificationRequest",
         Dict{String,Any}("QualificationRequestId" => QualificationRequestId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function accept_qualification_request(
@@ -46,6 +47,7 @@ function accept_qualification_request(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -81,6 +83,7 @@ function approve_assignment(AssignmentId; aws_config::AbstractAWSConfig=global_a
         "ApproveAssignment",
         Dict{String,Any}("AssignmentId" => AssignmentId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function approve_assignment(
@@ -94,6 +97,7 @@ function approve_assignment(
             mergewith(_merge, Dict{String,Any}("AssignmentId" => AssignmentId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -134,6 +138,7 @@ function associate_qualification_with_worker(
             "QualificationTypeId" => QualificationTypeId, "WorkerId" => WorkerId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_qualification_with_worker(
@@ -154,6 +159,7 @@ function associate_qualification_with_worker(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -195,6 +201,7 @@ function create_additional_assignments_for_hit(
             "NumberOfAdditionalAssignments" => NumberOfAdditionalAssignments,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_additional_assignments_for_hit(
@@ -216,6 +223,7 @@ function create_additional_assignments_for_hit(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -323,6 +331,7 @@ function create_hit(
             "Title" => Title,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_hit(
@@ -350,6 +359,7 @@ function create_hit(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -408,6 +418,7 @@ function create_hittype(
             "Title" => Title,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_hittype(
@@ -433,6 +444,7 @@ function create_hittype(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -501,6 +513,7 @@ function create_hitwith_hittype(
             "HITTypeId" => HITTypeId, "LifetimeInSeconds" => LifetimeInSeconds
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_hitwith_hittype(
@@ -521,6 +534,7 @@ function create_hitwith_hittype(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -583,6 +597,7 @@ function create_qualification_type(
             "QualificationTypeStatus" => QualificationTypeStatus,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_qualification_type(
@@ -606,6 +621,7 @@ function create_qualification_type(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -630,6 +646,7 @@ function create_worker_block(
         "CreateWorkerBlock",
         Dict{String,Any}("Reason" => Reason, "WorkerId" => WorkerId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_worker_block(
@@ -646,6 +663,7 @@ function create_worker_block(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -669,7 +687,12 @@ can improve the performance of operations such as ListReviewableHITs and ListHIT
 
 """
 function delete_hit(HITId; aws_config::AbstractAWSConfig=global_aws_config())
-    return mturk("DeleteHIT", Dict{String,Any}("HITId" => HITId); aws_config=aws_config)
+    return mturk(
+        "DeleteHIT",
+        Dict{String,Any}("HITId" => HITId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_hit(
     HITId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -678,6 +701,7 @@ function delete_hit(
         "DeleteHIT",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("HITId" => HITId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -706,6 +730,7 @@ function delete_qualification_type(
         "DeleteQualificationType",
         Dict{String,Any}("QualificationTypeId" => QualificationTypeId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_qualification_type(
@@ -723,6 +748,7 @@ function delete_qualification_type(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -746,7 +772,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function delete_worker_block(WorkerId; aws_config::AbstractAWSConfig=global_aws_config())
     return mturk(
-        "DeleteWorkerBlock", Dict{String,Any}("WorkerId" => WorkerId); aws_config=aws_config
+        "DeleteWorkerBlock",
+        Dict{String,Any}("WorkerId" => WorkerId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_worker_block(
@@ -760,6 +789,7 @@ function delete_worker_block(
             mergewith(_merge, Dict{String,Any}("WorkerId" => WorkerId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -790,6 +820,7 @@ function disassociate_qualification_from_worker(
             "QualificationTypeId" => QualificationTypeId, "WorkerId" => WorkerId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disassociate_qualification_from_worker(
@@ -810,6 +841,7 @@ function disassociate_qualification_from_worker(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -825,12 +857,16 @@ balance can be viewed on the My Account page in the Requester console.
 
 """
 function get_account_balance(; aws_config::AbstractAWSConfig=global_aws_config())
-    return mturk("GetAccountBalance"; aws_config=aws_config)
+    return mturk(
+        "GetAccountBalance"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_account_balance(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return mturk("GetAccountBalance", params; aws_config=aws_config)
+    return mturk(
+        "GetAccountBalance", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -848,6 +884,7 @@ function get_assignment(AssignmentId; aws_config::AbstractAWSConfig=global_aws_c
         "GetAssignment",
         Dict{String,Any}("AssignmentId" => AssignmentId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_assignment(
@@ -861,6 +898,7 @@ function get_assignment(
             mergewith(_merge, Dict{String,Any}("AssignmentId" => AssignmentId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -894,6 +932,7 @@ function get_file_upload_url(
             "AssignmentId" => AssignmentId, "QuestionIdentifier" => QuestionIdentifier
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_file_upload_url(
@@ -915,6 +954,7 @@ function get_file_upload_url(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -929,7 +969,12 @@ end
 
 """
 function get_hit(HITId; aws_config::AbstractAWSConfig=global_aws_config())
-    return mturk("GetHIT", Dict{String,Any}("HITId" => HITId); aws_config=aws_config)
+    return mturk(
+        "GetHIT",
+        Dict{String,Any}("HITId" => HITId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_hit(
     HITId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -938,6 +983,7 @@ function get_hit(
         "GetHIT",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("HITId" => HITId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -965,6 +1011,7 @@ function get_qualification_score(
             "QualificationTypeId" => QualificationTypeId, "WorkerId" => WorkerId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_qualification_score(
@@ -985,6 +1032,7 @@ function get_qualification_score(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1006,6 +1054,7 @@ function get_qualification_type(
         "GetQualificationType",
         Dict{String,Any}("QualificationTypeId" => QualificationTypeId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_qualification_type(
@@ -1023,6 +1072,7 @@ function get_qualification_type(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1055,7 +1105,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function list_assignments_for_hit(HITId; aws_config::AbstractAWSConfig=global_aws_config())
     return mturk(
-        "ListAssignmentsForHIT", Dict{String,Any}("HITId" => HITId); aws_config=aws_config
+        "ListAssignmentsForHIT",
+        Dict{String,Any}("HITId" => HITId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_assignments_for_hit(
@@ -1065,6 +1118,7 @@ function list_assignments_for_hit(
         "ListAssignmentsForHIT",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("HITId" => HITId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1087,12 +1141,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`: Pagination token
 """
 function list_bonus_payments(; aws_config::AbstractAWSConfig=global_aws_config())
-    return mturk("ListBonusPayments"; aws_config=aws_config)
+    return mturk(
+        "ListBonusPayments"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_bonus_payments(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return mturk("ListBonusPayments", params; aws_config=aws_config)
+    return mturk(
+        "ListBonusPayments", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1109,12 +1167,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`: Pagination token
 """
 function list_hits(; aws_config::AbstractAWSConfig=global_aws_config())
-    return mturk("ListHITs"; aws_config=aws_config)
+    return mturk("ListHITs"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_hits(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return mturk("ListHITs", params; aws_config=aws_config)
+    return mturk("ListHITs", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 
 """
@@ -1141,6 +1199,7 @@ function list_hits_for_qualification_type(
         "ListHITsForQualificationType",
         Dict{String,Any}("QualificationTypeId" => QualificationTypeId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_hits_for_qualification_type(
@@ -1158,6 +1217,7 @@ function list_hits_for_qualification_type(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1176,12 +1236,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"QualificationTypeId"`: The ID of the QualificationType.
 """
 function list_qualification_requests(; aws_config::AbstractAWSConfig=global_aws_config())
-    return mturk("ListQualificationRequests"; aws_config=aws_config)
+    return mturk(
+        "ListQualificationRequests"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_qualification_requests(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return mturk("ListQualificationRequests", params; aws_config=aws_config)
+    return mturk(
+        "ListQualificationRequests",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1214,6 +1281,7 @@ function list_qualification_types(
         "ListQualificationTypes",
         Dict{String,Any}("MustBeRequestable" => MustBeRequestable);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_qualification_types(
@@ -1229,6 +1297,7 @@ function list_qualification_types(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1264,6 +1333,7 @@ function list_review_policy_results_for_hit(
         "ListReviewPolicyResultsForHIT",
         Dict{String,Any}("HITId" => HITId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_review_policy_results_for_hit(
@@ -1273,6 +1343,7 @@ function list_review_policy_results_for_hit(
         "ListReviewPolicyResultsForHIT",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("HITId" => HITId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1292,12 +1363,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"Status"`:  Can be either Reviewable or Reviewing. Reviewable is the default value.
 """
 function list_reviewable_hits(; aws_config::AbstractAWSConfig=global_aws_config())
-    return mturk("ListReviewableHITs"; aws_config=aws_config)
+    return mturk(
+        "ListReviewableHITs"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_reviewable_hits(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return mturk("ListReviewableHITs", params; aws_config=aws_config)
+    return mturk(
+        "ListReviewableHITs", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1313,12 +1388,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`: Pagination token
 """
 function list_worker_blocks(; aws_config::AbstractAWSConfig=global_aws_config())
-    return mturk("ListWorkerBlocks"; aws_config=aws_config)
+    return mturk("ListWorkerBlocks"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_worker_blocks(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return mturk("ListWorkerBlocks", params; aws_config=aws_config)
+    return mturk(
+        "ListWorkerBlocks", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1344,6 +1421,7 @@ function list_workers_with_qualification_type(
         "ListWorkersWithQualificationType",
         Dict{String,Any}("QualificationTypeId" => QualificationTypeId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_workers_with_qualification_type(
@@ -1361,6 +1439,7 @@ function list_workers_with_qualification_type(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1390,6 +1469,7 @@ function notify_workers(
             "MessageText" => MessageText, "Subject" => Subject, "WorkerIds" => WorkerIds
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function notify_workers(
@@ -1413,6 +1493,7 @@ function notify_workers(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1443,6 +1524,7 @@ function reject_assignment(
             "AssignmentId" => AssignmentId, "RequesterFeedback" => RequesterFeedback
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function reject_assignment(
@@ -1463,6 +1545,7 @@ function reject_assignment(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1490,6 +1573,7 @@ function reject_qualification_request(
         "RejectQualificationRequest",
         Dict{String,Any}("QualificationRequestId" => QualificationRequestId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function reject_qualification_request(
@@ -1507,6 +1591,7 @@ function reject_qualification_request(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1557,6 +1642,7 @@ function send_bonus(
             "WorkerId" => WorkerId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function send_bonus(
@@ -1582,6 +1668,7 @@ function send_bonus(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1611,6 +1698,7 @@ function send_test_event_notification(
         "SendTestEventNotification",
         Dict{String,Any}("Notification" => Notification, "TestEventType" => TestEventType);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function send_test_event_notification(
@@ -1631,6 +1719,7 @@ function send_test_event_notification(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1653,6 +1742,7 @@ function update_expiration_for_hit(
         "UpdateExpirationForHIT",
         Dict{String,Any}("ExpireAt" => ExpireAt, "HITId" => HITId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_expiration_for_hit(
@@ -1669,6 +1759,7 @@ function update_expiration_for_hit(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1691,7 +1782,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function update_hitreview_status(HITId; aws_config::AbstractAWSConfig=global_aws_config())
     return mturk(
-        "UpdateHITReviewStatus", Dict{String,Any}("HITId" => HITId); aws_config=aws_config
+        "UpdateHITReviewStatus",
+        Dict{String,Any}("HITId" => HITId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_hitreview_status(
@@ -1701,6 +1795,7 @@ function update_hitreview_status(
         "UpdateHITReviewStatus",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("HITId" => HITId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1725,6 +1820,7 @@ function update_hittype_of_hit(
         "UpdateHITTypeOfHIT",
         Dict{String,Any}("HITId" => HITId, "HITTypeId" => HITTypeId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_hittype_of_hit(
@@ -1741,6 +1837,7 @@ function update_hittype_of_hit(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1775,6 +1872,7 @@ function update_notification_settings(
         "UpdateNotificationSettings",
         Dict{String,Any}("HITTypeId" => HITTypeId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_notification_settings(
@@ -1788,6 +1886,7 @@ function update_notification_settings(
             mergewith(_merge, Dict{String,Any}("HITTypeId" => HITTypeId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1852,6 +1951,7 @@ function update_qualification_type(
         "UpdateQualificationType",
         Dict{String,Any}("QualificationTypeId" => QualificationTypeId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_qualification_type(
@@ -1869,5 +1969,6 @@ function update_qualification_type(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/mwaa.jl
+++ b/src/services/mwaa.jl
@@ -15,12 +15,20 @@ Create a CLI token to use Airflow CLI.
 
 """
 function create_cli_token(Name; aws_config::AbstractAWSConfig=global_aws_config())
-    return mwaa("POST", "/clitoken/$(Name)"; aws_config=aws_config)
+    return mwaa(
+        "POST", "/clitoken/$(Name)"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function create_cli_token(
     Name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return mwaa("POST", "/clitoken/$(Name)", params; aws_config=aws_config)
+    return mwaa(
+        "POST",
+        "/clitoken/$(Name)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -110,6 +118,7 @@ function create_environment(
             "SourceBucketArn" => SourceBucketArn,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_environment(
@@ -137,6 +146,7 @@ function create_environment(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -151,12 +161,20 @@ Create a JWT token to be used to login to Airflow Web UI with claims based Authe
 
 """
 function create_web_login_token(Name; aws_config::AbstractAWSConfig=global_aws_config())
-    return mwaa("POST", "/webtoken/$(Name)"; aws_config=aws_config)
+    return mwaa(
+        "POST", "/webtoken/$(Name)"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function create_web_login_token(
     Name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return mwaa("POST", "/webtoken/$(Name)", params; aws_config=aws_config)
+    return mwaa(
+        "POST",
+        "/webtoken/$(Name)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -170,12 +188,23 @@ Deletes an Amazon Managed Workflows for Apache Airflow (MWAA) environment.
 
 """
 function delete_environment(Name; aws_config::AbstractAWSConfig=global_aws_config())
-    return mwaa("DELETE", "/environments/$(Name)"; aws_config=aws_config)
+    return mwaa(
+        "DELETE",
+        "/environments/$(Name)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_environment(
     Name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return mwaa("DELETE", "/environments/$(Name)", params; aws_config=aws_config)
+    return mwaa(
+        "DELETE",
+        "/environments/$(Name)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -189,12 +218,23 @@ Retrieves the details of an Amazon Managed Workflows for Apache Airflow (MWAA) e
 
 """
 function get_environment(Name; aws_config::AbstractAWSConfig=global_aws_config())
-    return mwaa("GET", "/environments/$(Name)"; aws_config=aws_config)
+    return mwaa(
+        "GET",
+        "/environments/$(Name)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_environment(
     Name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return mwaa("GET", "/environments/$(Name)", params; aws_config=aws_config)
+    return mwaa(
+        "GET",
+        "/environments/$(Name)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -210,12 +250,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`: Retrieves the next page of the results.
 """
 function list_environments(; aws_config::AbstractAWSConfig=global_aws_config())
-    return mwaa("GET", "/environments"; aws_config=aws_config)
+    return mwaa(
+        "GET", "/environments"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_environments(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return mwaa("GET", "/environments", params; aws_config=aws_config)
+    return mwaa(
+        "GET",
+        "/environments",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -233,14 +281,25 @@ Lists the key-value tag pairs associated to the Amazon Managed Workflows for Apa
 function list_tags_for_resource(
     ResourceArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return mwaa("GET", "/tags/$(ResourceArn)"; aws_config=aws_config)
+    return mwaa(
+        "GET",
+        "/tags/$(ResourceArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_tags_for_resource(
     ResourceArn,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return mwaa("GET", "/tags/$(ResourceArn)", params; aws_config=aws_config)
+    return mwaa(
+        "GET",
+        "/tags/$(ResourceArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -263,6 +322,7 @@ function publish_metrics(
         "/metrics/environments/$(EnvironmentName)",
         Dict{String,Any}("MetricData" => MetricData);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function publish_metrics(
@@ -278,6 +338,7 @@ function publish_metrics(
             mergewith(_merge, Dict{String,Any}("MetricData" => MetricData), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -301,6 +362,7 @@ function tag_resource(ResourceArn, Tags; aws_config::AbstractAWSConfig=global_aw
         "/tags/$(ResourceArn)",
         Dict{String,Any}("Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -314,6 +376,7 @@ function tag_resource(
         "/tags/$(ResourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Tags" => Tags), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -339,6 +402,7 @@ function untag_resource(
         "/tags/$(ResourceArn)",
         Dict{String,Any}("tagKeys" => tagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -352,6 +416,7 @@ function untag_resource(
         "/tags/$(ResourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tagKeys" => tagKeys), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -420,10 +485,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   includes the following:   MON|TUE|WED|THU|FRI|SAT|SUN:([01]d|2[0-3]):(00|30)
 """
 function update_environment(Name; aws_config::AbstractAWSConfig=global_aws_config())
-    return mwaa("PATCH", "/environments/$(Name)"; aws_config=aws_config)
+    return mwaa(
+        "PATCH",
+        "/environments/$(Name)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function update_environment(
     Name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return mwaa("PATCH", "/environments/$(Name)", params; aws_config=aws_config)
+    return mwaa(
+        "PATCH",
+        "/environments/$(Name)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end

--- a/src/services/neptune.jl
+++ b/src/services/neptune.jl
@@ -29,6 +29,7 @@ function add_role_to_dbcluster(
             "DBClusterIdentifier" => DBClusterIdentifier, "RoleArn" => RoleArn
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function add_role_to_dbcluster(
@@ -49,6 +50,7 @@ function add_role_to_dbcluster(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -77,6 +79,7 @@ function add_source_identifier_to_subscription(
             "SourceIdentifier" => SourceIdentifier, "SubscriptionName" => SubscriptionName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function add_source_identifier_to_subscription(
@@ -98,6 +101,7 @@ function add_source_identifier_to_subscription(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -126,6 +130,7 @@ function add_tags_to_resource(
         "AddTagsToResource",
         Dict{String,Any}("ResourceName" => ResourceName, "Tag" => Tag);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function add_tags_to_resource(
@@ -144,6 +149,7 @@ function add_tags_to_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -180,6 +186,7 @@ function apply_pending_maintenance_action(
             "ResourceIdentifier" => ResourceIdentifier,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function apply_pending_maintenance_action(
@@ -203,6 +210,7 @@ function apply_pending_maintenance_action(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -249,6 +257,7 @@ function copy_dbcluster_parameter_group(
                 TargetDBClusterParameterGroupIdentifier,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function copy_dbcluster_parameter_group(
@@ -275,6 +284,7 @@ function copy_dbcluster_parameter_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -328,6 +338,7 @@ function copy_dbcluster_snapshot(
             "TargetDBClusterSnapshotIdentifier" => TargetDBClusterSnapshotIdentifier,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function copy_dbcluster_snapshot(
@@ -351,6 +362,7 @@ function copy_dbcluster_snapshot(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -389,6 +401,7 @@ function copy_dbparameter_group(
             "TargetDBParameterGroupIdentifier" => TargetDBParameterGroupIdentifier,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function copy_dbparameter_group(
@@ -413,6 +426,7 @@ function copy_dbparameter_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -511,6 +525,7 @@ function create_dbcluster(
         "CreateDBCluster",
         Dict{String,Any}("DBClusterIdentifier" => DBClusterIdentifier, "Engine" => Engine);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_dbcluster(
@@ -531,6 +546,7 @@ function create_dbcluster(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -570,6 +586,7 @@ function create_dbcluster_endpoint(
             "EndpointType" => EndpointType,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_dbcluster_endpoint(
@@ -593,6 +610,7 @@ function create_dbcluster_endpoint(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -646,6 +664,7 @@ function create_dbcluster_parameter_group(
             "Description" => Description,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_dbcluster_parameter_group(
@@ -669,6 +688,7 @@ function create_dbcluster_parameter_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -703,6 +723,7 @@ function create_dbcluster_snapshot(
             "DBClusterSnapshotIdentifier" => DBClusterSnapshotIdentifier,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_dbcluster_snapshot(
@@ -724,6 +745,7 @@ function create_dbcluster_snapshot(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -856,6 +878,7 @@ function create_dbinstance(
             "Engine" => Engine,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_dbinstance(
@@ -879,6 +902,7 @@ function create_dbinstance(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -930,6 +954,7 @@ function create_dbparameter_group(
             "Description" => Description,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_dbparameter_group(
@@ -953,6 +978,7 @@ function create_dbparameter_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -989,6 +1015,7 @@ function create_dbsubnet_group(
             "SubnetIdentifier" => SubnetIdentifier,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_dbsubnet_group(
@@ -1012,6 +1039,7 @@ function create_dbsubnet_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1072,6 +1100,7 @@ function create_event_subscription(
             "SnsTopicArn" => SnsTopicArn, "SubscriptionName" => SubscriptionName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_event_subscription(
@@ -1092,6 +1121,7 @@ function create_event_subscription(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1129,6 +1159,7 @@ function delete_dbcluster(
         "DeleteDBCluster",
         Dict{String,Any}("DBClusterIdentifier" => DBClusterIdentifier);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_dbcluster(
@@ -1146,6 +1177,7 @@ function delete_dbcluster(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1167,6 +1199,7 @@ function delete_dbcluster_endpoint(
         "DeleteDBClusterEndpoint",
         Dict{String,Any}("DBClusterEndpointIdentifier" => DBClusterEndpointIdentifier);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_dbcluster_endpoint(
@@ -1186,6 +1219,7 @@ function delete_dbcluster_endpoint(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1209,6 +1243,7 @@ function delete_dbcluster_parameter_group(
         "DeleteDBClusterParameterGroup",
         Dict{String,Any}("DBClusterParameterGroupName" => DBClusterParameterGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_dbcluster_parameter_group(
@@ -1228,6 +1263,7 @@ function delete_dbcluster_parameter_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1250,6 +1286,7 @@ function delete_dbcluster_snapshot(
         "DeleteDBClusterSnapshot",
         Dict{String,Any}("DBClusterSnapshotIdentifier" => DBClusterSnapshotIdentifier);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_dbcluster_snapshot(
@@ -1269,6 +1306,7 @@ function delete_dbcluster_snapshot(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1314,6 +1352,7 @@ function delete_dbinstance(
         "DeleteDBInstance",
         Dict{String,Any}("DBInstanceIdentifier" => DBInstanceIdentifier);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_dbinstance(
@@ -1331,6 +1370,7 @@ function delete_dbinstance(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1354,6 +1394,7 @@ function delete_dbparameter_group(
         "DeleteDBParameterGroup",
         Dict{String,Any}("DBParameterGroupName" => DBParameterGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_dbparameter_group(
@@ -1371,6 +1412,7 @@ function delete_dbparameter_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1394,6 +1436,7 @@ function delete_dbsubnet_group(
         "DeleteDBSubnetGroup",
         Dict{String,Any}("DBSubnetGroupName" => DBSubnetGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_dbsubnet_group(
@@ -1409,6 +1452,7 @@ function delete_dbsubnet_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1429,6 +1473,7 @@ function delete_event_subscription(
         "DeleteEventSubscription",
         Dict{String,Any}("SubscriptionName" => SubscriptionName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_event_subscription(
@@ -1444,6 +1489,7 @@ function delete_event_subscription(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1477,12 +1523,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Minimum 20, maximum 100.
 """
 function describe_dbcluster_endpoints(; aws_config::AbstractAWSConfig=global_aws_config())
-    return neptune("DescribeDBClusterEndpoints"; aws_config=aws_config)
+    return neptune(
+        "DescribeDBClusterEndpoints"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_dbcluster_endpoints(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return neptune("DescribeDBClusterEndpoints", params; aws_config=aws_config)
+    return neptune(
+        "DescribeDBClusterEndpoints",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1510,12 +1563,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_dbcluster_parameter_groups(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return neptune("DescribeDBClusterParameterGroups"; aws_config=aws_config)
+    return neptune(
+        "DescribeDBClusterParameterGroups";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_dbcluster_parameter_groups(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return neptune("DescribeDBClusterParameterGroups", params; aws_config=aws_config)
+    return neptune(
+        "DescribeDBClusterParameterGroups",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1549,6 +1611,7 @@ function describe_dbcluster_parameters(
         "DescribeDBClusterParameters",
         Dict{String,Any}("DBClusterParameterGroupName" => DBClusterParameterGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_dbcluster_parameters(
@@ -1568,6 +1631,7 @@ function describe_dbcluster_parameters(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1597,6 +1661,7 @@ function describe_dbcluster_snapshot_attributes(
         "DescribeDBClusterSnapshotAttributes",
         Dict{String,Any}("DBClusterSnapshotIdentifier" => DBClusterSnapshotIdentifier);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_dbcluster_snapshot_attributes(
@@ -1616,6 +1681,7 @@ function describe_dbcluster_snapshot_attributes(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1668,12 +1734,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   SnapshotType is set to public.
 """
 function describe_dbcluster_snapshots(; aws_config::AbstractAWSConfig=global_aws_config())
-    return neptune("DescribeDBClusterSnapshots"; aws_config=aws_config)
+    return neptune(
+        "DescribeDBClusterSnapshots"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_dbcluster_snapshots(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return neptune("DescribeDBClusterSnapshots", params; aws_config=aws_config)
+    return neptune(
+        "DescribeDBClusterSnapshots",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1704,12 +1777,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Minimum 20, maximum 100.
 """
 function describe_dbclusters(; aws_config::AbstractAWSConfig=global_aws_config())
-    return neptune("DescribeDBClusters"; aws_config=aws_config)
+    return neptune(
+        "DescribeDBClusters"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_dbclusters(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return neptune("DescribeDBClusters", params; aws_config=aws_config)
+    return neptune(
+        "DescribeDBClusters", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1742,12 +1819,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   20, maximum 100.
 """
 function describe_dbengine_versions(; aws_config::AbstractAWSConfig=global_aws_config())
-    return neptune("DescribeDBEngineVersions"; aws_config=aws_config)
+    return neptune(
+        "DescribeDBEngineVersions"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_dbengine_versions(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return neptune("DescribeDBEngineVersions", params; aws_config=aws_config)
+    return neptune(
+        "DescribeDBEngineVersions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1779,12 +1863,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Constraints: Minimum 20, maximum 100.
 """
 function describe_dbinstances(; aws_config::AbstractAWSConfig=global_aws_config())
-    return neptune("DescribeDBInstances"; aws_config=aws_config)
+    return neptune(
+        "DescribeDBInstances"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_dbinstances(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return neptune("DescribeDBInstances", params; aws_config=aws_config)
+    return neptune(
+        "DescribeDBInstances",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1809,12 +1900,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Minimum 20, maximum 100.
 """
 function describe_dbparameter_groups(; aws_config::AbstractAWSConfig=global_aws_config())
-    return neptune("DescribeDBParameterGroups"; aws_config=aws_config)
+    return neptune(
+        "DescribeDBParameterGroups"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_dbparameter_groups(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return neptune("DescribeDBParameterGroups", params; aws_config=aws_config)
+    return neptune(
+        "DescribeDBParameterGroups",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1847,6 +1945,7 @@ function describe_dbparameters(
         "DescribeDBParameters",
         Dict{String,Any}("DBParameterGroupName" => DBParameterGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_dbparameters(
@@ -1864,6 +1963,7 @@ function describe_dbparameters(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1888,12 +1988,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Constraints: Minimum 20, maximum 100.
 """
 function describe_dbsubnet_groups(; aws_config::AbstractAWSConfig=global_aws_config())
-    return neptune("DescribeDBSubnetGroups"; aws_config=aws_config)
+    return neptune(
+        "DescribeDBSubnetGroups"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_dbsubnet_groups(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return neptune("DescribeDBSubnetGroups", params; aws_config=aws_config)
+    return neptune(
+        "DescribeDBSubnetGroups",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1924,6 +2031,7 @@ function describe_engine_default_cluster_parameters(
         "DescribeEngineDefaultClusterParameters",
         Dict{String,Any}("DBParameterGroupFamily" => DBParameterGroupFamily);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_engine_default_cluster_parameters(
@@ -1941,6 +2049,7 @@ function describe_engine_default_cluster_parameters(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1972,6 +2081,7 @@ function describe_engine_default_parameters(
         "DescribeEngineDefaultParameters",
         Dict{String,Any}("DBParameterGroupFamily" => DBParameterGroupFamily);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_engine_default_parameters(
@@ -1989,6 +2099,7 @@ function describe_engine_default_parameters(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2006,12 +2117,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   db-instance | db-parameter-group | db-security-group | db-snapshot
 """
 function describe_event_categories(; aws_config::AbstractAWSConfig=global_aws_config())
-    return neptune("DescribeEventCategories"; aws_config=aws_config)
+    return neptune(
+        "DescribeEventCategories"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_event_categories(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return neptune("DescribeEventCategories", params; aws_config=aws_config)
+    return neptune(
+        "DescribeEventCategories",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2037,12 +2155,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   describe.
 """
 function describe_event_subscriptions(; aws_config::AbstractAWSConfig=global_aws_config())
-    return neptune("DescribeEventSubscriptions"; aws_config=aws_config)
+    return neptune(
+        "DescribeEventSubscriptions"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_event_subscriptions(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return neptune("DescribeEventSubscriptions", params; aws_config=aws_config)
+    return neptune(
+        "DescribeEventSubscriptions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2085,12 +2210,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Example: 2009-07-08T18:00Z
 """
 function describe_events(; aws_config::AbstractAWSConfig=global_aws_config())
-    return neptune("DescribeEvents"; aws_config=aws_config)
+    return neptune("DescribeEvents"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function describe_events(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return neptune("DescribeEvents", params; aws_config=aws_config)
+    return neptune(
+        "DescribeEvents", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -2128,6 +2255,7 @@ function describe_orderable_dbinstance_options(
         "DescribeOrderableDBInstanceOptions",
         Dict{String,Any}("Engine" => Engine);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_orderable_dbinstance_options(
@@ -2137,6 +2265,7 @@ function describe_orderable_dbinstance_options(
         "DescribeOrderableDBInstanceOptions",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Engine" => Engine), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2167,12 +2296,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_pending_maintenance_actions(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return neptune("DescribePendingMaintenanceActions"; aws_config=aws_config)
+    return neptune(
+        "DescribePendingMaintenanceActions";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_pending_maintenance_actions(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return neptune("DescribePendingMaintenanceActions", params; aws_config=aws_config)
+    return neptune(
+        "DescribePendingMaintenanceActions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2193,6 +2331,7 @@ function describe_valid_dbinstance_modifications(
         "DescribeValidDBInstanceModifications",
         Dict{String,Any}("DBInstanceIdentifier" => DBInstanceIdentifier);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_valid_dbinstance_modifications(
@@ -2210,6 +2349,7 @@ function describe_valid_dbinstance_modifications(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2234,12 +2374,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   For example, mydbcluster-replica1.
 """
 function failover_dbcluster(; aws_config::AbstractAWSConfig=global_aws_config())
-    return neptune("FailoverDBCluster"; aws_config=aws_config)
+    return neptune(
+        "FailoverDBCluster"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function failover_dbcluster(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return neptune("FailoverDBCluster", params; aws_config=aws_config)
+    return neptune(
+        "FailoverDBCluster", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -2264,6 +2408,7 @@ function list_tags_for_resource(
         "ListTagsForResource",
         Dict{String,Any}("ResourceName" => ResourceName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags_for_resource(
@@ -2277,6 +2422,7 @@ function list_tags_for_resource(
             mergewith(_merge, Dict{String,Any}("ResourceName" => ResourceName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2349,6 +2495,7 @@ function modify_dbcluster(
         "ModifyDBCluster",
         Dict{String,Any}("DBClusterIdentifier" => DBClusterIdentifier);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_dbcluster(
@@ -2366,6 +2513,7 @@ function modify_dbcluster(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2395,6 +2543,7 @@ function modify_dbcluster_endpoint(
         "ModifyDBClusterEndpoint",
         Dict{String,Any}("DBClusterEndpointIdentifier" => DBClusterEndpointIdentifier);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_dbcluster_endpoint(
@@ -2414,6 +2563,7 @@ function modify_dbcluster_endpoint(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2456,6 +2606,7 @@ function modify_dbcluster_parameter_group(
             "Parameter" => Parameter,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_dbcluster_parameter_group(
@@ -2477,6 +2628,7 @@ function modify_dbcluster_parameter_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2531,6 +2683,7 @@ function modify_dbcluster_snapshot_attribute(
             "DBClusterSnapshotIdentifier" => DBClusterSnapshotIdentifier,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_dbcluster_snapshot_attribute(
@@ -2552,6 +2705,7 @@ function modify_dbcluster_snapshot_attribute(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2697,6 +2851,7 @@ function modify_dbinstance(
         "ModifyDBInstance",
         Dict{String,Any}("DBInstanceIdentifier" => DBInstanceIdentifier);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_dbinstance(
@@ -2714,6 +2869,7 @@ function modify_dbinstance(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2765,6 +2921,7 @@ function modify_dbparameter_group(
             "DBParameterGroupName" => DBParameterGroupName, "Parameter" => Parameter
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_dbparameter_group(
@@ -2785,6 +2942,7 @@ function modify_dbparameter_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2815,6 +2973,7 @@ function modify_dbsubnet_group(
             "DBSubnetGroupName" => DBSubnetGroupName, "SubnetIdentifier" => SubnetIdentifier
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_dbsubnet_group(
@@ -2836,6 +2995,7 @@ function modify_dbsubnet_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2872,6 +3032,7 @@ function modify_event_subscription(
         "ModifyEventSubscription",
         Dict{String,Any}("SubscriptionName" => SubscriptionName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_event_subscription(
@@ -2887,6 +3048,7 @@ function modify_event_subscription(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2907,6 +3069,7 @@ function promote_read_replica_dbcluster(
         "PromoteReadReplicaDBCluster",
         Dict{String,Any}("DBClusterIdentifier" => DBClusterIdentifier);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function promote_read_replica_dbcluster(
@@ -2924,6 +3087,7 @@ function promote_read_replica_dbcluster(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2953,6 +3117,7 @@ function reboot_dbinstance(
         "RebootDBInstance",
         Dict{String,Any}("DBInstanceIdentifier" => DBInstanceIdentifier);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function reboot_dbinstance(
@@ -2970,6 +3135,7 @@ function reboot_dbinstance(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2998,6 +3164,7 @@ function remove_role_from_dbcluster(
             "DBClusterIdentifier" => DBClusterIdentifier, "RoleArn" => RoleArn
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function remove_role_from_dbcluster(
@@ -3018,6 +3185,7 @@ function remove_role_from_dbcluster(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3043,6 +3211,7 @@ function remove_source_identifier_from_subscription(
             "SourceIdentifier" => SourceIdentifier, "SubscriptionName" => SubscriptionName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function remove_source_identifier_from_subscription(
@@ -3064,6 +3233,7 @@ function remove_source_identifier_from_subscription(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3087,6 +3257,7 @@ function remove_tags_from_resource(
         "RemoveTagsFromResource",
         Dict{String,Any}("ResourceName" => ResourceName, "TagKeys" => TagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function remove_tags_from_resource(
@@ -3105,6 +3276,7 @@ function remove_tags_from_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3139,6 +3311,7 @@ function reset_dbcluster_parameter_group(
         "ResetDBClusterParameterGroup",
         Dict{String,Any}("DBClusterParameterGroupName" => DBClusterParameterGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function reset_dbcluster_parameter_group(
@@ -3158,6 +3331,7 @@ function reset_dbcluster_parameter_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3192,6 +3366,7 @@ function reset_dbparameter_group(
         "ResetDBParameterGroup",
         Dict{String,Any}("DBParameterGroupName" => DBParameterGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function reset_dbparameter_group(
@@ -3209,6 +3384,7 @@ function reset_dbparameter_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3287,6 +3463,7 @@ function restore_dbcluster_from_snapshot(
             "SnapshotIdentifier" => SnapshotIdentifier,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function restore_dbcluster_from_snapshot(
@@ -3310,6 +3487,7 @@ function restore_dbcluster_from_snapshot(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3394,6 +3572,7 @@ function restore_dbcluster_to_point_in_time(
             "SourceDBClusterIdentifier" => SourceDBClusterIdentifier,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function restore_dbcluster_to_point_in_time(
@@ -3415,6 +3594,7 @@ function restore_dbcluster_to_point_in_time(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3437,6 +3617,7 @@ function start_dbcluster(
         "StartDBCluster",
         Dict{String,Any}("DBClusterIdentifier" => DBClusterIdentifier);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_dbcluster(
@@ -3454,6 +3635,7 @@ function start_dbcluster(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3477,6 +3659,7 @@ function stop_dbcluster(
         "StopDBCluster",
         Dict{String,Any}("DBClusterIdentifier" => DBClusterIdentifier);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function stop_dbcluster(
@@ -3494,5 +3677,6 @@ function stop_dbcluster(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/network_firewall.jl
+++ b/src/services/network_firewall.jl
@@ -42,6 +42,7 @@ function associate_firewall_policy(
         "AssociateFirewallPolicy",
         Dict{String,Any}("FirewallPolicyArn" => FirewallPolicyArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_firewall_policy(
@@ -57,6 +58,7 @@ function associate_firewall_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -100,6 +102,7 @@ function associate_subnets(
         "AssociateSubnets",
         Dict{String,Any}("SubnetMappings" => SubnetMappings);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_subnets(
@@ -113,6 +116,7 @@ function associate_subnets(
             mergewith(_merge, Dict{String,Any}("SubnetMappings" => SubnetMappings), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -175,6 +179,7 @@ function create_firewall(
             "VpcId" => VpcId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_firewall(
@@ -200,6 +205,7 @@ function create_firewall(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -239,6 +245,7 @@ function create_firewall_policy(
             "FirewallPolicy" => FirewallPolicy, "FirewallPolicyName" => FirewallPolicyName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_firewall_policy(
@@ -260,6 +267,7 @@ function create_firewall_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -329,6 +337,7 @@ function create_rule_group(
             "Capacity" => Capacity, "RuleGroupName" => RuleGroupName, "Type" => Type
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_rule_group(
@@ -350,6 +359,7 @@ function create_rule_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -376,12 +386,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   both.
 """
 function delete_firewall(; aws_config::AbstractAWSConfig=global_aws_config())
-    return network_firewall("DeleteFirewall"; aws_config=aws_config)
+    return network_firewall(
+        "DeleteFirewall"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function delete_firewall(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return network_firewall("DeleteFirewall", params; aws_config=aws_config)
+    return network_firewall(
+        "DeleteFirewall", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -399,12 +413,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   you can specify both.
 """
 function delete_firewall_policy(; aws_config::AbstractAWSConfig=global_aws_config())
-    return network_firewall("DeleteFirewallPolicy"; aws_config=aws_config)
+    return network_firewall(
+        "DeleteFirewallPolicy"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function delete_firewall_policy(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return network_firewall("DeleteFirewallPolicy", params; aws_config=aws_config)
+    return network_firewall(
+        "DeleteFirewallPolicy",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -425,6 +446,7 @@ function delete_resource_policy(
         "DeleteResourcePolicy",
         Dict{String,Any}("ResourceArn" => ResourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_resource_policy(
@@ -438,6 +460,7 @@ function delete_resource_policy(
             mergewith(_merge, Dict{String,Any}("ResourceArn" => ResourceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -459,12 +482,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   This setting is required for requests that do not include the RuleGroupARN.
 """
 function delete_rule_group(; aws_config::AbstractAWSConfig=global_aws_config())
-    return network_firewall("DeleteRuleGroup"; aws_config=aws_config)
+    return network_firewall(
+        "DeleteRuleGroup"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function delete_rule_group(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return network_firewall("DeleteRuleGroup", params; aws_config=aws_config)
+    return network_firewall(
+        "DeleteRuleGroup", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -482,12 +509,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   both.
 """
 function describe_firewall(; aws_config::AbstractAWSConfig=global_aws_config())
-    return network_firewall("DescribeFirewall"; aws_config=aws_config)
+    return network_firewall(
+        "DescribeFirewall"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_firewall(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return network_firewall("DescribeFirewall", params; aws_config=aws_config)
+    return network_firewall(
+        "DescribeFirewall", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -505,12 +536,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   you can specify both.
 """
 function describe_firewall_policy(; aws_config::AbstractAWSConfig=global_aws_config())
-    return network_firewall("DescribeFirewallPolicy"; aws_config=aws_config)
+    return network_firewall(
+        "DescribeFirewallPolicy"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_firewall_policy(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return network_firewall("DescribeFirewallPolicy", params; aws_config=aws_config)
+    return network_firewall(
+        "DescribeFirewallPolicy",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -528,12 +566,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   both.
 """
 function describe_logging_configuration(; aws_config::AbstractAWSConfig=global_aws_config())
-    return network_firewall("DescribeLoggingConfiguration"; aws_config=aws_config)
+    return network_firewall(
+        "DescribeLoggingConfiguration";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_logging_configuration(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return network_firewall("DescribeLoggingConfiguration", params; aws_config=aws_config)
+    return network_firewall(
+        "DescribeLoggingConfiguration",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -554,6 +601,7 @@ function describe_resource_policy(
         "DescribeResourcePolicy",
         Dict{String,Any}("ResourceArn" => ResourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_resource_policy(
@@ -567,6 +615,7 @@ function describe_resource_policy(
             mergewith(_merge, Dict{String,Any}("ResourceArn" => ResourceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -588,12 +637,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   This setting is required for requests that do not include the RuleGroupARN.
 """
 function describe_rule_group(; aws_config::AbstractAWSConfig=global_aws_config())
-    return network_firewall("DescribeRuleGroup"; aws_config=aws_config)
+    return network_firewall(
+        "DescribeRuleGroup"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_rule_group(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return network_firewall("DescribeRuleGroup", params; aws_config=aws_config)
+    return network_firewall(
+        "DescribeRuleGroup", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -631,6 +684,7 @@ function disassociate_subnets(SubnetIds; aws_config::AbstractAWSConfig=global_aw
         "DisassociateSubnets",
         Dict{String,Any}("SubnetIds" => SubnetIds);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disassociate_subnets(
@@ -644,6 +698,7 @@ function disassociate_subnets(
             mergewith(_merge, Dict{String,Any}("SubnetIds" => SubnetIds), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -666,12 +721,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   objects, use the token returned from the prior request in your next request.
 """
 function list_firewall_policies(; aws_config::AbstractAWSConfig=global_aws_config())
-    return network_firewall("ListFirewallPolicies"; aws_config=aws_config)
+    return network_firewall(
+        "ListFirewallPolicies"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_firewall_policies(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return network_firewall("ListFirewallPolicies", params; aws_config=aws_config)
+    return network_firewall(
+        "ListFirewallPolicies",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -696,12 +758,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   the firewalls for. Leave this blank to retrieve all firewalls that you have defined.
 """
 function list_firewalls(; aws_config::AbstractAWSConfig=global_aws_config())
-    return network_firewall("ListFirewalls"; aws_config=aws_config)
+    return network_firewall(
+        "ListFirewalls"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_firewalls(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return network_firewall("ListFirewalls", params; aws_config=aws_config)
+    return network_firewall(
+        "ListFirewalls", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -723,12 +789,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   objects, use the token returned from the prior request in your next request.
 """
 function list_rule_groups(; aws_config::AbstractAWSConfig=global_aws_config())
-    return network_firewall("ListRuleGroups"; aws_config=aws_config)
+    return network_firewall(
+        "ListRuleGroups"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_rule_groups(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return network_firewall("ListRuleGroups", params; aws_config=aws_config)
+    return network_firewall(
+        "ListRuleGroups", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -762,6 +832,7 @@ function list_tags_for_resource(
         "ListTagsForResource",
         Dict{String,Any}("ResourceArn" => ResourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags_for_resource(
@@ -775,6 +846,7 @@ function list_tags_for_resource(
             mergewith(_merge, Dict{String,Any}("ResourceArn" => ResourceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -818,6 +890,7 @@ function put_resource_policy(
         "PutResourcePolicy",
         Dict{String,Any}("Policy" => Policy, "ResourceArn" => ResourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_resource_policy(
@@ -836,6 +909,7 @@ function put_resource_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -860,6 +934,7 @@ function tag_resource(ResourceArn, Tags; aws_config::AbstractAWSConfig=global_aw
         "TagResource",
         Dict{String,Any}("ResourceArn" => ResourceArn, "Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -878,6 +953,7 @@ function tag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -904,6 +980,7 @@ function untag_resource(
         "UntagResource",
         Dict{String,Any}("ResourceArn" => ResourceArn, "TagKeys" => TagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -922,6 +999,7 @@ function untag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -965,6 +1043,7 @@ function update_firewall_delete_protection(
         "UpdateFirewallDeleteProtection",
         Dict{String,Any}("DeleteProtection" => DeleteProtection);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_firewall_delete_protection(
@@ -980,6 +1059,7 @@ function update_firewall_delete_protection(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1012,12 +1092,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   the new token.
 """
 function update_firewall_description(; aws_config::AbstractAWSConfig=global_aws_config())
-    return network_firewall("UpdateFirewallDescription"; aws_config=aws_config)
+    return network_firewall(
+        "UpdateFirewallDescription"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function update_firewall_description(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return network_firewall("UpdateFirewallDescription", params; aws_config=aws_config)
+    return network_firewall(
+        "UpdateFirewallDescription",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1061,6 +1148,7 @@ function update_firewall_policy(
         "UpdateFirewallPolicy",
         Dict{String,Any}("FirewallPolicy" => FirewallPolicy, "UpdateToken" => UpdateToken);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_firewall_policy(
@@ -1081,6 +1169,7 @@ function update_firewall_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1124,6 +1213,7 @@ function update_firewall_policy_change_protection(
             "FirewallPolicyChangeProtection" => FirewallPolicyChangeProtection
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_firewall_policy_change_protection(
@@ -1143,6 +1233,7 @@ function update_firewall_policy_change_protection(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1174,12 +1265,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   If you omit this setting, Network Firewall disables logging for the firewall.
 """
 function update_logging_configuration(; aws_config::AbstractAWSConfig=global_aws_config())
-    return network_firewall("UpdateLoggingConfiguration"; aws_config=aws_config)
+    return network_firewall(
+        "UpdateLoggingConfiguration"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function update_logging_configuration(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return network_firewall("UpdateLoggingConfiguration", params; aws_config=aws_config)
+    return network_firewall(
+        "UpdateLoggingConfiguration",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1235,6 +1333,7 @@ function update_rule_group(UpdateToken; aws_config::AbstractAWSConfig=global_aws
         "UpdateRuleGroup",
         Dict{String,Any}("UpdateToken" => UpdateToken);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_rule_group(
@@ -1248,6 +1347,7 @@ function update_rule_group(
             mergewith(_merge, Dict{String,Any}("UpdateToken" => UpdateToken), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1289,6 +1389,7 @@ function update_subnet_change_protection(
         "UpdateSubnetChangeProtection",
         Dict{String,Any}("SubnetChangeProtection" => SubnetChangeProtection);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_subnet_change_protection(
@@ -1306,5 +1407,6 @@ function update_subnet_change_protection(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/networkmanager.jl
+++ b/src/services/networkmanager.jl
@@ -40,6 +40,7 @@ function associate_customer_gateway(
             "CustomerGatewayArn" => CustomerGatewayArn, "DeviceId" => DeviceId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_customer_gateway(
@@ -62,6 +63,7 @@ function associate_customer_gateway(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -87,6 +89,7 @@ function associate_link(
         "/global-networks/$(globalNetworkId)/link-associations",
         Dict{String,Any}("DeviceId" => DeviceId, "LinkId" => LinkId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_link(
@@ -105,6 +108,7 @@ function associate_link(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -141,6 +145,7 @@ function associate_transit_gateway_connect_peer(
             "TransitGatewayConnectPeerArn" => TransitGatewayConnectPeerArn,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_transit_gateway_connect_peer(
@@ -164,6 +169,7 @@ function associate_transit_gateway_connect_peer(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -199,6 +205,7 @@ function create_connection(
         "/global-networks/$(globalNetworkId)/connections",
         Dict{String,Any}("ConnectedDeviceId" => ConnectedDeviceId, "DeviceId" => DeviceId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_connection(
@@ -221,6 +228,7 @@ function create_connection(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -251,7 +259,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function create_device(globalNetworkId; aws_config::AbstractAWSConfig=global_aws_config())
     return networkmanager(
-        "POST", "/global-networks/$(globalNetworkId)/devices"; aws_config=aws_config
+        "POST",
+        "/global-networks/$(globalNetworkId)/devices";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_device(
@@ -260,7 +271,11 @@ function create_device(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return networkmanager(
-        "POST", "/global-networks/$(globalNetworkId)/devices", params; aws_config=aws_config
+        "POST",
+        "/global-networks/$(globalNetworkId)/devices",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -277,12 +292,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"Tags"`: The tags to apply to the resource during creation.
 """
 function create_global_network(; aws_config::AbstractAWSConfig=global_aws_config())
-    return networkmanager("POST", "/global-networks"; aws_config=aws_config)
+    return networkmanager(
+        "POST", "/global-networks"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function create_global_network(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return networkmanager("POST", "/global-networks", params; aws_config=aws_config)
+    return networkmanager(
+        "POST",
+        "/global-networks",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -314,6 +337,7 @@ function create_link(
         "/global-networks/$(globalNetworkId)/links",
         Dict{String,Any}("Bandwidth" => Bandwidth, "SiteId" => SiteId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_link(
@@ -334,6 +358,7 @@ function create_link(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -358,7 +383,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function create_site(globalNetworkId; aws_config::AbstractAWSConfig=global_aws_config())
     return networkmanager(
-        "POST", "/global-networks/$(globalNetworkId)/sites"; aws_config=aws_config
+        "POST",
+        "/global-networks/$(globalNetworkId)/sites";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_site(
@@ -367,7 +395,11 @@ function create_site(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return networkmanager(
-        "POST", "/global-networks/$(globalNetworkId)/sites", params; aws_config=aws_config
+        "POST",
+        "/global-networks/$(globalNetworkId)/sites",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -389,6 +421,7 @@ function delete_connection(
         "DELETE",
         "/global-networks/$(globalNetworkId)/connections/$(connectionId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_connection(
@@ -402,6 +435,7 @@ function delete_connection(
         "/global-networks/$(globalNetworkId)/connections/$(connectionId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -424,6 +458,7 @@ function delete_device(
         "DELETE",
         "/global-networks/$(globalNetworkId)/devices/$(deviceId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_device(
@@ -437,6 +472,7 @@ function delete_device(
         "/global-networks/$(globalNetworkId)/devices/$(deviceId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -455,7 +491,10 @@ function delete_global_network(
     globalNetworkId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return networkmanager(
-        "DELETE", "/global-networks/$(globalNetworkId)"; aws_config=aws_config
+        "DELETE",
+        "/global-networks/$(globalNetworkId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_global_network(
@@ -464,7 +503,11 @@ function delete_global_network(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return networkmanager(
-        "DELETE", "/global-networks/$(globalNetworkId)", params; aws_config=aws_config
+        "DELETE",
+        "/global-networks/$(globalNetworkId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -487,6 +530,7 @@ function delete_link(
         "DELETE",
         "/global-networks/$(globalNetworkId)/links/$(linkId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_link(
@@ -500,6 +544,7 @@ function delete_link(
         "/global-networks/$(globalNetworkId)/links/$(linkId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -521,6 +566,7 @@ function delete_site(
         "DELETE",
         "/global-networks/$(globalNetworkId)/sites/$(siteId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_site(
@@ -534,6 +580,7 @@ function delete_site(
         "/global-networks/$(globalNetworkId)/sites/$(siteId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -557,6 +604,7 @@ function deregister_transit_gateway(
         "DELETE",
         "/global-networks/$(globalNetworkId)/transit-gateway-registrations/$(transitGatewayArn)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function deregister_transit_gateway(
@@ -570,6 +618,7 @@ function deregister_transit_gateway(
         "/global-networks/$(globalNetworkId)/transit-gateway-registrations/$(transitGatewayArn)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -589,12 +638,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: The token for the next page of results.
 """
 function describe_global_networks(; aws_config::AbstractAWSConfig=global_aws_config())
-    return networkmanager("GET", "/global-networks"; aws_config=aws_config)
+    return networkmanager(
+        "GET", "/global-networks"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_global_networks(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return networkmanager("GET", "/global-networks", params; aws_config=aws_config)
+    return networkmanager(
+        "GET",
+        "/global-networks",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -616,6 +673,7 @@ function disassociate_customer_gateway(
         "DELETE",
         "/global-networks/$(globalNetworkId)/customer-gateway-associations/$(customerGatewayArn)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disassociate_customer_gateway(
@@ -629,6 +687,7 @@ function disassociate_customer_gateway(
         "/global-networks/$(globalNetworkId)/customer-gateway-associations/$(customerGatewayArn)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -653,6 +712,7 @@ function disassociate_link(
         "/global-networks/$(globalNetworkId)/link-associations",
         Dict{String,Any}("deviceId" => deviceId, "linkId" => linkId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disassociate_link(
@@ -671,6 +731,7 @@ function disassociate_link(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -695,6 +756,7 @@ function disassociate_transit_gateway_connect_peer(
         "DELETE",
         "/global-networks/$(globalNetworkId)/transit-gateway-connect-peer-associations/$(transitGatewayConnectPeerArn)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disassociate_transit_gateway_connect_peer(
@@ -708,6 +770,7 @@ function disassociate_transit_gateway_connect_peer(
         "/global-networks/$(globalNetworkId)/transit-gateway-connect-peer-associations/$(transitGatewayConnectPeerArn)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -729,7 +792,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function get_connections(globalNetworkId; aws_config::AbstractAWSConfig=global_aws_config())
     return networkmanager(
-        "GET", "/global-networks/$(globalNetworkId)/connections"; aws_config=aws_config
+        "GET",
+        "/global-networks/$(globalNetworkId)/connections";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_connections(
@@ -742,6 +808,7 @@ function get_connections(
         "/global-networks/$(globalNetworkId)/connections",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -769,6 +836,7 @@ function get_customer_gateway_associations(
         "GET",
         "/global-networks/$(globalNetworkId)/customer-gateway-associations";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_customer_gateway_associations(
@@ -781,6 +849,7 @@ function get_customer_gateway_associations(
         "/global-networks/$(globalNetworkId)/customer-gateway-associations",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -802,7 +871,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function get_devices(globalNetworkId; aws_config::AbstractAWSConfig=global_aws_config())
     return networkmanager(
-        "GET", "/global-networks/$(globalNetworkId)/devices"; aws_config=aws_config
+        "GET",
+        "/global-networks/$(globalNetworkId)/devices";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_devices(
@@ -811,7 +883,11 @@ function get_devices(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return networkmanager(
-        "GET", "/global-networks/$(globalNetworkId)/devices", params; aws_config=aws_config
+        "GET",
+        "/global-networks/$(globalNetworkId)/devices",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -839,6 +915,7 @@ function get_link_associations(
         "GET",
         "/global-networks/$(globalNetworkId)/link-associations";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_link_associations(
@@ -851,6 +928,7 @@ function get_link_associations(
         "/global-networks/$(globalNetworkId)/link-associations",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -876,7 +954,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function get_links(globalNetworkId; aws_config::AbstractAWSConfig=global_aws_config())
     return networkmanager(
-        "GET", "/global-networks/$(globalNetworkId)/links"; aws_config=aws_config
+        "GET",
+        "/global-networks/$(globalNetworkId)/links";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_links(
@@ -885,7 +966,11 @@ function get_links(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return networkmanager(
-        "GET", "/global-networks/$(globalNetworkId)/links", params; aws_config=aws_config
+        "GET",
+        "/global-networks/$(globalNetworkId)/links",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -906,7 +991,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function get_sites(globalNetworkId; aws_config::AbstractAWSConfig=global_aws_config())
     return networkmanager(
-        "GET", "/global-networks/$(globalNetworkId)/sites"; aws_config=aws_config
+        "GET",
+        "/global-networks/$(globalNetworkId)/sites";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_sites(
@@ -915,7 +1003,11 @@ function get_sites(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return networkmanager(
-        "GET", "/global-networks/$(globalNetworkId)/sites", params; aws_config=aws_config
+        "GET",
+        "/global-networks/$(globalNetworkId)/sites",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -943,6 +1035,7 @@ function get_transit_gateway_connect_peer_associations(
         "GET",
         "/global-networks/$(globalNetworkId)/transit-gateway-connect-peer-associations";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_transit_gateway_connect_peer_associations(
@@ -955,6 +1048,7 @@ function get_transit_gateway_connect_peer_associations(
         "/global-networks/$(globalNetworkId)/transit-gateway-connect-peer-associations",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -981,6 +1075,7 @@ function get_transit_gateway_registrations(
         "GET",
         "/global-networks/$(globalNetworkId)/transit-gateway-registrations";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_transit_gateway_registrations(
@@ -993,6 +1088,7 @@ function get_transit_gateway_registrations(
         "/global-networks/$(globalNetworkId)/transit-gateway-registrations",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1009,14 +1105,25 @@ Lists the tags for a specified resource.
 function list_tags_for_resource(
     resourceArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return networkmanager("GET", "/tags/$(resourceArn)"; aws_config=aws_config)
+    return networkmanager(
+        "GET",
+        "/tags/$(resourceArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_tags_for_resource(
     resourceArn,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return networkmanager("GET", "/tags/$(resourceArn)", params; aws_config=aws_config)
+    return networkmanager(
+        "GET",
+        "/tags/$(resourceArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1041,6 +1148,7 @@ function register_transit_gateway(
         "/global-networks/$(globalNetworkId)/transit-gateway-registrations",
         Dict{String,Any}("TransitGatewayArn" => TransitGatewayArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function register_transit_gateway(
@@ -1058,6 +1166,7 @@ function register_transit_gateway(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1078,6 +1187,7 @@ function tag_resource(Tags, resourceArn; aws_config::AbstractAWSConfig=global_aw
         "/tags/$(resourceArn)",
         Dict{String,Any}("Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -1091,6 +1201,7 @@ function tag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Tags" => Tags), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1113,6 +1224,7 @@ function untag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}("tagKeys" => tagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -1126,6 +1238,7 @@ function untag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tagKeys" => tagKeys), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1154,6 +1267,7 @@ function update_connection(
         "PATCH",
         "/global-networks/$(globalNetworkId)/connections/$(connectionId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_connection(
@@ -1167,6 +1281,7 @@ function update_connection(
         "/global-networks/$(globalNetworkId)/connections/$(connectionId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1202,6 +1317,7 @@ function update_device(
         "PATCH",
         "/global-networks/$(globalNetworkId)/devices/$(deviceId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_device(
@@ -1215,6 +1331,7 @@ function update_device(
         "/global-networks/$(globalNetworkId)/devices/$(deviceId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1237,7 +1354,10 @@ function update_global_network(
     globalNetworkId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return networkmanager(
-        "PATCH", "/global-networks/$(globalNetworkId)"; aws_config=aws_config
+        "PATCH",
+        "/global-networks/$(globalNetworkId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_global_network(
@@ -1246,7 +1366,11 @@ function update_global_network(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return networkmanager(
-        "PATCH", "/global-networks/$(globalNetworkId)", params; aws_config=aws_config
+        "PATCH",
+        "/global-networks/$(globalNetworkId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1277,6 +1401,7 @@ function update_link(
         "PATCH",
         "/global-networks/$(globalNetworkId)/links/$(linkId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_link(
@@ -1290,6 +1415,7 @@ function update_link(
         "/global-networks/$(globalNetworkId)/links/$(linkId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1318,6 +1444,7 @@ function update_site(
         "PATCH",
         "/global-networks/$(globalNetworkId)/sites/$(siteId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_site(
@@ -1331,5 +1458,6 @@ function update_site(
         "/global-networks/$(globalNetworkId)/sites/$(siteId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/nimble.jl
+++ b/src/services/nimble.jl
@@ -29,6 +29,7 @@ function accept_eulas(studioId; aws_config::AbstractAWSConfig=global_aws_config(
         "/2020-08-01/studios/$(studioId)/eula-acceptances",
         Dict{String,Any}("X-Amz-Client-Token" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function accept_eulas(
@@ -45,6 +46,7 @@ function accept_eulas(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -97,6 +99,7 @@ function create_launch_profile(
             "X-Amz-Client-Token" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_launch_profile(
@@ -127,6 +130,7 @@ function create_launch_profile(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -165,6 +169,7 @@ function create_streaming_image(
             "X-Amz-Client-Token" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_streaming_image(
@@ -189,6 +194,7 @@ function create_streaming_image(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -225,6 +231,7 @@ function create_streaming_session(
         "/2020-08-01/studios/$(studioId)/streaming-sessions",
         Dict{String,Any}("X-Amz-Client-Token" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_streaming_session(
@@ -241,6 +248,7 @@ function create_streaming_session(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -274,6 +282,7 @@ function create_streaming_session_stream(
         "/2020-08-01/studios/$(studioId)/streaming-sessions/$(sessionId)/streams",
         Dict{String,Any}("X-Amz-Client-Token" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_streaming_session_stream(
@@ -291,6 +300,7 @@ function create_streaming_session_stream(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -352,6 +362,7 @@ function create_studio(
             "X-Amz-Client-Token" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_studio(
@@ -379,6 +390,7 @@ function create_studio(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -421,6 +433,7 @@ function create_studio_component(
             "name" => name, "type" => type, "X-Amz-Client-Token" => string(uuid4())
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_studio_component(
@@ -443,6 +456,7 @@ function create_studio_component(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -473,6 +487,7 @@ function delete_launch_profile(
         "/2020-08-01/studios/$(studioId)/launch-profiles/$(launchProfileId)",
         Dict{String,Any}("X-Amz-Client-Token" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_launch_profile(
@@ -490,6 +505,7 @@ function delete_launch_profile(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -524,6 +540,7 @@ function delete_launch_profile_member(
         "/2020-08-01/studios/$(studioId)/launch-profiles/$(launchProfileId)/membership/$(principalId)",
         Dict{String,Any}("X-Amz-Client-Token" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_launch_profile_member(
@@ -542,6 +559,7 @@ function delete_launch_profile_member(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -572,6 +590,7 @@ function delete_streaming_image(
         "/2020-08-01/studios/$(studioId)/streaming-images/$(streamingImageId)",
         Dict{String,Any}("X-Amz-Client-Token" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_streaming_image(
@@ -589,6 +608,7 @@ function delete_streaming_image(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -621,6 +641,7 @@ function delete_streaming_session(
         "/2020-08-01/studios/$(studioId)/streaming-sessions/$(sessionId)",
         Dict{String,Any}("X-Amz-Client-Token" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_streaming_session(
@@ -638,6 +659,7 @@ function delete_streaming_session(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -665,6 +687,7 @@ function delete_studio(studioId; aws_config::AbstractAWSConfig=global_aws_config
         "/2020-08-01/studios/$(studioId)",
         Dict{String,Any}("X-Amz-Client-Token" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_studio(
@@ -681,6 +704,7 @@ function delete_studio(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -711,6 +735,7 @@ function delete_studio_component(
         "/2020-08-01/studios/$(studioId)/studio-components/$(studioComponentId)",
         Dict{String,Any}("X-Amz-Client-Token" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_studio_component(
@@ -728,6 +753,7 @@ function delete_studio_component(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -758,6 +784,7 @@ function delete_studio_member(
         "/2020-08-01/studios/$(studioId)/membership/$(principalId)",
         Dict{String,Any}("X-Amz-Client-Token" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_studio_member(
@@ -775,6 +802,7 @@ function delete_studio_member(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -789,12 +817,23 @@ Get Eula.
 
 """
 function get_eula(eulaId; aws_config::AbstractAWSConfig=global_aws_config())
-    return nimble("GET", "/2020-08-01/eulas/$(eulaId)"; aws_config=aws_config)
+    return nimble(
+        "GET",
+        "/2020-08-01/eulas/$(eulaId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_eula(
     eulaId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return nimble("GET", "/2020-08-01/eulas/$(eulaId)", params; aws_config=aws_config)
+    return nimble(
+        "GET",
+        "/2020-08-01/eulas/$(eulaId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -815,6 +854,7 @@ function get_launch_profile(
         "GET",
         "/2020-08-01/studios/$(studioId)/launch-profiles/$(launchProfileId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_launch_profile(
@@ -828,6 +868,7 @@ function get_launch_profile(
         "/2020-08-01/studios/$(studioId)/launch-profiles/$(launchProfileId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -852,6 +893,7 @@ function get_launch_profile_details(
         "GET",
         "/2020-08-01/studios/$(studioId)/launch-profiles/$(launchProfileId)/details";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_launch_profile_details(
@@ -865,6 +907,7 @@ function get_launch_profile_details(
         "/2020-08-01/studios/$(studioId)/launch-profiles/$(launchProfileId)/details",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -899,6 +942,7 @@ function get_launch_profile_initialization(
             "platform" => platform,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_launch_profile_initialization(
@@ -925,6 +969,7 @@ function get_launch_profile_initialization(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -950,6 +995,7 @@ function get_launch_profile_member(
         "GET",
         "/2020-08-01/studios/$(studioId)/launch-profiles/$(launchProfileId)/membership/$(principalId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_launch_profile_member(
@@ -964,6 +1010,7 @@ function get_launch_profile_member(
         "/2020-08-01/studios/$(studioId)/launch-profiles/$(launchProfileId)/membership/$(principalId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -985,6 +1032,7 @@ function get_streaming_image(
         "GET",
         "/2020-08-01/studios/$(studioId)/streaming-images/$(streamingImageId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_streaming_image(
@@ -998,6 +1046,7 @@ function get_streaming_image(
         "/2020-08-01/studios/$(studioId)/streaming-images/$(streamingImageId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1020,6 +1069,7 @@ function get_streaming_session(
         "GET",
         "/2020-08-01/studios/$(studioId)/streaming-sessions/$(sessionId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_streaming_session(
@@ -1033,6 +1083,7 @@ function get_streaming_session(
         "/2020-08-01/studios/$(studioId)/streaming-sessions/$(sessionId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1058,6 +1109,7 @@ function get_streaming_session_stream(
         "GET",
         "/2020-08-01/studios/$(studioId)/streaming-sessions/$(sessionId)/streams/$(streamId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_streaming_session_stream(
@@ -1072,6 +1124,7 @@ function get_streaming_session_stream(
         "/2020-08-01/studios/$(studioId)/streaming-sessions/$(sessionId)/streams/$(streamId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1086,14 +1139,25 @@ Get a Studio resource.
 
 """
 function get_studio(studioId; aws_config::AbstractAWSConfig=global_aws_config())
-    return nimble("GET", "/2020-08-01/studios/$(studioId)"; aws_config=aws_config)
+    return nimble(
+        "GET",
+        "/2020-08-01/studios/$(studioId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_studio(
     studioId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return nimble("GET", "/2020-08-01/studios/$(studioId)", params; aws_config=aws_config)
+    return nimble(
+        "GET",
+        "/2020-08-01/studios/$(studioId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1114,6 +1178,7 @@ function get_studio_component(
         "GET",
         "/2020-08-01/studios/$(studioId)/studio-components/$(studioComponentId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_studio_component(
@@ -1127,6 +1192,7 @@ function get_studio_component(
         "/2020-08-01/studios/$(studioId)/studio-components/$(studioComponentId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1148,6 +1214,7 @@ function get_studio_member(
         "GET",
         "/2020-08-01/studios/$(studioId)/membership/$(principalId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_studio_member(
@@ -1161,6 +1228,7 @@ function get_studio_member(
         "/2020-08-01/studios/$(studioId)/membership/$(principalId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1181,7 +1249,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function list_eula_acceptances(studioId; aws_config::AbstractAWSConfig=global_aws_config())
     return nimble(
-        "GET", "/2020-08-01/studios/$(studioId)/eula-acceptances"; aws_config=aws_config
+        "GET",
+        "/2020-08-01/studios/$(studioId)/eula-acceptances";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_eula_acceptances(
@@ -1194,6 +1265,7 @@ function list_eula_acceptances(
         "/2020-08-01/studios/$(studioId)/eula-acceptances",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1210,12 +1282,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   results.
 """
 function list_eulas(; aws_config::AbstractAWSConfig=global_aws_config())
-    return nimble("GET", "/2020-08-01/eulas"; aws_config=aws_config)
+    return nimble(
+        "GET", "/2020-08-01/eulas"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_eulas(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return nimble("GET", "/2020-08-01/eulas", params; aws_config=aws_config)
+    return nimble(
+        "GET",
+        "/2020-08-01/eulas",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1241,6 +1321,7 @@ function list_launch_profile_members(
         "GET",
         "/2020-08-01/studios/$(studioId)/launch-profiles/$(launchProfileId)/membership";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_launch_profile_members(
@@ -1254,6 +1335,7 @@ function list_launch_profile_members(
         "/2020-08-01/studios/$(studioId)/launch-profiles/$(launchProfileId)/membership",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1276,7 +1358,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function list_launch_profiles(studioId; aws_config::AbstractAWSConfig=global_aws_config())
     return nimble(
-        "GET", "/2020-08-01/studios/$(studioId)/launch-profiles"; aws_config=aws_config
+        "GET",
+        "/2020-08-01/studios/$(studioId)/launch-profiles";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_launch_profiles(
@@ -1289,6 +1374,7 @@ function list_launch_profiles(
         "/2020-08-01/studios/$(studioId)/launch-profiles",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1311,7 +1397,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function list_streaming_images(studioId; aws_config::AbstractAWSConfig=global_aws_config())
     return nimble(
-        "GET", "/2020-08-01/studios/$(studioId)/streaming-images"; aws_config=aws_config
+        "GET",
+        "/2020-08-01/studios/$(studioId)/streaming-images";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_streaming_images(
@@ -1324,6 +1413,7 @@ function list_streaming_images(
         "/2020-08-01/studios/$(studioId)/streaming-images",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1348,7 +1438,10 @@ function list_streaming_sessions(
     studioId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return nimble(
-        "GET", "/2020-08-01/studios/$(studioId)/streaming-sessions"; aws_config=aws_config
+        "GET",
+        "/2020-08-01/studios/$(studioId)/streaming-sessions";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_streaming_sessions(
@@ -1361,6 +1454,7 @@ function list_streaming_sessions(
         "/2020-08-01/studios/$(studioId)/streaming-sessions",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1383,7 +1477,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function list_studio_components(studioId; aws_config::AbstractAWSConfig=global_aws_config())
     return nimble(
-        "GET", "/2020-08-01/studios/$(studioId)/studio-components"; aws_config=aws_config
+        "GET",
+        "/2020-08-01/studios/$(studioId)/studio-components";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_studio_components(
@@ -1396,6 +1493,7 @@ function list_studio_components(
         "/2020-08-01/studios/$(studioId)/studio-components",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1416,7 +1514,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function list_studio_members(studioId; aws_config::AbstractAWSConfig=global_aws_config())
     return nimble(
-        "GET", "/2020-08-01/studios/$(studioId)/membership"; aws_config=aws_config
+        "GET",
+        "/2020-08-01/studios/$(studioId)/membership";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_studio_members(
@@ -1425,7 +1526,11 @@ function list_studio_members(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return nimble(
-        "GET", "/2020-08-01/studios/$(studioId)/membership", params; aws_config=aws_config
+        "GET",
+        "/2020-08-01/studios/$(studioId)/membership",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1442,12 +1547,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   results.
 """
 function list_studios(; aws_config::AbstractAWSConfig=global_aws_config())
-    return nimble("GET", "/2020-08-01/studios"; aws_config=aws_config)
+    return nimble(
+        "GET", "/2020-08-01/studios"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_studios(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return nimble("GET", "/2020-08-01/studios", params; aws_config=aws_config)
+    return nimble(
+        "GET",
+        "/2020-08-01/studios",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1467,14 +1580,25 @@ yourself.
 function list_tags_for_resource(
     resourceArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return nimble("GET", "/2020-08-01/tags/$(resourceArn)"; aws_config=aws_config)
+    return nimble(
+        "GET",
+        "/2020-08-01/tags/$(resourceArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_tags_for_resource(
     resourceArn,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return nimble("GET", "/2020-08-01/tags/$(resourceArn)", params; aws_config=aws_config)
+    return nimble(
+        "GET",
+        "/2020-08-01/tags/$(resourceArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1514,6 +1638,7 @@ function put_launch_profile_members(
             "X-Amz-Client-Token" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_launch_profile_members(
@@ -1539,6 +1664,7 @@ function put_launch_profile_members(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1574,6 +1700,7 @@ function put_studio_members(
             "X-Amz-Client-Token" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_studio_members(
@@ -1598,6 +1725,7 @@ function put_studio_members(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1633,6 +1761,7 @@ function start_studio_ssoconfiguration_repair(
         "/2020-08-01/studios/$(studioId)/sso-configuration",
         Dict{String,Any}("X-Amz-Client-Token" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_studio_ssoconfiguration_repair(
@@ -1649,6 +1778,7 @@ function start_studio_ssoconfiguration_repair(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1667,14 +1797,25 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   resource.
 """
 function tag_resource(resourceArn; aws_config::AbstractAWSConfig=global_aws_config())
-    return nimble("POST", "/2020-08-01/tags/$(resourceArn)"; aws_config=aws_config)
+    return nimble(
+        "POST",
+        "/2020-08-01/tags/$(resourceArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function tag_resource(
     resourceArn,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return nimble("POST", "/2020-08-01/tags/$(resourceArn)", params; aws_config=aws_config)
+    return nimble(
+        "POST",
+        "/2020-08-01/tags/$(resourceArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1696,6 +1837,7 @@ function untag_resource(
         "/2020-08-01/tags/$(resourceArn)",
         Dict{String,Any}("tagKeys" => tagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -1709,6 +1851,7 @@ function untag_resource(
         "/2020-08-01/tags/$(resourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tagKeys" => tagKeys), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1746,6 +1889,7 @@ function update_launch_profile(
         "/2020-08-01/studios/$(studioId)/launch-profiles/$(launchProfileId)",
         Dict{String,Any}("X-Amz-Client-Token" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_launch_profile(
@@ -1763,6 +1907,7 @@ function update_launch_profile(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1799,6 +1944,7 @@ function update_launch_profile_member(
         "/2020-08-01/studios/$(studioId)/launch-profiles/$(launchProfileId)/membership/$(principalId)",
         Dict{String,Any}("persona" => persona, "X-Amz-Client-Token" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_launch_profile_member(
@@ -1822,6 +1968,7 @@ function update_launch_profile_member(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1854,6 +2001,7 @@ function update_streaming_image(
         "/2020-08-01/studios/$(studioId)/streaming-images/$(streamingImageId)",
         Dict{String,Any}("X-Amz-Client-Token" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_streaming_image(
@@ -1871,6 +2019,7 @@ function update_streaming_image(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1904,6 +2053,7 @@ function update_studio(studioId; aws_config::AbstractAWSConfig=global_aws_config
         "/2020-08-01/studios/$(studioId)",
         Dict{String,Any}("X-Amz-Client-Token" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_studio(
@@ -1920,6 +2070,7 @@ function update_studio(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1959,6 +2110,7 @@ function update_studio_component(
         "/2020-08-01/studios/$(studioId)/studio-components/$(studioComponentId)",
         Dict{String,Any}("X-Amz-Client-Token" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_studio_component(
@@ -1976,5 +2128,6 @@ function update_studio_component(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/opensearch.jl
+++ b/src/services/opensearch.jl
@@ -21,6 +21,7 @@ function accept_inbound_connection(
         "PUT",
         "/2021-01-01/opensearch/cc/inboundConnection/$(ConnectionId)/accept";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function accept_inbound_connection(
@@ -33,6 +34,7 @@ function accept_inbound_connection(
         "/2021-01-01/opensearch/cc/inboundConnection/$(ConnectionId)/accept",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -55,6 +57,7 @@ function add_tags(ARN, TagList; aws_config::AbstractAWSConfig=global_aws_config(
         "/2021-01-01/tags",
         Dict{String,Any}("ARN" => ARN, "TagList" => TagList);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function add_tags(
@@ -70,6 +73,7 @@ function add_tags(
             mergewith(_merge, Dict{String,Any}("ARN" => ARN, "TagList" => TagList), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -92,6 +96,7 @@ function associate_package(
         "POST",
         "/2021-01-01/packages/associate/$(PackageID)/$(DomainName)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_package(
@@ -105,6 +110,7 @@ function associate_package(
         "/2021-01-01/packages/associate/$(PackageID)/$(DomainName)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -129,6 +135,7 @@ function cancel_service_software_update(
         "/2021-01-01/opensearch/serviceSoftwareUpdate/cancel",
         Dict{String,Any}("DomainName" => DomainName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function cancel_service_software_update(
@@ -143,6 +150,7 @@ function cancel_service_software_update(
             mergewith(_merge, Dict{String,Any}("DomainName" => DomainName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -197,6 +205,7 @@ function create_domain(DomainName; aws_config::AbstractAWSConfig=global_aws_conf
         "/2021-01-01/opensearch/domain",
         Dict{String,Any}("DomainName" => DomainName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_domain(
@@ -211,6 +220,7 @@ function create_domain(
             mergewith(_merge, Dict{String,Any}("DomainName" => DomainName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -243,6 +253,7 @@ function create_outbound_connection(
             "RemoteDomainInfo" => RemoteDomainInfo,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_outbound_connection(
@@ -267,6 +278,7 @@ function create_outbound_connection(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -300,6 +312,7 @@ function create_package(
             "PackageType" => PackageType,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_package(
@@ -324,6 +337,7 @@ function create_package(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -340,7 +354,10 @@ cannot be recovered.
 """
 function delete_domain(DomainName; aws_config::AbstractAWSConfig=global_aws_config())
     return opensearch(
-        "DELETE", "/2021-01-01/opensearch/domain/$(DomainName)"; aws_config=aws_config
+        "DELETE",
+        "/2021-01-01/opensearch/domain/$(DomainName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_domain(
@@ -353,6 +370,7 @@ function delete_domain(
         "/2021-01-01/opensearch/domain/$(DomainName)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -373,6 +391,7 @@ function delete_inbound_connection(
         "DELETE",
         "/2021-01-01/opensearch/cc/inboundConnection/$(ConnectionId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_inbound_connection(
@@ -385,6 +404,7 @@ function delete_inbound_connection(
         "/2021-01-01/opensearch/cc/inboundConnection/$(ConnectionId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -405,6 +425,7 @@ function delete_outbound_connection(
         "DELETE",
         "/2021-01-01/opensearch/cc/outboundConnection/$(ConnectionId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_outbound_connection(
@@ -417,6 +438,7 @@ function delete_outbound_connection(
         "/2021-01-01/opensearch/cc/outboundConnection/$(ConnectionId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -432,7 +454,12 @@ Deletes the package.
 
 """
 function delete_package(PackageID; aws_config::AbstractAWSConfig=global_aws_config())
-    return opensearch("DELETE", "/2021-01-01/packages/$(PackageID)"; aws_config=aws_config)
+    return opensearch(
+        "DELETE",
+        "/2021-01-01/packages/$(PackageID)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_package(
     PackageID,
@@ -440,7 +467,11 @@ function delete_package(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return opensearch(
-        "DELETE", "/2021-01-01/packages/$(PackageID)", params; aws_config=aws_config
+        "DELETE",
+        "/2021-01-01/packages/$(PackageID)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -457,7 +488,10 @@ ID, domain endpoint, and domain ARN.
 """
 function describe_domain(DomainName; aws_config::AbstractAWSConfig=global_aws_config())
     return opensearch(
-        "GET", "/2021-01-01/opensearch/domain/$(DomainName)"; aws_config=aws_config
+        "GET",
+        "/2021-01-01/opensearch/domain/$(DomainName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_domain(
@@ -466,7 +500,11 @@ function describe_domain(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return opensearch(
-        "GET", "/2021-01-01/opensearch/domain/$(DomainName)", params; aws_config=aws_config
+        "GET",
+        "/2021-01-01/opensearch/domain/$(DomainName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -494,6 +532,7 @@ function describe_domain_auto_tunes(
         "GET",
         "/2021-01-01/opensearch/domain/$(DomainName)/autoTunes";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_domain_auto_tunes(
@@ -506,6 +545,7 @@ function describe_domain_auto_tunes(
         "/2021-01-01/opensearch/domain/$(DomainName)/autoTunes",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -524,7 +564,10 @@ function describe_domain_config(
     DomainName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return opensearch(
-        "GET", "/2021-01-01/opensearch/domain/$(DomainName)/config"; aws_config=aws_config
+        "GET",
+        "/2021-01-01/opensearch/domain/$(DomainName)/config";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_domain_config(
@@ -537,6 +580,7 @@ function describe_domain_config(
         "/2021-01-01/opensearch/domain/$(DomainName)/config",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -557,6 +601,7 @@ function describe_domains(DomainNames; aws_config::AbstractAWSConfig=global_aws_
         "/2021-01-01/opensearch/domain-info",
         Dict{String,Any}("DomainNames" => DomainNames);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_domains(
@@ -571,6 +616,7 @@ function describe_domains(
             mergewith(_merge, Dict{String,Any}("DomainNames" => DomainNames), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -592,7 +638,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function describe_inbound_connections(; aws_config::AbstractAWSConfig=global_aws_config())
     return opensearch(
-        "POST", "/2021-01-01/opensearch/cc/inboundConnection/search"; aws_config=aws_config
+        "POST",
+        "/2021-01-01/opensearch/cc/inboundConnection/search";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_inbound_connections(
@@ -603,6 +652,7 @@ function describe_inbound_connections(
         "/2021-01-01/opensearch/cc/inboundConnection/search",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -631,6 +681,7 @@ function describe_instance_type_limits(
         "GET",
         "/2021-01-01/opensearch/instanceTypeLimits/$(EngineVersion)/$(InstanceType)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_instance_type_limits(
@@ -644,6 +695,7 @@ function describe_instance_type_limits(
         "/2021-01-01/opensearch/instanceTypeLimits/$(EngineVersion)/$(InstanceType)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -666,7 +718,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function describe_outbound_connections(; aws_config::AbstractAWSConfig=global_aws_config())
     return opensearch(
-        "POST", "/2021-01-01/opensearch/cc/outboundConnection/search"; aws_config=aws_config
+        "POST",
+        "/2021-01-01/opensearch/cc/outboundConnection/search";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_outbound_connections(
@@ -677,6 +732,7 @@ function describe_outbound_connections(
         "/2021-01-01/opensearch/cc/outboundConnection/search",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -695,13 +751,22 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   non-null NextToken value. If provided, returns results for the next page.
 """
 function describe_packages(; aws_config::AbstractAWSConfig=global_aws_config())
-    return opensearch("POST", "/2021-01-01/packages/describe"; aws_config=aws_config)
+    return opensearch(
+        "POST",
+        "/2021-01-01/packages/describe";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_packages(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return opensearch(
-        "POST", "/2021-01-01/packages/describe", params; aws_config=aws_config
+        "POST",
+        "/2021-01-01/packages/describe",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -723,7 +788,10 @@ function describe_reserved_instance_offerings(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
     return opensearch(
-        "GET", "/2021-01-01/opensearch/reservedInstanceOfferings"; aws_config=aws_config
+        "GET",
+        "/2021-01-01/opensearch/reservedInstanceOfferings";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_reserved_instance_offerings(
@@ -734,6 +802,7 @@ function describe_reserved_instance_offerings(
         "/2021-01-01/opensearch/reservedInstanceOfferings",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -753,14 +822,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function describe_reserved_instances(; aws_config::AbstractAWSConfig=global_aws_config())
     return opensearch(
-        "GET", "/2021-01-01/opensearch/reservedInstances"; aws_config=aws_config
+        "GET",
+        "/2021-01-01/opensearch/reservedInstances";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_reserved_instances(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return opensearch(
-        "GET", "/2021-01-01/opensearch/reservedInstances", params; aws_config=aws_config
+        "GET",
+        "/2021-01-01/opensearch/reservedInstances",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -783,6 +859,7 @@ function dissociate_package(
         "POST",
         "/2021-01-01/packages/dissociate/$(PackageID)/$(DomainName)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function dissociate_package(
@@ -796,6 +873,7 @@ function dissociate_package(
         "/2021-01-01/packages/dissociate/$(PackageID)/$(DomainName)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -813,14 +891,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function get_compatible_versions(; aws_config::AbstractAWSConfig=global_aws_config())
     return opensearch(
-        "GET", "/2021-01-01/opensearch/compatibleVersions"; aws_config=aws_config
+        "GET",
+        "/2021-01-01/opensearch/compatibleVersions";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_compatible_versions(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return opensearch(
-        "GET", "/2021-01-01/opensearch/compatibleVersions", params; aws_config=aws_config
+        "GET",
+        "/2021-01-01/opensearch/compatibleVersions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -843,7 +928,10 @@ function get_package_version_history(
     PackageID; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return opensearch(
-        "GET", "/2021-01-01/packages/$(PackageID)/history"; aws_config=aws_config
+        "GET",
+        "/2021-01-01/packages/$(PackageID)/history";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_package_version_history(
@@ -852,7 +940,11 @@ function get_package_version_history(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return opensearch(
-        "GET", "/2021-01-01/packages/$(PackageID)/history", params; aws_config=aws_config
+        "GET",
+        "/2021-01-01/packages/$(PackageID)/history",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -875,6 +967,7 @@ function get_upgrade_history(DomainName; aws_config::AbstractAWSConfig=global_aw
         "GET",
         "/2021-01-01/opensearch/upgradeDomain/$(DomainName)/history";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_upgrade_history(
@@ -887,6 +980,7 @@ function get_upgrade_history(
         "/2021-01-01/opensearch/upgradeDomain/$(DomainName)/history",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -906,6 +1000,7 @@ function get_upgrade_status(DomainName; aws_config::AbstractAWSConfig=global_aws
         "GET",
         "/2021-01-01/opensearch/upgradeDomain/$(DomainName)/status";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_upgrade_status(
@@ -918,6 +1013,7 @@ function get_upgrade_status(
         "/2021-01-01/opensearch/upgradeDomain/$(DomainName)/status",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -933,12 +1029,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Acceptable values are 'Elasticsearch' and 'OpenSearch'.
 """
 function list_domain_names(; aws_config::AbstractAWSConfig=global_aws_config())
-    return opensearch("GET", "/2021-01-01/domain"; aws_config=aws_config)
+    return opensearch(
+        "GET", "/2021-01-01/domain"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_domain_names(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return opensearch("GET", "/2021-01-01/domain", params; aws_config=aws_config)
+    return opensearch(
+        "GET",
+        "/2021-01-01/domain",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -960,7 +1064,10 @@ function list_domains_for_package(
     PackageID; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return opensearch(
-        "GET", "/2021-01-01/packages/$(PackageID)/domains"; aws_config=aws_config
+        "GET",
+        "/2021-01-01/packages/$(PackageID)/domains";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_domains_for_package(
@@ -969,7 +1076,11 @@ function list_domains_for_package(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return opensearch(
-        "GET", "/2021-01-01/packages/$(PackageID)/domains", params; aws_config=aws_config
+        "GET",
+        "/2021-01-01/packages/$(PackageID)/domains",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -995,6 +1106,7 @@ function list_instance_type_details(
         "GET",
         "/2021-01-01/opensearch/instanceTypeDetails/$(EngineVersion)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_instance_type_details(
@@ -1007,6 +1119,7 @@ function list_instance_type_details(
         "/2021-01-01/opensearch/instanceTypeDetails/$(EngineVersion)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1029,7 +1142,10 @@ function list_packages_for_domain(
     DomainName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return opensearch(
-        "GET", "/2021-01-01/domain/$(DomainName)/packages"; aws_config=aws_config
+        "GET",
+        "/2021-01-01/domain/$(DomainName)/packages";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_packages_for_domain(
@@ -1038,7 +1154,11 @@ function list_packages_for_domain(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return opensearch(
-        "GET", "/2021-01-01/domain/$(DomainName)/packages", params; aws_config=aws_config
+        "GET",
+        "/2021-01-01/domain/$(DomainName)/packages",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1054,7 +1174,11 @@ Returns all tags for the given domain.
 """
 function list_tags(arn; aws_config::AbstractAWSConfig=global_aws_config())
     return opensearch(
-        "GET", "/2021-01-01/tags/", Dict{String,Any}("arn" => arn); aws_config=aws_config
+        "GET",
+        "/2021-01-01/tags/",
+        Dict{String,Any}("arn" => arn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags(
@@ -1065,6 +1189,7 @@ function list_tags(
         "/2021-01-01/tags/",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("arn" => arn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1081,13 +1206,22 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`:
 """
 function list_versions(; aws_config::AbstractAWSConfig=global_aws_config())
-    return opensearch("GET", "/2021-01-01/opensearch/versions"; aws_config=aws_config)
+    return opensearch(
+        "GET",
+        "/2021-01-01/opensearch/versions";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_versions(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return opensearch(
-        "GET", "/2021-01-01/opensearch/versions", params; aws_config=aws_config
+        "GET",
+        "/2021-01-01/opensearch/versions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1119,6 +1253,7 @@ function purchase_reserved_instance_offering(
             "ReservedInstanceOfferingId" => ReservedInstanceOfferingId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function purchase_reserved_instance_offering(
@@ -1141,6 +1276,7 @@ function purchase_reserved_instance_offering(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1161,6 +1297,7 @@ function reject_inbound_connection(
         "PUT",
         "/2021-01-01/opensearch/cc/inboundConnection/$(ConnectionId)/reject";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function reject_inbound_connection(
@@ -1173,6 +1310,7 @@ function reject_inbound_connection(
         "/2021-01-01/opensearch/cc/inboundConnection/$(ConnectionId)/reject",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1193,6 +1331,7 @@ function remove_tags(ARN, TagKeys; aws_config::AbstractAWSConfig=global_aws_conf
         "/2021-01-01/tags-removal",
         Dict{String,Any}("ARN" => ARN, "TagKeys" => TagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function remove_tags(
@@ -1208,6 +1347,7 @@ function remove_tags(
             mergewith(_merge, Dict{String,Any}("ARN" => ARN, "TagKeys" => TagKeys), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1230,6 +1370,7 @@ function start_service_software_update(
         "/2021-01-01/opensearch/serviceSoftwareUpdate/start",
         Dict{String,Any}("DomainName" => DomainName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_service_software_update(
@@ -1244,6 +1385,7 @@ function start_service_software_update(
             mergewith(_merge, Dict{String,Any}("DomainName" => DomainName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1283,7 +1425,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function update_domain_config(DomainName; aws_config::AbstractAWSConfig=global_aws_config())
     return opensearch(
-        "POST", "/2021-01-01/opensearch/domain/$(DomainName)/config"; aws_config=aws_config
+        "POST",
+        "/2021-01-01/opensearch/domain/$(DomainName)/config";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_domain_config(
@@ -1296,6 +1441,7 @@ function update_domain_config(
         "/2021-01-01/opensearch/domain/$(DomainName)/config",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1323,6 +1469,7 @@ function update_package(
         "/2021-01-01/packages/update",
         Dict{String,Any}("PackageID" => PackageID, "PackageSource" => PackageSource);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_package(
@@ -1344,6 +1491,7 @@ function update_package(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1372,6 +1520,7 @@ function upgrade_domain(
         "/2021-01-01/opensearch/upgradeDomain",
         Dict{String,Any}("DomainName" => DomainName, "TargetVersion" => TargetVersion);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function upgrade_domain(
@@ -1393,5 +1542,6 @@ function upgrade_domain(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/opsworks.jl
+++ b/src/services/opsworks.jl
@@ -28,6 +28,7 @@ function assign_instance(
         "AssignInstance",
         Dict{String,Any}("InstanceId" => InstanceId, "LayerIds" => LayerIds);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function assign_instance(
@@ -46,6 +47,7 @@ function assign_instance(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -70,7 +72,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function assign_volume(VolumeId; aws_config::AbstractAWSConfig=global_aws_config())
     return opsworks(
-        "AssignVolume", Dict{String,Any}("VolumeId" => VolumeId); aws_config=aws_config
+        "AssignVolume",
+        Dict{String,Any}("VolumeId" => VolumeId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function assign_volume(
@@ -84,6 +89,7 @@ function assign_volume(
             mergewith(_merge, Dict{String,Any}("VolumeId" => VolumeId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -110,6 +116,7 @@ function associate_elastic_ip(ElasticIp; aws_config::AbstractAWSConfig=global_aw
         "AssociateElasticIp",
         Dict{String,Any}("ElasticIp" => ElasticIp);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_elastic_ip(
@@ -123,6 +130,7 @@ function associate_elastic_ip(
             mergewith(_merge, Dict{String,Any}("ElasticIp" => ElasticIp), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -154,6 +162,7 @@ function attach_elastic_load_balancer(
             "ElasticLoadBalancerName" => ElasticLoadBalancerName, "LayerId" => LayerId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function attach_elastic_load_balancer(
@@ -175,6 +184,7 @@ function attach_elastic_load_balancer(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -311,6 +321,7 @@ function clone_stack(
             "ServiceRoleArn" => ServiceRoleArn, "SourceStackId" => SourceStackId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function clone_stack(
@@ -331,6 +342,7 @@ function clone_stack(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -379,6 +391,7 @@ function create_app(Name, StackId, Type; aws_config::AbstractAWSConfig=global_aw
         "CreateApp",
         Dict{String,Any}("Name" => Name, "StackId" => StackId, "Type" => Type);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_app(
@@ -398,6 +411,7 @@ function create_app(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -435,6 +449,7 @@ function create_deployment(
         "CreateDeployment",
         Dict{String,Any}("Command" => Command, "StackId" => StackId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_deployment(
@@ -451,6 +466,7 @@ function create_deployment(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -542,6 +558,7 @@ function create_instance(
             "InstanceType" => InstanceType, "LayerIds" => LayerIds, "StackId" => StackId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_instance(
@@ -565,6 +582,7 @@ function create_instance(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -636,6 +654,7 @@ function create_layer(
             "Name" => Name, "Shortname" => Shortname, "StackId" => StackId, "Type" => Type
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_layer(
@@ -661,6 +680,7 @@ function create_layer(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -807,6 +827,7 @@ function create_stack(
             "ServiceRoleArn" => ServiceRoleArn,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_stack(
@@ -832,6 +853,7 @@ function create_stack(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -861,6 +883,7 @@ function create_user_profile(IamUserArn; aws_config::AbstractAWSConfig=global_aw
         "CreateUserProfile",
         Dict{String,Any}("IamUserArn" => IamUserArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_user_profile(
@@ -874,6 +897,7 @@ function create_user_profile(
             mergewith(_merge, Dict{String,Any}("IamUserArn" => IamUserArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -890,7 +914,12 @@ permissions. For more information on user permissions, see Managing User Permiss
 
 """
 function delete_app(AppId; aws_config::AbstractAWSConfig=global_aws_config())
-    return opsworks("DeleteApp", Dict{String,Any}("AppId" => AppId); aws_config=aws_config)
+    return opsworks(
+        "DeleteApp",
+        Dict{String,Any}("AppId" => AppId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_app(
     AppId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -899,6 +928,7 @@ function delete_app(
         "DeleteApp",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("AppId" => AppId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -925,6 +955,7 @@ function delete_instance(InstanceId; aws_config::AbstractAWSConfig=global_aws_co
         "DeleteInstance",
         Dict{String,Any}("InstanceId" => InstanceId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_instance(
@@ -938,6 +969,7 @@ function delete_instance(
             mergewith(_merge, Dict{String,Any}("InstanceId" => InstanceId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -957,7 +989,10 @@ user permissions, see Managing User Permissions.
 """
 function delete_layer(LayerId; aws_config::AbstractAWSConfig=global_aws_config())
     return opsworks(
-        "DeleteLayer", Dict{String,Any}("LayerId" => LayerId); aws_config=aws_config
+        "DeleteLayer",
+        Dict{String,Any}("LayerId" => LayerId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_layer(
@@ -967,6 +1002,7 @@ function delete_layer(
         "DeleteLayer",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("LayerId" => LayerId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -986,7 +1022,10 @@ user permissions, see Managing User Permissions.
 """
 function delete_stack(StackId; aws_config::AbstractAWSConfig=global_aws_config())
     return opsworks(
-        "DeleteStack", Dict{String,Any}("StackId" => StackId); aws_config=aws_config
+        "DeleteStack",
+        Dict{String,Any}("StackId" => StackId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_stack(
@@ -996,6 +1035,7 @@ function delete_stack(
         "DeleteStack",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("StackId" => StackId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1016,6 +1056,7 @@ function delete_user_profile(IamUserArn; aws_config::AbstractAWSConfig=global_aw
         "DeleteUserProfile",
         Dict{String,Any}("IamUserArn" => IamUserArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_user_profile(
@@ -1029,6 +1070,7 @@ function delete_user_profile(
             mergewith(_merge, Dict{String,Any}("IamUserArn" => IamUserArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1053,6 +1095,7 @@ function deregister_ecs_cluster(
         "DeregisterEcsCluster",
         Dict{String,Any}("EcsClusterArn" => EcsClusterArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function deregister_ecs_cluster(
@@ -1066,6 +1109,7 @@ function deregister_ecs_cluster(
             mergewith(_merge, Dict{String,Any}("EcsClusterArn" => EcsClusterArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1088,6 +1132,7 @@ function deregister_elastic_ip(ElasticIp; aws_config::AbstractAWSConfig=global_a
         "DeregisterElasticIp",
         Dict{String,Any}("ElasticIp" => ElasticIp);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function deregister_elastic_ip(
@@ -1101,6 +1146,7 @@ function deregister_elastic_ip(
             mergewith(_merge, Dict{String,Any}("ElasticIp" => ElasticIp), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1124,6 +1170,7 @@ function deregister_instance(InstanceId; aws_config::AbstractAWSConfig=global_aw
         "DeregisterInstance",
         Dict{String,Any}("InstanceId" => InstanceId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function deregister_instance(
@@ -1137,6 +1184,7 @@ function deregister_instance(
             mergewith(_merge, Dict{String,Any}("InstanceId" => InstanceId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1159,6 +1207,7 @@ function deregister_rds_db_instance(
         "DeregisterRdsDbInstance",
         Dict{String,Any}("RdsDbInstanceArn" => RdsDbInstanceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function deregister_rds_db_instance(
@@ -1174,6 +1223,7 @@ function deregister_rds_db_instance(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1195,7 +1245,10 @@ Permissions.
 """
 function deregister_volume(VolumeId; aws_config::AbstractAWSConfig=global_aws_config())
     return opsworks(
-        "DeregisterVolume", Dict{String,Any}("VolumeId" => VolumeId); aws_config=aws_config
+        "DeregisterVolume",
+        Dict{String,Any}("VolumeId" => VolumeId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function deregister_volume(
@@ -1209,6 +1262,7 @@ function deregister_volume(
             mergewith(_merge, Dict{String,Any}("VolumeId" => VolumeId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1226,12 +1280,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"StackId"`: The stack ID.
 """
 function describe_agent_versions(; aws_config::AbstractAWSConfig=global_aws_config())
-    return opsworks("DescribeAgentVersions"; aws_config=aws_config)
+    return opsworks(
+        "DescribeAgentVersions"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_agent_versions(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return opsworks("DescribeAgentVersions", params; aws_config=aws_config)
+    return opsworks(
+        "DescribeAgentVersions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1253,12 +1314,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   description of the apps in the specified stack.
 """
 function describe_apps(; aws_config::AbstractAWSConfig=global_aws_config())
-    return opsworks("DescribeApps"; aws_config=aws_config)
+    return opsworks("DescribeApps"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function describe_apps(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return opsworks("DescribeApps", params; aws_config=aws_config)
+    return opsworks(
+        "DescribeApps", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1282,12 +1345,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   a description of the commands associated with the specified instance.
 """
 function describe_commands(; aws_config::AbstractAWSConfig=global_aws_config())
-    return opsworks("DescribeCommands"; aws_config=aws_config)
+    return opsworks(
+        "DescribeCommands"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_commands(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return opsworks("DescribeCommands", params; aws_config=aws_config)
+    return opsworks(
+        "DescribeCommands", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1311,12 +1378,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   description of the commands associated with the specified stack.
 """
 function describe_deployments(; aws_config::AbstractAWSConfig=global_aws_config())
-    return opsworks("DescribeDeployments"; aws_config=aws_config)
+    return opsworks(
+        "DescribeDeployments"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_deployments(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return opsworks("DescribeDeployments", params; aws_config=aws_config)
+    return opsworks(
+        "DescribeDeployments",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1347,12 +1421,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   registered with the stack.
 """
 function describe_ecs_clusters(; aws_config::AbstractAWSConfig=global_aws_config())
-    return opsworks("DescribeEcsClusters"; aws_config=aws_config)
+    return opsworks(
+        "DescribeEcsClusters"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_ecs_clusters(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return opsworks("DescribeEcsClusters", params; aws_config=aws_config)
+    return opsworks(
+        "DescribeEcsClusters",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1375,12 +1456,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   description of the Elastic IP addresses that are registered with the specified stack.
 """
 function describe_elastic_ips(; aws_config::AbstractAWSConfig=global_aws_config())
-    return opsworks("DescribeElasticIps"; aws_config=aws_config)
+    return opsworks(
+        "DescribeElasticIps"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_elastic_ips(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return opsworks("DescribeElasticIps", params; aws_config=aws_config)
+    return opsworks(
+        "DescribeElasticIps", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1403,12 +1488,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_elastic_load_balancers(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return opsworks("DescribeElasticLoadBalancers"; aws_config=aws_config)
+    return opsworks(
+        "DescribeElasticLoadBalancers";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_elastic_load_balancers(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return opsworks("DescribeElasticLoadBalancers", params; aws_config=aws_config)
+    return opsworks(
+        "DescribeElasticLoadBalancers",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1432,12 +1526,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   descriptions of the instances associated with the specified stack.
 """
 function describe_instances(; aws_config::AbstractAWSConfig=global_aws_config())
-    return opsworks("DescribeInstances"; aws_config=aws_config)
+    return opsworks(
+        "DescribeInstances"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_instances(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return opsworks("DescribeInstances", params; aws_config=aws_config)
+    return opsworks(
+        "DescribeInstances", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1457,12 +1555,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"StackId"`: The stack ID.
 """
 function describe_layers(; aws_config::AbstractAWSConfig=global_aws_config())
-    return opsworks("DescribeLayers"; aws_config=aws_config)
+    return opsworks(
+        "DescribeLayers"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_layers(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return opsworks("DescribeLayers", params; aws_config=aws_config)
+    return opsworks(
+        "DescribeLayers", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1486,6 +1588,7 @@ function describe_load_based_auto_scaling(
         "DescribeLoadBasedAutoScaling",
         Dict{String,Any}("LayerIds" => LayerIds);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_load_based_auto_scaling(
@@ -1499,6 +1602,7 @@ function describe_load_based_auto_scaling(
             mergewith(_merge, Dict{String,Any}("LayerIds" => LayerIds), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1512,12 +1616,19 @@ For more information about user permissions, see Managing User Permissions.
 
 """
 function describe_my_user_profile(; aws_config::AbstractAWSConfig=global_aws_config())
-    return opsworks("DescribeMyUserProfile"; aws_config=aws_config)
+    return opsworks(
+        "DescribeMyUserProfile"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_my_user_profile(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return opsworks("DescribeMyUserProfile", params; aws_config=aws_config)
+    return opsworks(
+        "DescribeMyUserProfile",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1528,12 +1639,19 @@ Describes the operating systems that are supported by AWS OpsWorks Stacks.
 
 """
 function describe_operating_systems(; aws_config::AbstractAWSConfig=global_aws_config())
-    return opsworks("DescribeOperatingSystems"; aws_config=aws_config)
+    return opsworks(
+        "DescribeOperatingSystems"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_operating_systems(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return opsworks("DescribeOperatingSystems", params; aws_config=aws_config)
+    return opsworks(
+        "DescribeOperatingSystems",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1552,12 +1670,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"StackId"`: The stack ID.
 """
 function describe_permissions(; aws_config::AbstractAWSConfig=global_aws_config())
-    return opsworks("DescribePermissions"; aws_config=aws_config)
+    return opsworks(
+        "DescribePermissions"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_permissions(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return opsworks("DescribePermissions", params; aws_config=aws_config)
+    return opsworks(
+        "DescribePermissions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1580,12 +1705,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"StackId"`: The stack ID.
 """
 function describe_raid_arrays(; aws_config::AbstractAWSConfig=global_aws_config())
-    return opsworks("DescribeRaidArrays"; aws_config=aws_config)
+    return opsworks(
+        "DescribeRaidArrays"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_raid_arrays(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return opsworks("DescribeRaidArrays", params; aws_config=aws_config)
+    return opsworks(
+        "DescribeRaidArrays", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1612,6 +1741,7 @@ function describe_rds_db_instances(
         "DescribeRdsDbInstances",
         Dict{String,Any}("StackId" => StackId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_rds_db_instances(
@@ -1621,6 +1751,7 @@ function describe_rds_db_instances(
         "DescribeRdsDbInstances",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("StackId" => StackId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1645,12 +1776,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   descriptions of the errors associated with the specified stack.
 """
 function describe_service_errors(; aws_config::AbstractAWSConfig=global_aws_config())
-    return opsworks("DescribeServiceErrors"; aws_config=aws_config)
+    return opsworks(
+        "DescribeServiceErrors"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_service_errors(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return opsworks("DescribeServiceErrors", params; aws_config=aws_config)
+    return opsworks(
+        "DescribeServiceErrors",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1673,6 +1811,7 @@ function describe_stack_provisioning_parameters(
         "DescribeStackProvisioningParameters",
         Dict{String,Any}("StackId" => StackId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_stack_provisioning_parameters(
@@ -1682,6 +1821,7 @@ function describe_stack_provisioning_parameters(
         "DescribeStackProvisioningParameters",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("StackId" => StackId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1704,6 +1844,7 @@ function describe_stack_summary(StackId; aws_config::AbstractAWSConfig=global_aw
         "DescribeStackSummary",
         Dict{String,Any}("StackId" => StackId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_stack_summary(
@@ -1713,6 +1854,7 @@ function describe_stack_summary(
         "DescribeStackSummary",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("StackId" => StackId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1731,12 +1873,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   this parameter, DescribeStacks returns a description of every stack.
 """
 function describe_stacks(; aws_config::AbstractAWSConfig=global_aws_config())
-    return opsworks("DescribeStacks"; aws_config=aws_config)
+    return opsworks(
+        "DescribeStacks"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_stacks(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return opsworks("DescribeStacks", params; aws_config=aws_config)
+    return opsworks(
+        "DescribeStacks", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1760,6 +1906,7 @@ function describe_time_based_auto_scaling(
         "DescribeTimeBasedAutoScaling",
         Dict{String,Any}("InstanceIds" => InstanceIds);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_time_based_auto_scaling(
@@ -1773,6 +1920,7 @@ function describe_time_based_auto_scaling(
             mergewith(_merge, Dict{String,Any}("InstanceIds" => InstanceIds), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1790,12 +1938,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   described.
 """
 function describe_user_profiles(; aws_config::AbstractAWSConfig=global_aws_config())
-    return opsworks("DescribeUserProfiles"; aws_config=aws_config)
+    return opsworks(
+        "DescribeUserProfiles"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_user_profiles(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return opsworks("DescribeUserProfiles", params; aws_config=aws_config)
+    return opsworks(
+        "DescribeUserProfiles",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1819,12 +1974,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   descriptions of the specified volumes. Otherwise, it returns a description of every volume.
 """
 function describe_volumes(; aws_config::AbstractAWSConfig=global_aws_config())
-    return opsworks("DescribeVolumes"; aws_config=aws_config)
+    return opsworks(
+        "DescribeVolumes"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_volumes(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return opsworks("DescribeVolumes", params; aws_config=aws_config)
+    return opsworks(
+        "DescribeVolumes", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1850,6 +2009,7 @@ function detach_elastic_load_balancer(
             "ElasticLoadBalancerName" => ElasticLoadBalancerName, "LayerId" => LayerId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function detach_elastic_load_balancer(
@@ -1871,6 +2031,7 @@ function detach_elastic_load_balancer(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1895,6 +2056,7 @@ function disassociate_elastic_ip(
         "DisassociateElasticIp",
         Dict{String,Any}("ElasticIp" => ElasticIp);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disassociate_elastic_ip(
@@ -1908,6 +2070,7 @@ function disassociate_elastic_ip(
             mergewith(_merge, Dict{String,Any}("ElasticIp" => ElasticIp), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1929,6 +2092,7 @@ function get_hostname_suggestion(LayerId; aws_config::AbstractAWSConfig=global_a
         "GetHostnameSuggestion",
         Dict{String,Any}("LayerId" => LayerId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_hostname_suggestion(
@@ -1938,6 +2102,7 @@ function get_hostname_suggestion(
         "GetHostnameSuggestion",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("LayerId" => LayerId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1960,7 +2125,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function grant_access(InstanceId; aws_config::AbstractAWSConfig=global_aws_config())
     return opsworks(
-        "GrantAccess", Dict{String,Any}("InstanceId" => InstanceId); aws_config=aws_config
+        "GrantAccess",
+        Dict{String,Any}("InstanceId" => InstanceId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function grant_access(
@@ -1974,6 +2142,7 @@ function grant_access(
             mergewith(_merge, Dict{String,Any}("InstanceId" => InstanceId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1995,7 +2164,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function list_tags(ResourceArn; aws_config::AbstractAWSConfig=global_aws_config())
     return opsworks(
-        "ListTags", Dict{String,Any}("ResourceArn" => ResourceArn); aws_config=aws_config
+        "ListTags",
+        Dict{String,Any}("ResourceArn" => ResourceArn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags(
@@ -2009,6 +2181,7 @@ function list_tags(
             mergewith(_merge, Dict{String,Any}("ResourceArn" => ResourceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2030,6 +2203,7 @@ function reboot_instance(InstanceId; aws_config::AbstractAWSConfig=global_aws_co
         "RebootInstance",
         Dict{String,Any}("InstanceId" => InstanceId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function reboot_instance(
@@ -2043,6 +2217,7 @@ function reboot_instance(
             mergewith(_merge, Dict{String,Any}("InstanceId" => InstanceId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2068,6 +2243,7 @@ function register_ecs_cluster(
         "RegisterEcsCluster",
         Dict{String,Any}("EcsClusterArn" => EcsClusterArn, "StackId" => StackId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function register_ecs_cluster(
@@ -2086,6 +2262,7 @@ function register_ecs_cluster(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2112,6 +2289,7 @@ function register_elastic_ip(
         "RegisterElasticIp",
         Dict{String,Any}("ElasticIp" => ElasticIp, "StackId" => StackId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function register_elastic_ip(
@@ -2130,6 +2308,7 @@ function register_elastic_ip(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2166,7 +2345,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function register_instance(StackId; aws_config::AbstractAWSConfig=global_aws_config())
     return opsworks(
-        "RegisterInstance", Dict{String,Any}("StackId" => StackId); aws_config=aws_config
+        "RegisterInstance",
+        Dict{String,Any}("StackId" => StackId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function register_instance(
@@ -2176,6 +2358,7 @@ function register_instance(
         "RegisterInstance",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("StackId" => StackId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2211,6 +2394,7 @@ function register_rds_db_instance(
             "StackId" => StackId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function register_rds_db_instance(
@@ -2236,6 +2420,7 @@ function register_rds_db_instance(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2259,7 +2444,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function register_volume(StackId; aws_config::AbstractAWSConfig=global_aws_config())
     return opsworks(
-        "RegisterVolume", Dict{String,Any}("StackId" => StackId); aws_config=aws_config
+        "RegisterVolume",
+        Dict{String,Any}("StackId" => StackId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function register_volume(
@@ -2269,6 +2457,7 @@ function register_volume(
         "RegisterVolume",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("StackId" => StackId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2305,6 +2494,7 @@ function set_load_based_auto_scaling(
         "SetLoadBasedAutoScaling",
         Dict{String,Any}("LayerId" => LayerId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function set_load_based_auto_scaling(
@@ -2314,6 +2504,7 @@ function set_load_based_auto_scaling(
         "SetLoadBasedAutoScaling",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("LayerId" => LayerId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2346,6 +2537,7 @@ function set_permission(
         "SetPermission",
         Dict{String,Any}("IamUserArn" => IamUserArn, "StackId" => StackId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function set_permission(
@@ -2364,6 +2556,7 @@ function set_permission(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2391,6 +2584,7 @@ function set_time_based_auto_scaling(
         "SetTimeBasedAutoScaling",
         Dict{String,Any}("InstanceId" => InstanceId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function set_time_based_auto_scaling(
@@ -2404,6 +2598,7 @@ function set_time_based_auto_scaling(
             mergewith(_merge, Dict{String,Any}("InstanceId" => InstanceId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2422,7 +2617,10 @@ For more information on user permissions, see Managing User Permissions.
 """
 function start_instance(InstanceId; aws_config::AbstractAWSConfig=global_aws_config())
     return opsworks(
-        "StartInstance", Dict{String,Any}("InstanceId" => InstanceId); aws_config=aws_config
+        "StartInstance",
+        Dict{String,Any}("InstanceId" => InstanceId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_instance(
@@ -2436,6 +2634,7 @@ function start_instance(
             mergewith(_merge, Dict{String,Any}("InstanceId" => InstanceId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2453,7 +2652,10 @@ permissions. For more information on user permissions, see Managing User Permiss
 """
 function start_stack(StackId; aws_config::AbstractAWSConfig=global_aws_config())
     return opsworks(
-        "StartStack", Dict{String,Any}("StackId" => StackId); aws_config=aws_config
+        "StartStack",
+        Dict{String,Any}("StackId" => StackId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_stack(
@@ -2463,6 +2665,7 @@ function start_stack(
         "StartStack",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("StackId" => StackId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2490,7 +2693,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function stop_instance(InstanceId; aws_config::AbstractAWSConfig=global_aws_config())
     return opsworks(
-        "StopInstance", Dict{String,Any}("InstanceId" => InstanceId); aws_config=aws_config
+        "StopInstance",
+        Dict{String,Any}("InstanceId" => InstanceId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function stop_instance(
@@ -2504,6 +2710,7 @@ function stop_instance(
             mergewith(_merge, Dict{String,Any}("InstanceId" => InstanceId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2521,7 +2728,10 @@ permissions. For more information on user permissions, see Managing User Permiss
 """
 function stop_stack(StackId; aws_config::AbstractAWSConfig=global_aws_config())
     return opsworks(
-        "StopStack", Dict{String,Any}("StackId" => StackId); aws_config=aws_config
+        "StopStack",
+        Dict{String,Any}("StackId" => StackId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function stop_stack(
@@ -2531,6 +2741,7 @@ function stop_stack(
         "StopStack",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("StackId" => StackId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2557,6 +2768,7 @@ function tag_resource(ResourceArn, Tags; aws_config::AbstractAWSConfig=global_aw
         "TagResource",
         Dict{String,Any}("ResourceArn" => ResourceArn, "Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -2575,6 +2787,7 @@ function tag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2598,6 +2811,7 @@ function unassign_instance(InstanceId; aws_config::AbstractAWSConfig=global_aws_
         "UnassignInstance",
         Dict{String,Any}("InstanceId" => InstanceId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function unassign_instance(
@@ -2611,6 +2825,7 @@ function unassign_instance(
             mergewith(_merge, Dict{String,Any}("InstanceId" => InstanceId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2630,7 +2845,10 @@ Permissions.
 """
 function unassign_volume(VolumeId; aws_config::AbstractAWSConfig=global_aws_config())
     return opsworks(
-        "UnassignVolume", Dict{String,Any}("VolumeId" => VolumeId); aws_config=aws_config
+        "UnassignVolume",
+        Dict{String,Any}("VolumeId" => VolumeId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function unassign_volume(
@@ -2644,6 +2862,7 @@ function unassign_volume(
             mergewith(_merge, Dict{String,Any}("VolumeId" => VolumeId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2665,6 +2884,7 @@ function untag_resource(
         "UntagResource",
         Dict{String,Any}("ResourceArn" => ResourceArn, "TagKeys" => TagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -2683,6 +2903,7 @@ function untag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2721,7 +2942,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"Type"`: The app type.
 """
 function update_app(AppId; aws_config::AbstractAWSConfig=global_aws_config())
-    return opsworks("UpdateApp", Dict{String,Any}("AppId" => AppId); aws_config=aws_config)
+    return opsworks(
+        "UpdateApp",
+        Dict{String,Any}("AppId" => AppId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function update_app(
     AppId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -2730,6 +2956,7 @@ function update_app(
         "UpdateApp",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("AppId" => AppId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2751,7 +2978,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function update_elastic_ip(ElasticIp; aws_config::AbstractAWSConfig=global_aws_config())
     return opsworks(
-        "UpdateElasticIp", Dict{String,Any}("ElasticIp" => ElasticIp); aws_config=aws_config
+        "UpdateElasticIp",
+        Dict{String,Any}("ElasticIp" => ElasticIp);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_elastic_ip(
@@ -2765,6 +2995,7 @@ function update_elastic_ip(
             mergewith(_merge, Dict{String,Any}("ElasticIp" => ElasticIp), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2835,6 +3066,7 @@ function update_instance(InstanceId; aws_config::AbstractAWSConfig=global_aws_co
         "UpdateInstance",
         Dict{String,Any}("InstanceId" => InstanceId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_instance(
@@ -2848,6 +3080,7 @@ function update_instance(
             mergewith(_merge, Dict{String,Any}("InstanceId" => InstanceId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2902,7 +3135,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function update_layer(LayerId; aws_config::AbstractAWSConfig=global_aws_config())
     return opsworks(
-        "UpdateLayer", Dict{String,Any}("LayerId" => LayerId); aws_config=aws_config
+        "UpdateLayer",
+        Dict{String,Any}("LayerId" => LayerId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_layer(
@@ -2912,6 +3148,7 @@ function update_layer(
         "UpdateLayer",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("LayerId" => LayerId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2928,12 +3165,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"SshPublicKey"`: The user's SSH public key.
 """
 function update_my_user_profile(; aws_config::AbstractAWSConfig=global_aws_config())
-    return opsworks("UpdateMyUserProfile"; aws_config=aws_config)
+    return opsworks(
+        "UpdateMyUserProfile"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function update_my_user_profile(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return opsworks("UpdateMyUserProfile", params; aws_config=aws_config)
+    return opsworks(
+        "UpdateMyUserProfile",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2959,6 +3203,7 @@ function update_rds_db_instance(
         "UpdateRdsDbInstance",
         Dict{String,Any}("RdsDbInstanceArn" => RdsDbInstanceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_rds_db_instance(
@@ -2974,6 +3219,7 @@ function update_rds_db_instance(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3077,7 +3323,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function update_stack(StackId; aws_config::AbstractAWSConfig=global_aws_config())
     return opsworks(
-        "UpdateStack", Dict{String,Any}("StackId" => StackId); aws_config=aws_config
+        "UpdateStack",
+        Dict{String,Any}("StackId" => StackId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_stack(
@@ -3087,6 +3336,7 @@ function update_stack(
         "UpdateStack",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("StackId" => StackId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3116,6 +3366,7 @@ function update_user_profile(IamUserArn; aws_config::AbstractAWSConfig=global_aw
         "UpdateUserProfile",
         Dict{String,Any}("IamUserArn" => IamUserArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_user_profile(
@@ -3129,6 +3380,7 @@ function update_user_profile(
             mergewith(_merge, Dict{String,Any}("IamUserArn" => IamUserArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3151,7 +3403,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function update_volume(VolumeId; aws_config::AbstractAWSConfig=global_aws_config())
     return opsworks(
-        "UpdateVolume", Dict{String,Any}("VolumeId" => VolumeId); aws_config=aws_config
+        "UpdateVolume",
+        Dict{String,Any}("VolumeId" => VolumeId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_volume(
@@ -3165,5 +3420,6 @@ function update_volume(
             mergewith(_merge, Dict{String,Any}("VolumeId" => VolumeId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/opsworkscm.jl
+++ b/src/services/opsworkscm.jl
@@ -48,6 +48,7 @@ function associate_node(
             "ServerName" => ServerName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_node(
@@ -71,6 +72,7 @@ function associate_node(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -103,7 +105,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function create_backup(ServerName; aws_config::AbstractAWSConfig=global_aws_config())
     return opsworkscm(
-        "CreateBackup", Dict{String,Any}("ServerName" => ServerName); aws_config=aws_config
+        "CreateBackup",
+        Dict{String,Any}("ServerName" => ServerName);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_backup(
@@ -117,6 +122,7 @@ function create_backup(
             mergewith(_merge, Dict{String,Any}("ServerName" => ServerName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -272,6 +278,7 @@ function create_server(
             "ServiceRoleArn" => ServiceRoleArn,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_server(
@@ -299,6 +306,7 @@ function create_server(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -318,7 +326,10 @@ ValidationException is thrown when parameters of the request are not valid.
 """
 function delete_backup(BackupId; aws_config::AbstractAWSConfig=global_aws_config())
     return opsworkscm(
-        "DeleteBackup", Dict{String,Any}("BackupId" => BackupId); aws_config=aws_config
+        "DeleteBackup",
+        Dict{String,Any}("BackupId" => BackupId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_backup(
@@ -332,6 +343,7 @@ function delete_backup(
             mergewith(_merge, Dict{String,Any}("BackupId" => BackupId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -353,7 +365,10 @@ ValidationException is raised when parameters of the request are not valid.
 """
 function delete_server(ServerName; aws_config::AbstractAWSConfig=global_aws_config())
     return opsworkscm(
-        "DeleteServer", Dict{String,Any}("ServerName" => ServerName); aws_config=aws_config
+        "DeleteServer",
+        Dict{String,Any}("ServerName" => ServerName);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_server(
@@ -367,6 +382,7 @@ function delete_server(
             mergewith(_merge, Dict{String,Any}("ServerName" => ServerName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -378,12 +394,19 @@ end
 
 """
 function describe_account_attributes(; aws_config::AbstractAWSConfig=global_aws_config())
-    return opsworkscm("DescribeAccountAttributes"; aws_config=aws_config)
+    return opsworkscm(
+        "DescribeAccountAttributes"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_account_attributes(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return opsworkscm("DescribeAccountAttributes", params; aws_config=aws_config)
+    return opsworkscm(
+        "DescribeAccountAttributes",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -403,12 +426,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"ServerName"`: Returns backups for the server with the specified ServerName.
 """
 function describe_backups(; aws_config::AbstractAWSConfig=global_aws_config())
-    return opsworkscm("DescribeBackups"; aws_config=aws_config)
+    return opsworkscm(
+        "DescribeBackups"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_backups(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return opsworkscm("DescribeBackups", params; aws_config=aws_config)
+    return opsworkscm(
+        "DescribeBackups", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -442,6 +469,7 @@ function describe_events(ServerName; aws_config::AbstractAWSConfig=global_aws_co
         "DescribeEvents",
         Dict{String,Any}("ServerName" => ServerName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_events(
@@ -455,6 +483,7 @@ function describe_events(
             mergewith(_merge, Dict{String,Any}("ServerName" => ServerName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -485,6 +514,7 @@ function describe_node_association_status(
             "ServerName" => ServerName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_node_association_status(
@@ -506,6 +536,7 @@ function describe_node_association_status(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -526,12 +557,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"ServerName"`: Describes the server with the specified ServerName.
 """
 function describe_servers(; aws_config::AbstractAWSConfig=global_aws_config())
-    return opsworkscm("DescribeServers"; aws_config=aws_config)
+    return opsworkscm(
+        "DescribeServers"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_servers(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return opsworkscm("DescribeServers", params; aws_config=aws_config)
+    return opsworkscm(
+        "DescribeServers", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -564,6 +599,7 @@ function disassociate_node(
         "DisassociateNode",
         Dict{String,Any}("NodeName" => NodeName, "ServerName" => ServerName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disassociate_node(
@@ -582,6 +618,7 @@ function disassociate_node(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -625,6 +662,7 @@ function export_server_engine_attribute(
             "ExportAttributeName" => ExportAttributeName, "ServerName" => ServerName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function export_server_engine_attribute(
@@ -645,6 +683,7 @@ function export_server_engine_attribute(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -683,6 +722,7 @@ function list_tags_for_resource(
         "ListTagsForResource",
         Dict{String,Any}("ResourceArn" => ResourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags_for_resource(
@@ -696,6 +736,7 @@ function list_tags_for_resource(
             mergewith(_merge, Dict{String,Any}("ResourceArn" => ResourceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -735,6 +776,7 @@ function restore_server(
         "RestoreServer",
         Dict{String,Any}("BackupId" => BackupId, "ServerName" => ServerName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function restore_server(
@@ -753,6 +795,7 @@ function restore_server(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -784,6 +827,7 @@ function start_maintenance(ServerName; aws_config::AbstractAWSConfig=global_aws_
         "StartMaintenance",
         Dict{String,Any}("ServerName" => ServerName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_maintenance(
@@ -797,6 +841,7 @@ function start_maintenance(
             mergewith(_merge, Dict{String,Any}("ServerName" => ServerName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -826,6 +871,7 @@ function tag_resource(ResourceArn, Tags; aws_config::AbstractAWSConfig=global_aw
         "TagResource",
         Dict{String,Any}("ResourceArn" => ResourceArn, "Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -844,6 +890,7 @@ function tag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -868,6 +915,7 @@ function untag_resource(
         "UntagResource",
         Dict{String,Any}("ResourceArn" => ResourceArn, "TagKeys" => TagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -886,6 +934,7 @@ function untag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -908,7 +957,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function update_server(ServerName; aws_config::AbstractAWSConfig=global_aws_config())
     return opsworkscm(
-        "UpdateServer", Dict{String,Any}("ServerName" => ServerName); aws_config=aws_config
+        "UpdateServer",
+        Dict{String,Any}("ServerName" => ServerName);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_server(
@@ -922,6 +974,7 @@ function update_server(
             mergewith(_merge, Dict{String,Any}("ServerName" => ServerName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -952,6 +1005,7 @@ function update_server_engine_attributes(
         "UpdateServerEngineAttributes",
         Dict{String,Any}("AttributeName" => AttributeName, "ServerName" => ServerName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_server_engine_attributes(
@@ -972,5 +1026,6 @@ function update_server_engine_attributes(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/organizations.jl
+++ b/src/services/organizations.jl
@@ -35,6 +35,7 @@ function accept_handshake(HandshakeId; aws_config::AbstractAWSConfig=global_aws_
         "AcceptHandshake",
         Dict{String,Any}("HandshakeId" => HandshakeId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function accept_handshake(
@@ -48,6 +49,7 @@ function accept_handshake(
             mergewith(_merge, Dict{String,Any}("HandshakeId" => HandshakeId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -84,6 +86,7 @@ function attach_policy(
         "AttachPolicy",
         Dict{String,Any}("PolicyId" => PolicyId, "TargetId" => TargetId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function attach_policy(
@@ -102,6 +105,7 @@ function attach_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -127,6 +131,7 @@ function cancel_handshake(HandshakeId; aws_config::AbstractAWSConfig=global_aws_
         "CancelHandshake",
         Dict{String,Any}("HandshakeId" => HandshakeId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function cancel_handshake(
@@ -140,6 +145,7 @@ function cancel_handshake(
             mergewith(_merge, Dict{String,Any}("HandshakeId" => HandshakeId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -230,6 +236,7 @@ function create_account(
         "CreateAccount",
         Dict{String,Any}("AccountName" => AccountName, "Email" => Email);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_account(
@@ -248,6 +255,7 @@ function create_account(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -366,6 +374,7 @@ function create_gov_cloud_account(
         "CreateGovCloudAccount",
         Dict{String,Any}("AccountName" => AccountName, "Email" => Email);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_gov_cloud_account(
@@ -384,6 +393,7 @@ function create_gov_cloud_account(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -415,12 +425,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Guide.
 """
 function create_organization(; aws_config::AbstractAWSConfig=global_aws_config())
-    return organizations("CreateOrganization"; aws_config=aws_config)
+    return organizations(
+        "CreateOrganization"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function create_organization(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return organizations("CreateOrganization", params; aws_config=aws_config)
+    return organizations(
+        "CreateOrganization", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -461,6 +475,7 @@ function create_organizational_unit(
         "CreateOrganizationalUnit",
         Dict{String,Any}("Name" => Name, "ParentId" => ParentId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_organizational_unit(
@@ -477,6 +492,7 @@ function create_organizational_unit(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -520,6 +536,7 @@ function create_policy(
             "Type" => Type,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_policy(
@@ -545,6 +562,7 @@ function create_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -570,6 +588,7 @@ function decline_handshake(HandshakeId; aws_config::AbstractAWSConfig=global_aws
         "DeclineHandshake",
         Dict{String,Any}("HandshakeId" => HandshakeId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function decline_handshake(
@@ -583,6 +602,7 @@ function decline_handshake(
             mergewith(_merge, Dict{String,Any}("HandshakeId" => HandshakeId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -595,12 +615,16 @@ management account. The organization must be empty of member accounts.
 
 """
 function delete_organization(; aws_config::AbstractAWSConfig=global_aws_config())
-    return organizations("DeleteOrganization"; aws_config=aws_config)
+    return organizations(
+        "DeleteOrganization"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function delete_organization(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return organizations("DeleteOrganization", params; aws_config=aws_config)
+    return organizations(
+        "DeleteOrganization", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -626,6 +650,7 @@ function delete_organizational_unit(
         "DeleteOrganizationalUnit",
         Dict{String,Any}("OrganizationalUnitId" => OrganizationalUnitId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_organizational_unit(
@@ -643,6 +668,7 @@ function delete_organizational_unit(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -663,7 +689,10 @@ operation can be called only from the organization's management account.
 """
 function delete_policy(PolicyId; aws_config::AbstractAWSConfig=global_aws_config())
     return organizations(
-        "DeletePolicy", Dict{String,Any}("PolicyId" => PolicyId); aws_config=aws_config
+        "DeletePolicy",
+        Dict{String,Any}("PolicyId" => PolicyId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_policy(
@@ -677,6 +706,7 @@ function delete_policy(
             mergewith(_merge, Dict{String,Any}("PolicyId" => PolicyId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -711,6 +741,7 @@ function deregister_delegated_administrator(
         "DeregisterDelegatedAdministrator",
         Dict{String,Any}("AccountId" => AccountId, "ServicePrincipal" => ServicePrincipal);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function deregister_delegated_administrator(
@@ -731,6 +762,7 @@ function deregister_delegated_administrator(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -750,7 +782,10 @@ is a delegated administrator for an AWS service.
 """
 function describe_account(AccountId; aws_config::AbstractAWSConfig=global_aws_config())
     return organizations(
-        "DescribeAccount", Dict{String,Any}("AccountId" => AccountId); aws_config=aws_config
+        "DescribeAccount",
+        Dict{String,Any}("AccountId" => AccountId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_account(
@@ -764,6 +799,7 @@ function describe_account(
             mergewith(_merge, Dict{String,Any}("AccountId" => AccountId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -790,6 +826,7 @@ function describe_create_account_status(
         "DescribeCreateAccountStatus",
         Dict{String,Any}("CreateAccountRequestId" => CreateAccountRequestId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_create_account_status(
@@ -807,6 +844,7 @@ function describe_create_account_status(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -840,6 +878,7 @@ function describe_effective_policy(
         "DescribeEffectivePolicy",
         Dict{String,Any}("PolicyType" => PolicyType);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_effective_policy(
@@ -853,6 +892,7 @@ function describe_effective_policy(
             mergewith(_merge, Dict{String,Any}("PolicyType" => PolicyType), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -878,6 +918,7 @@ function describe_handshake(HandshakeId; aws_config::AbstractAWSConfig=global_aw
         "DescribeHandshake",
         Dict{String,Any}("HandshakeId" => HandshakeId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_handshake(
@@ -891,6 +932,7 @@ function describe_handshake(
             mergewith(_merge, Dict{String,Any}("HandshakeId" => HandshakeId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -906,12 +948,19 @@ root.
 
 """
 function describe_organization(; aws_config::AbstractAWSConfig=global_aws_config())
-    return organizations("DescribeOrganization"; aws_config=aws_config)
+    return organizations(
+        "DescribeOrganization"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_organization(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return organizations("DescribeOrganization", params; aws_config=aws_config)
+    return organizations(
+        "DescribeOrganization",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -937,6 +986,7 @@ function describe_organizational_unit(
         "DescribeOrganizationalUnit",
         Dict{String,Any}("OrganizationalUnitId" => OrganizationalUnitId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_organizational_unit(
@@ -954,6 +1004,7 @@ function describe_organizational_unit(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -974,7 +1025,10 @@ for an AWS service.
 """
 function describe_policy(PolicyId; aws_config::AbstractAWSConfig=global_aws_config())
     return organizations(
-        "DescribePolicy", Dict{String,Any}("PolicyId" => PolicyId); aws_config=aws_config
+        "DescribePolicy",
+        Dict{String,Any}("PolicyId" => PolicyId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_policy(
@@ -988,6 +1042,7 @@ function describe_policy(
             mergewith(_merge, Dict{String,Any}("PolicyId" => PolicyId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1030,6 +1085,7 @@ function detach_policy(
         "DetachPolicy",
         Dict{String,Any}("PolicyId" => PolicyId, "TargetId" => TargetId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function detach_policy(
@@ -1048,6 +1104,7 @@ function detach_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1103,6 +1160,7 @@ function disable_awsservice_access(
         "DisableAWSServiceAccess",
         Dict{String,Any}("ServicePrincipal" => ServicePrincipal);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disable_awsservice_access(
@@ -1118,6 +1176,7 @@ function disable_awsservice_access(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1153,6 +1212,7 @@ function disable_policy_type(
         "DisablePolicyType",
         Dict{String,Any}("PolicyType" => PolicyType, "RootId" => RootId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disable_policy_type(
@@ -1171,6 +1231,7 @@ function disable_policy_type(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1201,12 +1262,16 @@ organization's management account.
 
 """
 function enable_all_features(; aws_config::AbstractAWSConfig=global_aws_config())
-    return organizations("EnableAllFeatures"; aws_config=aws_config)
+    return organizations(
+        "EnableAllFeatures"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function enable_all_features(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return organizations("EnableAllFeatures", params; aws_config=aws_config)
+    return organizations(
+        "EnableAllFeatures", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1240,6 +1305,7 @@ function enable_awsservice_access(
         "EnableAWSServiceAccess",
         Dict{String,Any}("ServicePrincipal" => ServicePrincipal);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function enable_awsservice_access(
@@ -1255,6 +1321,7 @@ function enable_awsservice_access(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1287,6 +1354,7 @@ function enable_policy_type(
         "EnablePolicyType",
         Dict{String,Any}("PolicyType" => PolicyType, "RootId" => RootId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function enable_policy_type(
@@ -1305,6 +1373,7 @@ function enable_policy_type(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1360,6 +1429,7 @@ function invite_account_to_organization(
         "InviteAccountToOrganization",
         Dict{String,Any}("Target" => Target);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function invite_account_to_organization(
@@ -1369,6 +1439,7 @@ function invite_account_to_organization(
         "InviteAccountToOrganization",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Target" => Target), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1407,12 +1478,16 @@ required, then try again in a few days.
 
 """
 function leave_organization(; aws_config::AbstractAWSConfig=global_aws_config())
-    return organizations("LeaveOrganization"; aws_config=aws_config)
+    return organizations(
+        "LeaveOrganization"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function leave_organization(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return organizations("LeaveOrganization", params; aws_config=aws_config)
+    return organizations(
+        "LeaveOrganization", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1444,12 +1519,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   indicate where the output should continue from.
 """
 function list_accounts(; aws_config::AbstractAWSConfig=global_aws_config())
-    return organizations("ListAccounts"; aws_config=aws_config)
+    return organizations(
+        "ListAccounts"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_accounts(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return organizations("ListAccounts", params; aws_config=aws_config)
+    return organizations(
+        "ListAccounts", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1493,6 +1572,7 @@ function list_accounts_for_parent(
         "ListAccountsForParent",
         Dict{String,Any}("ParentId" => ParentId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_accounts_for_parent(
@@ -1506,6 +1586,7 @@ function list_accounts_for_parent(
             mergewith(_merge, Dict{String,Any}("ParentId" => ParentId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1540,13 +1621,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function list_awsservice_access_for_organization(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return organizations("ListAWSServiceAccessForOrganization"; aws_config=aws_config)
+    return organizations(
+        "ListAWSServiceAccessForOrganization";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_awsservice_access_for_organization(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return organizations(
-        "ListAWSServiceAccessForOrganization", params; aws_config=aws_config
+        "ListAWSServiceAccessForOrganization",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1594,6 +1682,7 @@ function list_children(
         "ListChildren",
         Dict{String,Any}("ChildType" => ChildType, "ParentId" => ParentId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_children(
@@ -1612,6 +1701,7 @@ function list_children(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1645,12 +1735,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   parameter isn't present, all requests are included in the response.
 """
 function list_create_account_status(; aws_config::AbstractAWSConfig=global_aws_config())
-    return organizations("ListCreateAccountStatus"; aws_config=aws_config)
+    return organizations(
+        "ListCreateAccountStatus"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_create_account_status(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return organizations("ListCreateAccountStatus", params; aws_config=aws_config)
+    return organizations(
+        "ListCreateAccountStatus",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1681,12 +1778,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   services in your organization.
 """
 function list_delegated_administrators(; aws_config::AbstractAWSConfig=global_aws_config())
-    return organizations("ListDelegatedAdministrators"; aws_config=aws_config)
+    return organizations(
+        "ListDelegatedAdministrators";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_delegated_administrators(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return organizations("ListDelegatedAdministrators", params; aws_config=aws_config)
+    return organizations(
+        "ListDelegatedAdministrators",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1723,6 +1829,7 @@ function list_delegated_services_for_account(
         "ListDelegatedServicesForAccount",
         Dict{String,Any}("AccountId" => AccountId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_delegated_services_for_account(
@@ -1736,6 +1843,7 @@ function list_delegated_services_for_account(
             mergewith(_merge, Dict{String,Any}("AccountId" => AccountId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1774,12 +1882,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   indicate where the output should continue from.
 """
 function list_handshakes_for_account(; aws_config::AbstractAWSConfig=global_aws_config())
-    return organizations("ListHandshakesForAccount"; aws_config=aws_config)
+    return organizations(
+        "ListHandshakesForAccount"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_handshakes_for_account(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return organizations("ListHandshakesForAccount", params; aws_config=aws_config)
+    return organizations(
+        "ListHandshakesForAccount",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1822,12 +1937,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function list_handshakes_for_organization(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return organizations("ListHandshakesForOrganization"; aws_config=aws_config)
+    return organizations(
+        "ListHandshakesForOrganization";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_handshakes_for_organization(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return organizations("ListHandshakesForOrganization", params; aws_config=aws_config)
+    return organizations(
+        "ListHandshakesForOrganization",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1871,6 +1995,7 @@ function list_organizational_units_for_parent(
         "ListOrganizationalUnitsForParent",
         Dict{String,Any}("ParentId" => ParentId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_organizational_units_for_parent(
@@ -1884,6 +2009,7 @@ function list_organizational_units_for_parent(
             mergewith(_merge, Dict{String,Any}("ParentId" => ParentId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1926,7 +2052,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function list_parents(ChildId; aws_config::AbstractAWSConfig=global_aws_config())
     return organizations(
-        "ListParents", Dict{String,Any}("ChildId" => ChildId); aws_config=aws_config
+        "ListParents",
+        Dict{String,Any}("ChildId" => ChildId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_parents(
@@ -1936,6 +2065,7 @@ function list_parents(
         "ListParents",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("ChildId" => ChildId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1972,7 +2102,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function list_policies(Filter; aws_config::AbstractAWSConfig=global_aws_config())
     return organizations(
-        "ListPolicies", Dict{String,Any}("Filter" => Filter); aws_config=aws_config
+        "ListPolicies",
+        Dict{String,Any}("Filter" => Filter);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_policies(
@@ -1982,6 +2115,7 @@ function list_policies(
         "ListPolicies",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Filter" => Filter), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2032,6 +2166,7 @@ function list_policies_for_target(
         "ListPoliciesForTarget",
         Dict{String,Any}("Filter" => Filter, "TargetId" => TargetId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_policies_for_target(
@@ -2048,6 +2183,7 @@ function list_policies_for_target(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2082,12 +2218,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   indicate where the output should continue from.
 """
 function list_roots(; aws_config::AbstractAWSConfig=global_aws_config())
-    return organizations("ListRoots"; aws_config=aws_config)
+    return organizations(
+        "ListRoots"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_roots(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return organizations("ListRoots", params; aws_config=aws_config)
+    return organizations(
+        "ListRoots", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -2122,6 +2262,7 @@ function list_tags_for_resource(
         "ListTagsForResource",
         Dict{String,Any}("ResourceId" => ResourceId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags_for_resource(
@@ -2135,6 +2276,7 @@ function list_tags_for_resource(
             mergewith(_merge, Dict{String,Any}("ResourceId" => ResourceId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2177,6 +2319,7 @@ function list_targets_for_policy(
         "ListTargetsForPolicy",
         Dict{String,Any}("PolicyId" => PolicyId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_targets_for_policy(
@@ -2190,6 +2333,7 @@ function list_targets_for_policy(
             mergewith(_merge, Dict{String,Any}("PolicyId" => PolicyId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2234,6 +2378,7 @@ function move_account(
             "SourceParentId" => SourceParentId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function move_account(
@@ -2257,6 +2402,7 @@ function move_account(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2286,6 +2432,7 @@ function register_delegated_administrator(
         "RegisterDelegatedAdministrator",
         Dict{String,Any}("AccountId" => AccountId, "ServicePrincipal" => ServicePrincipal);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function register_delegated_administrator(
@@ -2306,6 +2453,7 @@ function register_delegated_administrator(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2349,6 +2497,7 @@ function remove_account_from_organization(
         "RemoveAccountFromOrganization",
         Dict{String,Any}("AccountId" => AccountId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function remove_account_from_organization(
@@ -2362,6 +2511,7 @@ function remove_account_from_organization(
             mergewith(_merge, Dict{String,Any}("AccountId" => AccountId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2392,6 +2542,7 @@ function tag_resource(ResourceId, Tags; aws_config::AbstractAWSConfig=global_aws
         "TagResource",
         Dict{String,Any}("ResourceId" => ResourceId, "Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -2408,6 +2559,7 @@ function tag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2437,6 +2589,7 @@ function untag_resource(
         "UntagResource",
         Dict{String,Any}("ResourceId" => ResourceId, "TagKeys" => TagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -2455,6 +2608,7 @@ function untag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2486,6 +2640,7 @@ function update_organizational_unit(
         "UpdateOrganizationalUnit",
         Dict{String,Any}("OrganizationalUnitId" => OrganizationalUnitId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_organizational_unit(
@@ -2503,6 +2658,7 @@ function update_organizational_unit(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2530,7 +2686,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function update_policy(PolicyId; aws_config::AbstractAWSConfig=global_aws_config())
     return organizations(
-        "UpdatePolicy", Dict{String,Any}("PolicyId" => PolicyId); aws_config=aws_config
+        "UpdatePolicy",
+        Dict{String,Any}("PolicyId" => PolicyId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_policy(
@@ -2544,5 +2703,6 @@ function update_policy(
             mergewith(_merge, Dict{String,Any}("PolicyId" => PolicyId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/outposts.jl
+++ b/src/services/outposts.jl
@@ -34,6 +34,7 @@ function create_order(
             "PaymentOption" => PaymentOption,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_order(
@@ -58,6 +59,7 @@ function create_order(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -84,6 +86,7 @@ function create_outpost(Name, SiteId; aws_config::AbstractAWSConfig=global_aws_c
         "/outposts",
         Dict{String,Any}("Name" => Name, "SiteId" => SiteId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_outpost(
@@ -99,6 +102,7 @@ function create_outpost(
             mergewith(_merge, Dict{String,Any}("Name" => Name, "SiteId" => SiteId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -113,14 +117,25 @@ Deletes the Outpost.
 
 """
 function delete_outpost(OutpostId; aws_config::AbstractAWSConfig=global_aws_config())
-    return outposts("DELETE", "/outposts/$(OutpostId)"; aws_config=aws_config)
+    return outposts(
+        "DELETE",
+        "/outposts/$(OutpostId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_outpost(
     OutpostId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return outposts("DELETE", "/outposts/$(OutpostId)", params; aws_config=aws_config)
+    return outposts(
+        "DELETE",
+        "/outposts/$(OutpostId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -134,12 +149,20 @@ Deletes the site.
 
 """
 function delete_site(SiteId; aws_config::AbstractAWSConfig=global_aws_config())
-    return outposts("DELETE", "/sites/$(SiteId)"; aws_config=aws_config)
+    return outposts(
+        "DELETE", "/sites/$(SiteId)"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function delete_site(
     SiteId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return outposts("DELETE", "/sites/$(SiteId)", params; aws_config=aws_config)
+    return outposts(
+        "DELETE",
+        "/sites/$(SiteId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -153,14 +176,25 @@ Gets information about the specified Outpost.
 
 """
 function get_outpost(OutpostId; aws_config::AbstractAWSConfig=global_aws_config())
-    return outposts("GET", "/outposts/$(OutpostId)"; aws_config=aws_config)
+    return outposts(
+        "GET",
+        "/outposts/$(OutpostId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_outpost(
     OutpostId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return outposts("GET", "/outposts/$(OutpostId)", params; aws_config=aws_config)
+    return outposts(
+        "GET",
+        "/outposts/$(OutpostId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -180,7 +214,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function get_outpost_instance_types(
     OutpostId; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return outposts("GET", "/outposts/$(OutpostId)/instanceTypes"; aws_config=aws_config)
+    return outposts(
+        "GET",
+        "/outposts/$(OutpostId)/instanceTypes";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_outpost_instance_types(
     OutpostId,
@@ -188,7 +227,11 @@ function get_outpost_instance_types(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return outposts(
-        "GET", "/outposts/$(OutpostId)/instanceTypes", params; aws_config=aws_config
+        "GET",
+        "/outposts/$(OutpostId)/instanceTypes",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -220,12 +263,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`:
 """
 function list_outposts(; aws_config::AbstractAWSConfig=global_aws_config())
-    return outposts("GET", "/outposts"; aws_config=aws_config)
+    return outposts(
+        "GET", "/outposts"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_outposts(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return outposts("GET", "/outposts", params; aws_config=aws_config)
+    return outposts(
+        "GET", "/outposts", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -240,12 +287,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`:
 """
 function list_sites(; aws_config::AbstractAWSConfig=global_aws_config())
-    return outposts("GET", "/sites"; aws_config=aws_config)
+    return outposts("GET", "/sites"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_sites(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return outposts("GET", "/sites", params; aws_config=aws_config)
+    return outposts(
+        "GET", "/sites", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -261,14 +310,25 @@ Lists the tags for the specified resource.
 function list_tags_for_resource(
     ResourceArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return outposts("GET", "/tags/$(ResourceArn)"; aws_config=aws_config)
+    return outposts(
+        "GET",
+        "/tags/$(ResourceArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_tags_for_resource(
     ResourceArn,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return outposts("GET", "/tags/$(ResourceArn)", params; aws_config=aws_config)
+    return outposts(
+        "GET",
+        "/tags/$(ResourceArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -288,6 +348,7 @@ function tag_resource(ResourceArn, Tags; aws_config::AbstractAWSConfig=global_aw
         "/tags/$(ResourceArn)",
         Dict{String,Any}("Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -301,6 +362,7 @@ function tag_resource(
         "/tags/$(ResourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Tags" => Tags), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -323,6 +385,7 @@ function untag_resource(
         "/tags/$(ResourceArn)",
         Dict{String,Any}("tagKeys" => tagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -336,5 +399,6 @@ function untag_resource(
         "/tags/$(ResourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tagKeys" => tagKeys), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/personalize.jl
+++ b/src/services/personalize.jl
@@ -46,6 +46,7 @@ function create_batch_inference_job(
             "solutionVersionArn" => solutionVersionArn,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_batch_inference_job(
@@ -73,6 +74,7 @@ function create_batch_inference_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -116,6 +118,7 @@ function create_campaign(
         "CreateCampaign",
         Dict{String,Any}("name" => name, "solutionVersionArn" => solutionVersionArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_campaign(
@@ -136,6 +139,7 @@ function create_campaign(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -178,6 +182,7 @@ function create_dataset(
             "schemaArn" => schemaArn,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_dataset(
@@ -203,6 +208,7 @@ function create_dataset(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -252,6 +258,7 @@ function create_dataset_export_job(
             "roleArn" => roleArn,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_dataset_export_job(
@@ -277,6 +284,7 @@ function create_dataset_export_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -312,7 +320,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function create_dataset_group(name; aws_config::AbstractAWSConfig=global_aws_config())
     return personalize(
-        "CreateDatasetGroup", Dict{String,Any}("name" => name); aws_config=aws_config
+        "CreateDatasetGroup",
+        Dict{String,Any}("name" => name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_dataset_group(
@@ -322,6 +333,7 @@ function create_dataset_group(
         "CreateDatasetGroup",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("name" => name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -368,6 +380,7 @@ function create_dataset_import_job(
             "roleArn" => roleArn,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_dataset_import_job(
@@ -393,6 +406,7 @@ function create_dataset_import_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -425,6 +439,7 @@ function create_event_tracker(
         "CreateEventTracker",
         Dict{String,Any}("datasetGroupArn" => datasetGroupArn, "name" => name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_event_tracker(
@@ -443,6 +458,7 @@ function create_event_tracker(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -474,6 +490,7 @@ function create_filter(
             "name" => name,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_filter(
@@ -497,6 +514,7 @@ function create_filter(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -520,6 +538,7 @@ function create_schema(name, schema; aws_config::AbstractAWSConfig=global_aws_co
         "CreateSchema",
         Dict{String,Any}("name" => name, "schema" => schema);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_schema(
@@ -534,6 +553,7 @@ function create_schema(
             mergewith(_merge, Dict{String,Any}("name" => name, "schema" => schema), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -595,6 +615,7 @@ function create_solution(
         "CreateSolution",
         Dict{String,Any}("datasetGroupArn" => datasetGroupArn, "name" => name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_solution(
@@ -613,6 +634,7 @@ function create_solution(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -653,6 +675,7 @@ function create_solution_version(
         "CreateSolutionVersion",
         Dict{String,Any}("solutionArn" => solutionArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_solution_version(
@@ -666,6 +689,7 @@ function create_solution_version(
             mergewith(_merge, Dict{String,Any}("solutionArn" => solutionArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -687,6 +711,7 @@ function delete_campaign(campaignArn; aws_config::AbstractAWSConfig=global_aws_c
         "DeleteCampaign",
         Dict{String,Any}("campaignArn" => campaignArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_campaign(
@@ -700,6 +725,7 @@ function delete_campaign(
             mergewith(_merge, Dict{String,Any}("campaignArn" => campaignArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -717,7 +743,10 @@ datasets, see CreateDataset.
 """
 function delete_dataset(datasetArn; aws_config::AbstractAWSConfig=global_aws_config())
     return personalize(
-        "DeleteDataset", Dict{String,Any}("datasetArn" => datasetArn); aws_config=aws_config
+        "DeleteDataset",
+        Dict{String,Any}("datasetArn" => datasetArn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_dataset(
@@ -731,6 +760,7 @@ function delete_dataset(
             mergewith(_merge, Dict{String,Any}("datasetArn" => datasetArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -753,6 +783,7 @@ function delete_dataset_group(
         "DeleteDatasetGroup",
         Dict{String,Any}("datasetGroupArn" => datasetGroupArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_dataset_group(
@@ -768,6 +799,7 @@ function delete_dataset_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -789,6 +821,7 @@ function delete_event_tracker(
         "DeleteEventTracker",
         Dict{String,Any}("eventTrackerArn" => eventTrackerArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_event_tracker(
@@ -804,6 +837,7 @@ function delete_event_tracker(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -819,7 +853,10 @@ Deletes a filter.
 """
 function delete_filter(filterArn; aws_config::AbstractAWSConfig=global_aws_config())
     return personalize(
-        "DeleteFilter", Dict{String,Any}("filterArn" => filterArn); aws_config=aws_config
+        "DeleteFilter",
+        Dict{String,Any}("filterArn" => filterArn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_filter(
@@ -833,6 +870,7 @@ function delete_filter(
             mergewith(_merge, Dict{String,Any}("filterArn" => filterArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -849,7 +887,10 @@ schema. For more information on schemas, see CreateSchema.
 """
 function delete_schema(schemaArn; aws_config::AbstractAWSConfig=global_aws_config())
     return personalize(
-        "DeleteSchema", Dict{String,Any}("schemaArn" => schemaArn); aws_config=aws_config
+        "DeleteSchema",
+        Dict{String,Any}("schemaArn" => schemaArn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_schema(
@@ -863,6 +904,7 @@ function delete_schema(
             mergewith(_merge, Dict{String,Any}("schemaArn" => schemaArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -885,6 +927,7 @@ function delete_solution(solutionArn; aws_config::AbstractAWSConfig=global_aws_c
         "DeleteSolution",
         Dict{String,Any}("solutionArn" => solutionArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_solution(
@@ -898,6 +941,7 @@ function delete_solution(
             mergewith(_merge, Dict{String,Any}("solutionArn" => solutionArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -916,6 +960,7 @@ function describe_algorithm(algorithmArn; aws_config::AbstractAWSConfig=global_a
         "DescribeAlgorithm",
         Dict{String,Any}("algorithmArn" => algorithmArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_algorithm(
@@ -929,6 +974,7 @@ function describe_algorithm(
             mergewith(_merge, Dict{String,Any}("algorithmArn" => algorithmArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -951,6 +997,7 @@ function describe_batch_inference_job(
         "DescribeBatchInferenceJob",
         Dict{String,Any}("batchInferenceJobArn" => batchInferenceJobArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_batch_inference_job(
@@ -968,6 +1015,7 @@ function describe_batch_inference_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -990,6 +1038,7 @@ function describe_campaign(campaignArn; aws_config::AbstractAWSConfig=global_aws
         "DescribeCampaign",
         Dict{String,Any}("campaignArn" => campaignArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_campaign(
@@ -1003,6 +1052,7 @@ function describe_campaign(
             mergewith(_merge, Dict{String,Any}("campaignArn" => campaignArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1021,6 +1071,7 @@ function describe_dataset(datasetArn; aws_config::AbstractAWSConfig=global_aws_c
         "DescribeDataset",
         Dict{String,Any}("datasetArn" => datasetArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_dataset(
@@ -1034,6 +1085,7 @@ function describe_dataset(
             mergewith(_merge, Dict{String,Any}("datasetArn" => datasetArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1056,6 +1108,7 @@ function describe_dataset_export_job(
         "DescribeDatasetExportJob",
         Dict{String,Any}("datasetExportJobArn" => datasetExportJobArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_dataset_export_job(
@@ -1073,6 +1126,7 @@ function describe_dataset_export_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1094,6 +1148,7 @@ function describe_dataset_group(
         "DescribeDatasetGroup",
         Dict{String,Any}("datasetGroupArn" => datasetGroupArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_dataset_group(
@@ -1109,6 +1164,7 @@ function describe_dataset_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1131,6 +1187,7 @@ function describe_dataset_import_job(
         "DescribeDatasetImportJob",
         Dict{String,Any}("datasetImportJobArn" => datasetImportJobArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_dataset_import_job(
@@ -1148,6 +1205,7 @@ function describe_dataset_import_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1169,6 +1227,7 @@ function describe_event_tracker(
         "DescribeEventTracker",
         Dict{String,Any}("eventTrackerArn" => eventTrackerArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_event_tracker(
@@ -1184,6 +1243,7 @@ function describe_event_tracker(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1205,6 +1265,7 @@ function describe_feature_transformation(
         "DescribeFeatureTransformation",
         Dict{String,Any}("featureTransformationArn" => featureTransformationArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_feature_transformation(
@@ -1222,6 +1283,7 @@ function describe_feature_transformation(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1237,7 +1299,10 @@ Describes a filter's properties.
 """
 function describe_filter(filterArn; aws_config::AbstractAWSConfig=global_aws_config())
     return personalize(
-        "DescribeFilter", Dict{String,Any}("filterArn" => filterArn); aws_config=aws_config
+        "DescribeFilter",
+        Dict{String,Any}("filterArn" => filterArn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_filter(
@@ -1251,6 +1316,7 @@ function describe_filter(
             mergewith(_merge, Dict{String,Any}("filterArn" => filterArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1272,7 +1338,10 @@ GetRecommendations API.
 """
 function describe_recipe(recipeArn; aws_config::AbstractAWSConfig=global_aws_config())
     return personalize(
-        "DescribeRecipe", Dict{String,Any}("recipeArn" => recipeArn); aws_config=aws_config
+        "DescribeRecipe",
+        Dict{String,Any}("recipeArn" => recipeArn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_recipe(
@@ -1286,6 +1355,7 @@ function describe_recipe(
             mergewith(_merge, Dict{String,Any}("recipeArn" => recipeArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1301,7 +1371,10 @@ Describes a schema. For more information on schemas, see CreateSchema.
 """
 function describe_schema(schemaArn; aws_config::AbstractAWSConfig=global_aws_config())
     return personalize(
-        "DescribeSchema", Dict{String,Any}("schemaArn" => schemaArn); aws_config=aws_config
+        "DescribeSchema",
+        Dict{String,Any}("schemaArn" => schemaArn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_schema(
@@ -1315,6 +1388,7 @@ function describe_schema(
             mergewith(_merge, Dict{String,Any}("schemaArn" => schemaArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1333,6 +1407,7 @@ function describe_solution(solutionArn; aws_config::AbstractAWSConfig=global_aws
         "DescribeSolution",
         Dict{String,Any}("solutionArn" => solutionArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_solution(
@@ -1346,6 +1421,7 @@ function describe_solution(
             mergewith(_merge, Dict{String,Any}("solutionArn" => solutionArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1367,6 +1443,7 @@ function describe_solution_version(
         "DescribeSolutionVersion",
         Dict{String,Any}("solutionVersionArn" => solutionVersionArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_solution_version(
@@ -1382,6 +1459,7 @@ function describe_solution_version(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1403,6 +1481,7 @@ function get_solution_metrics(
         "GetSolutionMetrics",
         Dict{String,Any}("solutionVersionArn" => solutionVersionArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_solution_metrics(
@@ -1418,6 +1497,7 @@ function get_solution_metrics(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1436,12 +1516,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   the batch inference jobs were created.
 """
 function list_batch_inference_jobs(; aws_config::AbstractAWSConfig=global_aws_config())
-    return personalize("ListBatchInferenceJobs"; aws_config=aws_config)
+    return personalize(
+        "ListBatchInferenceJobs"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_batch_inference_jobs(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return personalize("ListBatchInferenceJobs", params; aws_config=aws_config)
+    return personalize(
+        "ListBatchInferenceJobs",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1463,12 +1550,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   listed.
 """
 function list_campaigns(; aws_config::AbstractAWSConfig=global_aws_config())
-    return personalize("ListCampaigns"; aws_config=aws_config)
+    return personalize(
+        "ListCampaigns"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_campaigns(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return personalize("ListCampaigns", params; aws_config=aws_config)
+    return personalize(
+        "ListCampaigns", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1490,12 +1581,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   getting the next set of dataset export jobs (if they exist).
 """
 function list_dataset_export_jobs(; aws_config::AbstractAWSConfig=global_aws_config())
-    return personalize("ListDatasetExportJobs"; aws_config=aws_config)
+    return personalize(
+        "ListDatasetExportJobs"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_dataset_export_jobs(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return personalize("ListDatasetExportJobs", params; aws_config=aws_config)
+    return personalize(
+        "ListDatasetExportJobs",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1513,12 +1611,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   the next set of dataset groups (if they exist).
 """
 function list_dataset_groups(; aws_config::AbstractAWSConfig=global_aws_config())
-    return personalize("ListDatasetGroups"; aws_config=aws_config)
+    return personalize(
+        "ListDatasetGroups"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_dataset_groups(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return personalize("ListDatasetGroups", params; aws_config=aws_config)
+    return personalize(
+        "ListDatasetGroups", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1540,12 +1642,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   getting the next set of dataset import jobs (if they exist).
 """
 function list_dataset_import_jobs(; aws_config::AbstractAWSConfig=global_aws_config())
-    return personalize("ListDatasetImportJobs"; aws_config=aws_config)
+    return personalize(
+        "ListDatasetImportJobs"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_dataset_import_jobs(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return personalize("ListDatasetImportJobs", params; aws_config=aws_config)
+    return personalize(
+        "ListDatasetImportJobs",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1565,12 +1674,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   getting the next set of dataset import jobs (if they exist).
 """
 function list_datasets(; aws_config::AbstractAWSConfig=global_aws_config())
-    return personalize("ListDatasets"; aws_config=aws_config)
+    return personalize(
+        "ListDatasets"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_datasets(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return personalize("ListDatasets", params; aws_config=aws_config)
+    return personalize(
+        "ListDatasets", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1589,12 +1702,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   the next set of event trackers (if they exist).
 """
 function list_event_trackers(; aws_config::AbstractAWSConfig=global_aws_config())
-    return personalize("ListEventTrackers"; aws_config=aws_config)
+    return personalize(
+        "ListEventTrackers"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_event_trackers(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return personalize("ListEventTrackers", params; aws_config=aws_config)
+    return personalize(
+        "ListEventTrackers", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1611,12 +1728,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   next set of filters (if they exist).
 """
 function list_filters(; aws_config::AbstractAWSConfig=global_aws_config())
-    return personalize("ListFilters"; aws_config=aws_config)
+    return personalize(
+        "ListFilters"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_filters(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return personalize("ListFilters", params; aws_config=aws_config)
+    return personalize(
+        "ListFilters", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1634,12 +1755,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"recipeProvider"`: The default is SERVICE.
 """
 function list_recipes(; aws_config::AbstractAWSConfig=global_aws_config())
-    return personalize("ListRecipes"; aws_config=aws_config)
+    return personalize(
+        "ListRecipes"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_recipes(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return personalize("ListRecipes", params; aws_config=aws_config)
+    return personalize(
+        "ListRecipes", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1657,12 +1782,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   next set of schemas (if they exist).
 """
 function list_schemas(; aws_config::AbstractAWSConfig=global_aws_config())
-    return personalize("ListSchemas"; aws_config=aws_config)
+    return personalize(
+        "ListSchemas"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_schemas(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return personalize("ListSchemas", params; aws_config=aws_config)
+    return personalize(
+        "ListSchemas", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1682,12 +1811,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"solutionArn"`: The Amazon Resource Name (ARN) of the solution.
 """
 function list_solution_versions(; aws_config::AbstractAWSConfig=global_aws_config())
-    return personalize("ListSolutionVersions"; aws_config=aws_config)
+    return personalize(
+        "ListSolutionVersions"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_solution_versions(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return personalize("ListSolutionVersions", params; aws_config=aws_config)
+    return personalize(
+        "ListSolutionVersions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1707,12 +1843,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   next set of solutions (if they exist).
 """
 function list_solutions(; aws_config::AbstractAWSConfig=global_aws_config())
-    return personalize("ListSolutions"; aws_config=aws_config)
+    return personalize(
+        "ListSolutions"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_solutions(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return personalize("ListSolutions", params; aws_config=aws_config)
+    return personalize(
+        "ListSolutions", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1738,6 +1878,7 @@ function stop_solution_version_creation(
         "StopSolutionVersionCreation",
         Dict{String,Any}("solutionVersionArn" => solutionVersionArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function stop_solution_version_creation(
@@ -1753,6 +1894,7 @@ function stop_solution_version_creation(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1781,6 +1923,7 @@ function update_campaign(campaignArn; aws_config::AbstractAWSConfig=global_aws_c
         "UpdateCampaign",
         Dict{String,Any}("campaignArn" => campaignArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_campaign(
@@ -1794,5 +1937,6 @@ function update_campaign(
             mergewith(_merge, Dict{String,Any}("campaignArn" => campaignArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/personalize_events.jl
+++ b/src/services/personalize_events.jl
@@ -33,6 +33,7 @@ function put_events(
             "eventList" => eventList, "sessionId" => sessionId, "trackingId" => trackingId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_events(
@@ -57,6 +58,7 @@ function put_events(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -79,6 +81,7 @@ function put_items(datasetArn, items; aws_config::AbstractAWSConfig=global_aws_c
         "/items",
         Dict{String,Any}("datasetArn" => datasetArn, "items" => items);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_items(
@@ -98,6 +101,7 @@ function put_items(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -120,6 +124,7 @@ function put_users(datasetArn, users; aws_config::AbstractAWSConfig=global_aws_c
         "/users",
         Dict{String,Any}("datasetArn" => datasetArn, "users" => users);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_users(
@@ -139,5 +144,6 @@ function put_users(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/personalize_runtime.jl
+++ b/src/services/personalize_runtime.jl
@@ -46,6 +46,7 @@ function get_personalized_ranking(
             "campaignArn" => campaignArn, "inputList" => inputList, "userId" => userId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_personalized_ranking(
@@ -70,6 +71,7 @@ function get_personalized_ranking(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -114,6 +116,7 @@ function get_recommendations(campaignArn; aws_config::AbstractAWSConfig=global_a
         "/recommendations",
         Dict{String,Any}("campaignArn" => campaignArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_recommendations(
@@ -128,5 +131,6 @@ function get_recommendations(
             mergewith(_merge, Dict{String,Any}("campaignArn" => campaignArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/pi.jl
+++ b/src/services/pi.jl
@@ -80,6 +80,7 @@ function describe_dimension_keys(
             "StartTime" => StartTime,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_dimension_keys(
@@ -109,6 +110,7 @@ function describe_dimension_keys(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -157,6 +159,7 @@ function get_dimension_key_details(
             "ServiceType" => ServiceType,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_dimension_key_details(
@@ -182,6 +185,7 @@ function get_dimension_key_details(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -243,6 +247,7 @@ function get_resource_metrics(
             "StartTime" => StartTime,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_resource_metrics(
@@ -270,5 +275,6 @@ function get_resource_metrics(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/pinpoint.jl
+++ b/src/services/pinpoint.jl
@@ -22,6 +22,7 @@ function create_app(
         "/v1/apps",
         Dict{String,Any}("CreateApplicationRequest" => CreateApplicationRequest);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_app(
@@ -40,6 +41,7 @@ function create_app(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -64,6 +66,7 @@ function create_campaign(
         "/v1/apps/$(application-id)/campaigns",
         Dict{String,Any}("WriteCampaignRequest" => WriteCampaignRequest);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_campaign(
@@ -83,6 +86,7 @@ function create_campaign(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -107,6 +111,7 @@ function create_email_template(
         "/v1/templates/$(template-name)/email",
         Dict{String,Any}("EmailTemplateRequest" => EmailTemplateRequest);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_email_template(
@@ -126,6 +131,7 @@ function create_email_template(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -149,6 +155,7 @@ function create_export_job(
         "/v1/apps/$(application-id)/jobs/export",
         Dict{String,Any}("ExportJobRequest" => ExportJobRequest);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_export_job(
@@ -166,6 +173,7 @@ function create_export_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -189,6 +197,7 @@ function create_import_job(
         "/v1/apps/$(application-id)/jobs/import",
         Dict{String,Any}("ImportJobRequest" => ImportJobRequest);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_import_job(
@@ -206,6 +215,7 @@ function create_import_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -230,6 +240,7 @@ function create_in_app_template(
         "/v1/templates/$(template-name)/inapp",
         Dict{String,Any}("InAppTemplateRequest" => InAppTemplateRequest);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_in_app_template(
@@ -249,6 +260,7 @@ function create_in_app_template(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -272,6 +284,7 @@ function create_journey(
         "/v1/apps/$(application-id)/journeys",
         Dict{String,Any}("WriteJourneyRequest" => WriteJourneyRequest);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_journey(
@@ -291,6 +304,7 @@ function create_journey(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -319,6 +333,7 @@ function create_push_template(
             "PushNotificationTemplateRequest" => PushNotificationTemplateRequest
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_push_template(
@@ -340,6 +355,7 @@ function create_push_template(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -363,6 +379,7 @@ function create_recommender_configuration(
             "CreateRecommenderConfiguration" => CreateRecommenderConfiguration
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_recommender_configuration(
@@ -383,6 +400,7 @@ function create_recommender_configuration(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -407,6 +425,7 @@ function create_segment(
         "/v1/apps/$(application-id)/segments",
         Dict{String,Any}("WriteSegmentRequest" => WriteSegmentRequest);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_segment(
@@ -426,6 +445,7 @@ function create_segment(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -450,6 +470,7 @@ function create_sms_template(
         "/v1/templates/$(template-name)/sms",
         Dict{String,Any}("SMSTemplateRequest" => SMSTemplateRequest);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_sms_template(
@@ -467,6 +488,7 @@ function create_sms_template(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -491,6 +513,7 @@ function create_voice_template(
         "/v1/templates/$(template-name)/voice",
         Dict{String,Any}("VoiceTemplateRequest" => VoiceTemplateRequest);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_voice_template(
@@ -510,6 +533,7 @@ function create_voice_template(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -529,7 +553,10 @@ function delete_adm_channel(
     application_id; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return pinpoint(
-        "DELETE", "/v1/apps/$(application-id)/channels/adm"; aws_config=aws_config
+        "DELETE",
+        "/v1/apps/$(application-id)/channels/adm";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_adm_channel(
@@ -538,7 +565,11 @@ function delete_adm_channel(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return pinpoint(
-        "DELETE", "/v1/apps/$(application-id)/channels/adm", params; aws_config=aws_config
+        "DELETE",
+        "/v1/apps/$(application-id)/channels/adm",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -558,7 +589,10 @@ function delete_apns_channel(
     application_id; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return pinpoint(
-        "DELETE", "/v1/apps/$(application-id)/channels/apns"; aws_config=aws_config
+        "DELETE",
+        "/v1/apps/$(application-id)/channels/apns";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_apns_channel(
@@ -567,7 +601,11 @@ function delete_apns_channel(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return pinpoint(
-        "DELETE", "/v1/apps/$(application-id)/channels/apns", params; aws_config=aws_config
+        "DELETE",
+        "/v1/apps/$(application-id)/channels/apns",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -587,7 +625,10 @@ function delete_apns_sandbox_channel(
     application_id; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return pinpoint(
-        "DELETE", "/v1/apps/$(application-id)/channels/apns_sandbox"; aws_config=aws_config
+        "DELETE",
+        "/v1/apps/$(application-id)/channels/apns_sandbox";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_apns_sandbox_channel(
@@ -600,6 +641,7 @@ function delete_apns_sandbox_channel(
         "/v1/apps/$(application-id)/channels/apns_sandbox",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -619,7 +661,10 @@ function delete_apns_voip_channel(
     application_id; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return pinpoint(
-        "DELETE", "/v1/apps/$(application-id)/channels/apns_voip"; aws_config=aws_config
+        "DELETE",
+        "/v1/apps/$(application-id)/channels/apns_voip";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_apns_voip_channel(
@@ -632,6 +677,7 @@ function delete_apns_voip_channel(
         "/v1/apps/$(application-id)/channels/apns_voip",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -654,6 +700,7 @@ function delete_apns_voip_sandbox_channel(
         "DELETE",
         "/v1/apps/$(application-id)/channels/apns_voip_sandbox";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_apns_voip_sandbox_channel(
@@ -666,6 +713,7 @@ function delete_apns_voip_sandbox_channel(
         "/v1/apps/$(application-id)/channels/apns_voip_sandbox",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -681,14 +729,25 @@ Deletes an application.
 
 """
 function delete_app(application_id; aws_config::AbstractAWSConfig=global_aws_config())
-    return pinpoint("DELETE", "/v1/apps/$(application-id)"; aws_config=aws_config)
+    return pinpoint(
+        "DELETE",
+        "/v1/apps/$(application-id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_app(
     application_id,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return pinpoint("DELETE", "/v1/apps/$(application-id)", params; aws_config=aws_config)
+    return pinpoint(
+        "DELETE",
+        "/v1/apps/$(application-id)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -707,7 +766,10 @@ function delete_baidu_channel(
     application_id; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return pinpoint(
-        "DELETE", "/v1/apps/$(application-id)/channels/baidu"; aws_config=aws_config
+        "DELETE",
+        "/v1/apps/$(application-id)/channels/baidu";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_baidu_channel(
@@ -716,7 +778,11 @@ function delete_baidu_channel(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return pinpoint(
-        "DELETE", "/v1/apps/$(application-id)/channels/baidu", params; aws_config=aws_config
+        "DELETE",
+        "/v1/apps/$(application-id)/channels/baidu",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -739,6 +805,7 @@ function delete_campaign(
         "DELETE",
         "/v1/apps/$(application-id)/campaigns/$(campaign-id)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_campaign(
@@ -752,6 +819,7 @@ function delete_campaign(
         "/v1/apps/$(application-id)/campaigns/$(campaign-id)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -771,7 +839,10 @@ function delete_email_channel(
     application_id; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return pinpoint(
-        "DELETE", "/v1/apps/$(application-id)/channels/email"; aws_config=aws_config
+        "DELETE",
+        "/v1/apps/$(application-id)/channels/email";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_email_channel(
@@ -780,7 +851,11 @@ function delete_email_channel(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return pinpoint(
-        "DELETE", "/v1/apps/$(application-id)/channels/email", params; aws_config=aws_config
+        "DELETE",
+        "/v1/apps/$(application-id)/channels/email",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -812,7 +887,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function delete_email_template(
     template_name; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return pinpoint("DELETE", "/v1/templates/$(template-name)/email"; aws_config=aws_config)
+    return pinpoint(
+        "DELETE",
+        "/v1/templates/$(template-name)/email";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_email_template(
     template_name,
@@ -820,7 +900,11 @@ function delete_email_template(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return pinpoint(
-        "DELETE", "/v1/templates/$(template-name)/email", params; aws_config=aws_config
+        "DELETE",
+        "/v1/templates/$(template-name)/email",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -843,6 +927,7 @@ function delete_endpoint(
         "DELETE",
         "/v1/apps/$(application-id)/endpoints/$(endpoint-id)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_endpoint(
@@ -856,6 +941,7 @@ function delete_endpoint(
         "/v1/apps/$(application-id)/endpoints/$(endpoint-id)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -874,7 +960,10 @@ function delete_event_stream(
     application_id; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return pinpoint(
-        "DELETE", "/v1/apps/$(application-id)/eventstream"; aws_config=aws_config
+        "DELETE",
+        "/v1/apps/$(application-id)/eventstream";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_event_stream(
@@ -883,7 +972,11 @@ function delete_event_stream(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return pinpoint(
-        "DELETE", "/v1/apps/$(application-id)/eventstream", params; aws_config=aws_config
+        "DELETE",
+        "/v1/apps/$(application-id)/eventstream",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -903,7 +996,10 @@ function delete_gcm_channel(
     application_id; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return pinpoint(
-        "DELETE", "/v1/apps/$(application-id)/channels/gcm"; aws_config=aws_config
+        "DELETE",
+        "/v1/apps/$(application-id)/channels/gcm";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_gcm_channel(
@@ -912,7 +1008,11 @@ function delete_gcm_channel(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return pinpoint(
-        "DELETE", "/v1/apps/$(application-id)/channels/gcm", params; aws_config=aws_config
+        "DELETE",
+        "/v1/apps/$(application-id)/channels/gcm",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -944,7 +1044,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function delete_in_app_template(
     template_name; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return pinpoint("DELETE", "/v1/templates/$(template-name)/inapp"; aws_config=aws_config)
+    return pinpoint(
+        "DELETE",
+        "/v1/templates/$(template-name)/inapp";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_in_app_template(
     template_name,
@@ -952,7 +1057,11 @@ function delete_in_app_template(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return pinpoint(
-        "DELETE", "/v1/templates/$(template-name)/inapp", params; aws_config=aws_config
+        "DELETE",
+        "/v1/templates/$(template-name)/inapp",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -972,7 +1081,10 @@ function delete_journey(
     application_id, journey_id; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return pinpoint(
-        "DELETE", "/v1/apps/$(application-id)/journeys/$(journey-id)"; aws_config=aws_config
+        "DELETE",
+        "/v1/apps/$(application-id)/journeys/$(journey-id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_journey(
@@ -986,6 +1098,7 @@ function delete_journey(
         "/v1/apps/$(application-id)/journeys/$(journey-id)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1017,7 +1130,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function delete_push_template(
     template_name; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return pinpoint("DELETE", "/v1/templates/$(template-name)/push"; aws_config=aws_config)
+    return pinpoint(
+        "DELETE",
+        "/v1/templates/$(template-name)/push";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_push_template(
     template_name,
@@ -1025,7 +1143,11 @@ function delete_push_template(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return pinpoint(
-        "DELETE", "/v1/templates/$(template-name)/push", params; aws_config=aws_config
+        "DELETE",
+        "/v1/templates/$(template-name)/push",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1043,7 +1165,12 @@ Deletes an Amazon Pinpoint configuration for a recommender model.
 function delete_recommender_configuration(
     recommender_id; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return pinpoint("DELETE", "/v1/recommenders/$(recommender-id)"; aws_config=aws_config)
+    return pinpoint(
+        "DELETE",
+        "/v1/recommenders/$(recommender-id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_recommender_configuration(
     recommender_id,
@@ -1051,7 +1178,11 @@ function delete_recommender_configuration(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return pinpoint(
-        "DELETE", "/v1/recommenders/$(recommender-id)", params; aws_config=aws_config
+        "DELETE",
+        "/v1/recommenders/$(recommender-id)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1071,7 +1202,10 @@ function delete_segment(
     application_id, segment_id; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return pinpoint(
-        "DELETE", "/v1/apps/$(application-id)/segments/$(segment-id)"; aws_config=aws_config
+        "DELETE",
+        "/v1/apps/$(application-id)/segments/$(segment-id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_segment(
@@ -1085,6 +1219,7 @@ function delete_segment(
         "/v1/apps/$(application-id)/segments/$(segment-id)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1104,7 +1239,10 @@ function delete_sms_channel(
     application_id; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return pinpoint(
-        "DELETE", "/v1/apps/$(application-id)/channels/sms"; aws_config=aws_config
+        "DELETE",
+        "/v1/apps/$(application-id)/channels/sms";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_sms_channel(
@@ -1113,7 +1251,11 @@ function delete_sms_channel(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return pinpoint(
-        "DELETE", "/v1/apps/$(application-id)/channels/sms", params; aws_config=aws_config
+        "DELETE",
+        "/v1/apps/$(application-id)/channels/sms",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1145,7 +1287,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function delete_sms_template(
     template_name; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return pinpoint("DELETE", "/v1/templates/$(template-name)/sms"; aws_config=aws_config)
+    return pinpoint(
+        "DELETE",
+        "/v1/templates/$(template-name)/sms";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_sms_template(
     template_name,
@@ -1153,7 +1300,11 @@ function delete_sms_template(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return pinpoint(
-        "DELETE", "/v1/templates/$(template-name)/sms", params; aws_config=aws_config
+        "DELETE",
+        "/v1/templates/$(template-name)/sms",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1173,7 +1324,10 @@ function delete_user_endpoints(
     application_id, user_id; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return pinpoint(
-        "DELETE", "/v1/apps/$(application-id)/users/$(user-id)"; aws_config=aws_config
+        "DELETE",
+        "/v1/apps/$(application-id)/users/$(user-id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_user_endpoints(
@@ -1187,6 +1341,7 @@ function delete_user_endpoints(
         "/v1/apps/$(application-id)/users/$(user-id)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1206,7 +1361,10 @@ function delete_voice_channel(
     application_id; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return pinpoint(
-        "DELETE", "/v1/apps/$(application-id)/channels/voice"; aws_config=aws_config
+        "DELETE",
+        "/v1/apps/$(application-id)/channels/voice";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_voice_channel(
@@ -1215,7 +1373,11 @@ function delete_voice_channel(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return pinpoint(
-        "DELETE", "/v1/apps/$(application-id)/channels/voice", params; aws_config=aws_config
+        "DELETE",
+        "/v1/apps/$(application-id)/channels/voice",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1247,7 +1409,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function delete_voice_template(
     template_name; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return pinpoint("DELETE", "/v1/templates/$(template-name)/voice"; aws_config=aws_config)
+    return pinpoint(
+        "DELETE",
+        "/v1/templates/$(template-name)/voice";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_voice_template(
     template_name,
@@ -1255,7 +1422,11 @@ function delete_voice_template(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return pinpoint(
-        "DELETE", "/v1/templates/$(template-name)/voice", params; aws_config=aws_config
+        "DELETE",
+        "/v1/templates/$(template-name)/voice",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1271,7 +1442,12 @@ Retrieves information about the status and settings of the ADM channel for an ap
 
 """
 function get_adm_channel(application_id; aws_config::AbstractAWSConfig=global_aws_config())
-    return pinpoint("GET", "/v1/apps/$(application-id)/channels/adm"; aws_config=aws_config)
+    return pinpoint(
+        "GET",
+        "/v1/apps/$(application-id)/channels/adm";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_adm_channel(
     application_id,
@@ -1279,7 +1455,11 @@ function get_adm_channel(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return pinpoint(
-        "GET", "/v1/apps/$(application-id)/channels/adm", params; aws_config=aws_config
+        "GET",
+        "/v1/apps/$(application-id)/channels/adm",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1296,7 +1476,10 @@ Retrieves information about the status and settings of the APNs channel for an a
 """
 function get_apns_channel(application_id; aws_config::AbstractAWSConfig=global_aws_config())
     return pinpoint(
-        "GET", "/v1/apps/$(application-id)/channels/apns"; aws_config=aws_config
+        "GET",
+        "/v1/apps/$(application-id)/channels/apns";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_apns_channel(
@@ -1305,7 +1488,11 @@ function get_apns_channel(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return pinpoint(
-        "GET", "/v1/apps/$(application-id)/channels/apns", params; aws_config=aws_config
+        "GET",
+        "/v1/apps/$(application-id)/channels/apns",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1325,7 +1512,10 @@ function get_apns_sandbox_channel(
     application_id; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return pinpoint(
-        "GET", "/v1/apps/$(application-id)/channels/apns_sandbox"; aws_config=aws_config
+        "GET",
+        "/v1/apps/$(application-id)/channels/apns_sandbox";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_apns_sandbox_channel(
@@ -1338,6 +1528,7 @@ function get_apns_sandbox_channel(
         "/v1/apps/$(application-id)/channels/apns_sandbox",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1357,7 +1548,10 @@ function get_apns_voip_channel(
     application_id; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return pinpoint(
-        "GET", "/v1/apps/$(application-id)/channels/apns_voip"; aws_config=aws_config
+        "GET",
+        "/v1/apps/$(application-id)/channels/apns_voip";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_apns_voip_channel(
@@ -1370,6 +1564,7 @@ function get_apns_voip_channel(
         "/v1/apps/$(application-id)/channels/apns_voip",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1392,6 +1587,7 @@ function get_apns_voip_sandbox_channel(
         "GET",
         "/v1/apps/$(application-id)/channels/apns_voip_sandbox";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_apns_voip_sandbox_channel(
@@ -1404,6 +1600,7 @@ function get_apns_voip_sandbox_channel(
         "/v1/apps/$(application-id)/channels/apns_voip_sandbox",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1419,14 +1616,25 @@ Retrieves information about an application.
 
 """
 function get_app(application_id; aws_config::AbstractAWSConfig=global_aws_config())
-    return pinpoint("GET", "/v1/apps/$(application-id)"; aws_config=aws_config)
+    return pinpoint(
+        "GET",
+        "/v1/apps/$(application-id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_app(
     application_id,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return pinpoint("GET", "/v1/apps/$(application-id)", params; aws_config=aws_config)
+    return pinpoint(
+        "GET",
+        "/v1/apps/$(application-id)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1467,6 +1675,7 @@ function get_application_date_range_kpi(
         "GET",
         "/v1/apps/$(application-id)/kpis/daterange/$(kpi-name)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_application_date_range_kpi(
@@ -1480,6 +1689,7 @@ function get_application_date_range_kpi(
         "/v1/apps/$(application-id)/kpis/daterange/$(kpi-name)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1497,7 +1707,12 @@ Retrieves information about the settings for an application.
 function get_application_settings(
     application_id; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return pinpoint("GET", "/v1/apps/$(application-id)/settings"; aws_config=aws_config)
+    return pinpoint(
+        "GET",
+        "/v1/apps/$(application-id)/settings";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_application_settings(
     application_id,
@@ -1505,7 +1720,11 @@ function get_application_settings(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return pinpoint(
-        "GET", "/v1/apps/$(application-id)/settings", params; aws_config=aws_config
+        "GET",
+        "/v1/apps/$(application-id)/settings",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1524,12 +1743,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   paginated response.
 """
 function get_apps(; aws_config::AbstractAWSConfig=global_aws_config())
-    return pinpoint("GET", "/v1/apps"; aws_config=aws_config)
+    return pinpoint(
+        "GET", "/v1/apps"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_apps(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return pinpoint("GET", "/v1/apps", params; aws_config=aws_config)
+    return pinpoint(
+        "GET", "/v1/apps", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1547,7 +1770,10 @@ function get_baidu_channel(
     application_id; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return pinpoint(
-        "GET", "/v1/apps/$(application-id)/channels/baidu"; aws_config=aws_config
+        "GET",
+        "/v1/apps/$(application-id)/channels/baidu";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_baidu_channel(
@@ -1556,7 +1782,11 @@ function get_baidu_channel(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return pinpoint(
-        "GET", "/v1/apps/$(application-id)/channels/baidu", params; aws_config=aws_config
+        "GET",
+        "/v1/apps/$(application-id)/channels/baidu",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1576,7 +1806,10 @@ function get_campaign(
     application_id, campaign_id; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return pinpoint(
-        "GET", "/v1/apps/$(application-id)/campaigns/$(campaign-id)"; aws_config=aws_config
+        "GET",
+        "/v1/apps/$(application-id)/campaigns/$(campaign-id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_campaign(
@@ -1590,6 +1823,7 @@ function get_campaign(
         "/v1/apps/$(application-id)/campaigns/$(campaign-id)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1618,6 +1852,7 @@ function get_campaign_activities(
         "GET",
         "/v1/apps/$(application-id)/campaigns/$(campaign-id)/activities";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_campaign_activities(
@@ -1631,6 +1866,7 @@ function get_campaign_activities(
         "/v1/apps/$(application-id)/campaigns/$(campaign-id)/activities",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1672,6 +1908,7 @@ function get_campaign_date_range_kpi(
         "GET",
         "/v1/apps/$(application-id)/campaigns/$(campaign-id)/kpis/daterange/$(kpi-name)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_campaign_date_range_kpi(
@@ -1686,6 +1923,7 @@ function get_campaign_date_range_kpi(
         "/v1/apps/$(application-id)/campaigns/$(campaign-id)/kpis/daterange/$(kpi-name)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1710,6 +1948,7 @@ function get_campaign_version(
         "GET",
         "/v1/apps/$(application-id)/campaigns/$(campaign-id)/versions/$(version)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_campaign_version(
@@ -1724,6 +1963,7 @@ function get_campaign_version(
         "/v1/apps/$(application-id)/campaigns/$(campaign-id)/versions/$(version)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1753,6 +1993,7 @@ function get_campaign_versions(
         "GET",
         "/v1/apps/$(application-id)/campaigns/$(campaign-id)/versions";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_campaign_versions(
@@ -1766,6 +2007,7 @@ function get_campaign_versions(
         "/v1/apps/$(application-id)/campaigns/$(campaign-id)/versions",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1788,7 +2030,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   paginated response.
 """
 function get_campaigns(application_id; aws_config::AbstractAWSConfig=global_aws_config())
-    return pinpoint("GET", "/v1/apps/$(application-id)/campaigns"; aws_config=aws_config)
+    return pinpoint(
+        "GET",
+        "/v1/apps/$(application-id)/campaigns";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_campaigns(
     application_id,
@@ -1796,7 +2043,11 @@ function get_campaigns(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return pinpoint(
-        "GET", "/v1/apps/$(application-id)/campaigns", params; aws_config=aws_config
+        "GET",
+        "/v1/apps/$(application-id)/campaigns",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1812,7 +2063,12 @@ Retrieves information about the history and status of each channel for an applic
 
 """
 function get_channels(application_id; aws_config::AbstractAWSConfig=global_aws_config())
-    return pinpoint("GET", "/v1/apps/$(application-id)/channels"; aws_config=aws_config)
+    return pinpoint(
+        "GET",
+        "/v1/apps/$(application-id)/channels";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_channels(
     application_id,
@@ -1820,7 +2076,11 @@ function get_channels(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return pinpoint(
-        "GET", "/v1/apps/$(application-id)/channels", params; aws_config=aws_config
+        "GET",
+        "/v1/apps/$(application-id)/channels",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1839,7 +2099,10 @@ function get_email_channel(
     application_id; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return pinpoint(
-        "GET", "/v1/apps/$(application-id)/channels/email"; aws_config=aws_config
+        "GET",
+        "/v1/apps/$(application-id)/channels/email";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_email_channel(
@@ -1848,7 +2111,11 @@ function get_email_channel(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return pinpoint(
-        "GET", "/v1/apps/$(application-id)/channels/email", params; aws_config=aws_config
+        "GET",
+        "/v1/apps/$(application-id)/channels/email",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1881,7 +2148,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function get_email_template(
     template_name; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return pinpoint("GET", "/v1/templates/$(template-name)/email"; aws_config=aws_config)
+    return pinpoint(
+        "GET",
+        "/v1/templates/$(template-name)/email";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_email_template(
     template_name,
@@ -1889,7 +2161,11 @@ function get_email_template(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return pinpoint(
-        "GET", "/v1/templates/$(template-name)/email", params; aws_config=aws_config
+        "GET",
+        "/v1/templates/$(template-name)/email",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1910,7 +2186,10 @@ function get_endpoint(
     application_id, endpoint_id; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return pinpoint(
-        "GET", "/v1/apps/$(application-id)/endpoints/$(endpoint-id)"; aws_config=aws_config
+        "GET",
+        "/v1/apps/$(application-id)/endpoints/$(endpoint-id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_endpoint(
@@ -1924,6 +2203,7 @@ function get_endpoint(
         "/v1/apps/$(application-id)/endpoints/$(endpoint-id)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1939,7 +2219,12 @@ Retrieves information about the event stream settings for an application.
 
 """
 function get_event_stream(application_id; aws_config::AbstractAWSConfig=global_aws_config())
-    return pinpoint("GET", "/v1/apps/$(application-id)/eventstream"; aws_config=aws_config)
+    return pinpoint(
+        "GET",
+        "/v1/apps/$(application-id)/eventstream";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_event_stream(
     application_id,
@@ -1947,7 +2232,11 @@ function get_event_stream(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return pinpoint(
-        "GET", "/v1/apps/$(application-id)/eventstream", params; aws_config=aws_config
+        "GET",
+        "/v1/apps/$(application-id)/eventstream",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1968,7 +2257,10 @@ function get_export_job(
     application_id, job_id; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return pinpoint(
-        "GET", "/v1/apps/$(application-id)/jobs/export/$(job-id)"; aws_config=aws_config
+        "GET",
+        "/v1/apps/$(application-id)/jobs/export/$(job-id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_export_job(
@@ -1982,6 +2274,7 @@ function get_export_job(
         "/v1/apps/$(application-id)/jobs/export/$(job-id)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2004,7 +2297,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   paginated response.
 """
 function get_export_jobs(application_id; aws_config::AbstractAWSConfig=global_aws_config())
-    return pinpoint("GET", "/v1/apps/$(application-id)/jobs/export"; aws_config=aws_config)
+    return pinpoint(
+        "GET",
+        "/v1/apps/$(application-id)/jobs/export";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_export_jobs(
     application_id,
@@ -2012,7 +2310,11 @@ function get_export_jobs(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return pinpoint(
-        "GET", "/v1/apps/$(application-id)/jobs/export", params; aws_config=aws_config
+        "GET",
+        "/v1/apps/$(application-id)/jobs/export",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2028,7 +2330,12 @@ Retrieves information about the status and settings of the GCM channel for an ap
 
 """
 function get_gcm_channel(application_id; aws_config::AbstractAWSConfig=global_aws_config())
-    return pinpoint("GET", "/v1/apps/$(application-id)/channels/gcm"; aws_config=aws_config)
+    return pinpoint(
+        "GET",
+        "/v1/apps/$(application-id)/channels/gcm";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_gcm_channel(
     application_id,
@@ -2036,7 +2343,11 @@ function get_gcm_channel(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return pinpoint(
-        "GET", "/v1/apps/$(application-id)/channels/gcm", params; aws_config=aws_config
+        "GET",
+        "/v1/apps/$(application-id)/channels/gcm",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2057,7 +2368,10 @@ function get_import_job(
     application_id, job_id; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return pinpoint(
-        "GET", "/v1/apps/$(application-id)/jobs/import/$(job-id)"; aws_config=aws_config
+        "GET",
+        "/v1/apps/$(application-id)/jobs/import/$(job-id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_import_job(
@@ -2071,6 +2385,7 @@ function get_import_job(
         "/v1/apps/$(application-id)/jobs/import/$(job-id)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2093,7 +2408,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   paginated response.
 """
 function get_import_jobs(application_id; aws_config::AbstractAWSConfig=global_aws_config())
-    return pinpoint("GET", "/v1/apps/$(application-id)/jobs/import"; aws_config=aws_config)
+    return pinpoint(
+        "GET",
+        "/v1/apps/$(application-id)/jobs/import";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_import_jobs(
     application_id,
@@ -2101,7 +2421,11 @@ function get_import_jobs(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return pinpoint(
-        "GET", "/v1/apps/$(application-id)/jobs/import", params; aws_config=aws_config
+        "GET",
+        "/v1/apps/$(application-id)/jobs/import",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2124,6 +2448,7 @@ function get_in_app_messages(
         "GET",
         "/v1/apps/$(application-id)/endpoints/$(endpoint-id)/inappmessages";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_in_app_messages(
@@ -2137,6 +2462,7 @@ function get_in_app_messages(
         "/v1/apps/$(application-id)/endpoints/$(endpoint-id)/inappmessages",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2169,7 +2495,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function get_in_app_template(
     template_name; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return pinpoint("GET", "/v1/templates/$(template-name)/inapp"; aws_config=aws_config)
+    return pinpoint(
+        "GET",
+        "/v1/templates/$(template-name)/inapp";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_in_app_template(
     template_name,
@@ -2177,7 +2508,11 @@ function get_in_app_template(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return pinpoint(
-        "GET", "/v1/templates/$(template-name)/inapp", params; aws_config=aws_config
+        "GET",
+        "/v1/templates/$(template-name)/inapp",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2197,7 +2532,10 @@ function get_journey(
     application_id, journey_id; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return pinpoint(
-        "GET", "/v1/apps/$(application-id)/journeys/$(journey-id)"; aws_config=aws_config
+        "GET",
+        "/v1/apps/$(application-id)/journeys/$(journey-id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_journey(
@@ -2211,6 +2549,7 @@ function get_journey(
         "/v1/apps/$(application-id)/journeys/$(journey-id)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2253,6 +2592,7 @@ function get_journey_date_range_kpi(
         "GET",
         "/v1/apps/$(application-id)/journeys/$(journey-id)/kpis/daterange/$(kpi-name)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_journey_date_range_kpi(
@@ -2267,6 +2607,7 @@ function get_journey_date_range_kpi(
         "/v1/apps/$(application-id)/journeys/$(journey-id)/kpis/daterange/$(kpi-name)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2300,6 +2641,7 @@ function get_journey_execution_activity_metrics(
         "GET",
         "/v1/apps/$(application-id)/journeys/$(journey-id)/activities/$(journey-activity-id)/execution-metrics";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_journey_execution_activity_metrics(
@@ -2314,6 +2656,7 @@ function get_journey_execution_activity_metrics(
         "/v1/apps/$(application-id)/journeys/$(journey-id)/activities/$(journey-activity-id)/execution-metrics",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2343,6 +2686,7 @@ function get_journey_execution_metrics(
         "GET",
         "/v1/apps/$(application-id)/journeys/$(journey-id)/execution-metrics";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_journey_execution_metrics(
@@ -2356,6 +2700,7 @@ function get_journey_execution_metrics(
         "/v1/apps/$(application-id)/journeys/$(journey-id)/execution-metrics",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2386,7 +2731,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   deletes the template, including all versions of the template.
 """
 function get_push_template(template_name; aws_config::AbstractAWSConfig=global_aws_config())
-    return pinpoint("GET", "/v1/templates/$(template-name)/push"; aws_config=aws_config)
+    return pinpoint(
+        "GET",
+        "/v1/templates/$(template-name)/push";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_push_template(
     template_name,
@@ -2394,7 +2744,11 @@ function get_push_template(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return pinpoint(
-        "GET", "/v1/templates/$(template-name)/push", params; aws_config=aws_config
+        "GET",
+        "/v1/templates/$(template-name)/push",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2412,7 +2766,12 @@ Retrieves information about an Amazon Pinpoint configuration for a recommender m
 function get_recommender_configuration(
     recommender_id; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return pinpoint("GET", "/v1/recommenders/$(recommender-id)"; aws_config=aws_config)
+    return pinpoint(
+        "GET",
+        "/v1/recommenders/$(recommender-id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_recommender_configuration(
     recommender_id,
@@ -2420,7 +2779,11 @@ function get_recommender_configuration(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return pinpoint(
-        "GET", "/v1/recommenders/$(recommender-id)", params; aws_config=aws_config
+        "GET",
+        "/v1/recommenders/$(recommender-id)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2439,12 +2802,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   paginated response.
 """
 function get_recommender_configurations(; aws_config::AbstractAWSConfig=global_aws_config())
-    return pinpoint("GET", "/v1/recommenders"; aws_config=aws_config)
+    return pinpoint(
+        "GET", "/v1/recommenders"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_recommender_configurations(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return pinpoint("GET", "/v1/recommenders", params; aws_config=aws_config)
+    return pinpoint(
+        "GET",
+        "/v1/recommenders",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2464,7 +2835,10 @@ function get_segment(
     application_id, segment_id; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return pinpoint(
-        "GET", "/v1/apps/$(application-id)/segments/$(segment-id)"; aws_config=aws_config
+        "GET",
+        "/v1/apps/$(application-id)/segments/$(segment-id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_segment(
@@ -2478,6 +2852,7 @@ function get_segment(
         "/v1/apps/$(application-id)/segments/$(segment-id)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2506,6 +2881,7 @@ function get_segment_export_jobs(
         "GET",
         "/v1/apps/$(application-id)/segments/$(segment-id)/jobs/export";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_segment_export_jobs(
@@ -2519,6 +2895,7 @@ function get_segment_export_jobs(
         "/v1/apps/$(application-id)/segments/$(segment-id)/jobs/export",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2547,6 +2924,7 @@ function get_segment_import_jobs(
         "GET",
         "/v1/apps/$(application-id)/segments/$(segment-id)/jobs/import";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_segment_import_jobs(
@@ -2560,6 +2938,7 @@ function get_segment_import_jobs(
         "/v1/apps/$(application-id)/segments/$(segment-id)/jobs/import",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2584,6 +2963,7 @@ function get_segment_version(
         "GET",
         "/v1/apps/$(application-id)/segments/$(segment-id)/versions/$(version)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_segment_version(
@@ -2598,6 +2978,7 @@ function get_segment_version(
         "/v1/apps/$(application-id)/segments/$(segment-id)/versions/$(version)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2627,6 +3008,7 @@ function get_segment_versions(
         "GET",
         "/v1/apps/$(application-id)/segments/$(segment-id)/versions";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_segment_versions(
@@ -2640,6 +3022,7 @@ function get_segment_versions(
         "/v1/apps/$(application-id)/segments/$(segment-id)/versions",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2662,7 +3045,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   paginated response.
 """
 function get_segments(application_id; aws_config::AbstractAWSConfig=global_aws_config())
-    return pinpoint("GET", "/v1/apps/$(application-id)/segments"; aws_config=aws_config)
+    return pinpoint(
+        "GET",
+        "/v1/apps/$(application-id)/segments";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_segments(
     application_id,
@@ -2670,7 +3058,11 @@ function get_segments(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return pinpoint(
-        "GET", "/v1/apps/$(application-id)/segments", params; aws_config=aws_config
+        "GET",
+        "/v1/apps/$(application-id)/segments",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2686,7 +3078,12 @@ Retrieves information about the status and settings of the SMS channel for an ap
 
 """
 function get_sms_channel(application_id; aws_config::AbstractAWSConfig=global_aws_config())
-    return pinpoint("GET", "/v1/apps/$(application-id)/channels/sms"; aws_config=aws_config)
+    return pinpoint(
+        "GET",
+        "/v1/apps/$(application-id)/channels/sms";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_sms_channel(
     application_id,
@@ -2694,7 +3091,11 @@ function get_sms_channel(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return pinpoint(
-        "GET", "/v1/apps/$(application-id)/channels/sms", params; aws_config=aws_config
+        "GET",
+        "/v1/apps/$(application-id)/channels/sms",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2725,7 +3126,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   deletes the template, including all versions of the template.
 """
 function get_sms_template(template_name; aws_config::AbstractAWSConfig=global_aws_config())
-    return pinpoint("GET", "/v1/templates/$(template-name)/sms"; aws_config=aws_config)
+    return pinpoint(
+        "GET",
+        "/v1/templates/$(template-name)/sms";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_sms_template(
     template_name,
@@ -2733,7 +3139,11 @@ function get_sms_template(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return pinpoint(
-        "GET", "/v1/templates/$(template-name)/sms", params; aws_config=aws_config
+        "GET",
+        "/v1/templates/$(template-name)/sms",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2753,7 +3163,10 @@ function get_user_endpoints(
     application_id, user_id; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return pinpoint(
-        "GET", "/v1/apps/$(application-id)/users/$(user-id)"; aws_config=aws_config
+        "GET",
+        "/v1/apps/$(application-id)/users/$(user-id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_user_endpoints(
@@ -2763,7 +3176,11 @@ function get_user_endpoints(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return pinpoint(
-        "GET", "/v1/apps/$(application-id)/users/$(user-id)", params; aws_config=aws_config
+        "GET",
+        "/v1/apps/$(application-id)/users/$(user-id)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2782,7 +3199,10 @@ function get_voice_channel(
     application_id; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return pinpoint(
-        "GET", "/v1/apps/$(application-id)/channels/voice"; aws_config=aws_config
+        "GET",
+        "/v1/apps/$(application-id)/channels/voice";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_voice_channel(
@@ -2791,7 +3211,11 @@ function get_voice_channel(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return pinpoint(
-        "GET", "/v1/apps/$(application-id)/channels/voice", params; aws_config=aws_config
+        "GET",
+        "/v1/apps/$(application-id)/channels/voice",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2824,7 +3248,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function get_voice_template(
     template_name; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return pinpoint("GET", "/v1/templates/$(template-name)/voice"; aws_config=aws_config)
+    return pinpoint(
+        "GET",
+        "/v1/templates/$(template-name)/voice";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_voice_template(
     template_name,
@@ -2832,7 +3261,11 @@ function get_voice_template(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return pinpoint(
-        "GET", "/v1/templates/$(template-name)/voice", params; aws_config=aws_config
+        "GET",
+        "/v1/templates/$(template-name)/voice",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2855,7 +3288,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   paginated response.
 """
 function list_journeys(application_id; aws_config::AbstractAWSConfig=global_aws_config())
-    return pinpoint("GET", "/v1/apps/$(application-id)/journeys"; aws_config=aws_config)
+    return pinpoint(
+        "GET",
+        "/v1/apps/$(application-id)/journeys";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_journeys(
     application_id,
@@ -2863,7 +3301,11 @@ function list_journeys(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return pinpoint(
-        "GET", "/v1/apps/$(application-id)/journeys", params; aws_config=aws_config
+        "GET",
+        "/v1/apps/$(application-id)/journeys",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2881,14 +3323,25 @@ message template, or segment.
 function list_tags_for_resource(
     resource_arn; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return pinpoint("GET", "/v1/tags/$(resource-arn)"; aws_config=aws_config)
+    return pinpoint(
+        "GET",
+        "/v1/tags/$(resource-arn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_tags_for_resource(
     resource_arn,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return pinpoint("GET", "/v1/tags/$(resource-arn)", params; aws_config=aws_config)
+    return pinpoint(
+        "GET",
+        "/v1/tags/$(resource-arn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2918,6 +3371,7 @@ function list_template_versions(
         "GET",
         "/v1/templates/$(template-name)/$(template-type)/versions";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_template_versions(
@@ -2931,6 +3385,7 @@ function list_template_versions(
         "/v1/templates/$(template-name)/$(template-type)/versions",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2955,12 +3410,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   include this parameter in your request.
 """
 function list_templates(; aws_config::AbstractAWSConfig=global_aws_config())
-    return pinpoint("GET", "/v1/templates"; aws_config=aws_config)
+    return pinpoint(
+        "GET", "/v1/templates"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_templates(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return pinpoint("GET", "/v1/templates", params; aws_config=aws_config)
+    return pinpoint(
+        "GET",
+        "/v1/templates",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2981,6 +3444,7 @@ function phone_number_validate(
         "/v1/phone/number/validate",
         Dict{String,Any}("NumberValidateRequest" => NumberValidateRequest);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function phone_number_validate(
@@ -2999,6 +3463,7 @@ function phone_number_validate(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3023,6 +3488,7 @@ function put_event_stream(
         "/v1/apps/$(application-id)/eventstream",
         Dict{String,Any}("WriteEventStream" => WriteEventStream);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_event_stream(
@@ -3040,6 +3506,7 @@ function put_event_stream(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3064,6 +3531,7 @@ function put_events(
         "/v1/apps/$(application-id)/events",
         Dict{String,Any}("EventsRequest" => EventsRequest);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_events(
@@ -3079,6 +3547,7 @@ function put_events(
             mergewith(_merge, Dict{String,Any}("EventsRequest" => EventsRequest), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3113,6 +3582,7 @@ function remove_attributes(
         "/v1/apps/$(application-id)/attributes/$(attribute-type)",
         Dict{String,Any}("UpdateAttributesRequest" => UpdateAttributesRequest);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function remove_attributes(
@@ -3133,6 +3603,7 @@ function remove_attributes(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3156,6 +3627,7 @@ function send_messages(
         "/v1/apps/$(application-id)/messages",
         Dict{String,Any}("MessageRequest" => MessageRequest);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function send_messages(
@@ -3171,6 +3643,7 @@ function send_messages(
             mergewith(_merge, Dict{String,Any}("MessageRequest" => MessageRequest), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3196,6 +3669,7 @@ function send_users_messages(
         "/v1/apps/$(application-id)/users-messages",
         Dict{String,Any}("SendUsersMessageRequest" => SendUsersMessageRequest);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function send_users_messages(
@@ -3215,6 +3689,7 @@ function send_users_messages(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3238,6 +3713,7 @@ function tag_resource(
         "/v1/tags/$(resource-arn)",
         Dict{String,Any}("TagsModel" => TagsModel);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -3253,6 +3729,7 @@ function tag_resource(
             mergewith(_merge, Dict{String,Any}("TagsModel" => TagsModel), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3278,6 +3755,7 @@ function untag_resource(
         "/v1/tags/$(resource-arn)",
         Dict{String,Any}("tagKeys" => tagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -3291,6 +3769,7 @@ function untag_resource(
         "/v1/tags/$(resource-arn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tagKeys" => tagKeys), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3315,6 +3794,7 @@ function update_adm_channel(
         "/v1/apps/$(application-id)/channels/adm",
         Dict{String,Any}("ADMChannelRequest" => ADMChannelRequest);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_adm_channel(
@@ -3332,6 +3812,7 @@ function update_adm_channel(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3356,6 +3837,7 @@ function update_apns_channel(
         "/v1/apps/$(application-id)/channels/apns",
         Dict{String,Any}("APNSChannelRequest" => APNSChannelRequest);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_apns_channel(
@@ -3373,6 +3855,7 @@ function update_apns_channel(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3399,6 +3882,7 @@ function update_apns_sandbox_channel(
         "/v1/apps/$(application-id)/channels/apns_sandbox",
         Dict{String,Any}("APNSSandboxChannelRequest" => APNSSandboxChannelRequest);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_apns_sandbox_channel(
@@ -3418,6 +3902,7 @@ function update_apns_sandbox_channel(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3444,6 +3929,7 @@ function update_apns_voip_channel(
         "/v1/apps/$(application-id)/channels/apns_voip",
         Dict{String,Any}("APNSVoipChannelRequest" => APNSVoipChannelRequest);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_apns_voip_channel(
@@ -3463,6 +3949,7 @@ function update_apns_voip_channel(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3489,6 +3976,7 @@ function update_apns_voip_sandbox_channel(
         "/v1/apps/$(application-id)/channels/apns_voip_sandbox",
         Dict{String,Any}("APNSVoipSandboxChannelRequest" => APNSVoipSandboxChannelRequest);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_apns_voip_sandbox_channel(
@@ -3510,6 +3998,7 @@ function update_apns_voip_sandbox_channel(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3537,6 +4026,7 @@ function update_application_settings(
             "WriteApplicationSettingsRequest" => WriteApplicationSettingsRequest
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_application_settings(
@@ -3558,6 +4048,7 @@ function update_application_settings(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3582,6 +4073,7 @@ function update_baidu_channel(
         "/v1/apps/$(application-id)/channels/baidu",
         Dict{String,Any}("BaiduChannelRequest" => BaiduChannelRequest);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_baidu_channel(
@@ -3601,6 +4093,7 @@ function update_baidu_channel(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3628,6 +4121,7 @@ function update_campaign(
         "/v1/apps/$(application-id)/campaigns/$(campaign-id)",
         Dict{String,Any}("WriteCampaignRequest" => WriteCampaignRequest);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_campaign(
@@ -3648,6 +4142,7 @@ function update_campaign(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3672,6 +4167,7 @@ function update_email_channel(
         "/v1/apps/$(application-id)/channels/email",
         Dict{String,Any}("EmailChannelRequest" => EmailChannelRequest);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_email_channel(
@@ -3691,6 +4187,7 @@ function update_email_channel(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3734,6 +4231,7 @@ function update_email_template(
         "/v1/templates/$(template-name)/email",
         Dict{String,Any}("EmailTemplateRequest" => EmailTemplateRequest);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_email_template(
@@ -3753,6 +4251,7 @@ function update_email_template(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3783,6 +4282,7 @@ function update_endpoint(
         "/v1/apps/$(application-id)/endpoints/$(endpoint-id)",
         Dict{String,Any}("EndpointRequest" => EndpointRequest);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_endpoint(
@@ -3801,6 +4301,7 @@ function update_endpoint(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3828,6 +4329,7 @@ function update_endpoints_batch(
         "/v1/apps/$(application-id)/endpoints",
         Dict{String,Any}("EndpointBatchRequest" => EndpointBatchRequest);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_endpoints_batch(
@@ -3847,6 +4349,7 @@ function update_endpoints_batch(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3871,6 +4374,7 @@ function update_gcm_channel(
         "/v1/apps/$(application-id)/channels/gcm",
         Dict{String,Any}("GCMChannelRequest" => GCMChannelRequest);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_gcm_channel(
@@ -3888,6 +4392,7 @@ function update_gcm_channel(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3931,6 +4436,7 @@ function update_in_app_template(
         "/v1/templates/$(template-name)/inapp",
         Dict{String,Any}("InAppTemplateRequest" => InAppTemplateRequest);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_in_app_template(
@@ -3950,6 +4456,7 @@ function update_in_app_template(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3977,6 +4484,7 @@ function update_journey(
         "/v1/apps/$(application-id)/journeys/$(journey-id)",
         Dict{String,Any}("WriteJourneyRequest" => WriteJourneyRequest);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_journey(
@@ -3997,6 +4505,7 @@ function update_journey(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4024,6 +4533,7 @@ function update_journey_state(
         "/v1/apps/$(application-id)/journeys/$(journey-id)/state",
         Dict{String,Any}("JourneyStateRequest" => JourneyStateRequest);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_journey_state(
@@ -4044,6 +4554,7 @@ function update_journey_state(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4092,6 +4603,7 @@ function update_push_template(
             "PushNotificationTemplateRequest" => PushNotificationTemplateRequest
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_push_template(
@@ -4113,6 +4625,7 @@ function update_push_template(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4140,6 +4653,7 @@ function update_recommender_configuration(
             "UpdateRecommenderConfiguration" => UpdateRecommenderConfiguration
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_recommender_configuration(
@@ -4161,6 +4675,7 @@ function update_recommender_configuration(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4189,6 +4704,7 @@ function update_segment(
         "/v1/apps/$(application-id)/segments/$(segment-id)",
         Dict{String,Any}("WriteSegmentRequest" => WriteSegmentRequest);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_segment(
@@ -4209,6 +4725,7 @@ function update_segment(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4233,6 +4750,7 @@ function update_sms_channel(
         "/v1/apps/$(application-id)/channels/sms",
         Dict{String,Any}("SMSChannelRequest" => SMSChannelRequest);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_sms_channel(
@@ -4250,6 +4768,7 @@ function update_sms_channel(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4293,6 +4812,7 @@ function update_sms_template(
         "/v1/templates/$(template-name)/sms",
         Dict{String,Any}("SMSTemplateRequest" => SMSTemplateRequest);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_sms_template(
@@ -4310,6 +4830,7 @@ function update_sms_template(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4339,6 +4860,7 @@ function update_template_active_version(
         "/v1/templates/$(template-name)/$(template-type)/active-version",
         Dict{String,Any}("TemplateActiveVersionRequest" => TemplateActiveVersionRequest);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_template_active_version(
@@ -4361,6 +4883,7 @@ function update_template_active_version(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4385,6 +4908,7 @@ function update_voice_channel(
         "/v1/apps/$(application-id)/channels/voice",
         Dict{String,Any}("VoiceChannelRequest" => VoiceChannelRequest);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_voice_channel(
@@ -4404,6 +4928,7 @@ function update_voice_channel(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4447,6 +4972,7 @@ function update_voice_template(
         "/v1/templates/$(template-name)/voice",
         Dict{String,Any}("VoiceTemplateRequest" => VoiceTemplateRequest);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_voice_template(
@@ -4466,5 +4992,6 @@ function update_voice_template(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/pinpoint_email.jl
+++ b/src/services/pinpoint_email.jl
@@ -38,6 +38,7 @@ function create_configuration_set(
         "/v1/email/configuration-sets",
         Dict{String,Any}("ConfigurationSetName" => ConfigurationSetName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_configuration_set(
@@ -56,6 +57,7 @@ function create_configuration_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -92,6 +94,7 @@ function create_configuration_set_event_destination(
             "EventDestinationName" => EventDestinationName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_configuration_set_event_destination(
@@ -115,6 +118,7 @@ function create_configuration_set_event_destination(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -143,6 +147,7 @@ function create_dedicated_ip_pool(
         "/v1/email/dedicated-ip-pools",
         Dict{String,Any}("PoolName" => PoolName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_dedicated_ip_pool(
@@ -157,6 +162,7 @@ function create_dedicated_ip_pool(
             mergewith(_merge, Dict{String,Any}("PoolName" => PoolName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -193,6 +199,7 @@ function create_deliverability_test_report(
         "/v1/email/deliverability-dashboard/test",
         Dict{String,Any}("Content" => Content, "FromEmailAddress" => FromEmailAddress);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_deliverability_test_report(
@@ -214,6 +221,7 @@ function create_deliverability_test_report(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -249,6 +257,7 @@ function create_email_identity(
         "/v1/email/identities",
         Dict{String,Any}("EmailIdentity" => EmailIdentity);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_email_identity(
@@ -263,6 +272,7 @@ function create_email_identity(
             mergewith(_merge, Dict{String,Any}("EmailIdentity" => EmailIdentity), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -287,6 +297,7 @@ function delete_configuration_set(
         "DELETE",
         "/v1/email/configuration-sets/$(ConfigurationSetName)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_configuration_set(
@@ -299,6 +310,7 @@ function delete_configuration_set(
         "/v1/email/configuration-sets/$(ConfigurationSetName)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -327,6 +339,7 @@ function delete_configuration_set_event_destination(
         "DELETE",
         "/v1/email/configuration-sets/$(ConfigurationSetName)/event-destinations/$(EventDestinationName)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_configuration_set_event_destination(
@@ -340,6 +353,7 @@ function delete_configuration_set_event_destination(
         "/v1/email/configuration-sets/$(ConfigurationSetName)/event-destinations/$(EventDestinationName)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -357,7 +371,10 @@ function delete_dedicated_ip_pool(
     PoolName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return pinpoint_email(
-        "DELETE", "/v1/email/dedicated-ip-pools/$(PoolName)"; aws_config=aws_config
+        "DELETE",
+        "/v1/email/dedicated-ip-pools/$(PoolName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_dedicated_ip_pool(
@@ -366,7 +383,11 @@ function delete_dedicated_ip_pool(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return pinpoint_email(
-        "DELETE", "/v1/email/dedicated-ip-pools/$(PoolName)", params; aws_config=aws_config
+        "DELETE",
+        "/v1/email/dedicated-ip-pools/$(PoolName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -386,7 +407,10 @@ function delete_email_identity(
     EmailIdentity; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return pinpoint_email(
-        "DELETE", "/v1/email/identities/$(EmailIdentity)"; aws_config=aws_config
+        "DELETE",
+        "/v1/email/identities/$(EmailIdentity)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_email_identity(
@@ -395,7 +419,11 @@ function delete_email_identity(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return pinpoint_email(
-        "DELETE", "/v1/email/identities/$(EmailIdentity)", params; aws_config=aws_config
+        "DELETE",
+        "/v1/email/identities/$(EmailIdentity)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -408,12 +436,20 @@ account in the current AWS Region.
 
 """
 function get_account(; aws_config::AbstractAWSConfig=global_aws_config())
-    return pinpoint_email("GET", "/v1/email/account"; aws_config=aws_config)
+    return pinpoint_email(
+        "GET", "/v1/email/account"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_account(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return pinpoint_email("GET", "/v1/email/account", params; aws_config=aws_config)
+    return pinpoint_email(
+        "GET",
+        "/v1/email/account",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -436,6 +472,7 @@ function get_blacklist_reports(
         "/v1/email/deliverability-dashboard/blacklist-report",
         Dict{String,Any}("BlacklistItemNames" => BlacklistItemNames);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_blacklist_reports(
@@ -452,6 +489,7 @@ function get_blacklist_reports(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -475,7 +513,10 @@ function get_configuration_set(
     ConfigurationSetName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return pinpoint_email(
-        "GET", "/v1/email/configuration-sets/$(ConfigurationSetName)"; aws_config=aws_config
+        "GET",
+        "/v1/email/configuration-sets/$(ConfigurationSetName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_configuration_set(
@@ -488,6 +529,7 @@ function get_configuration_set(
         "/v1/email/configuration-sets/$(ConfigurationSetName)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -514,6 +556,7 @@ function get_configuration_set_event_destinations(
         "GET",
         "/v1/email/configuration-sets/$(ConfigurationSetName)/event-destinations";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_configuration_set_event_destinations(
@@ -526,6 +569,7 @@ function get_configuration_set_event_destinations(
         "/v1/email/configuration-sets/$(ConfigurationSetName)/event-destinations",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -544,13 +588,22 @@ address.
 
 """
 function get_dedicated_ip(IP; aws_config::AbstractAWSConfig=global_aws_config())
-    return pinpoint_email("GET", "/v1/email/dedicated-ips/$(IP)"; aws_config=aws_config)
+    return pinpoint_email(
+        "GET",
+        "/v1/email/dedicated-ips/$(IP)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_dedicated_ip(
     IP, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return pinpoint_email(
-        "GET", "/v1/email/dedicated-ips/$(IP)", params; aws_config=aws_config
+        "GET",
+        "/v1/email/dedicated-ips/$(IP)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -570,12 +623,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"PoolName"`: The name of the IP pool that the dedicated IP address is associated with.
 """
 function get_dedicated_ips(; aws_config::AbstractAWSConfig=global_aws_config())
-    return pinpoint_email("GET", "/v1/email/dedicated-ips"; aws_config=aws_config)
+    return pinpoint_email(
+        "GET",
+        "/v1/email/dedicated-ips";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_dedicated_ips(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return pinpoint_email("GET", "/v1/email/dedicated-ips", params; aws_config=aws_config)
+    return pinpoint_email(
+        "GET",
+        "/v1/email/dedicated-ips",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -596,14 +660,21 @@ function get_deliverability_dashboard_options(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
     return pinpoint_email(
-        "GET", "/v1/email/deliverability-dashboard"; aws_config=aws_config
+        "GET",
+        "/v1/email/deliverability-dashboard";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_deliverability_dashboard_options(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return pinpoint_email(
-        "GET", "/v1/email/deliverability-dashboard", params; aws_config=aws_config
+        "GET",
+        "/v1/email/deliverability-dashboard",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -624,6 +695,7 @@ function get_deliverability_test_report(
         "GET",
         "/v1/email/deliverability-dashboard/test-reports/$(ReportId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_deliverability_test_report(
@@ -636,6 +708,7 @@ function get_deliverability_test_report(
         "/v1/email/deliverability-dashboard/test-reports/$(ReportId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -661,6 +734,7 @@ function get_domain_deliverability_campaign(
         "GET",
         "/v1/email/deliverability-dashboard/campaigns/$(CampaignId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_domain_deliverability_campaign(
@@ -673,6 +747,7 @@ function get_domain_deliverability_campaign(
         "/v1/email/deliverability-dashboard/campaigns/$(CampaignId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -699,6 +774,7 @@ function get_domain_statistics_report(
         "/v1/email/deliverability-dashboard/statistics-report/$(Domain)",
         Dict{String,Any}("EndDate" => EndDate, "StartDate" => StartDate);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_domain_statistics_report(
@@ -719,6 +795,7 @@ function get_domain_statistics_report(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -738,7 +815,10 @@ function get_email_identity(
     EmailIdentity; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return pinpoint_email(
-        "GET", "/v1/email/identities/$(EmailIdentity)"; aws_config=aws_config
+        "GET",
+        "/v1/email/identities/$(EmailIdentity)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_email_identity(
@@ -747,7 +827,11 @@ function get_email_identity(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return pinpoint_email(
-        "GET", "/v1/email/identities/$(EmailIdentity)", params; aws_config=aws_config
+        "GET",
+        "/v1/email/identities/$(EmailIdentity)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -771,13 +855,22 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   response includes a NextToken element, which you can use to obtain additional results.
 """
 function list_configuration_sets(; aws_config::AbstractAWSConfig=global_aws_config())
-    return pinpoint_email("GET", "/v1/email/configuration-sets"; aws_config=aws_config)
+    return pinpoint_email(
+        "GET",
+        "/v1/email/configuration-sets";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_configuration_sets(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return pinpoint_email(
-        "GET", "/v1/email/configuration-sets", params; aws_config=aws_config
+        "GET",
+        "/v1/email/configuration-sets",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -797,13 +890,22 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   response includes a NextToken element, which you can use to obtain additional results.
 """
 function list_dedicated_ip_pools(; aws_config::AbstractAWSConfig=global_aws_config())
-    return pinpoint_email("GET", "/v1/email/dedicated-ip-pools"; aws_config=aws_config)
+    return pinpoint_email(
+        "GET",
+        "/v1/email/dedicated-ip-pools";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_dedicated_ip_pools(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return pinpoint_email(
-        "GET", "/v1/email/dedicated-ip-pools", params; aws_config=aws_config
+        "GET",
+        "/v1/email/dedicated-ip-pools",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -829,7 +931,10 @@ function list_deliverability_test_reports(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
     return pinpoint_email(
-        "GET", "/v1/email/deliverability-dashboard/test-reports"; aws_config=aws_config
+        "GET",
+        "/v1/email/deliverability-dashboard/test-reports";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_deliverability_test_reports(
@@ -840,6 +945,7 @@ function list_deliverability_test_reports(
         "/v1/email/deliverability-dashboard/test-reports",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -878,6 +984,7 @@ function list_domain_deliverability_campaigns(
         "/v1/email/deliverability-dashboard/domains/$(SubscribedDomain)/campaigns",
         Dict{String,Any}("EndDate" => EndDate, "StartDate" => StartDate);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_domain_deliverability_campaigns(
@@ -898,6 +1005,7 @@ function list_domain_deliverability_campaigns(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -919,12 +1027,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   value you specify has to be at least 0, and can be no more than 1000.
 """
 function list_email_identities(; aws_config::AbstractAWSConfig=global_aws_config())
-    return pinpoint_email("GET", "/v1/email/identities"; aws_config=aws_config)
+    return pinpoint_email(
+        "GET",
+        "/v1/email/identities";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_email_identities(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return pinpoint_email("GET", "/v1/email/identities", params; aws_config=aws_config)
+    return pinpoint_email(
+        "GET",
+        "/v1/email/identities",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -950,6 +1069,7 @@ function list_tags_for_resource(
         "/v1/email/tags",
         Dict{String,Any}("ResourceArn" => ResourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags_for_resource(
@@ -964,6 +1084,7 @@ function list_tags_for_resource(
             mergewith(_merge, Dict{String,Any}("ResourceArn" => ResourceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -983,14 +1104,21 @@ function put_account_dedicated_ip_warmup_attributes(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
     return pinpoint_email(
-        "PUT", "/v1/email/account/dedicated-ips/warmup"; aws_config=aws_config
+        "PUT",
+        "/v1/email/account/dedicated-ips/warmup";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_account_dedicated_ip_warmup_attributes(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return pinpoint_email(
-        "PUT", "/v1/email/account/dedicated-ips/warmup", params; aws_config=aws_config
+        "PUT",
+        "/v1/email/account/dedicated-ips/warmup",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1008,12 +1136,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   ability to send email.
 """
 function put_account_sending_attributes(; aws_config::AbstractAWSConfig=global_aws_config())
-    return pinpoint_email("PUT", "/v1/email/account/sending"; aws_config=aws_config)
+    return pinpoint_email(
+        "PUT",
+        "/v1/email/account/sending";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function put_account_sending_attributes(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return pinpoint_email("PUT", "/v1/email/account/sending", params; aws_config=aws_config)
+    return pinpoint_email(
+        "PUT",
+        "/v1/email/account/sending",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1043,6 +1182,7 @@ function put_configuration_set_delivery_options(
         "PUT",
         "/v1/email/configuration-sets/$(ConfigurationSetName)/delivery-options";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_configuration_set_delivery_options(
@@ -1055,6 +1195,7 @@ function put_configuration_set_delivery_options(
         "/v1/email/configuration-sets/$(ConfigurationSetName)/delivery-options",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1082,6 +1223,7 @@ function put_configuration_set_reputation_options(
         "PUT",
         "/v1/email/configuration-sets/$(ConfigurationSetName)/reputation-options";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_configuration_set_reputation_options(
@@ -1094,6 +1236,7 @@ function put_configuration_set_reputation_options(
         "/v1/email/configuration-sets/$(ConfigurationSetName)/reputation-options",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1120,6 +1263,7 @@ function put_configuration_set_sending_options(
         "PUT",
         "/v1/email/configuration-sets/$(ConfigurationSetName)/sending";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_configuration_set_sending_options(
@@ -1132,6 +1276,7 @@ function put_configuration_set_sending_options(
         "/v1/email/configuration-sets/$(ConfigurationSetName)/sending",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1157,6 +1302,7 @@ function put_configuration_set_tracking_options(
         "PUT",
         "/v1/email/configuration-sets/$(ConfigurationSetName)/tracking-options";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_configuration_set_tracking_options(
@@ -1169,6 +1315,7 @@ function put_configuration_set_tracking_options(
         "/v1/email/configuration-sets/$(ConfigurationSetName)/tracking-options",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1197,6 +1344,7 @@ function put_dedicated_ip_in_pool(
         "/v1/email/dedicated-ips/$(IP)/pool",
         Dict{String,Any}("DestinationPoolName" => DestinationPoolName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_dedicated_ip_in_pool(
@@ -1216,6 +1364,7 @@ function put_dedicated_ip_in_pool(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1239,6 +1388,7 @@ function put_dedicated_ip_warmup_attributes(
         "/v1/email/dedicated-ips/$(IP)/warmup",
         Dict{String,Any}("WarmupPercentage" => WarmupPercentage);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_dedicated_ip_warmup_attributes(
@@ -1256,6 +1406,7 @@ function put_dedicated_ip_warmup_attributes(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1288,6 +1439,7 @@ function put_deliverability_dashboard_option(
         "/v1/email/deliverability-dashboard",
         Dict{String,Any}("DashboardEnabled" => DashboardEnabled);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_deliverability_dashboard_option(
@@ -1304,6 +1456,7 @@ function put_deliverability_dashboard_option(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1327,7 +1480,10 @@ function put_email_identity_dkim_attributes(
     EmailIdentity; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return pinpoint_email(
-        "PUT", "/v1/email/identities/$(EmailIdentity)/dkim"; aws_config=aws_config
+        "PUT",
+        "/v1/email/identities/$(EmailIdentity)/dkim";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_email_identity_dkim_attributes(
@@ -1336,7 +1492,11 @@ function put_email_identity_dkim_attributes(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return pinpoint_email(
-        "PUT", "/v1/email/identities/$(EmailIdentity)/dkim", params; aws_config=aws_config
+        "PUT",
+        "/v1/email/identities/$(EmailIdentity)/dkim",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1375,7 +1535,10 @@ function put_email_identity_feedback_attributes(
     EmailIdentity; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return pinpoint_email(
-        "PUT", "/v1/email/identities/$(EmailIdentity)/feedback"; aws_config=aws_config
+        "PUT",
+        "/v1/email/identities/$(EmailIdentity)/feedback";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_email_identity_feedback_attributes(
@@ -1388,6 +1551,7 @@ function put_email_identity_feedback_attributes(
         "/v1/email/identities/$(EmailIdentity)/feedback",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1418,7 +1582,10 @@ function put_email_identity_mail_from_attributes(
     EmailIdentity; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return pinpoint_email(
-        "PUT", "/v1/email/identities/$(EmailIdentity)/mail-from"; aws_config=aws_config
+        "PUT",
+        "/v1/email/identities/$(EmailIdentity)/mail-from";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_email_identity_mail_from_attributes(
@@ -1431,6 +1598,7 @@ function put_email_identity_mail_from_attributes(
         "/v1/email/identities/$(EmailIdentity)/mail-from",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1471,6 +1639,7 @@ function send_email(Content, Destination; aws_config::AbstractAWSConfig=global_a
         "/v1/email/outbound-emails",
         Dict{String,Any}("Content" => Content, "Destination" => Destination);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function send_email(
@@ -1490,6 +1659,7 @@ function send_email(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1519,6 +1689,7 @@ function tag_resource(ResourceArn, Tags; aws_config::AbstractAWSConfig=global_aw
         "/v1/email/tags",
         Dict{String,Any}("ResourceArn" => ResourceArn, "Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -1538,6 +1709,7 @@ function tag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1565,6 +1737,7 @@ function untag_resource(
         "/v1/email/tags",
         Dict{String,Any}("ResourceArn" => ResourceArn, "TagKeys" => TagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -1584,6 +1757,7 @@ function untag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1616,6 +1790,7 @@ function update_configuration_set_event_destination(
         "/v1/email/configuration-sets/$(ConfigurationSetName)/event-destinations/$(EventDestinationName)",
         Dict{String,Any}("EventDestination" => EventDestination);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_configuration_set_event_destination(
@@ -1634,5 +1809,6 @@ function update_configuration_set_event_destination(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/pinpoint_sms_voice.jl
+++ b/src/services/pinpoint_sms_voice.jl
@@ -17,14 +17,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function create_configuration_set(; aws_config::AbstractAWSConfig=global_aws_config())
     return pinpoint_sms_voice(
-        "POST", "/v1/sms-voice/configuration-sets"; aws_config=aws_config
+        "POST",
+        "/v1/sms-voice/configuration-sets";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_configuration_set(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return pinpoint_sms_voice(
-        "POST", "/v1/sms-voice/configuration-sets", params; aws_config=aws_config
+        "POST",
+        "/v1/sms-voice/configuration-sets",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -49,6 +56,7 @@ function create_configuration_set_event_destination(
         "POST",
         "/v1/sms-voice/configuration-sets/$(ConfigurationSetName)/event-destinations";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_configuration_set_event_destination(
@@ -61,6 +69,7 @@ function create_configuration_set_event_destination(
         "/v1/sms-voice/configuration-sets/$(ConfigurationSetName)/event-destinations",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -81,6 +90,7 @@ function delete_configuration_set(
         "DELETE",
         "/v1/sms-voice/configuration-sets/$(ConfigurationSetName)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_configuration_set(
@@ -93,6 +103,7 @@ function delete_configuration_set(
         "/v1/sms-voice/configuration-sets/$(ConfigurationSetName)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -116,6 +127,7 @@ function delete_configuration_set_event_destination(
         "DELETE",
         "/v1/sms-voice/configuration-sets/$(ConfigurationSetName)/event-destinations/$(EventDestinationName)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_configuration_set_event_destination(
@@ -129,6 +141,7 @@ function delete_configuration_set_event_destination(
         "/v1/sms-voice/configuration-sets/$(ConfigurationSetName)/event-destinations/$(EventDestinationName)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -150,6 +163,7 @@ function get_configuration_set_event_destinations(
         "GET",
         "/v1/sms-voice/configuration-sets/$(ConfigurationSetName)/event-destinations";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_configuration_set_event_destinations(
@@ -162,6 +176,7 @@ function get_configuration_set_event_destinations(
         "/v1/sms-voice/configuration-sets/$(ConfigurationSetName)/event-destinations",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -180,14 +195,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function list_configuration_sets(; aws_config::AbstractAWSConfig=global_aws_config())
     return pinpoint_sms_voice(
-        "GET", "/v1/sms-voice/configuration-sets"; aws_config=aws_config
+        "GET",
+        "/v1/sms-voice/configuration-sets";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_configuration_sets(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return pinpoint_sms_voice(
-        "GET", "/v1/sms-voice/configuration-sets", params; aws_config=aws_config
+        "GET",
+        "/v1/sms-voice/configuration-sets",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -210,13 +232,22 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   when they receive the message, because you can specify a CallerId parameter in the request.
 """
 function send_voice_message(; aws_config::AbstractAWSConfig=global_aws_config())
-    return pinpoint_sms_voice("POST", "/v1/sms-voice/voice/message"; aws_config=aws_config)
+    return pinpoint_sms_voice(
+        "POST",
+        "/v1/sms-voice/voice/message";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function send_voice_message(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return pinpoint_sms_voice(
-        "POST", "/v1/sms-voice/voice/message", params; aws_config=aws_config
+        "POST",
+        "/v1/sms-voice/voice/message",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -245,6 +276,7 @@ function update_configuration_set_event_destination(
         "PUT",
         "/v1/sms-voice/configuration-sets/$(ConfigurationSetName)/event-destinations/$(EventDestinationName)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_configuration_set_event_destination(
@@ -258,5 +290,6 @@ function update_configuration_set_event_destination(
         "/v1/sms-voice/configuration-sets/$(ConfigurationSetName)/event-destinations/$(EventDestinationName)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/polly.jl
+++ b/src/services/polly.jl
@@ -19,14 +19,25 @@ Managing Lexicons.
 
 """
 function delete_lexicon(LexiconName; aws_config::AbstractAWSConfig=global_aws_config())
-    return polly("DELETE", "/v1/lexicons/$(LexiconName)"; aws_config=aws_config)
+    return polly(
+        "DELETE",
+        "/v1/lexicons/$(LexiconName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_lexicon(
     LexiconName,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return polly("DELETE", "/v1/lexicons/$(LexiconName)", params; aws_config=aws_config)
+    return polly(
+        "DELETE",
+        "/v1/lexicons/$(LexiconName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -60,12 +71,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   operation. If present, this indicates where to continue the listing.
 """
 function describe_voices(; aws_config::AbstractAWSConfig=global_aws_config())
-    return polly("GET", "/v1/voices"; aws_config=aws_config)
+    return polly(
+        "GET", "/v1/voices"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_voices(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return polly("GET", "/v1/voices", params; aws_config=aws_config)
+    return polly(
+        "GET", "/v1/voices", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -80,14 +95,25 @@ Region. For more information, see Managing Lexicons.
 
 """
 function get_lexicon(LexiconName; aws_config::AbstractAWSConfig=global_aws_config())
-    return polly("GET", "/v1/lexicons/$(LexiconName)"; aws_config=aws_config)
+    return polly(
+        "GET",
+        "/v1/lexicons/$(LexiconName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_lexicon(
     LexiconName,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return polly("GET", "/v1/lexicons/$(LexiconName)", params; aws_config=aws_config)
+    return polly(
+        "GET",
+        "/v1/lexicons/$(LexiconName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -105,12 +131,23 @@ link to the S3 bucket containing the output of the task.
 function get_speech_synthesis_task(
     TaskId; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return polly("GET", "/v1/synthesisTasks/$(TaskId)"; aws_config=aws_config)
+    return polly(
+        "GET",
+        "/v1/synthesisTasks/$(TaskId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_speech_synthesis_task(
     TaskId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return polly("GET", "/v1/synthesisTasks/$(TaskId)", params; aws_config=aws_config)
+    return polly(
+        "GET",
+        "/v1/synthesisTasks/$(TaskId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -126,12 +163,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   If present, indicates where to continue the list of lexicons.
 """
 function list_lexicons(; aws_config::AbstractAWSConfig=global_aws_config())
-    return polly("GET", "/v1/lexicons"; aws_config=aws_config)
+    return polly(
+        "GET", "/v1/lexicons"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_lexicons(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return polly("GET", "/v1/lexicons", params; aws_config=aws_config)
+    return polly(
+        "GET",
+        "/v1/lexicons",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -150,12 +195,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"Status"`: Status of the speech synthesis tasks returned in a List operation
 """
 function list_speech_synthesis_tasks(; aws_config::AbstractAWSConfig=global_aws_config())
-    return polly("GET", "/v1/synthesisTasks"; aws_config=aws_config)
+    return polly(
+        "GET", "/v1/synthesisTasks"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_speech_synthesis_tasks(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return polly("GET", "/v1/synthesisTasks", params; aws_config=aws_config)
+    return polly(
+        "GET",
+        "/v1/synthesisTasks",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -182,6 +235,7 @@ function put_lexicon(
         "/v1/lexicons/$(LexiconName)",
         Dict{String,Any}("Content" => Content);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_lexicon(
@@ -195,6 +249,7 @@ function put_lexicon(
         "/v1/lexicons/$(LexiconName)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Content" => Content), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -262,6 +317,7 @@ function start_speech_synthesis_task(
             "VoiceId" => VoiceId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_speech_synthesis_task(
@@ -288,6 +344,7 @@ function start_speech_synthesis_task(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -349,6 +406,7 @@ function synthesize_speech(
             "OutputFormat" => OutputFormat, "Text" => Text, "VoiceId" => VoiceId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function synthesize_speech(
@@ -371,5 +429,6 @@ function synthesize_speech(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/pricing.jl
+++ b/src/services/pricing.jl
@@ -26,12 +26,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   retrieve a list of all services, leave this blank.
 """
 function describe_services(; aws_config::AbstractAWSConfig=global_aws_config())
-    return pricing("DescribeServices"; aws_config=aws_config)
+    return pricing(
+        "DescribeServices"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_services(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return pricing("DescribeServices", params; aws_config=aws_config)
+    return pricing(
+        "DescribeServices", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -61,6 +65,7 @@ function get_attribute_values(
         "GetAttributeValues",
         Dict{String,Any}("AttributeName" => AttributeName, "ServiceCode" => ServiceCode);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_attribute_values(
@@ -81,6 +86,7 @@ function get_attribute_values(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -102,10 +108,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"ServiceCode"`: The code for the service whose products you want to retrieve.
 """
 function get_products(; aws_config::AbstractAWSConfig=global_aws_config())
-    return pricing("GetProducts"; aws_config=aws_config)
+    return pricing("GetProducts"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function get_products(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return pricing("GetProducts", params; aws_config=aws_config)
+    return pricing(
+        "GetProducts", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end

--- a/src/services/proton.jl
+++ b/src/services/proton.jl
@@ -25,6 +25,7 @@ function accept_environment_account_connection(
         "AcceptEnvironmentAccountConnection",
         Dict{String,Any}("id" => id);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function accept_environment_account_connection(
@@ -34,6 +35,7 @@ function accept_environment_account_connection(
         "AcceptEnvironmentAccountConnection",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("id" => id), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -60,6 +62,7 @@ function cancel_environment_deployment(
         "CancelEnvironmentDeployment",
         Dict{String,Any}("environmentName" => environmentName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function cancel_environment_deployment(
@@ -75,6 +78,7 @@ function cancel_environment_deployment(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -105,6 +109,7 @@ function cancel_service_instance_deployment(
             "serviceInstanceName" => serviceInstanceName, "serviceName" => serviceName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function cancel_service_instance_deployment(
@@ -126,6 +131,7 @@ function cancel_service_instance_deployment(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -153,6 +159,7 @@ function cancel_service_pipeline_deployment(
         "CancelServicePipelineDeployment",
         Dict{String,Any}("serviceName" => serviceName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function cancel_service_pipeline_deployment(
@@ -166,6 +173,7 @@ function cancel_service_pipeline_deployment(
             mergewith(_merge, Dict{String,Any}("serviceName" => serviceName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -217,6 +225,7 @@ function create_environment(
             "templateName" => templateName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_environment(
@@ -242,6 +251,7 @@ function create_environment(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -288,6 +298,7 @@ function create_environment_account_connection(
             "clientToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_environment_account_connection(
@@ -312,6 +323,7 @@ function create_environment_account_connection(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -348,7 +360,10 @@ function create_environment_template(
     name; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return proton(
-        "CreateEnvironmentTemplate", Dict{String,Any}("name" => name); aws_config=aws_config
+        "CreateEnvironmentTemplate",
+        Dict{String,Any}("name" => name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_environment_template(
@@ -358,6 +373,7 @@ function create_environment_template(
         "CreateEnvironmentTemplate",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("name" => name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -395,6 +411,7 @@ function create_environment_template_version(
             "clientToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_environment_template_version(
@@ -417,6 +434,7 @@ function create_environment_template_version(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -473,6 +491,7 @@ function create_service(
             "templateName" => templateName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_service(
@@ -498,6 +517,7 @@ function create_service(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -529,7 +549,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function create_service_template(name; aws_config::AbstractAWSConfig=global_aws_config())
     return proton(
-        "CreateServiceTemplate", Dict{String,Any}("name" => name); aws_config=aws_config
+        "CreateServiceTemplate",
+        Dict{String,Any}("name" => name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_service_template(
@@ -539,6 +562,7 @@ function create_service_template(
         "CreateServiceTemplate",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("name" => name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -582,6 +606,7 @@ function create_service_template_version(
             "clientToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_service_template_version(
@@ -606,6 +631,7 @@ function create_service_template_version(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -621,7 +647,10 @@ Delete an environment.
 """
 function delete_environment(name; aws_config::AbstractAWSConfig=global_aws_config())
     return proton(
-        "DeleteEnvironment", Dict{String,Any}("name" => name); aws_config=aws_config
+        "DeleteEnvironment",
+        Dict{String,Any}("name" => name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_environment(
@@ -631,6 +660,7 @@ function delete_environment(
         "DeleteEnvironment",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("name" => name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -657,6 +687,7 @@ function delete_environment_account_connection(
         "DeleteEnvironmentAccountConnection",
         Dict{String,Any}("id" => id);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_environment_account_connection(
@@ -666,6 +697,7 @@ function delete_environment_account_connection(
         "DeleteEnvironmentAccountConnection",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("id" => id), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -684,7 +716,10 @@ function delete_environment_template(
     name; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return proton(
-        "DeleteEnvironmentTemplate", Dict{String,Any}("name" => name); aws_config=aws_config
+        "DeleteEnvironmentTemplate",
+        Dict{String,Any}("name" => name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_environment_template(
@@ -694,6 +729,7 @@ function delete_environment_template(
         "DeleteEnvironmentTemplate",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("name" => name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -730,6 +766,7 @@ function delete_environment_template_version(
             "templateName" => templateName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_environment_template_version(
@@ -753,6 +790,7 @@ function delete_environment_template_version(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -767,7 +805,12 @@ Delete a service.
 
 """
 function delete_service(name; aws_config::AbstractAWSConfig=global_aws_config())
-    return proton("DeleteService", Dict{String,Any}("name" => name); aws_config=aws_config)
+    return proton(
+        "DeleteService",
+        Dict{String,Any}("name" => name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_service(
     name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -776,6 +819,7 @@ function delete_service(
         "DeleteService",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("name" => name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -792,7 +836,10 @@ template.
 """
 function delete_service_template(name; aws_config::AbstractAWSConfig=global_aws_config())
     return proton(
-        "DeleteServiceTemplate", Dict{String,Any}("name" => name); aws_config=aws_config
+        "DeleteServiceTemplate",
+        Dict{String,Any}("name" => name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_service_template(
@@ -802,6 +849,7 @@ function delete_service_template(
         "DeleteServiceTemplate",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("name" => name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -838,6 +886,7 @@ function delete_service_template_version(
             "templateName" => templateName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_service_template_version(
@@ -861,6 +910,7 @@ function delete_service_template_version(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -872,12 +922,16 @@ Get detail data for the AWS Proton pipeline service role.
 
 """
 function get_account_settings(; aws_config::AbstractAWSConfig=global_aws_config())
-    return proton("GetAccountSettings"; aws_config=aws_config)
+    return proton(
+        "GetAccountSettings"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_account_settings(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return proton("GetAccountSettings", params; aws_config=aws_config)
+    return proton(
+        "GetAccountSettings", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -891,7 +945,12 @@ Get detail data for an environment.
 
 """
 function get_environment(name; aws_config::AbstractAWSConfig=global_aws_config())
-    return proton("GetEnvironment", Dict{String,Any}("name" => name); aws_config=aws_config)
+    return proton(
+        "GetEnvironment",
+        Dict{String,Any}("name" => name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_environment(
     name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -900,6 +959,7 @@ function get_environment(
         "GetEnvironment",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("name" => name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -921,6 +981,7 @@ function get_environment_account_connection(
         "GetEnvironmentAccountConnection",
         Dict{String,Any}("id" => id);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_environment_account_connection(
@@ -930,6 +991,7 @@ function get_environment_account_connection(
         "GetEnvironmentAccountConnection",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("id" => id), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -945,7 +1007,10 @@ Get detail data for an environment template.
 """
 function get_environment_template(name; aws_config::AbstractAWSConfig=global_aws_config())
     return proton(
-        "GetEnvironmentTemplate", Dict{String,Any}("name" => name); aws_config=aws_config
+        "GetEnvironmentTemplate",
+        Dict{String,Any}("name" => name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_environment_template(
@@ -955,6 +1020,7 @@ function get_environment_template(
         "GetEnvironmentTemplate",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("name" => name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -986,6 +1052,7 @@ function get_environment_template_version(
             "templateName" => templateName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_environment_template_version(
@@ -1009,6 +1076,7 @@ function get_environment_template_version(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1023,7 +1091,12 @@ Get detail data for a service.
 
 """
 function get_service(name; aws_config::AbstractAWSConfig=global_aws_config())
-    return proton("GetService", Dict{String,Any}("name" => name); aws_config=aws_config)
+    return proton(
+        "GetService",
+        Dict{String,Any}("name" => name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_service(
     name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -1032,6 +1105,7 @@ function get_service(
         "GetService",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("name" => name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1054,6 +1128,7 @@ function get_service_instance(
         "GetServiceInstance",
         Dict{String,Any}("name" => name, "serviceName" => serviceName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_service_instance(
@@ -1072,6 +1147,7 @@ function get_service_instance(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1087,7 +1163,10 @@ Get detail data for a service template.
 """
 function get_service_template(name; aws_config::AbstractAWSConfig=global_aws_config())
     return proton(
-        "GetServiceTemplate", Dict{String,Any}("name" => name); aws_config=aws_config
+        "GetServiceTemplate",
+        Dict{String,Any}("name" => name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_service_template(
@@ -1097,6 +1176,7 @@ function get_service_template(
         "GetServiceTemplate",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("name" => name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1126,6 +1206,7 @@ function get_service_template_version(
             "templateName" => templateName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_service_template_version(
@@ -1149,6 +1230,7 @@ function get_service_template_version(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1179,6 +1261,7 @@ function list_environment_account_connections(
         "ListEnvironmentAccountConnections",
         Dict{String,Any}("requestedBy" => requestedBy);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_environment_account_connections(
@@ -1192,6 +1275,7 @@ function list_environment_account_connections(
             mergewith(_merge, Dict{String,Any}("requestedBy" => requestedBy), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1222,6 +1306,7 @@ function list_environment_template_versions(
         "ListEnvironmentTemplateVersions",
         Dict{String,Any}("templateName" => templateName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_environment_template_versions(
@@ -1235,6 +1320,7 @@ function list_environment_template_versions(
             mergewith(_merge, Dict{String,Any}("templateName" => templateName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1252,12 +1338,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   requested.
 """
 function list_environment_templates(; aws_config::AbstractAWSConfig=global_aws_config())
-    return proton("ListEnvironmentTemplates"; aws_config=aws_config)
+    return proton(
+        "ListEnvironmentTemplates"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_environment_templates(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return proton("ListEnvironmentTemplates", params; aws_config=aws_config)
+    return proton(
+        "ListEnvironmentTemplates",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1274,12 +1367,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   environments, after the list of environments that was previously requested.
 """
 function list_environments(; aws_config::AbstractAWSConfig=global_aws_config())
-    return proton("ListEnvironments"; aws_config=aws_config)
+    return proton(
+        "ListEnvironments"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_environments(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return proton("ListEnvironments", params; aws_config=aws_config)
+    return proton(
+        "ListEnvironments", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1296,12 +1393,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"serviceName"`: The name of the service that the service instance belongs to.
 """
 function list_service_instances(; aws_config::AbstractAWSConfig=global_aws_config())
-    return proton("ListServiceInstances"; aws_config=aws_config)
+    return proton(
+        "ListServiceInstances"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_service_instances(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return proton("ListServiceInstances", params; aws_config=aws_config)
+    return proton(
+        "ListServiceInstances",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1331,6 +1435,7 @@ function list_service_template_versions(
         "ListServiceTemplateVersions",
         Dict{String,Any}("templateName" => templateName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_service_template_versions(
@@ -1344,6 +1449,7 @@ function list_service_template_versions(
             mergewith(_merge, Dict{String,Any}("templateName" => templateName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1360,12 +1466,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   of service templates, after the list of service templates previously requested.
 """
 function list_service_templates(; aws_config::AbstractAWSConfig=global_aws_config())
-    return proton("ListServiceTemplates"; aws_config=aws_config)
+    return proton(
+        "ListServiceTemplates"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_service_templates(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return proton("ListServiceTemplates", params; aws_config=aws_config)
+    return proton(
+        "ListServiceTemplates",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1381,12 +1494,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   services, after the list of services that was previously requested.
 """
 function list_services(; aws_config::AbstractAWSConfig=global_aws_config())
-    return proton("ListServices"; aws_config=aws_config)
+    return proton("ListServices"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_services(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return proton("ListServices", params; aws_config=aws_config)
+    return proton(
+        "ListServices", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1412,6 +1527,7 @@ function list_tags_for_resource(
         "ListTagsForResource",
         Dict{String,Any}("resourceArn" => resourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags_for_resource(
@@ -1425,6 +1541,7 @@ function list_tags_for_resource(
             mergewith(_merge, Dict{String,Any}("resourceArn" => resourceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1449,6 +1566,7 @@ function reject_environment_account_connection(
         "RejectEnvironmentAccountConnection",
         Dict{String,Any}("id" => id);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function reject_environment_account_connection(
@@ -1458,6 +1576,7 @@ function reject_environment_account_connection(
         "RejectEnvironmentAccountConnection",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("id" => id), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1479,6 +1598,7 @@ function tag_resource(resourceArn, tags; aws_config::AbstractAWSConfig=global_aw
         "TagResource",
         Dict{String,Any}("resourceArn" => resourceArn, "tags" => tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -1497,6 +1617,7 @@ function tag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1521,6 +1642,7 @@ function untag_resource(
         "UntagResource",
         Dict{String,Any}("resourceArn" => resourceArn, "tagKeys" => tagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -1539,6 +1661,7 @@ function untag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1554,12 +1677,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   service role.
 """
 function update_account_settings(; aws_config::AbstractAWSConfig=global_aws_config())
-    return proton("UpdateAccountSettings"; aws_config=aws_config)
+    return proton(
+        "UpdateAccountSettings"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function update_account_settings(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return proton("UpdateAccountSettings", params; aws_config=aws_config)
+    return proton(
+        "UpdateAccountSettings",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1623,6 +1753,7 @@ function update_environment(
         "UpdateEnvironment",
         Dict{String,Any}("deploymentType" => deploymentType, "name" => name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_environment(
@@ -1641,6 +1772,7 @@ function update_environment(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1665,6 +1797,7 @@ function update_environment_account_connection(
         "UpdateEnvironmentAccountConnection",
         Dict{String,Any}("id" => id, "roleArn" => roleArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_environment_account_connection(
@@ -1679,6 +1812,7 @@ function update_environment_account_connection(
             mergewith(_merge, Dict{String,Any}("id" => id, "roleArn" => roleArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1701,7 +1835,10 @@ function update_environment_template(
     name; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return proton(
-        "UpdateEnvironmentTemplate", Dict{String,Any}("name" => name); aws_config=aws_config
+        "UpdateEnvironmentTemplate",
+        Dict{String,Any}("name" => name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_environment_template(
@@ -1711,6 +1848,7 @@ function update_environment_template(
         "UpdateEnvironmentTemplate",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("name" => name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1746,6 +1884,7 @@ function update_environment_template_version(
             "templateName" => templateName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_environment_template_version(
@@ -1769,6 +1908,7 @@ function update_environment_template_version(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1793,7 +1933,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   AWS Proton Administrator Guide or the AWS Proton User Guide.
 """
 function update_service(name; aws_config::AbstractAWSConfig=global_aws_config())
-    return proton("UpdateService", Dict{String,Any}("name" => name); aws_config=aws_config)
+    return proton(
+        "UpdateService",
+        Dict{String,Any}("name" => name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function update_service(
     name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -1802,6 +1947,7 @@ function update_service(
         "UpdateService",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("name" => name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1855,6 +2001,7 @@ function update_service_instance(
             "deploymentType" => deploymentType, "name" => name, "serviceName" => serviceName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_service_instance(
@@ -1878,6 +2025,7 @@ function update_service_instance(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1932,6 +2080,7 @@ function update_service_pipeline(
             "deploymentType" => deploymentType, "serviceName" => serviceName, "spec" => spec
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_service_pipeline(
@@ -1955,6 +2104,7 @@ function update_service_pipeline(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1975,7 +2125,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function update_service_template(name; aws_config::AbstractAWSConfig=global_aws_config())
     return proton(
-        "UpdateServiceTemplate", Dict{String,Any}("name" => name); aws_config=aws_config
+        "UpdateServiceTemplate",
+        Dict{String,Any}("name" => name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_service_template(
@@ -1985,6 +2138,7 @@ function update_service_template(
         "UpdateServiceTemplate",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("name" => name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2020,6 +2174,7 @@ function update_service_template_version(
             "templateName" => templateName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_service_template_version(
@@ -2043,5 +2198,6 @@ function update_service_template_version(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/qldb.jl
+++ b/src/services/qldb.jl
@@ -26,6 +26,7 @@ function cancel_journal_kinesis_stream(
         "DELETE",
         "/ledgers/$(name)/journal-kinesis-streams/$(streamId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function cancel_journal_kinesis_stream(
@@ -39,6 +40,7 @@ function cancel_journal_kinesis_stream(
         "/ledgers/$(name)/journal-kinesis-streams/$(streamId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -100,6 +102,7 @@ function create_ledger(
         "/ledgers",
         Dict{String,Any}("Name" => Name, "PermissionsMode" => PermissionsMode);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_ledger(
@@ -119,6 +122,7 @@ function create_ledger(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -135,12 +139,20 @@ disable it by calling the UpdateLedger operation to set the flag to false.
 
 """
 function delete_ledger(name; aws_config::AbstractAWSConfig=global_aws_config())
-    return qldb("DELETE", "/ledgers/$(name)"; aws_config=aws_config)
+    return qldb(
+        "DELETE", "/ledgers/$(name)"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function delete_ledger(
     name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return qldb("DELETE", "/ledgers/$(name)", params; aws_config=aws_config)
+    return qldb(
+        "DELETE",
+        "/ledgers/$(name)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -163,7 +175,10 @@ function describe_journal_kinesis_stream(
     name, streamId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return qldb(
-        "GET", "/ledgers/$(name)/journal-kinesis-streams/$(streamId)"; aws_config=aws_config
+        "GET",
+        "/ledgers/$(name)/journal-kinesis-streams/$(streamId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_journal_kinesis_stream(
@@ -177,6 +192,7 @@ function describe_journal_kinesis_stream(
         "/ledgers/$(name)/journal-kinesis-streams/$(streamId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -201,7 +217,10 @@ function describe_journal_s3_export(
     exportId, name; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return qldb(
-        "GET", "/ledgers/$(name)/journal-s3-exports/$(exportId)"; aws_config=aws_config
+        "GET",
+        "/ledgers/$(name)/journal-s3-exports/$(exportId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_journal_s3_export(
@@ -215,6 +234,7 @@ function describe_journal_s3_export(
         "/ledgers/$(name)/journal-s3-exports/$(exportId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -230,12 +250,20 @@ rest settings, and when it was created.
 
 """
 function describe_ledger(name; aws_config::AbstractAWSConfig=global_aws_config())
-    return qldb("GET", "/ledgers/$(name)"; aws_config=aws_config)
+    return qldb(
+        "GET", "/ledgers/$(name)"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_ledger(
     name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return qldb("GET", "/ledgers/$(name)", params; aws_config=aws_config)
+    return qldb(
+        "GET",
+        "/ledgers/$(name)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -287,6 +315,7 @@ function export_journal_to_s3(
             "S3ExportConfiguration" => S3ExportConfiguration,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function export_journal_to_s3(
@@ -314,6 +343,7 @@ function export_journal_to_s3(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -347,6 +377,7 @@ function get_block(BlockAddress, name; aws_config::AbstractAWSConfig=global_aws_
         "/ledgers/$(name)/block",
         Dict{String,Any}("BlockAddress" => BlockAddress);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_block(
@@ -362,6 +393,7 @@ function get_block(
             mergewith(_merge, Dict{String,Any}("BlockAddress" => BlockAddress), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -377,12 +409,23 @@ includes a 256-bit hash value and a block address.
 
 """
 function get_digest(name; aws_config::AbstractAWSConfig=global_aws_config())
-    return qldb("POST", "/ledgers/$(name)/digest"; aws_config=aws_config)
+    return qldb(
+        "POST",
+        "/ledgers/$(name)/digest";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_digest(
     name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return qldb("POST", "/ledgers/$(name)/digest", params; aws_config=aws_config)
+    return qldb(
+        "POST",
+        "/ledgers/$(name)/digest",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -414,6 +457,7 @@ function get_revision(
         "/ledgers/$(name)/revision",
         Dict{String,Any}("BlockAddress" => BlockAddress, "DocumentId" => DocumentId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_revision(
@@ -436,6 +480,7 @@ function get_revision(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -465,13 +510,22 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function list_journal_kinesis_streams_for_ledger(
     name; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return qldb("GET", "/ledgers/$(name)/journal-kinesis-streams"; aws_config=aws_config)
+    return qldb(
+        "GET",
+        "/ledgers/$(name)/journal-kinesis-streams";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_journal_kinesis_streams_for_ledger(
     name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return qldb(
-        "GET", "/ledgers/$(name)/journal-kinesis-streams", params; aws_config=aws_config
+        "GET",
+        "/ledgers/$(name)/journal-kinesis-streams",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -494,12 +548,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   ListJournalS3Exports call, then you should use that value as input here.
 """
 function list_journal_s3_exports(; aws_config::AbstractAWSConfig=global_aws_config())
-    return qldb("GET", "/journal-s3-exports"; aws_config=aws_config)
+    return qldb(
+        "GET", "/journal-s3-exports"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_journal_s3_exports(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return qldb("GET", "/journal-s3-exports", params; aws_config=aws_config)
+    return qldb(
+        "GET",
+        "/journal-s3-exports",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -527,12 +589,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function list_journal_s3_exports_for_ledger(
     name; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return qldb("GET", "/ledgers/$(name)/journal-s3-exports"; aws_config=aws_config)
+    return qldb(
+        "GET",
+        "/ledgers/$(name)/journal-s3-exports";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_journal_s3_exports_for_ledger(
     name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return qldb("GET", "/ledgers/$(name)/journal-s3-exports", params; aws_config=aws_config)
+    return qldb(
+        "GET",
+        "/ledgers/$(name)/journal-s3-exports",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -552,12 +625,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   call, then you should use that value as input here.
 """
 function list_ledgers(; aws_config::AbstractAWSConfig=global_aws_config())
-    return qldb("GET", "/ledgers"; aws_config=aws_config)
+    return qldb("GET", "/ledgers"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_ledgers(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return qldb("GET", "/ledgers", params; aws_config=aws_config)
+    return qldb(
+        "GET", "/ledgers", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -574,14 +649,25 @@ Returns all tags for a specified Amazon QLDB resource.
 function list_tags_for_resource(
     resourceArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return qldb("GET", "/tags/$(resourceArn)"; aws_config=aws_config)
+    return qldb(
+        "GET",
+        "/tags/$(resourceArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_tags_for_resource(
     resourceArn,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return qldb("GET", "/tags/$(resourceArn)", params; aws_config=aws_config)
+    return qldb(
+        "GET",
+        "/tags/$(resourceArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -637,6 +723,7 @@ function stream_journal_to_kinesis(
             "StreamName" => StreamName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function stream_journal_to_kinesis(
@@ -664,6 +751,7 @@ function stream_journal_to_kinesis(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -689,6 +777,7 @@ function tag_resource(Tags, resourceArn; aws_config::AbstractAWSConfig=global_aw
         "/tags/$(resourceArn)",
         Dict{String,Any}("Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -702,6 +791,7 @@ function tag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Tags" => Tags), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -726,6 +816,7 @@ function untag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}("tagKeys" => tagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -739,6 +830,7 @@ function untag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tagKeys" => tagKeys), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -775,12 +867,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Guide.
 """
 function update_ledger(name; aws_config::AbstractAWSConfig=global_aws_config())
-    return qldb("PATCH", "/ledgers/$(name)"; aws_config=aws_config)
+    return qldb(
+        "PATCH", "/ledgers/$(name)"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function update_ledger(
     name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return qldb("PATCH", "/ledgers/$(name)", params; aws_config=aws_config)
+    return qldb(
+        "PATCH",
+        "/ledgers/$(name)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -818,6 +918,7 @@ function update_ledger_permissions_mode(
         "/ledgers/$(name)/permissions-mode",
         Dict{String,Any}("PermissionsMode" => PermissionsMode);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_ledger_permissions_mode(
@@ -835,5 +936,6 @@ function update_ledger_permissions_mode(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/qldb_session.jl
+++ b/src/services/qldb_session.jl
@@ -34,10 +34,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"StartTransaction"`: Command to start a new transaction.
 """
 function send_command(; aws_config::AbstractAWSConfig=global_aws_config())
-    return qldb_session("SendCommand"; aws_config=aws_config)
+    return qldb_session(
+        "SendCommand"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function send_command(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return qldb_session("SendCommand", params; aws_config=aws_config)
+    return qldb_session(
+        "SendCommand", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end

--- a/src/services/quicksight.jl
+++ b/src/services/quicksight.jl
@@ -23,6 +23,7 @@ function cancel_ingestion(
         "DELETE",
         "/accounts/$(AwsAccountId)/data-sets/$(DataSetId)/ingestions/$(IngestionId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function cancel_ingestion(
@@ -37,6 +38,7 @@ function cancel_ingestion(
         "/accounts/$(AwsAccountId)/data-sets/$(DataSetId)/ingestions/$(IngestionId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -84,6 +86,7 @@ function create_account_customization(
         "/accounts/$(AwsAccountId)/customizations",
         Dict{String,Any}("AccountCustomization" => AccountCustomization);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_account_customization(
@@ -103,6 +106,7 @@ function create_account_customization(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -149,6 +153,7 @@ function create_analysis(
         "/accounts/$(AwsAccountId)/analyses/$(AnalysisId)",
         Dict{String,Any}("Name" => Name, "SourceEntity" => SourceEntity);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_analysis(
@@ -170,6 +175,7 @@ function create_analysis(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -237,6 +243,7 @@ function create_dashboard(
         "/accounts/$(AwsAccountId)/dashboards/$(DashboardId)",
         Dict{String,Any}("Name" => Name, "SourceEntity" => SourceEntity);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_dashboard(
@@ -258,6 +265,7 @@ function create_dashboard(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -313,6 +321,7 @@ function create_data_set(
             "PhysicalTableMap" => PhysicalTableMap,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_data_set(
@@ -340,6 +349,7 @@ function create_data_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -384,6 +394,7 @@ function create_data_source(
         "/accounts/$(AwsAccountId)/data-sources",
         Dict{String,Any}("DataSourceId" => DataSourceId, "Name" => Name, "Type" => Type);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_data_source(
@@ -407,6 +418,7 @@ function create_data_source(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -434,7 +446,10 @@ function create_folder(
     AwsAccountId, FolderId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return quicksight(
-        "POST", "/accounts/$(AwsAccountId)/folders/$(FolderId)"; aws_config=aws_config
+        "POST",
+        "/accounts/$(AwsAccountId)/folders/$(FolderId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_folder(
@@ -448,6 +463,7 @@ function create_folder(
         "/accounts/$(AwsAccountId)/folders/$(FolderId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -475,6 +491,7 @@ function create_folder_membership(
         "PUT",
         "/accounts/$(AwsAccountId)/folders/$(FolderId)/members/$(MemberType)/$(MemberId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_folder_membership(
@@ -490,6 +507,7 @@ function create_folder_membership(
         "/accounts/$(AwsAccountId)/folders/$(FolderId)/members/$(MemberType)/$(MemberId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -520,6 +538,7 @@ function create_group(
         "/accounts/$(AwsAccountId)/namespaces/$(Namespace)/groups",
         Dict{String,Any}("GroupName" => GroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_group(
@@ -536,6 +555,7 @@ function create_group(
             mergewith(_merge, Dict{String,Any}("GroupName" => GroupName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -565,6 +585,7 @@ function create_group_membership(
         "PUT",
         "/accounts/$(AwsAccountId)/namespaces/$(Namespace)/groups/$(GroupName)/members/$(MemberName)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_group_membership(
@@ -580,6 +601,7 @@ function create_group_membership(
         "/accounts/$(AwsAccountId)/namespaces/$(Namespace)/groups/$(GroupName)/members/$(MemberName)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -624,6 +646,7 @@ function create_iampolicy_assignment(
             "AssignmentName" => AssignmentName, "AssignmentStatus" => AssignmentStatus
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_iampolicy_assignment(
@@ -648,6 +671,7 @@ function create_iampolicy_assignment(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -674,6 +698,7 @@ function create_ingestion(
         "PUT",
         "/accounts/$(AwsAccountId)/data-sets/$(DataSetId)/ingestions/$(IngestionId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_ingestion(
@@ -688,6 +713,7 @@ function create_ingestion(
         "/accounts/$(AwsAccountId)/data-sets/$(DataSetId)/ingestions/$(IngestionId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -726,6 +752,7 @@ function create_namespace(
         "/accounts/$(AwsAccountId)",
         Dict{String,Any}("IdentityStore" => IdentityStore, "Namespace" => Namespace);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_namespace(
@@ -748,6 +775,7 @@ function create_namespace(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -800,6 +828,7 @@ function create_template(
         "/accounts/$(AwsAccountId)/templates/$(TemplateId)",
         Dict{String,Any}("SourceEntity" => SourceEntity);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_template(
@@ -816,6 +845,7 @@ function create_template(
             mergewith(_merge, Dict{String,Any}("SourceEntity" => SourceEntity), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -847,6 +877,7 @@ function create_template_alias(
         "/accounts/$(AwsAccountId)/templates/$(TemplateId)/aliases/$(AliasName)",
         Dict{String,Any}("TemplateVersionNumber" => TemplateVersionNumber);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_template_alias(
@@ -868,6 +899,7 @@ function create_template_alias(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -914,6 +946,7 @@ function create_theme(
             "BaseThemeId" => BaseThemeId, "Configuration" => Configuration, "Name" => Name
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_theme(
@@ -940,6 +973,7 @@ function create_theme(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -971,6 +1005,7 @@ function create_theme_alias(
         "/accounts/$(AwsAccountId)/themes/$(ThemeId)/aliases/$(AliasName)",
         Dict{String,Any}("ThemeVersionNumber" => ThemeVersionNumber);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_theme_alias(
@@ -990,6 +1025,7 @@ function create_theme_alias(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1013,7 +1049,10 @@ function delete_account_customization(
     AwsAccountId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return quicksight(
-        "DELETE", "/accounts/$(AwsAccountId)/customizations"; aws_config=aws_config
+        "DELETE",
+        "/accounts/$(AwsAccountId)/customizations";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_account_customization(
@@ -1022,7 +1061,11 @@ function delete_account_customization(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return quicksight(
-        "DELETE", "/accounts/$(AwsAccountId)/customizations", params; aws_config=aws_config
+        "DELETE",
+        "/accounts/$(AwsAccountId)/customizations",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1060,7 +1103,10 @@ function delete_analysis(
     AnalysisId, AwsAccountId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return quicksight(
-        "DELETE", "/accounts/$(AwsAccountId)/analyses/$(AnalysisId)"; aws_config=aws_config
+        "DELETE",
+        "/accounts/$(AwsAccountId)/analyses/$(AnalysisId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_analysis(
@@ -1074,6 +1120,7 @@ function delete_analysis(
         "/accounts/$(AwsAccountId)/analyses/$(AnalysisId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1100,6 +1147,7 @@ function delete_dashboard(
         "DELETE",
         "/accounts/$(AwsAccountId)/dashboards/$(DashboardId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_dashboard(
@@ -1113,6 +1161,7 @@ function delete_dashboard(
         "/accounts/$(AwsAccountId)/dashboards/$(DashboardId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1132,7 +1181,10 @@ function delete_data_set(
     AwsAccountId, DataSetId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return quicksight(
-        "DELETE", "/accounts/$(AwsAccountId)/data-sets/$(DataSetId)"; aws_config=aws_config
+        "DELETE",
+        "/accounts/$(AwsAccountId)/data-sets/$(DataSetId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_data_set(
@@ -1146,6 +1198,7 @@ function delete_data_set(
         "/accounts/$(AwsAccountId)/data-sets/$(DataSetId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1169,6 +1222,7 @@ function delete_data_source(
         "DELETE",
         "/accounts/$(AwsAccountId)/data-sources/$(DataSourceId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_data_source(
@@ -1182,6 +1236,7 @@ function delete_data_source(
         "/accounts/$(AwsAccountId)/data-sources/$(DataSourceId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1200,7 +1255,10 @@ function delete_folder(
     AwsAccountId, FolderId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return quicksight(
-        "DELETE", "/accounts/$(AwsAccountId)/folders/$(FolderId)"; aws_config=aws_config
+        "DELETE",
+        "/accounts/$(AwsAccountId)/folders/$(FolderId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_folder(
@@ -1214,6 +1272,7 @@ function delete_folder(
         "/accounts/$(AwsAccountId)/folders/$(FolderId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1242,6 +1301,7 @@ function delete_folder_membership(
         "DELETE",
         "/accounts/$(AwsAccountId)/folders/$(FolderId)/members/$(MemberType)/$(MemberId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_folder_membership(
@@ -1257,6 +1317,7 @@ function delete_folder_membership(
         "/accounts/$(AwsAccountId)/folders/$(FolderId)/members/$(MemberType)/$(MemberId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1281,6 +1342,7 @@ function delete_group(
         "DELETE",
         "/accounts/$(AwsAccountId)/namespaces/$(Namespace)/groups/$(GroupName)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_group(
@@ -1295,6 +1357,7 @@ function delete_group(
         "/accounts/$(AwsAccountId)/namespaces/$(Namespace)/groups/$(GroupName)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1324,6 +1387,7 @@ function delete_group_membership(
         "DELETE",
         "/accounts/$(AwsAccountId)/namespaces/$(Namespace)/groups/$(GroupName)/members/$(MemberName)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_group_membership(
@@ -1339,6 +1403,7 @@ function delete_group_membership(
         "/accounts/$(AwsAccountId)/namespaces/$(Namespace)/groups/$(GroupName)/members/$(MemberName)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1365,6 +1430,7 @@ function delete_iampolicy_assignment(
         "DELETE",
         "/accounts/$(AwsAccountId)/namespace/$(Namespace)/iam-policy-assignments/$(AssignmentName)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_iampolicy_assignment(
@@ -1379,6 +1445,7 @@ function delete_iampolicy_assignment(
         "/accounts/$(AwsAccountId)/namespace/$(Namespace)/iam-policy-assignments/$(AssignmentName)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1401,7 +1468,10 @@ function delete_namespace(
     AwsAccountId, Namespace; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return quicksight(
-        "DELETE", "/accounts/$(AwsAccountId)/namespaces/$(Namespace)"; aws_config=aws_config
+        "DELETE",
+        "/accounts/$(AwsAccountId)/namespaces/$(Namespace)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_namespace(
@@ -1415,6 +1485,7 @@ function delete_namespace(
         "/accounts/$(AwsAccountId)/namespaces/$(Namespace)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1438,7 +1509,10 @@ function delete_template(
     AwsAccountId, TemplateId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return quicksight(
-        "DELETE", "/accounts/$(AwsAccountId)/templates/$(TemplateId)"; aws_config=aws_config
+        "DELETE",
+        "/accounts/$(AwsAccountId)/templates/$(TemplateId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_template(
@@ -1452,6 +1526,7 @@ function delete_template(
         "/accounts/$(AwsAccountId)/templates/$(TemplateId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1478,6 +1553,7 @@ function delete_template_alias(
         "DELETE",
         "/accounts/$(AwsAccountId)/templates/$(TemplateId)/aliases/$(AliasName)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_template_alias(
@@ -1492,6 +1568,7 @@ function delete_template_alias(
         "/accounts/$(AwsAccountId)/templates/$(TemplateId)/aliases/$(AliasName)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1516,7 +1593,10 @@ function delete_theme(
     AwsAccountId, ThemeId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return quicksight(
-        "DELETE", "/accounts/$(AwsAccountId)/themes/$(ThemeId)"; aws_config=aws_config
+        "DELETE",
+        "/accounts/$(AwsAccountId)/themes/$(ThemeId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_theme(
@@ -1530,6 +1610,7 @@ function delete_theme(
         "/accounts/$(AwsAccountId)/themes/$(ThemeId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1554,6 +1635,7 @@ function delete_theme_alias(
         "DELETE",
         "/accounts/$(AwsAccountId)/themes/$(ThemeId)/aliases/$(AliasName)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_theme_alias(
@@ -1568,6 +1650,7 @@ function delete_theme_alias(
         "/accounts/$(AwsAccountId)/themes/$(ThemeId)/aliases/$(AliasName)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1594,6 +1677,7 @@ function delete_user(
         "DELETE",
         "/accounts/$(AwsAccountId)/namespaces/$(Namespace)/users/$(UserName)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_user(
@@ -1608,6 +1692,7 @@ function delete_user(
         "/accounts/$(AwsAccountId)/namespaces/$(Namespace)/users/$(UserName)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1632,6 +1717,7 @@ function delete_user_by_principal_id(
         "DELETE",
         "/accounts/$(AwsAccountId)/namespaces/$(Namespace)/user-principals/$(PrincipalId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_user_by_principal_id(
@@ -1646,6 +1732,7 @@ function delete_user_by_principal_id(
         "/accounts/$(AwsAccountId)/namespaces/$(Namespace)/user-principals/$(PrincipalId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1702,7 +1789,10 @@ function describe_account_customization(
     AwsAccountId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return quicksight(
-        "GET", "/accounts/$(AwsAccountId)/customizations"; aws_config=aws_config
+        "GET",
+        "/accounts/$(AwsAccountId)/customizations";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_account_customization(
@@ -1711,7 +1801,11 @@ function describe_account_customization(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return quicksight(
-        "GET", "/accounts/$(AwsAccountId)/customizations", params; aws_config=aws_config
+        "GET",
+        "/accounts/$(AwsAccountId)/customizations",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1730,7 +1824,12 @@ created in this Amazon Web Services account.
 function describe_account_settings(
     AwsAccountId; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return quicksight("GET", "/accounts/$(AwsAccountId)/settings"; aws_config=aws_config)
+    return quicksight(
+        "GET",
+        "/accounts/$(AwsAccountId)/settings";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_account_settings(
     AwsAccountId,
@@ -1738,7 +1837,11 @@ function describe_account_settings(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return quicksight(
-        "GET", "/accounts/$(AwsAccountId)/settings", params; aws_config=aws_config
+        "GET",
+        "/accounts/$(AwsAccountId)/settings",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1759,7 +1862,10 @@ function describe_analysis(
     AnalysisId, AwsAccountId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return quicksight(
-        "GET", "/accounts/$(AwsAccountId)/analyses/$(AnalysisId)"; aws_config=aws_config
+        "GET",
+        "/accounts/$(AwsAccountId)/analyses/$(AnalysisId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_analysis(
@@ -1773,6 +1879,7 @@ function describe_analysis(
         "/accounts/$(AwsAccountId)/analyses/$(AnalysisId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1797,6 +1904,7 @@ function describe_analysis_permissions(
         "GET",
         "/accounts/$(AwsAccountId)/analyses/$(AnalysisId)/permissions";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_analysis_permissions(
@@ -1810,6 +1918,7 @@ function describe_analysis_permissions(
         "/accounts/$(AwsAccountId)/analyses/$(AnalysisId)/permissions",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1834,7 +1943,10 @@ function describe_dashboard(
     AwsAccountId, DashboardId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return quicksight(
-        "GET", "/accounts/$(AwsAccountId)/dashboards/$(DashboardId)"; aws_config=aws_config
+        "GET",
+        "/accounts/$(AwsAccountId)/dashboards/$(DashboardId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_dashboard(
@@ -1848,6 +1960,7 @@ function describe_dashboard(
         "/accounts/$(AwsAccountId)/dashboards/$(DashboardId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1870,6 +1983,7 @@ function describe_dashboard_permissions(
         "GET",
         "/accounts/$(AwsAccountId)/dashboards/$(DashboardId)/permissions";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_dashboard_permissions(
@@ -1883,6 +1997,7 @@ function describe_dashboard_permissions(
         "/accounts/$(AwsAccountId)/dashboards/$(DashboardId)/permissions",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1902,7 +2017,10 @@ function describe_data_set(
     AwsAccountId, DataSetId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return quicksight(
-        "GET", "/accounts/$(AwsAccountId)/data-sets/$(DataSetId)"; aws_config=aws_config
+        "GET",
+        "/accounts/$(AwsAccountId)/data-sets/$(DataSetId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_data_set(
@@ -1916,6 +2034,7 @@ function describe_data_set(
         "/accounts/$(AwsAccountId)/data-sets/$(DataSetId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1939,6 +2058,7 @@ function describe_data_set_permissions(
         "GET",
         "/accounts/$(AwsAccountId)/data-sets/$(DataSetId)/permissions";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_data_set_permissions(
@@ -1952,6 +2072,7 @@ function describe_data_set_permissions(
         "/accounts/$(AwsAccountId)/data-sets/$(DataSetId)/permissions",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1974,6 +2095,7 @@ function describe_data_source(
         "GET",
         "/accounts/$(AwsAccountId)/data-sources/$(DataSourceId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_data_source(
@@ -1987,6 +2109,7 @@ function describe_data_source(
         "/accounts/$(AwsAccountId)/data-sources/$(DataSourceId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2009,6 +2132,7 @@ function describe_data_source_permissions(
         "GET",
         "/accounts/$(AwsAccountId)/data-sources/$(DataSourceId)/permissions";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_data_source_permissions(
@@ -2022,6 +2146,7 @@ function describe_data_source_permissions(
         "/accounts/$(AwsAccountId)/data-sources/$(DataSourceId)/permissions",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2040,7 +2165,10 @@ function describe_folder(
     AwsAccountId, FolderId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return quicksight(
-        "GET", "/accounts/$(AwsAccountId)/folders/$(FolderId)"; aws_config=aws_config
+        "GET",
+        "/accounts/$(AwsAccountId)/folders/$(FolderId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_folder(
@@ -2054,6 +2182,7 @@ function describe_folder(
         "/accounts/$(AwsAccountId)/folders/$(FolderId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2075,6 +2204,7 @@ function describe_folder_permissions(
         "GET",
         "/accounts/$(AwsAccountId)/folders/$(FolderId)/permissions";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_folder_permissions(
@@ -2088,6 +2218,7 @@ function describe_folder_permissions(
         "/accounts/$(AwsAccountId)/folders/$(FolderId)/permissions",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2110,6 +2241,7 @@ function describe_folder_resolved_permissions(
         "GET",
         "/accounts/$(AwsAccountId)/folders/$(FolderId)/resolved-permissions";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_folder_resolved_permissions(
@@ -2123,6 +2255,7 @@ function describe_folder_resolved_permissions(
         "/accounts/$(AwsAccountId)/folders/$(FolderId)/resolved-permissions",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2147,6 +2280,7 @@ function describe_group(
         "GET",
         "/accounts/$(AwsAccountId)/namespaces/$(Namespace)/groups/$(GroupName)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_group(
@@ -2161,6 +2295,7 @@ function describe_group(
         "/accounts/$(AwsAccountId)/namespaces/$(Namespace)/groups/$(GroupName)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2187,6 +2322,7 @@ function describe_iampolicy_assignment(
         "GET",
         "/accounts/$(AwsAccountId)/namespaces/$(Namespace)/iam-policy-assignments/$(AssignmentName)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_iampolicy_assignment(
@@ -2201,6 +2337,7 @@ function describe_iampolicy_assignment(
         "/accounts/$(AwsAccountId)/namespaces/$(Namespace)/iam-policy-assignments/$(AssignmentName)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2223,6 +2360,7 @@ function describe_ingestion(
         "GET",
         "/accounts/$(AwsAccountId)/data-sets/$(DataSetId)/ingestions/$(IngestionId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_ingestion(
@@ -2237,6 +2375,7 @@ function describe_ingestion(
         "/accounts/$(AwsAccountId)/data-sets/$(DataSetId)/ingestions/$(IngestionId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2256,7 +2395,10 @@ function describe_namespace(
     AwsAccountId, Namespace; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return quicksight(
-        "GET", "/accounts/$(AwsAccountId)/namespaces/$(Namespace)"; aws_config=aws_config
+        "GET",
+        "/accounts/$(AwsAccountId)/namespaces/$(Namespace)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_namespace(
@@ -2270,6 +2412,7 @@ function describe_namespace(
         "/accounts/$(AwsAccountId)/namespaces/$(Namespace)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2297,7 +2440,10 @@ function describe_template(
     AwsAccountId, TemplateId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return quicksight(
-        "GET", "/accounts/$(AwsAccountId)/templates/$(TemplateId)"; aws_config=aws_config
+        "GET",
+        "/accounts/$(AwsAccountId)/templates/$(TemplateId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_template(
@@ -2311,6 +2457,7 @@ function describe_template(
         "/accounts/$(AwsAccountId)/templates/$(TemplateId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2337,6 +2484,7 @@ function describe_template_alias(
         "GET",
         "/accounts/$(AwsAccountId)/templates/$(TemplateId)/aliases/$(AliasName)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_template_alias(
@@ -2351,6 +2499,7 @@ function describe_template_alias(
         "/accounts/$(AwsAccountId)/templates/$(TemplateId)/aliases/$(AliasName)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2373,6 +2522,7 @@ function describe_template_permissions(
         "GET",
         "/accounts/$(AwsAccountId)/templates/$(TemplateId)/permissions";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_template_permissions(
@@ -2386,6 +2536,7 @@ function describe_template_permissions(
         "/accounts/$(AwsAccountId)/templates/$(TemplateId)/permissions",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2413,7 +2564,10 @@ function describe_theme(
     AwsAccountId, ThemeId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return quicksight(
-        "GET", "/accounts/$(AwsAccountId)/themes/$(ThemeId)"; aws_config=aws_config
+        "GET",
+        "/accounts/$(AwsAccountId)/themes/$(ThemeId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_theme(
@@ -2423,7 +2577,11 @@ function describe_theme(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return quicksight(
-        "GET", "/accounts/$(AwsAccountId)/themes/$(ThemeId)", params; aws_config=aws_config
+        "GET",
+        "/accounts/$(AwsAccountId)/themes/$(ThemeId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2447,6 +2605,7 @@ function describe_theme_alias(
         "GET",
         "/accounts/$(AwsAccountId)/themes/$(ThemeId)/aliases/$(AliasName)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_theme_alias(
@@ -2461,6 +2620,7 @@ function describe_theme_alias(
         "/accounts/$(AwsAccountId)/themes/$(ThemeId)/aliases/$(AliasName)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2483,6 +2643,7 @@ function describe_theme_permissions(
         "GET",
         "/accounts/$(AwsAccountId)/themes/$(ThemeId)/permissions";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_theme_permissions(
@@ -2496,6 +2657,7 @@ function describe_theme_permissions(
         "/accounts/$(AwsAccountId)/themes/$(ThemeId)/permissions",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2520,6 +2682,7 @@ function describe_user(
         "GET",
         "/accounts/$(AwsAccountId)/namespaces/$(Namespace)/users/$(UserName)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_user(
@@ -2534,6 +2697,7 @@ function describe_user(
         "/accounts/$(AwsAccountId)/namespaces/$(Namespace)/users/$(UserName)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2592,6 +2756,7 @@ function generate_embed_url_for_anonymous_user(
             "Namespace" => Namespace,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function generate_embed_url_for_anonymous_user(
@@ -2617,6 +2782,7 @@ function generate_embed_url_for_anonymous_user(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2663,6 +2829,7 @@ function generate_embed_url_for_registered_user(
             "ExperienceConfiguration" => ExperienceConfiguration, "UserArn" => UserArn
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function generate_embed_url_for_registered_user(
@@ -2686,6 +2853,7 @@ function generate_embed_url_for_registered_user(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2749,6 +2917,7 @@ function get_dashboard_embed_url(
         "/accounts/$(AwsAccountId)/dashboards/$(DashboardId)/embed-url",
         Dict{String,Any}("creds-type" => creds_type);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_dashboard_embed_url(
@@ -2765,6 +2934,7 @@ function get_dashboard_embed_url(
             mergewith(_merge, Dict{String,Any}("creds-type" => creds_type), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2807,7 +2977,10 @@ function get_session_embed_url(
     AwsAccountId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return quicksight(
-        "GET", "/accounts/$(AwsAccountId)/session-embed-url"; aws_config=aws_config
+        "GET",
+        "/accounts/$(AwsAccountId)/session-embed-url";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_session_embed_url(
@@ -2816,7 +2989,11 @@ function get_session_embed_url(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return quicksight(
-        "GET", "/accounts/$(AwsAccountId)/session-embed-url", params; aws_config=aws_config
+        "GET",
+        "/accounts/$(AwsAccountId)/session-embed-url",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2835,7 +3012,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"next-token"`: A pagination token that can be used in a subsequent request.
 """
 function list_analyses(AwsAccountId; aws_config::AbstractAWSConfig=global_aws_config())
-    return quicksight("GET", "/accounts/$(AwsAccountId)/analyses"; aws_config=aws_config)
+    return quicksight(
+        "GET",
+        "/accounts/$(AwsAccountId)/analyses";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_analyses(
     AwsAccountId,
@@ -2843,7 +3025,11 @@ function list_analyses(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return quicksight(
-        "GET", "/accounts/$(AwsAccountId)/analyses", params; aws_config=aws_config
+        "GET",
+        "/accounts/$(AwsAccountId)/analyses",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2871,6 +3057,7 @@ function list_dashboard_versions(
         "GET",
         "/accounts/$(AwsAccountId)/dashboards/$(DashboardId)/versions";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_dashboard_versions(
@@ -2884,6 +3071,7 @@ function list_dashboard_versions(
         "/accounts/$(AwsAccountId)/dashboards/$(DashboardId)/versions",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2904,7 +3092,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   results.
 """
 function list_dashboards(AwsAccountId; aws_config::AbstractAWSConfig=global_aws_config())
-    return quicksight("GET", "/accounts/$(AwsAccountId)/dashboards"; aws_config=aws_config)
+    return quicksight(
+        "GET",
+        "/accounts/$(AwsAccountId)/dashboards";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_dashboards(
     AwsAccountId,
@@ -2912,7 +3105,11 @@ function list_dashboards(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return quicksight(
-        "GET", "/accounts/$(AwsAccountId)/dashboards", params; aws_config=aws_config
+        "GET",
+        "/accounts/$(AwsAccountId)/dashboards",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2934,7 +3131,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   results.
 """
 function list_data_sets(AwsAccountId; aws_config::AbstractAWSConfig=global_aws_config())
-    return quicksight("GET", "/accounts/$(AwsAccountId)/data-sets"; aws_config=aws_config)
+    return quicksight(
+        "GET",
+        "/accounts/$(AwsAccountId)/data-sets";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_data_sets(
     AwsAccountId,
@@ -2942,7 +3144,11 @@ function list_data_sets(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return quicksight(
-        "GET", "/accounts/$(AwsAccountId)/data-sets", params; aws_config=aws_config
+        "GET",
+        "/accounts/$(AwsAccountId)/data-sets",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2964,7 +3170,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function list_data_sources(AwsAccountId; aws_config::AbstractAWSConfig=global_aws_config())
     return quicksight(
-        "GET", "/accounts/$(AwsAccountId)/data-sources"; aws_config=aws_config
+        "GET",
+        "/accounts/$(AwsAccountId)/data-sources";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_data_sources(
@@ -2973,7 +3182,11 @@ function list_data_sources(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return quicksight(
-        "GET", "/accounts/$(AwsAccountId)/data-sources", params; aws_config=aws_config
+        "GET",
+        "/accounts/$(AwsAccountId)/data-sources",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3000,6 +3213,7 @@ function list_folder_members(
         "GET",
         "/accounts/$(AwsAccountId)/folders/$(FolderId)/members";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_folder_members(
@@ -3013,6 +3227,7 @@ function list_folder_members(
         "/accounts/$(AwsAccountId)/folders/$(FolderId)/members",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3032,7 +3247,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   results.
 """
 function list_folders(AwsAccountId; aws_config::AbstractAWSConfig=global_aws_config())
-    return quicksight("GET", "/accounts/$(AwsAccountId)/folders"; aws_config=aws_config)
+    return quicksight(
+        "GET",
+        "/accounts/$(AwsAccountId)/folders";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_folders(
     AwsAccountId,
@@ -3040,7 +3260,11 @@ function list_folders(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return quicksight(
-        "GET", "/accounts/$(AwsAccountId)/folders", params; aws_config=aws_config
+        "GET",
+        "/accounts/$(AwsAccountId)/folders",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3069,6 +3293,7 @@ function list_group_memberships(
         "GET",
         "/accounts/$(AwsAccountId)/namespaces/$(Namespace)/groups/$(GroupName)/members";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_group_memberships(
@@ -3083,6 +3308,7 @@ function list_group_memberships(
         "/accounts/$(AwsAccountId)/namespaces/$(Namespace)/groups/$(GroupName)/members",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3110,6 +3336,7 @@ function list_groups(
         "GET",
         "/accounts/$(AwsAccountId)/namespaces/$(Namespace)/groups";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_groups(
@@ -3123,6 +3350,7 @@ function list_groups(
         "/accounts/$(AwsAccountId)/namespaces/$(Namespace)/groups",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3151,6 +3379,7 @@ function list_iampolicy_assignments(
         "GET",
         "/accounts/$(AwsAccountId)/namespaces/$(Namespace)/iam-policy-assignments";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_iampolicy_assignments(
@@ -3164,6 +3393,7 @@ function list_iampolicy_assignments(
         "/accounts/$(AwsAccountId)/namespaces/$(Namespace)/iam-policy-assignments",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3192,6 +3422,7 @@ function list_iampolicy_assignments_for_user(
         "GET",
         "/accounts/$(AwsAccountId)/namespaces/$(Namespace)/users/$(UserName)/iam-policy-assignments";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_iampolicy_assignments_for_user(
@@ -3206,6 +3437,7 @@ function list_iampolicy_assignments_for_user(
         "/accounts/$(AwsAccountId)/namespaces/$(Namespace)/users/$(UserName)/iam-policy-assignments",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3232,6 +3464,7 @@ function list_ingestions(
         "GET",
         "/accounts/$(AwsAccountId)/data-sets/$(DataSetId)/ingestions";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_ingestions(
@@ -3245,6 +3478,7 @@ function list_ingestions(
         "/accounts/$(AwsAccountId)/data-sets/$(DataSetId)/ingestions",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3264,7 +3498,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"next-token"`: A pagination token that can be used in a subsequent request.
 """
 function list_namespaces(AwsAccountId; aws_config::AbstractAWSConfig=global_aws_config())
-    return quicksight("GET", "/accounts/$(AwsAccountId)/namespaces"; aws_config=aws_config)
+    return quicksight(
+        "GET",
+        "/accounts/$(AwsAccountId)/namespaces";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_namespaces(
     AwsAccountId,
@@ -3272,7 +3511,11 @@ function list_namespaces(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return quicksight(
-        "GET", "/accounts/$(AwsAccountId)/namespaces", params; aws_config=aws_config
+        "GET",
+        "/accounts/$(AwsAccountId)/namespaces",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3290,7 +3533,12 @@ Lists the tags assigned to a resource.
 function list_tags_for_resource(
     ResourceArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return quicksight("GET", "/resources/$(ResourceArn)/tags"; aws_config=aws_config)
+    return quicksight(
+        "GET",
+        "/resources/$(ResourceArn)/tags";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_tags_for_resource(
     ResourceArn,
@@ -3298,7 +3546,11 @@ function list_tags_for_resource(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return quicksight(
-        "GET", "/resources/$(ResourceArn)/tags", params; aws_config=aws_config
+        "GET",
+        "/resources/$(ResourceArn)/tags",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3326,6 +3578,7 @@ function list_template_aliases(
         "GET",
         "/accounts/$(AwsAccountId)/templates/$(TemplateId)/aliases";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_template_aliases(
@@ -3339,6 +3592,7 @@ function list_template_aliases(
         "/accounts/$(AwsAccountId)/templates/$(TemplateId)/aliases",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3366,6 +3620,7 @@ function list_template_versions(
         "GET",
         "/accounts/$(AwsAccountId)/templates/$(TemplateId)/versions";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_template_versions(
@@ -3379,6 +3634,7 @@ function list_template_versions(
         "/accounts/$(AwsAccountId)/templates/$(TemplateId)/versions",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3399,7 +3655,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   results.
 """
 function list_templates(AwsAccountId; aws_config::AbstractAWSConfig=global_aws_config())
-    return quicksight("GET", "/accounts/$(AwsAccountId)/templates"; aws_config=aws_config)
+    return quicksight(
+        "GET",
+        "/accounts/$(AwsAccountId)/templates";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_templates(
     AwsAccountId,
@@ -3407,7 +3668,11 @@ function list_templates(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return quicksight(
-        "GET", "/accounts/$(AwsAccountId)/templates", params; aws_config=aws_config
+        "GET",
+        "/accounts/$(AwsAccountId)/templates",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3432,7 +3697,10 @@ function list_theme_aliases(
     AwsAccountId, ThemeId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return quicksight(
-        "GET", "/accounts/$(AwsAccountId)/themes/$(ThemeId)/aliases"; aws_config=aws_config
+        "GET",
+        "/accounts/$(AwsAccountId)/themes/$(ThemeId)/aliases";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_theme_aliases(
@@ -3446,6 +3714,7 @@ function list_theme_aliases(
         "/accounts/$(AwsAccountId)/themes/$(ThemeId)/aliases",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3470,7 +3739,10 @@ function list_theme_versions(
     AwsAccountId, ThemeId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return quicksight(
-        "GET", "/accounts/$(AwsAccountId)/themes/$(ThemeId)/versions"; aws_config=aws_config
+        "GET",
+        "/accounts/$(AwsAccountId)/themes/$(ThemeId)/versions";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_theme_versions(
@@ -3484,6 +3756,7 @@ function list_theme_versions(
         "/accounts/$(AwsAccountId)/themes/$(ThemeId)/versions",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3508,7 +3781,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   by Amazon QuickSight.
 """
 function list_themes(AwsAccountId; aws_config::AbstractAWSConfig=global_aws_config())
-    return quicksight("GET", "/accounts/$(AwsAccountId)/themes"; aws_config=aws_config)
+    return quicksight(
+        "GET",
+        "/accounts/$(AwsAccountId)/themes";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_themes(
     AwsAccountId,
@@ -3516,7 +3794,11 @@ function list_themes(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return quicksight(
-        "GET", "/accounts/$(AwsAccountId)/themes", params; aws_config=aws_config
+        "GET",
+        "/accounts/$(AwsAccountId)/themes",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3544,6 +3826,7 @@ function list_user_groups(
         "GET",
         "/accounts/$(AwsAccountId)/namespaces/$(Namespace)/users/$(UserName)/groups";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_user_groups(
@@ -3558,6 +3841,7 @@ function list_user_groups(
         "/accounts/$(AwsAccountId)/namespaces/$(Namespace)/users/$(UserName)/groups",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3585,6 +3869,7 @@ function list_users(
         "GET",
         "/accounts/$(AwsAccountId)/namespaces/$(Namespace)/users";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_users(
@@ -3598,6 +3883,7 @@ function list_users(
         "/accounts/$(AwsAccountId)/namespaces/$(Namespace)/users",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3679,6 +3965,7 @@ function register_user(
             "Email" => Email, "IdentityType" => IdentityType, "UserRole" => UserRole
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function register_user(
@@ -3703,6 +3990,7 @@ function register_user(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3724,6 +4012,7 @@ function restore_analysis(
         "POST",
         "/accounts/$(AwsAccountId)/restore/analyses/$(AnalysisId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function restore_analysis(
@@ -3737,6 +4026,7 @@ function restore_analysis(
         "/accounts/$(AwsAccountId)/restore/analyses/$(AnalysisId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3766,6 +4056,7 @@ function search_analyses(
         "/accounts/$(AwsAccountId)/search/analyses",
         Dict{String,Any}("Filters" => Filters);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function search_analyses(
@@ -3779,6 +4070,7 @@ function search_analyses(
         "/accounts/$(AwsAccountId)/search/analyses",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Filters" => Filters), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3810,6 +4102,7 @@ function search_dashboards(
         "/accounts/$(AwsAccountId)/search/dashboards",
         Dict{String,Any}("Filters" => Filters);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function search_dashboards(
@@ -3823,6 +4116,7 @@ function search_dashboards(
         "/accounts/$(AwsAccountId)/search/dashboards",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Filters" => Filters), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3853,6 +4147,7 @@ function search_folders(
         "/accounts/$(AwsAccountId)/search/folders",
         Dict{String,Any}("Filters" => Filters);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function search_folders(
@@ -3866,6 +4161,7 @@ function search_folders(
         "/accounts/$(AwsAccountId)/search/folders",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Filters" => Filters), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3899,6 +4195,7 @@ function tag_resource(ResourceArn, Tags; aws_config::AbstractAWSConfig=global_aw
         "/resources/$(ResourceArn)/tags",
         Dict{String,Any}("Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -3912,6 +4209,7 @@ function tag_resource(
         "/resources/$(ResourceArn)/tags",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Tags" => Tags), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3935,6 +4233,7 @@ function untag_resource(
         "/resources/$(ResourceArn)/tags",
         Dict{String,Any}("keys" => keys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -3948,6 +4247,7 @@ function untag_resource(
         "/resources/$(ResourceArn)/tags",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("keys" => keys), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3980,6 +4280,7 @@ function update_account_customization(
         "/accounts/$(AwsAccountId)/customizations",
         Dict{String,Any}("AccountCustomization" => AccountCustomization);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_account_customization(
@@ -3999,6 +4300,7 @@ function update_account_customization(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4030,6 +4332,7 @@ function update_account_settings(
         "/accounts/$(AwsAccountId)/settings",
         Dict{String,Any}("DefaultNamespace" => DefaultNamespace);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_account_settings(
@@ -4047,6 +4350,7 @@ function update_account_settings(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4087,6 +4391,7 @@ function update_analysis(
         "/accounts/$(AwsAccountId)/analyses/$(AnalysisId)",
         Dict{String,Any}("Name" => Name, "SourceEntity" => SourceEntity);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_analysis(
@@ -4108,6 +4413,7 @@ function update_analysis(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4138,6 +4444,7 @@ function update_analysis_permissions(
         "PUT",
         "/accounts/$(AwsAccountId)/analyses/$(AnalysisId)/permissions";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_analysis_permissions(
@@ -4151,6 +4458,7 @@ function update_analysis_permissions(
         "/accounts/$(AwsAccountId)/analyses/$(AnalysisId)/permissions",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4211,6 +4519,7 @@ function update_dashboard(
         "/accounts/$(AwsAccountId)/dashboards/$(DashboardId)",
         Dict{String,Any}("Name" => Name, "SourceEntity" => SourceEntity);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_dashboard(
@@ -4232,6 +4541,7 @@ function update_dashboard(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4258,6 +4568,7 @@ function update_dashboard_permissions(
         "PUT",
         "/accounts/$(AwsAccountId)/dashboards/$(DashboardId)/permissions";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_dashboard_permissions(
@@ -4271,6 +4582,7 @@ function update_dashboard_permissions(
         "/accounts/$(AwsAccountId)/dashboards/$(DashboardId)/permissions",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4297,6 +4609,7 @@ function update_dashboard_published_version(
         "PUT",
         "/accounts/$(AwsAccountId)/dashboards/$(DashboardId)/versions/$(VersionNumber)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_dashboard_published_version(
@@ -4311,6 +4624,7 @@ function update_dashboard_published_version(
         "/accounts/$(AwsAccountId)/dashboards/$(DashboardId)/versions/$(VersionNumber)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4362,6 +4676,7 @@ function update_data_set(
             "PhysicalTableMap" => PhysicalTableMap,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_data_set(
@@ -4388,6 +4703,7 @@ function update_data_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4415,6 +4731,7 @@ function update_data_set_permissions(
         "POST",
         "/accounts/$(AwsAccountId)/data-sets/$(DataSetId)/permissions";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_data_set_permissions(
@@ -4428,6 +4745,7 @@ function update_data_set_permissions(
         "/accounts/$(AwsAccountId)/data-sets/$(DataSetId)/permissions",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4463,6 +4781,7 @@ function update_data_source(
         "/accounts/$(AwsAccountId)/data-sources/$(DataSourceId)",
         Dict{String,Any}("Name" => Name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_data_source(
@@ -4477,6 +4796,7 @@ function update_data_source(
         "/accounts/$(AwsAccountId)/data-sources/$(DataSourceId)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4505,6 +4825,7 @@ function update_data_source_permissions(
         "POST",
         "/accounts/$(AwsAccountId)/data-sources/$(DataSourceId)/permissions";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_data_source_permissions(
@@ -4518,6 +4839,7 @@ function update_data_source_permissions(
         "/accounts/$(AwsAccountId)/data-sources/$(DataSourceId)/permissions",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4541,6 +4863,7 @@ function update_folder(
         "/accounts/$(AwsAccountId)/folders/$(FolderId)",
         Dict{String,Any}("Name" => Name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_folder(
@@ -4555,6 +4878,7 @@ function update_folder(
         "/accounts/$(AwsAccountId)/folders/$(FolderId)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4580,6 +4904,7 @@ function update_folder_permissions(
         "PUT",
         "/accounts/$(AwsAccountId)/folders/$(FolderId)/permissions";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_folder_permissions(
@@ -4593,6 +4918,7 @@ function update_folder_permissions(
         "/accounts/$(AwsAccountId)/folders/$(FolderId)/permissions",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4620,6 +4946,7 @@ function update_group(
         "PUT",
         "/accounts/$(AwsAccountId)/namespaces/$(Namespace)/groups/$(GroupName)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_group(
@@ -4634,6 +4961,7 @@ function update_group(
         "/accounts/$(AwsAccountId)/namespaces/$(Namespace)/groups/$(GroupName)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4673,6 +5001,7 @@ function update_iampolicy_assignment(
         "PUT",
         "/accounts/$(AwsAccountId)/namespaces/$(Namespace)/iam-policy-assignments/$(AssignmentName)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_iampolicy_assignment(
@@ -4687,6 +5016,7 @@ function update_iampolicy_assignment(
         "/accounts/$(AwsAccountId)/namespaces/$(Namespace)/iam-policy-assignments/$(AssignmentName)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4729,6 +5059,7 @@ function update_template(
         "/accounts/$(AwsAccountId)/templates/$(TemplateId)",
         Dict{String,Any}("SourceEntity" => SourceEntity);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_template(
@@ -4745,6 +5076,7 @@ function update_template(
             mergewith(_merge, Dict{String,Any}("SourceEntity" => SourceEntity), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4777,6 +5109,7 @@ function update_template_alias(
         "/accounts/$(AwsAccountId)/templates/$(TemplateId)/aliases/$(AliasName)",
         Dict{String,Any}("TemplateVersionNumber" => TemplateVersionNumber);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_template_alias(
@@ -4798,6 +5131,7 @@ function update_template_alias(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4823,6 +5157,7 @@ function update_template_permissions(
         "PUT",
         "/accounts/$(AwsAccountId)/templates/$(TemplateId)/permissions";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_template_permissions(
@@ -4836,6 +5171,7 @@ function update_template_permissions(
         "/accounts/$(AwsAccountId)/templates/$(TemplateId)/permissions",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4868,6 +5204,7 @@ function update_theme(
         "/accounts/$(AwsAccountId)/themes/$(ThemeId)",
         Dict{String,Any}("BaseThemeId" => BaseThemeId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_theme(
@@ -4884,6 +5221,7 @@ function update_theme(
             mergewith(_merge, Dict{String,Any}("BaseThemeId" => BaseThemeId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4913,6 +5251,7 @@ function update_theme_alias(
         "/accounts/$(AwsAccountId)/themes/$(ThemeId)/aliases/$(AliasName)",
         Dict{String,Any}("ThemeVersionNumber" => ThemeVersionNumber);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_theme_alias(
@@ -4932,6 +5271,7 @@ function update_theme_alias(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4968,6 +5308,7 @@ function update_theme_permissions(
         "PUT",
         "/accounts/$(AwsAccountId)/themes/$(ThemeId)/permissions";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_theme_permissions(
@@ -4981,6 +5322,7 @@ function update_theme_permissions(
         "/accounts/$(AwsAccountId)/themes/$(ThemeId)/permissions",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5051,6 +5393,7 @@ function update_user(
         "/accounts/$(AwsAccountId)/namespaces/$(Namespace)/users/$(UserName)",
         Dict{String,Any}("Email" => Email, "Role" => Role);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_user(
@@ -5069,5 +5412,6 @@ function update_user(
             mergewith(_merge, Dict{String,Any}("Email" => Email, "Role" => Role), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/ram.jl
+++ b/src/services/ram.jl
@@ -26,6 +26,7 @@ function accept_resource_share_invitation(
         "/acceptresourceshareinvitation",
         Dict{String,Any}("resourceShareInvitationArn" => resourceShareInvitationArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function accept_resource_share_invitation(
@@ -46,6 +47,7 @@ function accept_resource_share_invitation(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -78,6 +80,7 @@ function associate_resource_share(
         "/associateresourceshare",
         Dict{String,Any}("resourceShareArn" => resourceShareArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_resource_share(
@@ -94,6 +97,7 @@ function associate_resource_share(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -128,6 +132,7 @@ function associate_resource_share_permission(
             "permissionArn" => permissionArn, "resourceShareArn" => resourceShareArn
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_resource_share_permission(
@@ -149,6 +154,7 @@ function associate_resource_share_permission(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -191,6 +197,7 @@ function create_resource_share(name; aws_config::AbstractAWSConfig=global_aws_co
         "/createresourceshare",
         Dict{String,Any}("name" => name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_resource_share(
@@ -201,6 +208,7 @@ function create_resource_share(
         "/createresourceshare",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("name" => name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -226,6 +234,7 @@ function delete_resource_share(
         "/deleteresourceshare",
         Dict{String,Any}("resourceShareArn" => resourceShareArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_resource_share(
@@ -242,6 +251,7 @@ function delete_resource_share(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -269,6 +279,7 @@ function disassociate_resource_share(
         "/disassociateresourceshare",
         Dict{String,Any}("resourceShareArn" => resourceShareArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disassociate_resource_share(
@@ -285,6 +296,7 @@ function disassociate_resource_share(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -314,6 +326,7 @@ function disassociate_resource_share_permission(
             "permissionArn" => permissionArn, "resourceShareArn" => resourceShareArn
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disassociate_resource_share_permission(
@@ -335,6 +348,7 @@ function disassociate_resource_share_permission(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -349,12 +363,23 @@ master account for the organization.
 function enable_sharing_with_aws_organization(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ram("POST", "/enablesharingwithawsorganization"; aws_config=aws_config)
+    return ram(
+        "POST",
+        "/enablesharingwithawsorganization";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function enable_sharing_with_aws_organization(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ram("POST", "/enablesharingwithawsorganization", params; aws_config=aws_config)
+    return ram(
+        "POST",
+        "/enablesharingwithawsorganization",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -376,6 +401,7 @@ function get_permission(permissionArn; aws_config::AbstractAWSConfig=global_aws_
         "/getpermission",
         Dict{String,Any}("permissionArn" => permissionArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_permission(
@@ -390,6 +416,7 @@ function get_permission(
             mergewith(_merge, Dict{String,Any}("permissionArn" => permissionArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -417,6 +444,7 @@ function get_resource_policies(
         "/getresourcepolicies",
         Dict{String,Any}("resourceArns" => resourceArns);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_resource_policies(
@@ -431,6 +459,7 @@ function get_resource_policies(
             mergewith(_merge, Dict{String,Any}("resourceArns" => resourceArns), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -465,6 +494,7 @@ function get_resource_share_associations(
         "/getresourceshareassociations",
         Dict{String,Any}("associationType" => associationType);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_resource_share_associations(
@@ -481,6 +511,7 @@ function get_resource_share_associations(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -499,12 +530,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"resourceShareInvitationArns"`: The Amazon Resource Names (ARN) of the invitations.
 """
 function get_resource_share_invitations(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ram("POST", "/getresourceshareinvitations"; aws_config=aws_config)
+    return ram(
+        "POST",
+        "/getresourceshareinvitations";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_resource_share_invitations(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ram("POST", "/getresourceshareinvitations", params; aws_config=aws_config)
+    return ram(
+        "POST",
+        "/getresourceshareinvitations",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -536,6 +578,7 @@ function get_resource_shares(
         "/getresourceshares",
         Dict{String,Any}("resourceOwner" => resourceOwner);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_resource_shares(
@@ -550,6 +593,7 @@ function get_resource_shares(
             mergewith(_merge, Dict{String,Any}("resourceOwner" => resourceOwner), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -577,6 +621,7 @@ function list_pending_invitation_resources(
         "/listpendinginvitationresources",
         Dict{String,Any}("resourceShareInvitationArn" => resourceShareInvitationArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_pending_invitation_resources(
@@ -597,6 +642,7 @@ function list_pending_invitation_resources(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -615,12 +661,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   to list only permissions that apply to EC2 subnets, specify ec2:Subnet.
 """
 function list_permissions(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ram("POST", "/listpermissions"; aws_config=aws_config)
+    return ram(
+        "POST", "/listpermissions"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_permissions(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ram("POST", "/listpermissions", params; aws_config=aws_config)
+    return ram(
+        "POST",
+        "/listpermissions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -658,6 +712,7 @@ function list_principals(resourceOwner; aws_config::AbstractAWSConfig=global_aws
         "/listprincipals",
         Dict{String,Any}("resourceOwner" => resourceOwner);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_principals(
@@ -672,6 +727,7 @@ function list_principals(
             mergewith(_merge, Dict{String,Any}("resourceOwner" => resourceOwner), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -698,6 +754,7 @@ function list_resource_share_permissions(
         "/listresourcesharepermissions",
         Dict{String,Any}("resourceShareArn" => resourceShareArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_resource_share_permissions(
@@ -714,6 +771,7 @@ function list_resource_share_permissions(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -730,12 +788,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: The token for the next page of results.
 """
 function list_resource_types(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ram("POST", "/listresourcetypes"; aws_config=aws_config)
+    return ram(
+        "POST", "/listresourcetypes"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_resource_types(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ram("POST", "/listresourcetypes", params; aws_config=aws_config)
+    return ram(
+        "POST",
+        "/listresourcetypes",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -773,6 +839,7 @@ function list_resources(resourceOwner; aws_config::AbstractAWSConfig=global_aws_
         "/listresources",
         Dict{String,Any}("resourceOwner" => resourceOwner);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_resources(
@@ -787,6 +854,7 @@ function list_resources(
             mergewith(_merge, Dict{String,Any}("resourceOwner" => resourceOwner), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -811,6 +879,7 @@ function promote_resource_share_created_from_policy(
         "/promoteresourcesharecreatedfrompolicy",
         Dict{String,Any}("resourceShareArn" => resourceShareArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function promote_resource_share_created_from_policy(
@@ -827,6 +896,7 @@ function promote_resource_share_created_from_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -852,6 +922,7 @@ function reject_resource_share_invitation(
         "/rejectresourceshareinvitation",
         Dict{String,Any}("resourceShareInvitationArn" => resourceShareInvitationArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function reject_resource_share_invitation(
@@ -872,6 +943,7 @@ function reject_resource_share_invitation(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -894,6 +966,7 @@ function tag_resource(
         "/tagresource",
         Dict{String,Any}("resourceShareArn" => resourceShareArn, "tags" => tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -913,6 +986,7 @@ function tag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -935,6 +1009,7 @@ function untag_resource(
         "/untagresource",
         Dict{String,Any}("resourceShareArn" => resourceShareArn, "tagKeys" => tagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -956,6 +1031,7 @@ function untag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -984,6 +1060,7 @@ function update_resource_share(
         "/updateresourceshare",
         Dict{String,Any}("resourceShareArn" => resourceShareArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_resource_share(
@@ -1000,5 +1077,6 @@ function update_resource_share(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/rds.jl
+++ b/src/services/rds.jl
@@ -32,6 +32,7 @@ function add_role_to_dbcluster(
             "DBClusterIdentifier" => DBClusterIdentifier, "RoleArn" => RoleArn
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function add_role_to_dbcluster(
@@ -52,6 +53,7 @@ function add_role_to_dbcluster(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -84,6 +86,7 @@ function add_role_to_dbinstance(
             "RoleArn" => RoleArn,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function add_role_to_dbinstance(
@@ -107,6 +110,7 @@ function add_role_to_dbinstance(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -138,6 +142,7 @@ function add_source_identifier_to_subscription(
             "SourceIdentifier" => SourceIdentifier, "SubscriptionName" => SubscriptionName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function add_source_identifier_to_subscription(
@@ -159,6 +164,7 @@ function add_source_identifier_to_subscription(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -188,6 +194,7 @@ function add_tags_to_resource(
         "AddTagsToResource",
         Dict{String,Any}("ResourceName" => ResourceName, "Tag" => Tag);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function add_tags_to_resource(
@@ -206,6 +213,7 @@ function add_tags_to_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -242,6 +250,7 @@ function apply_pending_maintenance_action(
             "ResourceIdentifier" => ResourceIdentifier,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function apply_pending_maintenance_action(
@@ -265,6 +274,7 @@ function apply_pending_maintenance_action(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -308,6 +318,7 @@ function authorize_dbsecurity_group_ingress(
         "AuthorizeDBSecurityGroupIngress",
         Dict{String,Any}("DBSecurityGroupName" => DBSecurityGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function authorize_dbsecurity_group_ingress(
@@ -325,6 +336,7 @@ function authorize_dbsecurity_group_ingress(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -366,6 +378,7 @@ function backtrack_dbcluster(
             "BacktrackTo" => BacktrackTo, "DBClusterIdentifier" => DBClusterIdentifier
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function backtrack_dbcluster(
@@ -387,6 +400,7 @@ function backtrack_dbcluster(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -408,6 +422,7 @@ function cancel_export_task(
         "CancelExportTask",
         Dict{String,Any}("ExportTaskIdentifier" => ExportTaskIdentifier);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function cancel_export_task(
@@ -425,6 +440,7 @@ function cancel_export_task(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -468,6 +484,7 @@ function copy_dbcluster_parameter_group(
                 TargetDBClusterParameterGroupIdentifier,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function copy_dbcluster_parameter_group(
@@ -494,6 +511,7 @@ function copy_dbcluster_parameter_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -624,6 +642,7 @@ function copy_dbcluster_snapshot(
             "TargetDBClusterSnapshotIdentifier" => TargetDBClusterSnapshotIdentifier,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function copy_dbcluster_snapshot(
@@ -647,6 +666,7 @@ function copy_dbcluster_snapshot(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -684,6 +704,7 @@ function copy_dbparameter_group(
             "TargetDBParameterGroupIdentifier" => TargetDBParameterGroupIdentifier,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function copy_dbparameter_group(
@@ -708,6 +729,7 @@ function copy_dbparameter_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -814,6 +836,7 @@ function copy_dbsnapshot(
             "TargetDBSnapshotIdentifier" => TargetDBSnapshotIdentifier,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function copy_dbsnapshot(
@@ -835,6 +858,7 @@ function copy_dbsnapshot(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -871,6 +895,7 @@ function copy_option_group(
             "TargetOptionGroupIdentifier" => TargetOptionGroupIdentifier,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function copy_option_group(
@@ -894,6 +919,7 @@ function copy_option_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -925,6 +951,7 @@ function create_custom_availability_zone(
         "CreateCustomAvailabilityZone",
         Dict{String,Any}("CustomAvailabilityZoneName" => CustomAvailabilityZoneName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_custom_availability_zone(
@@ -944,6 +971,7 @@ function create_custom_availability_zone(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1128,6 +1156,7 @@ function create_dbcluster(
         "CreateDBCluster",
         Dict{String,Any}("DBClusterIdentifier" => DBClusterIdentifier, "Engine" => Engine);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_dbcluster(
@@ -1148,6 +1177,7 @@ function create_dbcluster(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1188,6 +1218,7 @@ function create_dbcluster_endpoint(
             "EndpointType" => EndpointType,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_dbcluster_endpoint(
@@ -1211,6 +1242,7 @@ function create_dbcluster_endpoint(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1275,6 +1307,7 @@ function create_dbcluster_parameter_group(
             "Description" => Description,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_dbcluster_parameter_group(
@@ -1298,6 +1331,7 @@ function create_dbcluster_parameter_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1334,6 +1368,7 @@ function create_dbcluster_snapshot(
             "DBClusterSnapshotIdentifier" => DBClusterSnapshotIdentifier,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_dbcluster_snapshot(
@@ -1355,6 +1390,7 @@ function create_dbcluster_snapshot(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1657,6 +1693,7 @@ function create_dbinstance(
             "Engine" => Engine,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_dbinstance(
@@ -1680,6 +1717,7 @@ function create_dbinstance(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1892,6 +1930,7 @@ function create_dbinstance_read_replica(
             "SourceDBInstanceIdentifier" => SourceDBInstanceIdentifier,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_dbinstance_read_replica(
@@ -1913,6 +1952,7 @@ function create_dbinstance_read_replica(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1974,6 +2014,7 @@ function create_dbparameter_group(
             "Description" => Description,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_dbparameter_group(
@@ -1997,6 +2038,7 @@ function create_dbparameter_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2057,6 +2099,7 @@ function create_dbproxy(
             "VpcSubnetIds" => VpcSubnetIds,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_dbproxy(
@@ -2084,6 +2127,7 @@ function create_dbproxy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2126,6 +2170,7 @@ function create_dbproxy_endpoint(
             "VpcSubnetIds" => VpcSubnetIds,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_dbproxy_endpoint(
@@ -2149,6 +2194,7 @@ function create_dbproxy_endpoint(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2182,6 +2228,7 @@ function create_dbsecurity_group(
             "DBSecurityGroupName" => DBSecurityGroupName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_dbsecurity_group(
@@ -2203,6 +2250,7 @@ function create_dbsecurity_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2237,6 +2285,7 @@ function create_dbsnapshot(
             "DBSnapshotIdentifier" => DBSnapshotIdentifier,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_dbsnapshot(
@@ -2258,6 +2307,7 @@ function create_dbsnapshot(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2294,6 +2344,7 @@ function create_dbsubnet_group(
             "SubnetIdentifier" => SubnetIdentifier,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_dbsubnet_group(
@@ -2317,6 +2368,7 @@ function create_dbsubnet_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2382,6 +2434,7 @@ function create_event_subscription(
             "SnsTopicArn" => SnsTopicArn, "SubscriptionName" => SubscriptionName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_event_subscription(
@@ -2402,6 +2455,7 @@ function create_event_subscription(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2434,12 +2488,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   cluster.
 """
 function create_global_cluster(; aws_config::AbstractAWSConfig=global_aws_config())
-    return rds("CreateGlobalCluster"; aws_config=aws_config)
+    return rds(
+        "CreateGlobalCluster"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function create_global_cluster(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return rds("CreateGlobalCluster", params; aws_config=aws_config)
+    return rds(
+        "CreateGlobalCluster",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2480,6 +2541,7 @@ function create_option_group(
             "OptionGroupName" => OptionGroupName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_option_group(
@@ -2505,6 +2567,7 @@ function create_option_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2527,6 +2590,7 @@ function delete_custom_availability_zone(
         "DeleteCustomAvailabilityZone",
         Dict{String,Any}("CustomAvailabilityZoneId" => CustomAvailabilityZoneId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_custom_availability_zone(
@@ -2544,6 +2608,7 @@ function delete_custom_availability_zone(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2582,6 +2647,7 @@ function delete_dbcluster(
         "DeleteDBCluster",
         Dict{String,Any}("DBClusterIdentifier" => DBClusterIdentifier);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_dbcluster(
@@ -2599,6 +2665,7 @@ function delete_dbcluster(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2621,6 +2688,7 @@ function delete_dbcluster_endpoint(
         "DeleteDBClusterEndpoint",
         Dict{String,Any}("DBClusterEndpointIdentifier" => DBClusterEndpointIdentifier);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_dbcluster_endpoint(
@@ -2640,6 +2708,7 @@ function delete_dbcluster_endpoint(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2665,6 +2734,7 @@ function delete_dbcluster_parameter_group(
         "DeleteDBClusterParameterGroup",
         Dict{String,Any}("DBClusterParameterGroupName" => DBClusterParameterGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_dbcluster_parameter_group(
@@ -2684,6 +2754,7 @@ function delete_dbcluster_parameter_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2708,6 +2779,7 @@ function delete_dbcluster_snapshot(
         "DeleteDBClusterSnapshot",
         Dict{String,Any}("DBClusterSnapshotIdentifier" => DBClusterSnapshotIdentifier);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_dbcluster_snapshot(
@@ -2727,6 +2799,7 @@ function delete_dbcluster_snapshot(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2782,6 +2855,7 @@ function delete_dbinstance(
         "DeleteDBInstance",
         Dict{String,Any}("DBInstanceIdentifier" => DBInstanceIdentifier);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_dbinstance(
@@ -2799,6 +2873,7 @@ function delete_dbinstance(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2820,12 +2895,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function delete_dbinstance_automated_backup(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return rds("DeleteDBInstanceAutomatedBackup"; aws_config=aws_config)
+    return rds(
+        "DeleteDBInstanceAutomatedBackup";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_dbinstance_automated_backup(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return rds("DeleteDBInstanceAutomatedBackup", params; aws_config=aws_config)
+    return rds(
+        "DeleteDBInstanceAutomatedBackup",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2848,6 +2932,7 @@ function delete_dbparameter_group(
         "DeleteDBParameterGroup",
         Dict{String,Any}("DBParameterGroupName" => DBParameterGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_dbparameter_group(
@@ -2865,6 +2950,7 @@ function delete_dbparameter_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2883,6 +2969,7 @@ function delete_dbproxy(DBProxyName; aws_config::AbstractAWSConfig=global_aws_co
         "DeleteDBProxy",
         Dict{String,Any}("DBProxyName" => DBProxyName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_dbproxy(
@@ -2896,6 +2983,7 @@ function delete_dbproxy(
             mergewith(_merge, Dict{String,Any}("DBProxyName" => DBProxyName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2919,6 +3007,7 @@ function delete_dbproxy_endpoint(
         "DeleteDBProxyEndpoint",
         Dict{String,Any}("DBProxyEndpointName" => DBProxyEndpointName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_dbproxy_endpoint(
@@ -2936,6 +3025,7 @@ function delete_dbproxy_endpoint(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2960,6 +3050,7 @@ function delete_dbsecurity_group(
         "DeleteDBSecurityGroup",
         Dict{String,Any}("DBSecurityGroupName" => DBSecurityGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_dbsecurity_group(
@@ -2977,6 +3068,7 @@ function delete_dbsecurity_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2999,6 +3091,7 @@ function delete_dbsnapshot(
         "DeleteDBSnapshot",
         Dict{String,Any}("DBSnapshotIdentifier" => DBSnapshotIdentifier);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_dbsnapshot(
@@ -3016,6 +3109,7 @@ function delete_dbsnapshot(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3039,6 +3133,7 @@ function delete_dbsubnet_group(
         "DeleteDBSubnetGroup",
         Dict{String,Any}("DBSubnetGroupName" => DBSubnetGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_dbsubnet_group(
@@ -3054,6 +3149,7 @@ function delete_dbsubnet_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3075,6 +3171,7 @@ function delete_event_subscription(
         "DeleteEventSubscription",
         Dict{String,Any}("SubscriptionName" => SubscriptionName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_event_subscription(
@@ -3090,6 +3187,7 @@ function delete_event_subscription(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3112,6 +3210,7 @@ function delete_global_cluster(
         "DeleteGlobalCluster",
         Dict{String,Any}("GlobalClusterIdentifier" => GlobalClusterIdentifier);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_global_cluster(
@@ -3129,6 +3228,7 @@ function delete_global_cluster(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3150,6 +3250,7 @@ function delete_installation_media(
         "DeleteInstallationMedia",
         Dict{String,Any}("InstallationMediaId" => InstallationMediaId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_installation_media(
@@ -3167,6 +3268,7 @@ function delete_installation_media(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3188,6 +3290,7 @@ function delete_option_group(
         "DeleteOptionGroup",
         Dict{String,Any}("OptionGroupName" => OptionGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_option_group(
@@ -3203,6 +3306,7 @@ function delete_option_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3230,6 +3334,7 @@ function deregister_dbproxy_targets(
         "DeregisterDBProxyTargets",
         Dict{String,Any}("DBProxyName" => DBProxyName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function deregister_dbproxy_targets(
@@ -3243,6 +3348,7 @@ function deregister_dbproxy_targets(
             mergewith(_merge, Dict{String,Any}("DBProxyName" => DBProxyName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3257,12 +3363,19 @@ value. This command doesn't take any parameters.
 
 """
 function describe_account_attributes(; aws_config::AbstractAWSConfig=global_aws_config())
-    return rds("DescribeAccountAttributes"; aws_config=aws_config)
+    return rds(
+        "DescribeAccountAttributes"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_account_attributes(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return rds("DescribeAccountAttributes", params; aws_config=aws_config)
+    return rds(
+        "DescribeAccountAttributes",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -3287,12 +3400,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Constraints: Minimum 20, maximum 100.
 """
 function describe_certificates(; aws_config::AbstractAWSConfig=global_aws_config())
-    return rds("DescribeCertificates"; aws_config=aws_config)
+    return rds(
+        "DescribeCertificates"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_certificates(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return rds("DescribeCertificates", params; aws_config=aws_config)
+    return rds(
+        "DescribeCertificates",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -3319,12 +3439,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_custom_availability_zones(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return rds("DescribeCustomAvailabilityZones"; aws_config=aws_config)
+    return rds(
+        "DescribeCustomAvailabilityZones";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_custom_availability_zones(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return rds("DescribeCustomAvailabilityZones", params; aws_config=aws_config)
+    return rds(
+        "DescribeCustomAvailabilityZones",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -3368,6 +3497,7 @@ function describe_dbcluster_backtracks(
         "DescribeDBClusterBacktracks",
         Dict{String,Any}("DBClusterIdentifier" => DBClusterIdentifier);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_dbcluster_backtracks(
@@ -3385,6 +3515,7 @@ function describe_dbcluster_backtracks(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3418,12 +3549,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Minimum 20, maximum 100.
 """
 function describe_dbcluster_endpoints(; aws_config::AbstractAWSConfig=global_aws_config())
-    return rds("DescribeDBClusterEndpoints"; aws_config=aws_config)
+    return rds(
+        "DescribeDBClusterEndpoints"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_dbcluster_endpoints(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return rds("DescribeDBClusterEndpoints", params; aws_config=aws_config)
+    return rds(
+        "DescribeDBClusterEndpoints",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -3452,12 +3590,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_dbcluster_parameter_groups(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return rds("DescribeDBClusterParameterGroups"; aws_config=aws_config)
+    return rds(
+        "DescribeDBClusterParameterGroups";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_dbcluster_parameter_groups(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return rds("DescribeDBClusterParameterGroups", params; aws_config=aws_config)
+    return rds(
+        "DescribeDBClusterParameterGroups",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -3493,6 +3640,7 @@ function describe_dbcluster_parameters(
         "DescribeDBClusterParameters",
         Dict{String,Any}("DBClusterParameterGroupName" => DBClusterParameterGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_dbcluster_parameters(
@@ -3512,6 +3660,7 @@ function describe_dbcluster_parameters(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3542,6 +3691,7 @@ function describe_dbcluster_snapshot_attributes(
         "DescribeDBClusterSnapshotAttributes",
         Dict{String,Any}("DBClusterSnapshotIdentifier" => DBClusterSnapshotIdentifier);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_dbcluster_snapshot_attributes(
@@ -3561,6 +3711,7 @@ function describe_dbcluster_snapshot_attributes(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3619,12 +3770,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   when SnapshotType is set to public.
 """
 function describe_dbcluster_snapshots(; aws_config::AbstractAWSConfig=global_aws_config())
-    return rds("DescribeDBClusterSnapshots"; aws_config=aws_config)
+    return rds(
+        "DescribeDBClusterSnapshots"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_dbcluster_snapshots(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return rds("DescribeDBClusterSnapshots", params; aws_config=aws_config)
+    return rds(
+        "DescribeDBClusterSnapshots",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -3661,12 +3819,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Minimum 20, maximum 100.
 """
 function describe_dbclusters(; aws_config::AbstractAWSConfig=global_aws_config())
-    return rds("DescribeDBClusters"; aws_config=aws_config)
+    return rds("DescribeDBClusters"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function describe_dbclusters(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return rds("DescribeDBClusters", params; aws_config=aws_config)
+    return rds(
+        "DescribeDBClusters", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -3707,12 +3867,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   maximum 100.
 """
 function describe_dbengine_versions(; aws_config::AbstractAWSConfig=global_aws_config())
-    return rds("DescribeDBEngineVersions"; aws_config=aws_config)
+    return rds(
+        "DescribeDBEngineVersions"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_dbengine_versions(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return rds("DescribeDBEngineVersions", params; aws_config=aws_config)
+    return rds(
+        "DescribeDBEngineVersions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -3755,12 +3922,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_dbinstance_automated_backups(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return rds("DescribeDBInstanceAutomatedBackups"; aws_config=aws_config)
+    return rds(
+        "DescribeDBInstanceAutomatedBackups";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_dbinstance_automated_backups(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return rds("DescribeDBInstanceAutomatedBackups", params; aws_config=aws_config)
+    return rds(
+        "DescribeDBInstanceAutomatedBackups",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -3798,12 +3974,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Constraints: Minimum 20, maximum 100.
 """
 function describe_dbinstances(; aws_config::AbstractAWSConfig=global_aws_config())
-    return rds("DescribeDBInstances"; aws_config=aws_config)
+    return rds(
+        "DescribeDBInstances"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_dbinstances(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return rds("DescribeDBInstances", params; aws_config=aws_config)
+    return rds(
+        "DescribeDBInstances",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -3838,6 +4021,7 @@ function describe_dblog_files(
         "DescribeDBLogFiles",
         Dict{String,Any}("DBInstanceIdentifier" => DBInstanceIdentifier);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_dblog_files(
@@ -3855,6 +4039,7 @@ function describe_dblog_files(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3880,12 +4065,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Constraints: Minimum 20, maximum 100.
 """
 function describe_dbparameter_groups(; aws_config::AbstractAWSConfig=global_aws_config())
-    return rds("DescribeDBParameterGroups"; aws_config=aws_config)
+    return rds(
+        "DescribeDBParameterGroups"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_dbparameter_groups(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return rds("DescribeDBParameterGroups", params; aws_config=aws_config)
+    return rds(
+        "DescribeDBParameterGroups",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -3918,6 +4110,7 @@ function describe_dbparameters(
         "DescribeDBParameters",
         Dict{String,Any}("DBParameterGroupName" => DBParameterGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_dbparameters(
@@ -3935,6 +4128,7 @@ function describe_dbparameters(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3958,12 +4152,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Minimum 20, maximum 100.
 """
 function describe_dbproxies(; aws_config::AbstractAWSConfig=global_aws_config())
-    return rds("DescribeDBProxies"; aws_config=aws_config)
+    return rds("DescribeDBProxies"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function describe_dbproxies(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return rds("DescribeDBProxies", params; aws_config=aws_config)
+    return rds(
+        "DescribeDBProxies", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -3990,12 +4186,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Minimum 20, maximum 100.
 """
 function describe_dbproxy_endpoints(; aws_config::AbstractAWSConfig=global_aws_config())
-    return rds("DescribeDBProxyEndpoints"; aws_config=aws_config)
+    return rds(
+        "DescribeDBProxyEndpoints"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_dbproxy_endpoints(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return rds("DescribeDBProxyEndpoints", params; aws_config=aws_config)
+    return rds(
+        "DescribeDBProxyEndpoints",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -4027,6 +4230,7 @@ function describe_dbproxy_target_groups(
         "DescribeDBProxyTargetGroups",
         Dict{String,Any}("DBProxyName" => DBProxyName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_dbproxy_target_groups(
@@ -4040,6 +4244,7 @@ function describe_dbproxy_target_groups(
             mergewith(_merge, Dict{String,Any}("DBProxyName" => DBProxyName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4071,6 +4276,7 @@ function describe_dbproxy_targets(
         "DescribeDBProxyTargets",
         Dict{String,Any}("DBProxyName" => DBProxyName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_dbproxy_targets(
@@ -4084,6 +4290,7 @@ function describe_dbproxy_targets(
             mergewith(_merge, Dict{String,Any}("DBProxyName" => DBProxyName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4107,12 +4314,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Constraints: Minimum 20, maximum 100.
 """
 function describe_dbsecurity_groups(; aws_config::AbstractAWSConfig=global_aws_config())
-    return rds("DescribeDBSecurityGroups"; aws_config=aws_config)
+    return rds(
+        "DescribeDBSecurityGroups"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_dbsecurity_groups(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return rds("DescribeDBSecurityGroups", params; aws_config=aws_config)
+    return rds(
+        "DescribeDBSecurityGroups",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -4140,6 +4354,7 @@ function describe_dbsnapshot_attributes(
         "DescribeDBSnapshotAttributes",
         Dict{String,Any}("DBSnapshotIdentifier" => DBSnapshotIdentifier);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_dbsnapshot_attributes(
@@ -4157,6 +4372,7 @@ function describe_dbsnapshot_attributes(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4217,12 +4433,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   when SnapshotType is set to public.
 """
 function describe_dbsnapshots(; aws_config::AbstractAWSConfig=global_aws_config())
-    return rds("DescribeDBSnapshots"; aws_config=aws_config)
+    return rds(
+        "DescribeDBSnapshots"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_dbsnapshots(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return rds("DescribeDBSnapshots", params; aws_config=aws_config)
+    return rds(
+        "DescribeDBSnapshots",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -4246,12 +4469,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Constraints: Minimum 20, maximum 100.
 """
 function describe_dbsubnet_groups(; aws_config::AbstractAWSConfig=global_aws_config())
-    return rds("DescribeDBSubnetGroups"; aws_config=aws_config)
+    return rds(
+        "DescribeDBSubnetGroups"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_dbsubnet_groups(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return rds("DescribeDBSubnetGroups", params; aws_config=aws_config)
+    return rds(
+        "DescribeDBSubnetGroups",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -4284,6 +4514,7 @@ function describe_engine_default_cluster_parameters(
         "DescribeEngineDefaultClusterParameters",
         Dict{String,Any}("DBParameterGroupFamily" => DBParameterGroupFamily);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_engine_default_cluster_parameters(
@@ -4301,6 +4532,7 @@ function describe_engine_default_cluster_parameters(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4332,6 +4564,7 @@ function describe_engine_default_parameters(
         "DescribeEngineDefaultParameters",
         Dict{String,Any}("DBParameterGroupFamily" => DBParameterGroupFamily);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_engine_default_parameters(
@@ -4349,6 +4582,7 @@ function describe_engine_default_parameters(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4368,12 +4602,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   db-cluster-snapshot
 """
 function describe_event_categories(; aws_config::AbstractAWSConfig=global_aws_config())
-    return rds("DescribeEventCategories"; aws_config=aws_config)
+    return rds(
+        "DescribeEventCategories"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_event_categories(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return rds("DescribeEventCategories", params; aws_config=aws_config)
+    return rds(
+        "DescribeEventCategories",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -4399,12 +4640,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   describe.
 """
 function describe_event_subscriptions(; aws_config::AbstractAWSConfig=global_aws_config())
-    return rds("DescribeEventSubscriptions"; aws_config=aws_config)
+    return rds(
+        "DescribeEventSubscriptions"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_event_subscriptions(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return rds("DescribeEventSubscriptions", params; aws_config=aws_config)
+    return rds(
+        "DescribeEventSubscriptions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -4450,12 +4698,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Example: 2009-07-08T18:00Z
 """
 function describe_events(; aws_config::AbstractAWSConfig=global_aws_config())
-    return rds("DescribeEvents"; aws_config=aws_config)
+    return rds("DescribeEvents"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function describe_events(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return rds("DescribeEvents", params; aws_config=aws_config)
+    return rds(
+        "DescribeEvents", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -4485,12 +4735,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"SourceArn"`: The Amazon Resource Name (ARN) of the snapshot exported to Amazon S3.
 """
 function describe_export_tasks(; aws_config::AbstractAWSConfig=global_aws_config())
-    return rds("DescribeExportTasks"; aws_config=aws_config)
+    return rds(
+        "DescribeExportTasks"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_export_tasks(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return rds("DescribeExportTasks", params; aws_config=aws_config)
+    return rds(
+        "DescribeExportTasks",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -4517,12 +4774,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Constraints: Minimum 20, maximum 100.
 """
 function describe_global_clusters(; aws_config::AbstractAWSConfig=global_aws_config())
-    return rds("DescribeGlobalClusters"; aws_config=aws_config)
+    return rds(
+        "DescribeGlobalClusters"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_global_clusters(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return rds("DescribeGlobalClusters", params; aws_config=aws_config)
+    return rds(
+        "DescribeGlobalClusters",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -4550,12 +4814,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   only records beyond the marker, up to the value specified by MaxRecords.
 """
 function describe_installation_media(; aws_config::AbstractAWSConfig=global_aws_config())
-    return rds("DescribeInstallationMedia"; aws_config=aws_config)
+    return rds(
+        "DescribeInstallationMedia"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_installation_media(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return rds("DescribeInstallationMedia", params; aws_config=aws_config)
+    return rds(
+        "DescribeInstallationMedia",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -4590,6 +4861,7 @@ function describe_option_group_options(
         "DescribeOptionGroupOptions",
         Dict{String,Any}("EngineName" => EngineName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_option_group_options(
@@ -4603,6 +4875,7 @@ function describe_option_group_options(
             mergewith(_merge, Dict{String,Any}("EngineName" => EngineName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4633,12 +4906,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   with EngineName or MajorEngineVersion.
 """
 function describe_option_groups(; aws_config::AbstractAWSConfig=global_aws_config())
-    return rds("DescribeOptionGroups"; aws_config=aws_config)
+    return rds(
+        "DescribeOptionGroups"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_option_groups(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return rds("DescribeOptionGroups", params; aws_config=aws_config)
+    return rds(
+        "DescribeOptionGroups",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -4683,6 +4963,7 @@ function describe_orderable_dbinstance_options(
         "DescribeOrderableDBInstanceOptions",
         Dict{String,Any}("Engine" => Engine);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_orderable_dbinstance_options(
@@ -4692,6 +4973,7 @@ function describe_orderable_dbinstance_options(
         "DescribeOrderableDBInstanceOptions",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Engine" => Engine), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4722,12 +5004,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_pending_maintenance_actions(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return rds("DescribePendingMaintenanceActions"; aws_config=aws_config)
+    return rds(
+        "DescribePendingMaintenanceActions";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_pending_maintenance_actions(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return rds("DescribePendingMaintenanceActions", params; aws_config=aws_config)
+    return rds(
+        "DescribePendingMaintenanceActions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -4768,12 +5059,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   parameter to show only purchased reservations matching the specified offering identifier.
 """
 function describe_reserved_dbinstances(; aws_config::AbstractAWSConfig=global_aws_config())
-    return rds("DescribeReservedDBInstances"; aws_config=aws_config)
+    return rds(
+        "DescribeReservedDBInstances";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_reserved_dbinstances(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return rds("DescribeReservedDBInstances", params; aws_config=aws_config)
+    return rds(
+        "DescribeReservedDBInstances",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -4812,12 +5112,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_reserved_dbinstances_offerings(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return rds("DescribeReservedDBInstancesOfferings"; aws_config=aws_config)
+    return rds(
+        "DescribeReservedDBInstancesOfferings";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_reserved_dbinstances_offerings(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return rds("DescribeReservedDBInstancesOfferings", params; aws_config=aws_config)
+    return rds(
+        "DescribeReservedDBInstancesOfferings",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -4842,12 +5151,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Constraints:   Must specify a valid Amazon Web Services Region name.
 """
 function describe_source_regions(; aws_config::AbstractAWSConfig=global_aws_config())
-    return rds("DescribeSourceRegions"; aws_config=aws_config)
+    return rds(
+        "DescribeSourceRegions"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_source_regions(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return rds("DescribeSourceRegions", params; aws_config=aws_config)
+    return rds(
+        "DescribeSourceRegions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -4868,6 +5184,7 @@ function describe_valid_dbinstance_modifications(
         "DescribeValidDBInstanceModifications",
         Dict{String,Any}("DBInstanceIdentifier" => DBInstanceIdentifier);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_valid_dbinstance_modifications(
@@ -4885,6 +5202,7 @@ function describe_valid_dbinstance_modifications(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4928,6 +5246,7 @@ function download_dblog_file_portion(
             "DBInstanceIdentifier" => DBInstanceIdentifier, "LogFileName" => LogFileName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function download_dblog_file_portion(
@@ -4949,6 +5268,7 @@ function download_dblog_file_portion(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4983,6 +5303,7 @@ function failover_dbcluster(
         "FailoverDBCluster",
         Dict{String,Any}("DBClusterIdentifier" => DBClusterIdentifier);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function failover_dbcluster(
@@ -5000,6 +5321,7 @@ function failover_dbcluster(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5043,6 +5365,7 @@ function failover_global_cluster(
             "TargetDbClusterIdentifier" => TargetDbClusterIdentifier,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function failover_global_cluster(
@@ -5064,6 +5387,7 @@ function failover_global_cluster(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5110,6 +5434,7 @@ function import_installation_media(
             "OSInstallationMediaPath" => OSInstallationMediaPath,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function import_installation_media(
@@ -5137,6 +5462,7 @@ function import_installation_media(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5163,6 +5489,7 @@ function list_tags_for_resource(
         "ListTagsForResource",
         Dict{String,Any}("ResourceName" => ResourceName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags_for_resource(
@@ -5176,6 +5503,7 @@ function list_tags_for_resource(
             mergewith(_merge, Dict{String,Any}("ResourceName" => ResourceName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5209,12 +5537,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   default.
 """
 function modify_certificates(; aws_config::AbstractAWSConfig=global_aws_config())
-    return rds("ModifyCertificates"; aws_config=aws_config)
+    return rds("ModifyCertificates"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function modify_certificates(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return rds("ModifyCertificates", params; aws_config=aws_config)
+    return rds(
+        "ModifyCertificates", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -5260,6 +5590,7 @@ function modify_current_dbcluster_capacity(
         "ModifyCurrentDBClusterCapacity",
         Dict{String,Any}("DBClusterIdentifier" => DBClusterIdentifier);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_current_dbcluster_capacity(
@@ -5277,6 +5608,7 @@ function modify_current_dbcluster_capacity(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5411,6 +5743,7 @@ function modify_dbcluster(
         "ModifyDBCluster",
         Dict{String,Any}("DBClusterIdentifier" => DBClusterIdentifier);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_dbcluster(
@@ -5428,6 +5761,7 @@ function modify_dbcluster(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5458,6 +5792,7 @@ function modify_dbcluster_endpoint(
         "ModifyDBClusterEndpoint",
         Dict{String,Any}("DBClusterEndpointIdentifier" => DBClusterEndpointIdentifier);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_dbcluster_endpoint(
@@ -5477,6 +5812,7 @@ function modify_dbcluster_endpoint(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5536,6 +5872,7 @@ function modify_dbcluster_parameter_group(
             "Parameter" => Parameter,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_dbcluster_parameter_group(
@@ -5557,6 +5894,7 @@ function modify_dbcluster_parameter_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5616,6 +5954,7 @@ function modify_dbcluster_snapshot_attribute(
             "DBClusterSnapshotIdentifier" => DBClusterSnapshotIdentifier,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_dbcluster_snapshot_attribute(
@@ -5637,6 +5976,7 @@ function modify_dbcluster_snapshot_attribute(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5939,6 +6279,7 @@ function modify_dbinstance(
         "ModifyDBInstance",
         Dict{String,Any}("DBInstanceIdentifier" => DBInstanceIdentifier);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_dbinstance(
@@ -5956,6 +6297,7 @@ function modify_dbinstance(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6011,6 +6353,7 @@ function modify_dbparameter_group(
             "DBParameterGroupName" => DBParameterGroupName, "Parameter" => Parameter
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_dbparameter_group(
@@ -6031,6 +6374,7 @@ function modify_dbparameter_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6070,6 +6414,7 @@ function modify_dbproxy(DBProxyName; aws_config::AbstractAWSConfig=global_aws_co
         "ModifyDBProxy",
         Dict{String,Any}("DBProxyName" => DBProxyName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_dbproxy(
@@ -6083,6 +6428,7 @@ function modify_dbproxy(
             mergewith(_merge, Dict{String,Any}("DBProxyName" => DBProxyName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6112,6 +6458,7 @@ function modify_dbproxy_endpoint(
         "ModifyDBProxyEndpoint",
         Dict{String,Any}("DBProxyEndpointName" => DBProxyEndpointName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_dbproxy_endpoint(
@@ -6129,6 +6476,7 @@ function modify_dbproxy_endpoint(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6159,6 +6507,7 @@ function modify_dbproxy_target_group(
             "DBProxyName" => DBProxyName, "TargetGroupName" => TargetGroupName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_dbproxy_target_group(
@@ -6179,6 +6528,7 @@ function modify_dbproxy_target_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6214,6 +6564,7 @@ function modify_dbsnapshot(
         "ModifyDBSnapshot",
         Dict{String,Any}("DBSnapshotIdentifier" => DBSnapshotIdentifier);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_dbsnapshot(
@@ -6231,6 +6582,7 @@ function modify_dbsnapshot(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6284,6 +6636,7 @@ function modify_dbsnapshot_attribute(
             "AttributeName" => AttributeName, "DBSnapshotIdentifier" => DBSnapshotIdentifier
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_dbsnapshot_attribute(
@@ -6305,6 +6658,7 @@ function modify_dbsnapshot_attribute(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6335,6 +6689,7 @@ function modify_dbsubnet_group(
             "DBSubnetGroupName" => DBSubnetGroupName, "SubnetIdentifier" => SubnetIdentifier
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_dbsubnet_group(
@@ -6356,6 +6711,7 @@ function modify_dbsubnet_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6393,6 +6749,7 @@ function modify_event_subscription(
         "ModifyEventSubscription",
         Dict{String,Any}("SubscriptionName" => SubscriptionName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_event_subscription(
@@ -6408,6 +6765,7 @@ function modify_event_subscription(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6451,12 +6809,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Example: my-cluster2
 """
 function modify_global_cluster(; aws_config::AbstractAWSConfig=global_aws_config())
-    return rds("ModifyGlobalCluster"; aws_config=aws_config)
+    return rds(
+        "ModifyGlobalCluster"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function modify_global_cluster(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return rds("ModifyGlobalCluster", params; aws_config=aws_config)
+    return rds(
+        "ModifyGlobalCluster",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -6486,6 +6851,7 @@ function modify_option_group(
         "ModifyOptionGroup",
         Dict{String,Any}("OptionGroupName" => OptionGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_option_group(
@@ -6501,6 +6867,7 @@ function modify_option_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6543,6 +6910,7 @@ function promote_read_replica(
         "PromoteReadReplica",
         Dict{String,Any}("DBInstanceIdentifier" => DBInstanceIdentifier);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function promote_read_replica(
@@ -6560,6 +6928,7 @@ function promote_read_replica(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6583,6 +6952,7 @@ function promote_read_replica_dbcluster(
         "PromoteReadReplicaDBCluster",
         Dict{String,Any}("DBClusterIdentifier" => DBClusterIdentifier);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function promote_read_replica_dbcluster(
@@ -6600,6 +6970,7 @@ function promote_read_replica_dbcluster(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6627,6 +6998,7 @@ function purchase_reserved_dbinstances_offering(
         "PurchaseReservedDBInstancesOffering",
         Dict{String,Any}("ReservedDBInstancesOfferingId" => ReservedDBInstancesOfferingId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function purchase_reserved_dbinstances_offering(
@@ -6646,6 +7018,7 @@ function purchase_reserved_dbinstances_offering(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6677,6 +7050,7 @@ function reboot_dbinstance(
         "RebootDBInstance",
         Dict{String,Any}("DBInstanceIdentifier" => DBInstanceIdentifier);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function reboot_dbinstance(
@@ -6694,6 +7068,7 @@ function reboot_dbinstance(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6720,6 +7095,7 @@ function register_dbproxy_targets(
         "RegisterDBProxyTargets",
         Dict{String,Any}("DBProxyName" => DBProxyName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function register_dbproxy_targets(
@@ -6733,6 +7109,7 @@ function register_dbproxy_targets(
             mergewith(_merge, Dict{String,Any}("DBProxyName" => DBProxyName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6753,12 +7130,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   database cluster.
 """
 function remove_from_global_cluster(; aws_config::AbstractAWSConfig=global_aws_config())
-    return rds("RemoveFromGlobalCluster"; aws_config=aws_config)
+    return rds(
+        "RemoveFromGlobalCluster"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function remove_from_global_cluster(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return rds("RemoveFromGlobalCluster", params; aws_config=aws_config)
+    return rds(
+        "RemoveFromGlobalCluster",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -6789,6 +7173,7 @@ function remove_role_from_dbcluster(
             "DBClusterIdentifier" => DBClusterIdentifier, "RoleArn" => RoleArn
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function remove_role_from_dbcluster(
@@ -6809,6 +7194,7 @@ function remove_role_from_dbcluster(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6841,6 +7227,7 @@ function remove_role_from_dbinstance(
             "RoleArn" => RoleArn,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function remove_role_from_dbinstance(
@@ -6864,6 +7251,7 @@ function remove_role_from_dbinstance(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6889,6 +7277,7 @@ function remove_source_identifier_from_subscription(
             "SourceIdentifier" => SourceIdentifier, "SubscriptionName" => SubscriptionName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function remove_source_identifier_from_subscription(
@@ -6910,6 +7299,7 @@ function remove_source_identifier_from_subscription(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6934,6 +7324,7 @@ function remove_tags_from_resource(
         "RemoveTagsFromResource",
         Dict{String,Any}("ResourceName" => ResourceName, "TagKeys" => TagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function remove_tags_from_resource(
@@ -6952,6 +7343,7 @@ function remove_tags_from_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6988,6 +7380,7 @@ function reset_dbcluster_parameter_group(
         "ResetDBClusterParameterGroup",
         Dict{String,Any}("DBClusterParameterGroupName" => DBClusterParameterGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function reset_dbcluster_parameter_group(
@@ -7007,6 +7400,7 @@ function reset_dbcluster_parameter_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -7048,6 +7442,7 @@ function reset_dbparameter_group(
         "ResetDBParameterGroup",
         Dict{String,Any}("DBParameterGroupName" => DBParameterGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function reset_dbparameter_group(
@@ -7065,6 +7460,7 @@ function reset_dbparameter_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -7215,6 +7611,7 @@ function restore_dbcluster_from_s3(
             "SourceEngineVersion" => SourceEngineVersion,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function restore_dbcluster_from_s3(
@@ -7248,6 +7645,7 @@ function restore_dbcluster_from_s3(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -7362,6 +7760,7 @@ function restore_dbcluster_from_snapshot(
             "SnapshotIdentifier" => SnapshotIdentifier,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function restore_dbcluster_from_snapshot(
@@ -7385,6 +7784,7 @@ function restore_dbcluster_from_snapshot(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -7498,6 +7898,7 @@ function restore_dbcluster_to_point_in_time(
             "SourceDBClusterIdentifier" => SourceDBClusterIdentifier,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function restore_dbcluster_to_point_in_time(
@@ -7519,6 +7920,7 @@ function restore_dbcluster_to_point_in_time(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -7661,6 +8063,7 @@ function restore_dbinstance_from_dbsnapshot(
             "DBSnapshotIdentifier" => DBSnapshotIdentifier,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function restore_dbinstance_from_dbsnapshot(
@@ -7682,6 +8085,7 @@ function restore_dbinstance_from_dbsnapshot(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -7865,6 +8269,7 @@ function restore_dbinstance_from_s3(
             "SourceEngineVersion" => SourceEngineVersion,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function restore_dbinstance_from_s3(
@@ -7896,6 +8301,7 @@ function restore_dbinstance_from_s3(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -8035,6 +8441,7 @@ function restore_dbinstance_to_point_in_time(
         "RestoreDBInstanceToPointInTime",
         Dict{String,Any}("TargetDBInstanceIdentifier" => TargetDBInstanceIdentifier);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function restore_dbinstance_to_point_in_time(
@@ -8054,6 +8461,7 @@ function restore_dbinstance_to_point_in_time(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -8093,6 +8501,7 @@ function revoke_dbsecurity_group_ingress(
         "RevokeDBSecurityGroupIngress",
         Dict{String,Any}("DBSecurityGroupName" => DBSecurityGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function revoke_dbsecurity_group_ingress(
@@ -8110,6 +8519,7 @@ function revoke_dbsecurity_group_ingress(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -8147,6 +8557,7 @@ function start_activity_stream(
             "KmsKeyId" => KmsKeyId, "Mode" => Mode, "ResourceArn" => ResourceArn
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_activity_stream(
@@ -8168,6 +8579,7 @@ function start_activity_stream(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -8192,6 +8604,7 @@ function start_dbcluster(
         "StartDBCluster",
         Dict{String,Any}("DBClusterIdentifier" => DBClusterIdentifier);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_dbcluster(
@@ -8209,6 +8622,7 @@ function start_dbcluster(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -8233,6 +8647,7 @@ function start_dbinstance(
         "StartDBInstance",
         Dict{String,Any}("DBInstanceIdentifier" => DBInstanceIdentifier);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_dbinstance(
@@ -8250,6 +8665,7 @@ function start_dbinstance(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -8285,6 +8701,7 @@ function start_dbinstance_automated_backups_replication(
         "StartDBInstanceAutomatedBackupsReplication",
         Dict{String,Any}("SourceDBInstanceArn" => SourceDBInstanceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_dbinstance_automated_backups_replication(
@@ -8302,6 +8719,7 @@ function start_dbinstance_automated_backups_replication(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -8360,6 +8778,7 @@ function start_export_task(
             "SourceArn" => SourceArn,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_export_task(
@@ -8387,6 +8806,7 @@ function start_export_task(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -8414,6 +8834,7 @@ function stop_activity_stream(
         "StopActivityStream",
         Dict{String,Any}("ResourceArn" => ResourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function stop_activity_stream(
@@ -8427,6 +8848,7 @@ function stop_activity_stream(
             mergewith(_merge, Dict{String,Any}("ResourceArn" => ResourceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -8452,6 +8874,7 @@ function stop_dbcluster(
         "StopDBCluster",
         Dict{String,Any}("DBClusterIdentifier" => DBClusterIdentifier);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function stop_dbcluster(
@@ -8469,6 +8892,7 @@ function stop_dbcluster(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -8498,6 +8922,7 @@ function stop_dbinstance(
         "StopDBInstance",
         Dict{String,Any}("DBInstanceIdentifier" => DBInstanceIdentifier);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function stop_dbinstance(
@@ -8515,6 +8940,7 @@ function stop_dbinstance(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -8539,6 +8965,7 @@ function stop_dbinstance_automated_backups_replication(
         "StopDBInstanceAutomatedBackupsReplication",
         Dict{String,Any}("SourceDBInstanceArn" => SourceDBInstanceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function stop_dbinstance_automated_backups_replication(
@@ -8556,5 +8983,6 @@ function stop_dbinstance_automated_backups_replication(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/rds_data.jl
+++ b/src/services/rds_data.jl
@@ -43,6 +43,7 @@ function batch_execute_statement(
             "resourceArn" => resourceArn, "secretArn" => secretArn, "sql" => sql
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_execute_statement(
@@ -65,6 +66,7 @@ function batch_execute_statement(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -98,6 +100,7 @@ function begin_transaction(
         "/BeginTransaction",
         Dict{String,Any}("resourceArn" => resourceArn, "secretArn" => secretArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function begin_transaction(
@@ -117,6 +120,7 @@ function begin_transaction(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -144,6 +148,7 @@ function commit_transaction(
             "transactionId" => transactionId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function commit_transaction(
@@ -168,6 +173,7 @@ function commit_transaction(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -206,6 +212,7 @@ function execute_sql(
             "sqlStatements" => sqlStatements,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function execute_sql(
@@ -230,6 +237,7 @@ function execute_sql(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -277,6 +285,7 @@ function execute_statement(
             "resourceArn" => resourceArn, "secretArn" => secretArn, "sql" => sql
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function execute_statement(
@@ -299,6 +308,7 @@ function execute_statement(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -326,6 +336,7 @@ function rollback_transaction(
             "transactionId" => transactionId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function rollback_transaction(
@@ -350,5 +361,6 @@ function rollback_transaction(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/redshift.jl
+++ b/src/services/redshift.jl
@@ -31,6 +31,7 @@ function accept_reserved_node_exchange(
             "TargetReservedNodeOfferingId" => TargetReservedNodeOfferingId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function accept_reserved_node_exchange(
@@ -52,6 +53,7 @@ function accept_reserved_node_exchange(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -87,6 +89,7 @@ function add_partner(
             "PartnerName" => PartnerName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function add_partner(
@@ -112,6 +115,7 @@ function add_partner(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -141,6 +145,7 @@ function associate_data_share_consumer(
         "AssociateDataShareConsumer",
         Dict{String,Any}("DataShareArn" => DataShareArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_data_share_consumer(
@@ -154,6 +159,7 @@ function associate_data_share_consumer(
             mergewith(_merge, Dict{String,Any}("DataShareArn" => DataShareArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -195,6 +201,7 @@ function authorize_cluster_security_group_ingress(
         "AuthorizeClusterSecurityGroupIngress",
         Dict{String,Any}("ClusterSecurityGroupName" => ClusterSecurityGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function authorize_cluster_security_group_ingress(
@@ -212,6 +219,7 @@ function authorize_cluster_security_group_ingress(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -239,6 +247,7 @@ function authorize_data_share(
             "ConsumerIdentifier" => ConsumerIdentifier, "DataShareArn" => DataShareArn
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function authorize_data_share(
@@ -260,6 +269,7 @@ function authorize_data_share(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -284,6 +294,7 @@ function authorize_endpoint_access(
         "AuthorizeEndpointAccess",
         Dict{String,Any}("Account" => Account);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function authorize_endpoint_access(
@@ -293,6 +304,7 @@ function authorize_endpoint_access(
         "AuthorizeEndpointAccess",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Account" => Account), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -329,6 +341,7 @@ function authorize_snapshot_access(
             "SnapshotIdentifier" => SnapshotIdentifier,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function authorize_snapshot_access(
@@ -350,6 +363,7 @@ function authorize_snapshot_access(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -374,6 +388,7 @@ function batch_delete_cluster_snapshots(
         "BatchDeleteClusterSnapshots",
         Dict{String,Any}("DeleteClusterSnapshotMessage" => DeleteClusterSnapshotMessage);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_delete_cluster_snapshots(
@@ -393,6 +408,7 @@ function batch_delete_cluster_snapshots(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -424,6 +440,7 @@ function batch_modify_cluster_snapshots(
         "BatchModifyClusterSnapshots",
         Dict{String,Any}("String" => String);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_modify_cluster_snapshots(
@@ -433,6 +450,7 @@ function batch_modify_cluster_snapshots(
         "BatchModifyClusterSnapshots",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("String" => String), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -452,6 +470,7 @@ function cancel_resize(ClusterIdentifier; aws_config::AbstractAWSConfig=global_a
         "CancelResize",
         Dict{String,Any}("ClusterIdentifier" => ClusterIdentifier);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function cancel_resize(
@@ -467,6 +486,7 @@ function cancel_resize(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -514,6 +534,7 @@ function copy_cluster_snapshot(
             "TargetSnapshotIdentifier" => TargetSnapshotIdentifier,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function copy_cluster_snapshot(
@@ -535,6 +556,7 @@ function copy_cluster_snapshot(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -562,6 +584,7 @@ function create_authentication_profile(
             "AuthenticationProfileName" => AuthenticationProfileName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_authentication_profile(
@@ -583,6 +606,7 @@ function create_authentication_profile(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -736,6 +760,7 @@ function create_cluster(
             "NodeType" => NodeType,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_cluster(
@@ -761,6 +786,7 @@ function create_cluster(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -809,6 +835,7 @@ function create_cluster_parameter_group(
             "ParameterGroupName" => ParameterGroupName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_cluster_parameter_group(
@@ -832,6 +859,7 @@ function create_cluster_parameter_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -864,6 +892,7 @@ function create_cluster_security_group(
             "Description" => Description,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_cluster_security_group(
@@ -885,6 +914,7 @@ function create_cluster_security_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -921,6 +951,7 @@ function create_cluster_snapshot(
             "SnapshotIdentifier" => SnapshotIdentifier,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_cluster_snapshot(
@@ -942,6 +973,7 @@ function create_cluster_snapshot(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -983,6 +1015,7 @@ function create_cluster_subnet_group(
             "SubnetIdentifier" => SubnetIdentifier,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_cluster_subnet_group(
@@ -1006,6 +1039,7 @@ function create_cluster_subnet_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1039,6 +1073,7 @@ function create_endpoint_access(
             "EndpointName" => EndpointName, "SubnetGroupName" => SubnetGroupName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_endpoint_access(
@@ -1059,6 +1094,7 @@ function create_endpoint_access(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1124,6 +1160,7 @@ function create_event_subscription(
             "SnsTopicArn" => SnsTopicArn, "SubscriptionName" => SubscriptionName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_event_subscription(
@@ -1144,6 +1181,7 @@ function create_event_subscription(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1177,6 +1215,7 @@ function create_hsm_client_certificate(
             "HsmClientCertificateIdentifier" => HsmClientCertificateIdentifier
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_hsm_client_certificate(
@@ -1196,6 +1235,7 @@ function create_hsm_client_certificate(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1247,6 +1287,7 @@ function create_hsm_configuration(
             "HsmServerPublicCertificate" => HsmServerPublicCertificate,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_hsm_configuration(
@@ -1276,6 +1317,7 @@ function create_hsm_configuration(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1324,6 +1366,7 @@ function create_scheduled_action(
             "TargetAction" => TargetAction,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_scheduled_action(
@@ -1349,6 +1392,7 @@ function create_scheduled_action(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1381,6 +1425,7 @@ function create_snapshot_copy_grant(
         "CreateSnapshotCopyGrant",
         Dict{String,Any}("SnapshotCopyGrantName" => SnapshotCopyGrantName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_snapshot_copy_grant(
@@ -1398,6 +1443,7 @@ function create_snapshot_copy_grant(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1420,12 +1466,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"Tags"`: An optional set of tags you can use to search for the schedule.
 """
 function create_snapshot_schedule(; aws_config::AbstractAWSConfig=global_aws_config())
-    return redshift("CreateSnapshotSchedule"; aws_config=aws_config)
+    return redshift(
+        "CreateSnapshotSchedule"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function create_snapshot_schedule(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return redshift("CreateSnapshotSchedule", params; aws_config=aws_config)
+    return redshift(
+        "CreateSnapshotSchedule",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1459,6 +1512,7 @@ function create_tags(ResourceName, Tag; aws_config::AbstractAWSConfig=global_aws
         "CreateTags",
         Dict{String,Any}("ResourceName" => ResourceName, "Tag" => Tag);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_tags(
@@ -1477,6 +1531,7 @@ function create_tags(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1520,6 +1575,7 @@ function create_usage_limit(
             "LimitType" => LimitType,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_usage_limit(
@@ -1545,6 +1601,7 @@ function create_usage_limit(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1570,6 +1627,7 @@ function deauthorize_data_share(
             "ConsumerIdentifier" => ConsumerIdentifier, "DataShareArn" => DataShareArn
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function deauthorize_data_share(
@@ -1591,6 +1649,7 @@ function deauthorize_data_share(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1611,6 +1670,7 @@ function delete_authentication_profile(
         "DeleteAuthenticationProfile",
         Dict{String,Any}("AuthenticationProfileName" => AuthenticationProfileName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_authentication_profile(
@@ -1628,6 +1688,7 @@ function delete_authentication_profile(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1677,6 +1738,7 @@ function delete_cluster(
         "DeleteCluster",
         Dict{String,Any}("ClusterIdentifier" => ClusterIdentifier);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_cluster(
@@ -1692,6 +1754,7 @@ function delete_cluster(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1715,6 +1778,7 @@ function delete_cluster_parameter_group(
         "DeleteClusterParameterGroup",
         Dict{String,Any}("ParameterGroupName" => ParameterGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_cluster_parameter_group(
@@ -1730,6 +1794,7 @@ function delete_cluster_parameter_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1753,6 +1818,7 @@ function delete_cluster_security_group(
         "DeleteClusterSecurityGroup",
         Dict{String,Any}("ClusterSecurityGroupName" => ClusterSecurityGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_cluster_security_group(
@@ -1770,6 +1836,7 @@ function delete_cluster_security_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1803,6 +1870,7 @@ function delete_cluster_snapshot(
         "DeleteClusterSnapshot",
         Dict{String,Any}("SnapshotIdentifier" => SnapshotIdentifier);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_cluster_snapshot(
@@ -1818,6 +1886,7 @@ function delete_cluster_snapshot(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1838,6 +1907,7 @@ function delete_cluster_subnet_group(
         "DeleteClusterSubnetGroup",
         Dict{String,Any}("ClusterSubnetGroupName" => ClusterSubnetGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_cluster_subnet_group(
@@ -1855,6 +1925,7 @@ function delete_cluster_subnet_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1875,6 +1946,7 @@ function delete_endpoint_access(
         "DeleteEndpointAccess",
         Dict{String,Any}("EndpointName" => EndpointName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_endpoint_access(
@@ -1888,6 +1960,7 @@ function delete_endpoint_access(
             mergewith(_merge, Dict{String,Any}("EndpointName" => EndpointName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1909,6 +1982,7 @@ function delete_event_subscription(
         "DeleteEventSubscription",
         Dict{String,Any}("SubscriptionName" => SubscriptionName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_event_subscription(
@@ -1924,6 +1998,7 @@ function delete_event_subscription(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1947,6 +2022,7 @@ function delete_hsm_client_certificate(
             "HsmClientCertificateIdentifier" => HsmClientCertificateIdentifier
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_hsm_client_certificate(
@@ -1966,6 +2042,7 @@ function delete_hsm_client_certificate(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1987,6 +2064,7 @@ function delete_hsm_configuration(
         "DeleteHsmConfiguration",
         Dict{String,Any}("HsmConfigurationIdentifier" => HsmConfigurationIdentifier);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_hsm_configuration(
@@ -2006,6 +2084,7 @@ function delete_hsm_configuration(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2040,6 +2119,7 @@ function delete_partner(
             "PartnerName" => PartnerName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_partner(
@@ -2065,6 +2145,7 @@ function delete_partner(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2085,6 +2166,7 @@ function delete_scheduled_action(
         "DeleteScheduledAction",
         Dict{String,Any}("ScheduledActionName" => ScheduledActionName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_scheduled_action(
@@ -2102,6 +2184,7 @@ function delete_scheduled_action(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2122,6 +2205,7 @@ function delete_snapshot_copy_grant(
         "DeleteSnapshotCopyGrant",
         Dict{String,Any}("SnapshotCopyGrantName" => SnapshotCopyGrantName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_snapshot_copy_grant(
@@ -2139,6 +2223,7 @@ function delete_snapshot_copy_grant(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2159,6 +2244,7 @@ function delete_snapshot_schedule(
         "DeleteSnapshotSchedule",
         Dict{String,Any}("ScheduleIdentifier" => ScheduleIdentifier);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_snapshot_schedule(
@@ -2174,6 +2260,7 @@ function delete_snapshot_schedule(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2200,6 +2287,7 @@ function delete_tags(
         "DeleteTags",
         Dict{String,Any}("ResourceName" => ResourceName, "TagKey" => TagKey);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_tags(
@@ -2218,6 +2306,7 @@ function delete_tags(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2236,6 +2325,7 @@ function delete_usage_limit(UsageLimitId; aws_config::AbstractAWSConfig=global_a
         "DeleteUsageLimit",
         Dict{String,Any}("UsageLimitId" => UsageLimitId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_usage_limit(
@@ -2249,6 +2339,7 @@ function delete_usage_limit(
             mergewith(_merge, Dict{String,Any}("UsageLimitId" => UsageLimitId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2263,12 +2354,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"AttributeNames"`: A list of attribute names.
 """
 function describe_account_attributes(; aws_config::AbstractAWSConfig=global_aws_config())
-    return redshift("DescribeAccountAttributes"; aws_config=aws_config)
+    return redshift(
+        "DescribeAccountAttributes"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_account_attributes(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return redshift("DescribeAccountAttributes", params; aws_config=aws_config)
+    return redshift(
+        "DescribeAccountAttributes",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2285,12 +2383,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_authentication_profiles(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return redshift("DescribeAuthenticationProfiles"; aws_config=aws_config)
+    return redshift(
+        "DescribeAuthenticationProfiles";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_authentication_profiles(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return redshift("DescribeAuthenticationProfiles", params; aws_config=aws_config)
+    return redshift(
+        "DescribeAuthenticationProfiles",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2317,12 +2424,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   request.  Default: 100 Constraints: minimum 20, maximum 100.
 """
 function describe_cluster_db_revisions(; aws_config::AbstractAWSConfig=global_aws_config())
-    return redshift("DescribeClusterDbRevisions"; aws_config=aws_config)
+    return redshift(
+        "DescribeClusterDbRevisions"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_cluster_db_revisions(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return redshift("DescribeClusterDbRevisions", params; aws_config=aws_config)
+    return redshift(
+        "DescribeClusterDbRevisions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2371,12 +2485,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_cluster_parameter_groups(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return redshift("DescribeClusterParameterGroups"; aws_config=aws_config)
+    return redshift(
+        "DescribeClusterParameterGroups";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_cluster_parameter_groups(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return redshift("DescribeClusterParameterGroups", params; aws_config=aws_config)
+    return redshift(
+        "DescribeClusterParameterGroups",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2419,6 +2542,7 @@ function describe_cluster_parameters(
         "DescribeClusterParameters",
         Dict{String,Any}("ParameterGroupName" => ParameterGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_cluster_parameters(
@@ -2434,6 +2558,7 @@ function describe_cluster_parameters(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2483,12 +2608,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_cluster_security_groups(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return redshift("DescribeClusterSecurityGroups"; aws_config=aws_config)
+    return redshift(
+        "DescribeClusterSecurityGroups";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_cluster_security_groups(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return redshift("DescribeClusterSecurityGroups", params; aws_config=aws_config)
+    return redshift(
+        "DescribeClusterSecurityGroups",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2557,12 +2691,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   snapshots that have either or both of these tag values associated with them.
 """
 function describe_cluster_snapshots(; aws_config::AbstractAWSConfig=global_aws_config())
-    return redshift("DescribeClusterSnapshots"; aws_config=aws_config)
+    return redshift(
+        "DescribeClusterSnapshots"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_cluster_snapshots(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return redshift("DescribeClusterSnapshots", params; aws_config=aws_config)
+    return redshift(
+        "DescribeClusterSnapshots",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2605,12 +2746,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   with the subnet groups that have either or both of these tag values associated with them.
 """
 function describe_cluster_subnet_groups(; aws_config::AbstractAWSConfig=global_aws_config())
-    return redshift("DescribeClusterSubnetGroups"; aws_config=aws_config)
+    return redshift(
+        "DescribeClusterSubnetGroups";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_cluster_subnet_groups(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return redshift("DescribeClusterSubnetGroups", params; aws_config=aws_config)
+    return redshift(
+        "DescribeClusterSubnetGroups",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2630,12 +2780,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"MaxRecords"`: An integer value for the maximum number of maintenance tracks to return.
 """
 function describe_cluster_tracks(; aws_config::AbstractAWSConfig=global_aws_config())
-    return redshift("DescribeClusterTracks"; aws_config=aws_config)
+    return redshift(
+        "DescribeClusterTracks"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_cluster_tracks(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return redshift("DescribeClusterTracks", params; aws_config=aws_config)
+    return redshift(
+        "DescribeClusterTracks",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2665,12 +2822,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   20, maximum 100.
 """
 function describe_cluster_versions(; aws_config::AbstractAWSConfig=global_aws_config())
-    return redshift("DescribeClusterVersions"; aws_config=aws_config)
+    return redshift(
+        "DescribeClusterVersions"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_cluster_versions(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return redshift("DescribeClusterVersions", params; aws_config=aws_config)
+    return redshift(
+        "DescribeClusterVersions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2716,12 +2880,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   have either or both of these tag values associated with them.
 """
 function describe_clusters(; aws_config::AbstractAWSConfig=global_aws_config())
-    return redshift("DescribeClusters"; aws_config=aws_config)
+    return redshift(
+        "DescribeClusters"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_clusters(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return redshift("DescribeClusters", params; aws_config=aws_config)
+    return redshift(
+        "DescribeClusters", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -2744,12 +2912,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   retrying the command with the returned marker value.
 """
 function describe_data_shares(; aws_config::AbstractAWSConfig=global_aws_config())
-    return redshift("DescribeDataShares"; aws_config=aws_config)
+    return redshift(
+        "DescribeDataShares"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_data_shares(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return redshift("DescribeDataShares", params; aws_config=aws_config)
+    return redshift(
+        "DescribeDataShares", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -2779,12 +2951,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_data_shares_for_consumer(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return redshift("DescribeDataSharesForConsumer"; aws_config=aws_config)
+    return redshift(
+        "DescribeDataSharesForConsumer";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_data_shares_for_consumer(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return redshift("DescribeDataSharesForConsumer", params; aws_config=aws_config)
+    return redshift(
+        "DescribeDataSharesForConsumer",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2813,12 +2994,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_data_shares_for_producer(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return redshift("DescribeDataSharesForProducer"; aws_config=aws_config)
+    return redshift(
+        "DescribeDataSharesForProducer";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_data_shares_for_producer(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return redshift("DescribeDataSharesForProducer", params; aws_config=aws_config)
+    return redshift(
+        "DescribeDataSharesForProducer",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2852,6 +3042,7 @@ function describe_default_cluster_parameters(
         "DescribeDefaultClusterParameters",
         Dict{String,Any}("ParameterGroupFamily" => ParameterGroupFamily);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_default_cluster_parameters(
@@ -2869,6 +3060,7 @@ function describe_default_cluster_parameters(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2892,12 +3084,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"VpcId"`: The virtual private cloud (VPC) identifier with access to the cluster.
 """
 function describe_endpoint_access(; aws_config::AbstractAWSConfig=global_aws_config())
-    return redshift("DescribeEndpointAccess"; aws_config=aws_config)
+    return redshift(
+        "DescribeEndpointAccess"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_endpoint_access(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return redshift("DescribeEndpointAccess", params; aws_config=aws_config)
+    return redshift(
+        "DescribeEndpointAccess",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2925,12 +3124,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_endpoint_authorization(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return redshift("DescribeEndpointAuthorization"; aws_config=aws_config)
+    return redshift(
+        "DescribeEndpointAuthorization";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_endpoint_authorization(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return redshift("DescribeEndpointAuthorization", params; aws_config=aws_config)
+    return redshift(
+        "DescribeEndpointAuthorization",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2948,12 +3156,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   cluster-parameter-group, cluster-security-group, and scheduled-action.
 """
 function describe_event_categories(; aws_config::AbstractAWSConfig=global_aws_config())
-    return redshift("DescribeEventCategories"; aws_config=aws_config)
+    return redshift(
+        "DescribeEventCategories"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_event_categories(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return redshift("DescribeEventCategories", params; aws_config=aws_config)
+    return redshift(
+        "DescribeEventCategories",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2996,12 +3211,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   with them.
 """
 function describe_event_subscriptions(; aws_config::AbstractAWSConfig=global_aws_config())
-    return redshift("DescribeEventSubscriptions"; aws_config=aws_config)
+    return redshift(
+        "DescribeEventSubscriptions"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_event_subscriptions(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return redshift("DescribeEventSubscriptions", params; aws_config=aws_config)
+    return redshift(
+        "DescribeEventSubscriptions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -3049,12 +3271,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Example: 2009-07-08T18:00Z
 """
 function describe_events(; aws_config::AbstractAWSConfig=global_aws_config())
-    return redshift("DescribeEvents"; aws_config=aws_config)
+    return redshift(
+        "DescribeEvents"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_events(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return redshift("DescribeEvents", params; aws_config=aws_config)
+    return redshift(
+        "DescribeEvents", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -3101,12 +3327,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_hsm_client_certificates(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return redshift("DescribeHsmClientCertificates"; aws_config=aws_config)
+    return redshift(
+        "DescribeHsmClientCertificates";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_hsm_client_certificates(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return redshift("DescribeHsmClientCertificates", params; aws_config=aws_config)
+    return redshift(
+        "DescribeHsmClientCertificates",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -3151,12 +3386,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   them.
 """
 function describe_hsm_configurations(; aws_config::AbstractAWSConfig=global_aws_config())
-    return redshift("DescribeHsmConfigurations"; aws_config=aws_config)
+    return redshift(
+        "DescribeHsmConfigurations"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_hsm_configurations(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return redshift("DescribeHsmConfigurations", params; aws_config=aws_config)
+    return redshift(
+        "DescribeHsmConfigurations",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -3178,6 +3420,7 @@ function describe_logging_status(
         "DescribeLoggingStatus",
         Dict{String,Any}("ClusterIdentifier" => ClusterIdentifier);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_logging_status(
@@ -3193,6 +3436,7 @@ function describe_logging_status(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3237,6 +3481,7 @@ function describe_node_configuration_options(
         "DescribeNodeConfigurationOptions",
         Dict{String,Any}("ActionType" => ActionType);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_node_configuration_options(
@@ -3250,6 +3495,7 @@ function describe_node_configuration_options(
             mergewith(_merge, Dict{String,Any}("ActionType" => ActionType), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3286,12 +3532,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_orderable_cluster_options(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return redshift("DescribeOrderableClusterOptions"; aws_config=aws_config)
+    return redshift(
+        "DescribeOrderableClusterOptions";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_orderable_cluster_options(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return redshift("DescribeOrderableClusterOptions", params; aws_config=aws_config)
+    return redshift(
+        "DescribeOrderableClusterOptions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -3321,6 +3576,7 @@ function describe_partners(
             "AccountId" => AccountId, "ClusterIdentifier" => ClusterIdentifier
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_partners(
@@ -3341,6 +3597,7 @@ function describe_partners(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3373,12 +3630,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_reserved_node_offerings(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return redshift("DescribeReservedNodeOfferings"; aws_config=aws_config)
+    return redshift(
+        "DescribeReservedNodeOfferings";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_reserved_node_offerings(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return redshift("DescribeReservedNodeOfferings", params; aws_config=aws_config)
+    return redshift(
+        "DescribeReservedNodeOfferings",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -3402,12 +3668,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"ReservedNodeId"`: Identifier for the node reservation.
 """
 function describe_reserved_nodes(; aws_config::AbstractAWSConfig=global_aws_config())
-    return redshift("DescribeReservedNodes"; aws_config=aws_config)
+    return redshift(
+        "DescribeReservedNodes"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_reserved_nodes(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return redshift("DescribeReservedNodes", params; aws_config=aws_config)
+    return redshift(
+        "DescribeReservedNodes",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -3433,6 +3706,7 @@ function describe_resize(
         "DescribeResize",
         Dict{String,Any}("ClusterIdentifier" => ClusterIdentifier);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_resize(
@@ -3448,6 +3722,7 @@ function describe_resize(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3480,12 +3755,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"TargetActionType"`: The type of the scheduled actions to retrieve.
 """
 function describe_scheduled_actions(; aws_config::AbstractAWSConfig=global_aws_config())
-    return redshift("DescribeScheduledActions"; aws_config=aws_config)
+    return redshift(
+        "DescribeScheduledActions"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_scheduled_actions(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return redshift("DescribeScheduledActions", params; aws_config=aws_config)
+    return redshift(
+        "DescribeScheduledActions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -3522,12 +3804,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   both of these tag values associated with them.
 """
 function describe_snapshot_copy_grants(; aws_config::AbstractAWSConfig=global_aws_config())
-    return redshift("DescribeSnapshotCopyGrants"; aws_config=aws_config)
+    return redshift(
+        "DescribeSnapshotCopyGrants"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_snapshot_copy_grants(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return redshift("DescribeSnapshotCopyGrants", params; aws_config=aws_config)
+    return redshift(
+        "DescribeSnapshotCopyGrants",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -3554,12 +3843,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"TagValues"`: The value corresponding to the key of the snapshot schedule tag.
 """
 function describe_snapshot_schedules(; aws_config::AbstractAWSConfig=global_aws_config())
-    return redshift("DescribeSnapshotSchedules"; aws_config=aws_config)
+    return redshift(
+        "DescribeSnapshotSchedules"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_snapshot_schedules(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return redshift("DescribeSnapshotSchedules", params; aws_config=aws_config)
+    return redshift(
+        "DescribeSnapshotSchedules",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -3570,12 +3866,16 @@ Returns account level backups storage size and provisional storage.
 
 """
 function describe_storage(; aws_config::AbstractAWSConfig=global_aws_config())
-    return redshift("DescribeStorage"; aws_config=aws_config)
+    return redshift(
+        "DescribeStorage"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_storage(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return redshift("DescribeStorage", params; aws_config=aws_config)
+    return redshift(
+        "DescribeStorage", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -3603,12 +3903,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   returns the status of all in-progress table restore requests.
 """
 function describe_table_restore_status(; aws_config::AbstractAWSConfig=global_aws_config())
-    return redshift("DescribeTableRestoreStatus"; aws_config=aws_config)
+    return redshift(
+        "DescribeTableRestoreStatus"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_table_restore_status(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return redshift("DescribeTableRestoreStatus", params; aws_config=aws_config)
+    return redshift(
+        "DescribeTableRestoreStatus",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -3659,12 +3966,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   both of these tag values associated with them.
 """
 function describe_tags(; aws_config::AbstractAWSConfig=global_aws_config())
-    return redshift("DescribeTags"; aws_config=aws_config)
+    return redshift("DescribeTags"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function describe_tags(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return redshift("DescribeTags", params; aws_config=aws_config)
+    return redshift(
+        "DescribeTags", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -3709,12 +4018,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"UsageLimitId"`: The identifier of the usage limit to describe.
 """
 function describe_usage_limits(; aws_config::AbstractAWSConfig=global_aws_config())
-    return redshift("DescribeUsageLimits"; aws_config=aws_config)
+    return redshift(
+        "DescribeUsageLimits"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_usage_limits(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return redshift("DescribeUsageLimits", params; aws_config=aws_config)
+    return redshift(
+        "DescribeUsageLimits",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -3736,6 +4052,7 @@ function disable_logging(
         "DisableLogging",
         Dict{String,Any}("ClusterIdentifier" => ClusterIdentifier);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disable_logging(
@@ -3751,6 +4068,7 @@ function disable_logging(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3776,6 +4094,7 @@ function disable_snapshot_copy(
         "DisableSnapshotCopy",
         Dict{String,Any}("ClusterIdentifier" => ClusterIdentifier);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disable_snapshot_copy(
@@ -3791,6 +4110,7 @@ function disable_snapshot_copy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3818,6 +4138,7 @@ function disassociate_data_share_consumer(
         "DisassociateDataShareConsumer",
         Dict{String,Any}("DataShareArn" => DataShareArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disassociate_data_share_consumer(
@@ -3831,6 +4152,7 @@ function disassociate_data_share_consumer(
             mergewith(_merge, Dict{String,Any}("DataShareArn" => DataShareArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3864,6 +4186,7 @@ function enable_logging(
             "BucketName" => BucketName, "ClusterIdentifier" => ClusterIdentifier
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function enable_logging(
@@ -3884,6 +4207,7 @@ function enable_logging(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3924,6 +4248,7 @@ function enable_snapshot_copy(
             "DestinationRegion" => DestinationRegion,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function enable_snapshot_copy(
@@ -3945,6 +4270,7 @@ function enable_snapshot_copy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4014,6 +4340,7 @@ function get_cluster_credentials(
         "GetClusterCredentials",
         Dict{String,Any}("ClusterIdentifier" => ClusterIdentifier, "DbUser" => DbUser);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_cluster_credentials(
@@ -4034,6 +4361,7 @@ function get_cluster_credentials(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4062,6 +4390,7 @@ function get_reserved_node_exchange_offerings(
         "GetReservedNodeExchangeOfferings",
         Dict{String,Any}("ReservedNodeId" => ReservedNodeId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_reserved_node_exchange_offerings(
@@ -4075,6 +4404,7 @@ function get_reserved_node_exchange_offerings(
             mergewith(_merge, Dict{String,Any}("ReservedNodeId" => ReservedNodeId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4101,6 +4431,7 @@ function modify_aqua_configuration(
         "ModifyAquaConfiguration",
         Dict{String,Any}("ClusterIdentifier" => ClusterIdentifier);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_aqua_configuration(
@@ -4116,6 +4447,7 @@ function modify_aqua_configuration(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4143,6 +4475,7 @@ function modify_authentication_profile(
             "AuthenticationProfileName" => AuthenticationProfileName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_authentication_profile(
@@ -4164,6 +4497,7 @@ function modify_authentication_profile(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4295,6 +4629,7 @@ function modify_cluster(
         "ModifyCluster",
         Dict{String,Any}("ClusterIdentifier" => ClusterIdentifier);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_cluster(
@@ -4310,6 +4645,7 @@ function modify_cluster(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4336,6 +4672,7 @@ function modify_cluster_db_revision(
             "ClusterIdentifier" => ClusterIdentifier, "RevisionTarget" => RevisionTarget
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_cluster_db_revision(
@@ -4357,6 +4694,7 @@ function modify_cluster_db_revision(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4387,6 +4725,7 @@ function modify_cluster_iam_roles(
         "ModifyClusterIamRoles",
         Dict{String,Any}("ClusterIdentifier" => ClusterIdentifier);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_cluster_iam_roles(
@@ -4402,6 +4741,7 @@ function modify_cluster_iam_roles(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4434,6 +4774,7 @@ function modify_cluster_maintenance(
         "ModifyClusterMaintenance",
         Dict{String,Any}("ClusterIdentifier" => ClusterIdentifier);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_cluster_maintenance(
@@ -4449,6 +4790,7 @@ function modify_cluster_maintenance(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4485,6 +4827,7 @@ function modify_cluster_parameter_group(
             "Parameter" => Parameter, "ParameterGroupName" => ParameterGroupName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_cluster_parameter_group(
@@ -4505,6 +4848,7 @@ function modify_cluster_parameter_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4534,6 +4878,7 @@ function modify_cluster_snapshot(
         "ModifyClusterSnapshot",
         Dict{String,Any}("SnapshotIdentifier" => SnapshotIdentifier);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_cluster_snapshot(
@@ -4549,6 +4894,7 @@ function modify_cluster_snapshot(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4576,6 +4922,7 @@ function modify_cluster_snapshot_schedule(
         "ModifyClusterSnapshotSchedule",
         Dict{String,Any}("ClusterIdentifier" => ClusterIdentifier);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_cluster_snapshot_schedule(
@@ -4591,6 +4938,7 @@ function modify_cluster_snapshot_schedule(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4624,6 +4972,7 @@ function modify_cluster_subnet_group(
             "SubnetIdentifier" => SubnetIdentifier,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_cluster_subnet_group(
@@ -4645,6 +4994,7 @@ function modify_cluster_subnet_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4669,6 +5019,7 @@ function modify_endpoint_access(
         "ModifyEndpointAccess",
         Dict{String,Any}("EndpointName" => EndpointName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_endpoint_access(
@@ -4682,6 +5033,7 @@ function modify_endpoint_access(
             mergewith(_merge, Dict{String,Any}("EndpointName" => EndpointName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4725,6 +5077,7 @@ function modify_event_subscription(
         "ModifyEventSubscription",
         Dict{String,Any}("SubscriptionName" => SubscriptionName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_event_subscription(
@@ -4740,6 +5093,7 @@ function modify_event_subscription(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4775,6 +5129,7 @@ function modify_scheduled_action(
         "ModifyScheduledAction",
         Dict{String,Any}("ScheduledActionName" => ScheduledActionName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_scheduled_action(
@@ -4792,6 +5147,7 @@ function modify_scheduled_action(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4838,6 +5194,7 @@ function modify_snapshot_copy_retention_period(
             "ClusterIdentifier" => ClusterIdentifier, "RetentionPeriod" => RetentionPeriod
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_snapshot_copy_retention_period(
@@ -4859,6 +5216,7 @@ function modify_snapshot_copy_retention_period(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4891,6 +5249,7 @@ function modify_snapshot_schedule(
             "ScheduleIdentifier" => ScheduleIdentifier,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_snapshot_schedule(
@@ -4912,6 +5271,7 @@ function modify_snapshot_schedule(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4937,6 +5297,7 @@ function modify_usage_limit(UsageLimitId; aws_config::AbstractAWSConfig=global_a
         "ModifyUsageLimit",
         Dict{String,Any}("UsageLimitId" => UsageLimitId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_usage_limit(
@@ -4950,6 +5311,7 @@ function modify_usage_limit(
             mergewith(_merge, Dict{String,Any}("UsageLimitId" => UsageLimitId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4968,6 +5330,7 @@ function pause_cluster(ClusterIdentifier; aws_config::AbstractAWSConfig=global_a
         "PauseCluster",
         Dict{String,Any}("ClusterIdentifier" => ClusterIdentifier);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function pause_cluster(
@@ -4983,6 +5346,7 @@ function pause_cluster(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5012,6 +5376,7 @@ function purchase_reserved_node_offering(
         "PurchaseReservedNodeOffering",
         Dict{String,Any}("ReservedNodeOfferingId" => ReservedNodeOfferingId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function purchase_reserved_node_offering(
@@ -5029,6 +5394,7 @@ function purchase_reserved_node_offering(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5053,6 +5419,7 @@ function reboot_cluster(
         "RebootCluster",
         Dict{String,Any}("ClusterIdentifier" => ClusterIdentifier);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function reboot_cluster(
@@ -5068,6 +5435,7 @@ function reboot_cluster(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5086,6 +5454,7 @@ function reject_data_share(DataShareArn; aws_config::AbstractAWSConfig=global_aw
         "RejectDataShare",
         Dict{String,Any}("DataShareArn" => DataShareArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function reject_data_share(
@@ -5099,6 +5468,7 @@ function reject_data_share(
             mergewith(_merge, Dict{String,Any}("DataShareArn" => DataShareArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5129,6 +5499,7 @@ function reset_cluster_parameter_group(
         "ResetClusterParameterGroup",
         Dict{String,Any}("ParameterGroupName" => ParameterGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function reset_cluster_parameter_group(
@@ -5144,6 +5515,7 @@ function reset_cluster_parameter_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5181,6 +5553,7 @@ function resize_cluster(
         "ResizeCluster",
         Dict{String,Any}("ClusterIdentifier" => ClusterIdentifier);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function resize_cluster(
@@ -5196,6 +5569,7 @@ function resize_cluster(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5321,6 +5695,7 @@ function restore_from_cluster_snapshot(
             "SnapshotIdentifier" => SnapshotIdentifier,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function restore_from_cluster_snapshot(
@@ -5342,6 +5717,7 @@ function restore_from_cluster_snapshot(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5399,6 +5775,7 @@ function restore_table_from_cluster_snapshot(
             "SourceTableName" => SourceTableName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function restore_table_from_cluster_snapshot(
@@ -5426,6 +5803,7 @@ function restore_table_from_cluster_snapshot(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5446,6 +5824,7 @@ function resume_cluster(
         "ResumeCluster",
         Dict{String,Any}("ClusterIdentifier" => ClusterIdentifier);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function resume_cluster(
@@ -5461,6 +5840,7 @@ function resume_cluster(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5498,6 +5878,7 @@ function revoke_cluster_security_group_ingress(
         "RevokeClusterSecurityGroupIngress",
         Dict{String,Any}("ClusterSecurityGroupName" => ClusterSecurityGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function revoke_cluster_security_group_ingress(
@@ -5515,6 +5896,7 @@ function revoke_cluster_security_group_ingress(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5533,12 +5915,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"VpcIds"`: The virtual private cloud (VPC) identifiers for which access is to be revoked.
 """
 function revoke_endpoint_access(; aws_config::AbstractAWSConfig=global_aws_config())
-    return redshift("RevokeEndpointAccess"; aws_config=aws_config)
+    return redshift(
+        "RevokeEndpointAccess"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function revoke_endpoint_access(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return redshift("RevokeEndpointAccess", params; aws_config=aws_config)
+    return redshift(
+        "RevokeEndpointAccess",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -5574,6 +5963,7 @@ function revoke_snapshot_access(
             "SnapshotIdentifier" => SnapshotIdentifier,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function revoke_snapshot_access(
@@ -5595,6 +5985,7 @@ function revoke_snapshot_access(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5617,6 +6008,7 @@ function rotate_encryption_key(
         "RotateEncryptionKey",
         Dict{String,Any}("ClusterIdentifier" => ClusterIdentifier);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function rotate_encryption_key(
@@ -5632,6 +6024,7 @@ function rotate_encryption_key(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5672,6 +6065,7 @@ function update_partner_status(
             "Status" => Status,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_partner_status(
@@ -5699,5 +6093,6 @@ function update_partner_status(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/redshift_data.jl
+++ b/src/services/redshift_data.jl
@@ -43,6 +43,7 @@ function batch_execute_statement(
             "ClusterIdentifier" => ClusterIdentifier, "Database" => Database, "Sqls" => Sqls
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_execute_statement(
@@ -66,6 +67,7 @@ function batch_execute_statement(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -83,7 +85,10 @@ Cancels a running query. To be canceled, a query must be running.
 """
 function cancel_statement(Id; aws_config::AbstractAWSConfig=global_aws_config())
     return redshift_data(
-        "CancelStatement", Dict{String,Any}("Id" => Id); aws_config=aws_config
+        "CancelStatement",
+        Dict{String,Any}("Id" => Id);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function cancel_statement(
@@ -93,6 +98,7 @@ function cancel_statement(
         "CancelStatement",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Id" => Id), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -114,7 +120,10 @@ status, the number of rows returned, and the SQL statement.
 """
 function describe_statement(Id; aws_config::AbstractAWSConfig=global_aws_config())
     return redshift_data(
-        "DescribeStatement", Dict{String,Any}("Id" => Id); aws_config=aws_config
+        "DescribeStatement",
+        Dict{String,Any}("Id" => Id);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_statement(
@@ -124,6 +133,7 @@ function describe_statement(
         "DescribeStatement",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Id" => Id), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -175,6 +185,7 @@ function describe_table(
         "DescribeTable",
         Dict{String,Any}("ClusterIdentifier" => ClusterIdentifier, "Database" => Database);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_table(
@@ -195,6 +206,7 @@ function describe_table(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -238,6 +250,7 @@ function execute_statement(
             "ClusterIdentifier" => ClusterIdentifier, "Database" => Database, "Sql" => Sql
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function execute_statement(
@@ -261,6 +274,7 @@ function execute_statement(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -289,7 +303,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function get_statement_result(Id; aws_config::AbstractAWSConfig=global_aws_config())
     return redshift_data(
-        "GetStatementResult", Dict{String,Any}("Id" => Id); aws_config=aws_config
+        "GetStatementResult",
+        Dict{String,Any}("Id" => Id);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_statement_result(
@@ -299,6 +316,7 @@ function get_statement_result(
         "GetStatementResult",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Id" => Id), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -342,6 +360,7 @@ function list_databases(
         "ListDatabases",
         Dict{String,Any}("ClusterIdentifier" => ClusterIdentifier, "Database" => Database);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_databases(
@@ -362,6 +381,7 @@ function list_databases(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -410,6 +430,7 @@ function list_schemas(
         "ListSchemas",
         Dict{String,Any}("ClusterIdentifier" => ClusterIdentifier, "Database" => Database);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_schemas(
@@ -430,6 +451,7 @@ function list_schemas(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -467,12 +489,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   submitted, but not yet processed.
 """
 function list_statements(; aws_config::AbstractAWSConfig=global_aws_config())
-    return redshift_data("ListStatements"; aws_config=aws_config)
+    return redshift_data(
+        "ListStatements"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_statements(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return redshift_data("ListStatements", params; aws_config=aws_config)
+    return redshift_data(
+        "ListStatements", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -528,6 +554,7 @@ function list_tables(
         "ListTables",
         Dict{String,Any}("ClusterIdentifier" => ClusterIdentifier, "Database" => Database);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tables(
@@ -548,5 +575,6 @@ function list_tables(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/rekognition.jl
+++ b/src/services/rekognition.jl
@@ -76,6 +76,7 @@ function compare_faces(
         "CompareFaces",
         Dict{String,Any}("SourceImage" => SourceImage, "TargetImage" => TargetImage);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function compare_faces(
@@ -96,6 +97,7 @@ function compare_faces(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -125,6 +127,7 @@ function create_collection(CollectionId; aws_config::AbstractAWSConfig=global_aw
         "CreateCollection",
         Dict{String,Any}("CollectionId" => CollectionId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_collection(
@@ -138,6 +141,7 @@ function create_collection(
             mergewith(_merge, Dict{String,Any}("CollectionId" => CollectionId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -158,6 +162,7 @@ function create_project(ProjectName; aws_config::AbstractAWSConfig=global_aws_co
         "CreateProject",
         Dict{String,Any}("ProjectName" => ProjectName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_project(
@@ -171,6 +176,7 @@ function create_project(
             mergewith(_merge, Dict{String,Any}("ProjectName" => ProjectName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -228,6 +234,7 @@ function create_project_version(
             "VersionName" => VersionName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_project_version(
@@ -255,6 +262,7 @@ function create_project_version(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -311,6 +319,7 @@ function create_stream_processor(
             "Settings" => Settings,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_stream_processor(
@@ -338,6 +347,7 @@ function create_stream_processor(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -358,6 +368,7 @@ function delete_collection(CollectionId; aws_config::AbstractAWSConfig=global_aw
         "DeleteCollection",
         Dict{String,Any}("CollectionId" => CollectionId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_collection(
@@ -371,6 +382,7 @@ function delete_collection(
             mergewith(_merge, Dict{String,Any}("CollectionId" => CollectionId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -394,6 +406,7 @@ function delete_faces(
         "DeleteFaces",
         Dict{String,Any}("CollectionId" => CollectionId, "FaceIds" => FaceIds);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_faces(
@@ -412,6 +425,7 @@ function delete_faces(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -429,7 +443,10 @@ This operation requires permissions to perform the rekognition:DeleteProject act
 """
 function delete_project(ProjectArn; aws_config::AbstractAWSConfig=global_aws_config())
     return rekognition(
-        "DeleteProject", Dict{String,Any}("ProjectArn" => ProjectArn); aws_config=aws_config
+        "DeleteProject",
+        Dict{String,Any}("ProjectArn" => ProjectArn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_project(
@@ -443,6 +460,7 @@ function delete_project(
             mergewith(_merge, Dict{String,Any}("ProjectArn" => ProjectArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -468,6 +486,7 @@ function delete_project_version(
         "DeleteProjectVersion",
         Dict{String,Any}("ProjectVersionArn" => ProjectVersionArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_project_version(
@@ -483,6 +502,7 @@ function delete_project_version(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -500,7 +520,10 @@ same name for a stream processor for a few seconds after calling DeleteStreamPro
 """
 function delete_stream_processor(Name; aws_config::AbstractAWSConfig=global_aws_config())
     return rekognition(
-        "DeleteStreamProcessor", Dict{String,Any}("Name" => Name); aws_config=aws_config
+        "DeleteStreamProcessor",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_stream_processor(
@@ -510,6 +533,7 @@ function delete_stream_processor(
         "DeleteStreamProcessor",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -533,6 +557,7 @@ function describe_collection(
         "DescribeCollection",
         Dict{String,Any}("CollectionId" => CollectionId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_collection(
@@ -546,6 +571,7 @@ function describe_collection(
             mergewith(_merge, Dict{String,Any}("CollectionId" => CollectionId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -584,6 +610,7 @@ function describe_project_versions(
         "DescribeProjectVersions",
         Dict{String,Any}("ProjectArn" => ProjectArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_project_versions(
@@ -597,6 +624,7 @@ function describe_project_versions(
             mergewith(_merge, Dict{String,Any}("ProjectArn" => ProjectArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -617,12 +645,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   can use this pagination token to retrieve the next set of results.
 """
 function describe_projects(; aws_config::AbstractAWSConfig=global_aws_config())
-    return rekognition("DescribeProjects"; aws_config=aws_config)
+    return rekognition(
+        "DescribeProjects"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_projects(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return rekognition("DescribeProjects", params; aws_config=aws_config)
+    return rekognition(
+        "DescribeProjects", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -639,7 +671,10 @@ recognition being performed, and the current status of the stream processor.
 """
 function describe_stream_processor(Name; aws_config::AbstractAWSConfig=global_aws_config())
     return rekognition(
-        "DescribeStreamProcessor", Dict{String,Any}("Name" => Name); aws_config=aws_config
+        "DescribeStreamProcessor",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_stream_processor(
@@ -649,6 +684,7 @@ function describe_stream_processor(
         "DescribeStreamProcessor",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -704,6 +740,7 @@ function detect_custom_labels(
         "DetectCustomLabels",
         Dict{String,Any}("Image" => Image, "ProjectVersionArn" => ProjectVersionArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function detect_custom_labels(
@@ -724,6 +761,7 @@ function detect_custom_labels(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -764,7 +802,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function detect_faces(Image; aws_config::AbstractAWSConfig=global_aws_config())
     return rekognition(
-        "DetectFaces", Dict{String,Any}("Image" => Image); aws_config=aws_config
+        "DetectFaces",
+        Dict{String,Any}("Image" => Image);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function detect_faces(
@@ -774,6 +815,7 @@ function detect_faces(
         "DetectFaces",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Image" => Image), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -835,7 +877,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function detect_labels(Image; aws_config::AbstractAWSConfig=global_aws_config())
     return rekognition(
-        "DetectLabels", Dict{String,Any}("Image" => Image); aws_config=aws_config
+        "DetectLabels",
+        Dict{String,Any}("Image" => Image);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function detect_labels(
@@ -845,6 +890,7 @@ function detect_labels(
         "DetectLabels",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Image" => Image), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -880,7 +926,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function detect_moderation_labels(Image; aws_config::AbstractAWSConfig=global_aws_config())
     return rekognition(
-        "DetectModerationLabels", Dict{String,Any}("Image" => Image); aws_config=aws_config
+        "DetectModerationLabels",
+        Dict{String,Any}("Image" => Image);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function detect_moderation_labels(
@@ -890,6 +939,7 @@ function detect_moderation_labels(
         "DetectModerationLabels",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Image" => Image), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -930,6 +980,7 @@ function detect_protective_equipment(
         "DetectProtectiveEquipment",
         Dict{String,Any}("Image" => Image);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function detect_protective_equipment(
@@ -939,6 +990,7 @@ function detect_protective_equipment(
         "DetectProtectiveEquipment",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Image" => Image), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -980,7 +1032,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function detect_text(Image; aws_config::AbstractAWSConfig=global_aws_config())
     return rekognition(
-        "DetectText", Dict{String,Any}("Image" => Image); aws_config=aws_config
+        "DetectText",
+        Dict{String,Any}("Image" => Image);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function detect_text(
@@ -990,6 +1045,7 @@ function detect_text(
         "DetectText",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Image" => Image), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1010,7 +1066,10 @@ operation requires permissions to perform the rekognition:GetCelebrityInfo actio
 """
 function get_celebrity_info(Id; aws_config::AbstractAWSConfig=global_aws_config())
     return rekognition(
-        "GetCelebrityInfo", Dict{String,Any}("Id" => Id); aws_config=aws_config
+        "GetCelebrityInfo",
+        Dict{String,Any}("Id" => Id);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_celebrity_info(
@@ -1020,6 +1079,7 @@ function get_celebrity_info(
         "GetCelebrityInfo",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Id" => Id), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1073,7 +1133,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function get_celebrity_recognition(JobId; aws_config::AbstractAWSConfig=global_aws_config())
     return rekognition(
-        "GetCelebrityRecognition", Dict{String,Any}("JobId" => JobId); aws_config=aws_config
+        "GetCelebrityRecognition",
+        Dict{String,Any}("JobId" => JobId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_celebrity_recognition(
@@ -1083,6 +1146,7 @@ function get_celebrity_recognition(
         "GetCelebrityRecognition",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("JobId" => JobId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1133,7 +1197,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function get_content_moderation(JobId; aws_config::AbstractAWSConfig=global_aws_config())
     return rekognition(
-        "GetContentModeration", Dict{String,Any}("JobId" => JobId); aws_config=aws_config
+        "GetContentModeration",
+        Dict{String,Any}("JobId" => JobId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_content_moderation(
@@ -1143,6 +1210,7 @@ function get_content_moderation(
         "GetContentModeration",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("JobId" => JobId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1180,7 +1248,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function get_face_detection(JobId; aws_config::AbstractAWSConfig=global_aws_config())
     return rekognition(
-        "GetFaceDetection", Dict{String,Any}("JobId" => JobId); aws_config=aws_config
+        "GetFaceDetection",
+        Dict{String,Any}("JobId" => JobId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_face_detection(
@@ -1190,6 +1261,7 @@ function get_face_detection(
         "GetFaceDetection",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("JobId" => JobId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1235,7 +1307,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function get_face_search(JobId; aws_config::AbstractAWSConfig=global_aws_config())
     return rekognition(
-        "GetFaceSearch", Dict{String,Any}("JobId" => JobId); aws_config=aws_config
+        "GetFaceSearch",
+        Dict{String,Any}("JobId" => JobId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_face_search(
@@ -1245,6 +1320,7 @@ function get_face_search(
         "GetFaceSearch",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("JobId" => JobId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1291,7 +1367,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function get_label_detection(JobId; aws_config::AbstractAWSConfig=global_aws_config())
     return rekognition(
-        "GetLabelDetection", Dict{String,Any}("JobId" => JobId); aws_config=aws_config
+        "GetLabelDetection",
+        Dict{String,Any}("JobId" => JobId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_label_detection(
@@ -1301,6 +1380,7 @@ function get_label_detection(
         "GetLabelDetection",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("JobId" => JobId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1347,7 +1427,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function get_person_tracking(JobId; aws_config::AbstractAWSConfig=global_aws_config())
     return rekognition(
-        "GetPersonTracking", Dict{String,Any}("JobId" => JobId); aws_config=aws_config
+        "GetPersonTracking",
+        Dict{String,Any}("JobId" => JobId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_person_tracking(
@@ -1357,6 +1440,7 @@ function get_person_tracking(
         "GetPersonTracking",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("JobId" => JobId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1399,7 +1483,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function get_segment_detection(JobId; aws_config::AbstractAWSConfig=global_aws_config())
     return rekognition(
-        "GetSegmentDetection", Dict{String,Any}("JobId" => JobId); aws_config=aws_config
+        "GetSegmentDetection",
+        Dict{String,Any}("JobId" => JobId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_segment_detection(
@@ -1409,6 +1496,7 @@ function get_segment_detection(
         "GetSegmentDetection",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("JobId" => JobId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1449,7 +1537,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function get_text_detection(JobId; aws_config::AbstractAWSConfig=global_aws_config())
     return rekognition(
-        "GetTextDetection", Dict{String,Any}("JobId" => JobId); aws_config=aws_config
+        "GetTextDetection",
+        Dict{String,Any}("JobId" => JobId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_text_detection(
@@ -1459,6 +1550,7 @@ function get_text_detection(
         "GetTextDetection",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("JobId" => JobId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1560,6 +1652,7 @@ function index_faces(CollectionId, Image; aws_config::AbstractAWSConfig=global_a
         "IndexFaces",
         Dict{String,Any}("CollectionId" => CollectionId, "Image" => Image);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function index_faces(
@@ -1578,6 +1671,7 @@ function index_faces(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1597,12 +1691,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`: Pagination token from the previous response.
 """
 function list_collections(; aws_config::AbstractAWSConfig=global_aws_config())
-    return rekognition("ListCollections"; aws_config=aws_config)
+    return rekognition(
+        "ListCollections"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_collections(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return rekognition("ListCollections", params; aws_config=aws_config)
+    return rekognition(
+        "ListCollections", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1627,7 +1725,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function list_faces(CollectionId; aws_config::AbstractAWSConfig=global_aws_config())
     return rekognition(
-        "ListFaces", Dict{String,Any}("CollectionId" => CollectionId); aws_config=aws_config
+        "ListFaces",
+        Dict{String,Any}("CollectionId" => CollectionId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_faces(
@@ -1641,6 +1742,7 @@ function list_faces(
             mergewith(_merge, Dict{String,Any}("CollectionId" => CollectionId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1659,12 +1761,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   response. You can use this pagination token to retrieve the next set of stream processors.
 """
 function list_stream_processors(; aws_config::AbstractAWSConfig=global_aws_config())
-    return rekognition("ListStreamProcessors"; aws_config=aws_config)
+    return rekognition(
+        "ListStreamProcessors"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_stream_processors(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return rekognition("ListStreamProcessors", params; aws_config=aws_config)
+    return rekognition(
+        "ListStreamProcessors",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1687,6 +1796,7 @@ function list_tags_for_resource(
         "ListTagsForResource",
         Dict{String,Any}("ResourceArn" => ResourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags_for_resource(
@@ -1700,6 +1810,7 @@ function list_tags_for_resource(
             mergewith(_merge, Dict{String,Any}("ResourceArn" => ResourceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1737,7 +1848,10 @@ operation.
 """
 function recognize_celebrities(Image; aws_config::AbstractAWSConfig=global_aws_config())
     return rekognition(
-        "RecognizeCelebrities", Dict{String,Any}("Image" => Image); aws_config=aws_config
+        "RecognizeCelebrities",
+        Dict{String,Any}("Image" => Image);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function recognize_celebrities(
@@ -1747,6 +1861,7 @@ function recognize_celebrities(
         "RecognizeCelebrities",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Image" => Image), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1785,6 +1900,7 @@ function search_faces(
         "SearchFaces",
         Dict{String,Any}("CollectionId" => CollectionId, "FaceId" => FaceId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function search_faces(
@@ -1803,6 +1919,7 @@ function search_faces(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1868,6 +1985,7 @@ function search_faces_by_image(
         "SearchFacesByImage",
         Dict{String,Any}("CollectionId" => CollectionId, "Image" => Image);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function search_faces_by_image(
@@ -1886,6 +2004,7 @@ function search_faces_by_image(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1929,6 +2048,7 @@ function start_celebrity_recognition(
         "StartCelebrityRecognition",
         Dict{String,Any}("Video" => Video);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_celebrity_recognition(
@@ -1938,6 +2058,7 @@ function start_celebrity_recognition(
         "StartCelebrityRecognition",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Video" => Video), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1985,7 +2106,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function start_content_moderation(Video; aws_config::AbstractAWSConfig=global_aws_config())
     return rekognition(
-        "StartContentModeration", Dict{String,Any}("Video" => Video); aws_config=aws_config
+        "StartContentModeration",
+        Dict{String,Any}("Video" => Video);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_content_moderation(
@@ -1995,6 +2119,7 @@ function start_content_moderation(
         "StartContentModeration",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Video" => Video), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2035,7 +2160,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function start_face_detection(Video; aws_config::AbstractAWSConfig=global_aws_config())
     return rekognition(
-        "StartFaceDetection", Dict{String,Any}("Video" => Video); aws_config=aws_config
+        "StartFaceDetection",
+        Dict{String,Any}("Video" => Video);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_face_detection(
@@ -2045,6 +2173,7 @@ function start_face_detection(
         "StartFaceDetection",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Video" => Video), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2089,6 +2218,7 @@ function start_face_search(
         "StartFaceSearch",
         Dict{String,Any}("CollectionId" => CollectionId, "Video" => Video);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_face_search(
@@ -2107,6 +2237,7 @@ function start_face_search(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2152,7 +2283,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function start_label_detection(Video; aws_config::AbstractAWSConfig=global_aws_config())
     return rekognition(
-        "StartLabelDetection", Dict{String,Any}("Video" => Video); aws_config=aws_config
+        "StartLabelDetection",
+        Dict{String,Any}("Video" => Video);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_label_detection(
@@ -2162,6 +2296,7 @@ function start_label_detection(
         "StartLabelDetection",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Video" => Video), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2198,7 +2333,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function start_person_tracking(Video; aws_config::AbstractAWSConfig=global_aws_config())
     return rekognition(
-        "StartPersonTracking", Dict{String,Any}("Video" => Video); aws_config=aws_config
+        "StartPersonTracking",
+        Dict{String,Any}("Video" => Video);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_person_tracking(
@@ -2208,6 +2346,7 @@ function start_person_tracking(
         "StartPersonTracking",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Video" => Video), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2241,6 +2380,7 @@ function start_project_version(
             "ProjectVersionArn" => ProjectVersionArn,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_project_version(
@@ -2262,6 +2402,7 @@ function start_project_version(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2311,6 +2452,7 @@ function start_segment_detection(
         "StartSegmentDetection",
         Dict{String,Any}("SegmentTypes" => SegmentTypes, "Video" => Video);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_segment_detection(
@@ -2329,6 +2471,7 @@ function start_segment_detection(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2346,7 +2489,10 @@ the value of the Name field specified in the call to CreateStreamProcessor.
 """
 function start_stream_processor(Name; aws_config::AbstractAWSConfig=global_aws_config())
     return rekognition(
-        "StartStreamProcessor", Dict{String,Any}("Name" => Name); aws_config=aws_config
+        "StartStreamProcessor",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_stream_processor(
@@ -2356,6 +2502,7 @@ function start_stream_processor(
         "StartStreamProcessor",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2390,7 +2537,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function start_text_detection(Video; aws_config::AbstractAWSConfig=global_aws_config())
     return rekognition(
-        "StartTextDetection", Dict{String,Any}("Video" => Video); aws_config=aws_config
+        "StartTextDetection",
+        Dict{String,Any}("Video" => Video);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_text_detection(
@@ -2400,6 +2550,7 @@ function start_text_detection(
         "StartTextDetection",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Video" => Video), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2423,6 +2574,7 @@ function stop_project_version(
         "StopProjectVersion",
         Dict{String,Any}("ProjectVersionArn" => ProjectVersionArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function stop_project_version(
@@ -2438,6 +2590,7 @@ function stop_project_version(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2453,7 +2606,10 @@ Stops a running stream processor that was created by CreateStreamProcessor.
 """
 function stop_stream_processor(Name; aws_config::AbstractAWSConfig=global_aws_config())
     return rekognition(
-        "StopStreamProcessor", Dict{String,Any}("Name" => Name); aws_config=aws_config
+        "StopStreamProcessor",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function stop_stream_processor(
@@ -2463,6 +2619,7 @@ function stop_stream_processor(
         "StopStreamProcessor",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2485,6 +2642,7 @@ function tag_resource(ResourceArn, Tags; aws_config::AbstractAWSConfig=global_aw
         "TagResource",
         Dict{String,Any}("ResourceArn" => ResourceArn, "Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -2503,6 +2661,7 @@ function tag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2527,6 +2686,7 @@ function untag_resource(
         "UntagResource",
         Dict{String,Any}("ResourceArn" => ResourceArn, "TagKeys" => TagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -2545,5 +2705,6 @@ function untag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/resource_groups.jl
+++ b/src/services/resource_groups.jl
@@ -39,7 +39,11 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function create_group(Name; aws_config::AbstractAWSConfig=global_aws_config())
     return resource_groups(
-        "POST", "/groups", Dict{String,Any}("Name" => Name); aws_config=aws_config
+        "POST",
+        "/groups",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_group(
@@ -50,6 +54,7 @@ function create_group(
         "/groups",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -68,12 +73,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"GroupName"`: Deprecated - don't use this parameter. Use Group instead.
 """
 function delete_group(; aws_config::AbstractAWSConfig=global_aws_config())
-    return resource_groups("POST", "/delete-group"; aws_config=aws_config)
+    return resource_groups(
+        "POST", "/delete-group"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function delete_group(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return resource_groups("POST", "/delete-group", params; aws_config=aws_config)
+    return resource_groups(
+        "POST",
+        "/delete-group",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -89,12 +102,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"GroupName"`: Deprecated - don't use this parameter. Use Group instead.
 """
 function get_group(; aws_config::AbstractAWSConfig=global_aws_config())
-    return resource_groups("POST", "/get-group"; aws_config=aws_config)
+    return resource_groups(
+        "POST", "/get-group"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_group(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return resource_groups("POST", "/get-group", params; aws_config=aws_config)
+    return resource_groups(
+        "POST", "/get-group", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -111,13 +128,22 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"Group"`: The name or the ARN of the resource group.
 """
 function get_group_configuration(; aws_config::AbstractAWSConfig=global_aws_config())
-    return resource_groups("POST", "/get-group-configuration"; aws_config=aws_config)
+    return resource_groups(
+        "POST",
+        "/get-group-configuration";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_group_configuration(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return resource_groups(
-        "POST", "/get-group-configuration", params; aws_config=aws_config
+        "POST",
+        "/get-group-configuration",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -136,12 +162,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"GroupName"`: Don't use this parameter. Use Group instead.
 """
 function get_group_query(; aws_config::AbstractAWSConfig=global_aws_config())
-    return resource_groups("POST", "/get-group-query"; aws_config=aws_config)
+    return resource_groups(
+        "POST", "/get-group-query"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_group_query(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return resource_groups("POST", "/get-group-query", params; aws_config=aws_config)
+    return resource_groups(
+        "POST",
+        "/get-group-query",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -157,12 +191,23 @@ resource-groups:GetTags
 
 """
 function get_tags(Arn; aws_config::AbstractAWSConfig=global_aws_config())
-    return resource_groups("GET", "/resources/$(Arn)/tags"; aws_config=aws_config)
+    return resource_groups(
+        "GET",
+        "/resources/$(Arn)/tags";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_tags(
     Arn, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return resource_groups("GET", "/resources/$(Arn)/tags", params; aws_config=aws_config)
+    return resource_groups(
+        "GET",
+        "/resources/$(Arn)/tags",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -185,6 +230,7 @@ function group_resources(
         "/group-resources",
         Dict{String,Any}("Group" => Group, "ResourceArns" => ResourceArns);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function group_resources(
@@ -204,6 +250,7 @@ function group_resources(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -251,12 +298,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   to indicate where the output should continue from.
 """
 function list_group_resources(; aws_config::AbstractAWSConfig=global_aws_config())
-    return resource_groups("POST", "/list-group-resources"; aws_config=aws_config)
+    return resource_groups(
+        "POST",
+        "/list-group-resources";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_group_resources(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return resource_groups("POST", "/list-group-resources", params; aws_config=aws_config)
+    return resource_groups(
+        "POST",
+        "/list-group-resources",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -289,12 +347,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   to indicate where the output should continue from.
 """
 function list_groups(; aws_config::AbstractAWSConfig=global_aws_config())
-    return resource_groups("POST", "/groups-list"; aws_config=aws_config)
+    return resource_groups(
+        "POST", "/groups-list"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_groups(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return resource_groups("POST", "/groups-list", params; aws_config=aws_config)
+    return resource_groups(
+        "POST",
+        "/groups-list",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -318,13 +384,22 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   update.
 """
 function put_group_configuration(; aws_config::AbstractAWSConfig=global_aws_config())
-    return resource_groups("POST", "/put-group-configuration"; aws_config=aws_config)
+    return resource_groups(
+        "POST",
+        "/put-group-configuration";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function put_group_configuration(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return resource_groups(
-        "POST", "/put-group-configuration", params; aws_config=aws_config
+        "POST",
+        "/put-group-configuration",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -363,6 +438,7 @@ function search_resources(ResourceQuery; aws_config::AbstractAWSConfig=global_aw
         "/resources/search",
         Dict{String,Any}("ResourceQuery" => ResourceQuery);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function search_resources(
@@ -377,6 +453,7 @@ function search_resources(
             mergewith(_merge, Dict{String,Any}("ResourceQuery" => ResourceQuery), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -403,6 +480,7 @@ function tag(Arn, Tags; aws_config::AbstractAWSConfig=global_aws_config())
         "/resources/$(Arn)/tags",
         Dict{String,Any}("Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag(
@@ -416,6 +494,7 @@ function tag(
         "/resources/$(Arn)/tags",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Tags" => Tags), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -439,6 +518,7 @@ function ungroup_resources(
         "/ungroup-resources",
         Dict{String,Any}("Group" => Group, "ResourceArns" => ResourceArns);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function ungroup_resources(
@@ -458,6 +538,7 @@ function ungroup_resources(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -480,6 +561,7 @@ function untag(Arn, Keys; aws_config::AbstractAWSConfig=global_aws_config())
         "/resources/$(Arn)/tags",
         Dict{String,Any}("Keys" => Keys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag(
@@ -493,6 +575,7 @@ function untag(
         "/resources/$(Arn)/tags",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Keys" => Keys), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -512,12 +595,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"GroupName"`: Don't use this parameter. Use Group instead.
 """
 function update_group(; aws_config::AbstractAWSConfig=global_aws_config())
-    return resource_groups("POST", "/update-group"; aws_config=aws_config)
+    return resource_groups(
+        "POST", "/update-group"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function update_group(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return resource_groups("POST", "/update-group", params; aws_config=aws_config)
+    return resource_groups(
+        "POST",
+        "/update-group",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -546,6 +637,7 @@ function update_group_query(
         "/update-group-query",
         Dict{String,Any}("ResourceQuery" => ResourceQuery);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_group_query(
@@ -560,5 +652,6 @@ function update_group_query(
             mergewith(_merge, Dict{String,Any}("ResourceQuery" => ResourceQuery), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/resource_groups_tagging_api.jl
+++ b/src/services/resource_groups_tagging_api.jl
@@ -13,13 +13,18 @@ only from the organization's management account and from the us-east-1 Region.
 
 """
 function describe_report_creation(; aws_config::AbstractAWSConfig=global_aws_config())
-    return resource_groups_tagging_api("DescribeReportCreation"; aws_config=aws_config)
+    return resource_groups_tagging_api(
+        "DescribeReportCreation"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_report_creation(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return resource_groups_tagging_api(
-        "DescribeReportCreation", params; aws_config=aws_config
+        "DescribeReportCreation",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -70,13 +75,18 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   resources includes only resources with the specified target IDs.
 """
 function get_compliance_summary(; aws_config::AbstractAWSConfig=global_aws_config())
-    return resource_groups_tagging_api("GetComplianceSummary"; aws_config=aws_config)
+    return resource_groups_tagging_api(
+        "GetComplianceSummary"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_compliance_summary(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return resource_groups_tagging_api(
-        "GetComplianceSummary", params; aws_config=aws_config
+        "GetComplianceSummary",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -160,12 +170,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   minimum of 100 items up to a maximum of 500 items.
 """
 function get_resources(; aws_config::AbstractAWSConfig=global_aws_config())
-    return resource_groups_tagging_api("GetResources"; aws_config=aws_config)
+    return resource_groups_tagging_api(
+        "GetResources"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_resources(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return resource_groups_tagging_api("GetResources", params; aws_config=aws_config)
+    return resource_groups_tagging_api(
+        "GetResources", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -186,12 +200,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   initial request.
 """
 function get_tag_keys(; aws_config::AbstractAWSConfig=global_aws_config())
-    return resource_groups_tagging_api("GetTagKeys"; aws_config=aws_config)
+    return resource_groups_tagging_api(
+        "GetTagKeys"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_tag_keys(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return resource_groups_tagging_api("GetTagKeys", params; aws_config=aws_config)
+    return resource_groups_tagging_api(
+        "GetTagKeys", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -218,7 +236,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function get_tag_values(Key; aws_config::AbstractAWSConfig=global_aws_config())
     return resource_groups_tagging_api(
-        "GetTagValues", Dict{String,Any}("Key" => Key); aws_config=aws_config
+        "GetTagValues",
+        Dict{String,Any}("Key" => Key);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_tag_values(
@@ -228,6 +249,7 @@ function get_tag_values(
         "GetTagValues",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Key" => Key), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -254,6 +276,7 @@ function start_report_creation(S3Bucket; aws_config::AbstractAWSConfig=global_aw
         "StartReportCreation",
         Dict{String,Any}("S3Bucket" => S3Bucket);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_report_creation(
@@ -267,6 +290,7 @@ function start_report_creation(
             mergewith(_merge, Dict{String,Any}("S3Bucket" => S3Bucket), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -302,6 +326,7 @@ function tag_resources(
         "TagResources",
         Dict{String,Any}("ResourceARNList" => ResourceARNList, "Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resources(
@@ -320,6 +345,7 @@ function tag_resources(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -351,6 +377,7 @@ function untag_resources(
         "UntagResources",
         Dict{String,Any}("ResourceARNList" => ResourceARNList, "TagKeys" => TagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resources(
@@ -371,5 +398,6 @@ function untag_resources(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/robomaker.jl
+++ b/src/services/robomaker.jl
@@ -20,6 +20,7 @@ function batch_delete_worlds(worlds; aws_config::AbstractAWSConfig=global_aws_co
         "/batchDeleteWorlds",
         Dict{String,Any}("worlds" => worlds);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_delete_worlds(
@@ -30,6 +31,7 @@ function batch_delete_worlds(
         "/batchDeleteWorlds",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("worlds" => worlds), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -51,6 +53,7 @@ function batch_describe_simulation_job(
         "/batchDescribeSimulationJob",
         Dict{String,Any}("jobs" => jobs);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_describe_simulation_job(
@@ -61,6 +64,7 @@ function batch_describe_simulation_job(
         "/batchDescribeSimulationJob",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("jobs" => jobs), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -80,6 +84,7 @@ function cancel_deployment_job(job; aws_config::AbstractAWSConfig=global_aws_con
         "/cancelDeploymentJob",
         Dict{String,Any}("job" => job);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function cancel_deployment_job(
@@ -90,6 +95,7 @@ function cancel_deployment_job(
         "/cancelDeploymentJob",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("job" => job), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -109,6 +115,7 @@ function cancel_simulation_job(job; aws_config::AbstractAWSConfig=global_aws_con
         "/cancelSimulationJob",
         Dict{String,Any}("job" => job);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function cancel_simulation_job(
@@ -119,6 +126,7 @@ function cancel_simulation_job(
         "/cancelSimulationJob",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("job" => job), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -141,6 +149,7 @@ function cancel_simulation_job_batch(
         "/cancelSimulationJobBatch",
         Dict{String,Any}("batch" => batch);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function cancel_simulation_job_batch(
@@ -151,6 +160,7 @@ function cancel_simulation_job_batch(
         "/cancelSimulationJobBatch",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("batch" => batch), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -170,6 +180,7 @@ function cancel_world_export_job(job; aws_config::AbstractAWSConfig=global_aws_c
         "/cancelWorldExportJob",
         Dict{String,Any}("job" => job);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function cancel_world_export_job(
@@ -180,6 +191,7 @@ function cancel_world_export_job(
         "/cancelWorldExportJob",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("job" => job), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -199,6 +211,7 @@ function cancel_world_generation_job(job; aws_config::AbstractAWSConfig=global_a
         "/cancelWorldGenerationJob",
         Dict{String,Any}("job" => job);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function cancel_world_generation_job(
@@ -209,6 +222,7 @@ function cancel_world_generation_job(
         "/cancelWorldGenerationJob",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("job" => job), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -249,6 +263,7 @@ function create_deployment_job(
             "fleet" => fleet,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_deployment_job(
@@ -273,6 +288,7 @@ function create_deployment_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -291,7 +307,11 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function create_fleet(name; aws_config::AbstractAWSConfig=global_aws_config())
     return robomaker(
-        "POST", "/createFleet", Dict{String,Any}("name" => name); aws_config=aws_config
+        "POST",
+        "/createFleet",
+        Dict{String,Any}("name" => name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_fleet(
@@ -302,6 +322,7 @@ function create_fleet(
         "/createFleet",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("name" => name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -332,6 +353,7 @@ function create_robot(
             "name" => name,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_robot(
@@ -356,6 +378,7 @@ function create_robot(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -386,6 +409,7 @@ function create_robot_application(
         "/createRobotApplication",
         Dict{String,Any}("name" => name, "robotSoftwareSuite" => robotSoftwareSuite);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_robot_application(
@@ -407,6 +431,7 @@ function create_robot_application(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -436,6 +461,7 @@ function create_robot_application_version(
         "/createRobotApplicationVersion",
         Dict{String,Any}("application" => application);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_robot_application_version(
@@ -450,6 +476,7 @@ function create_robot_application_version(
             mergewith(_merge, Dict{String,Any}("application" => application), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -490,6 +517,7 @@ function create_simulation_application(
             "simulationSoftwareSuite" => simulationSoftwareSuite,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_simulation_application(
@@ -514,6 +542,7 @@ function create_simulation_application(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -543,6 +572,7 @@ function create_simulation_application_version(
         "/createSimulationApplicationVersion",
         Dict{String,Any}("application" => application);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_simulation_application_version(
@@ -557,6 +587,7 @@ function create_simulation_application_version(
             mergewith(_merge, Dict{String,Any}("application" => application), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -609,6 +640,7 @@ function create_simulation_job(
             "clientRequestToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_simulation_job(
@@ -632,6 +664,7 @@ function create_simulation_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -667,6 +700,7 @@ function create_world_export_job(
             "clientRequestToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_world_export_job(
@@ -692,6 +726,7 @@ function create_world_export_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -727,6 +762,7 @@ function create_world_generation_job(
             "clientRequestToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_world_generation_job(
@@ -750,6 +786,7 @@ function create_world_generation_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -770,12 +807,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"templateLocation"`: The location of the world template.
 """
 function create_world_template(; aws_config::AbstractAWSConfig=global_aws_config())
-    return robomaker("POST", "/createWorldTemplate"; aws_config=aws_config)
+    return robomaker(
+        "POST",
+        "/createWorldTemplate";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function create_world_template(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return robomaker("POST", "/createWorldTemplate", params; aws_config=aws_config)
+    return robomaker(
+        "POST",
+        "/createWorldTemplate",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -790,7 +838,11 @@ Deletes a fleet.
 """
 function delete_fleet(fleet; aws_config::AbstractAWSConfig=global_aws_config())
     return robomaker(
-        "POST", "/deleteFleet", Dict{String,Any}("fleet" => fleet); aws_config=aws_config
+        "POST",
+        "/deleteFleet",
+        Dict{String,Any}("fleet" => fleet);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_fleet(
@@ -801,6 +853,7 @@ function delete_fleet(
         "/deleteFleet",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("fleet" => fleet), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -816,7 +869,11 @@ Deletes a robot.
 """
 function delete_robot(robot; aws_config::AbstractAWSConfig=global_aws_config())
     return robomaker(
-        "POST", "/deleteRobot", Dict{String,Any}("robot" => robot); aws_config=aws_config
+        "POST",
+        "/deleteRobot",
+        Dict{String,Any}("robot" => robot);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_robot(
@@ -827,6 +884,7 @@ function delete_robot(
         "/deleteRobot",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("robot" => robot), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -851,6 +909,7 @@ function delete_robot_application(
         "/deleteRobotApplication",
         Dict{String,Any}("application" => application);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_robot_application(
@@ -865,6 +924,7 @@ function delete_robot_application(
             mergewith(_merge, Dict{String,Any}("application" => application), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -889,6 +949,7 @@ function delete_simulation_application(
         "/deleteSimulationApplication",
         Dict{String,Any}("application" => application);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_simulation_application(
@@ -903,6 +964,7 @@ function delete_simulation_application(
             mergewith(_merge, Dict{String,Any}("application" => application), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -922,6 +984,7 @@ function delete_world_template(template; aws_config::AbstractAWSConfig=global_aw
         "/deleteWorldTemplate",
         Dict{String,Any}("template" => template);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_world_template(
@@ -936,6 +999,7 @@ function delete_world_template(
             mergewith(_merge, Dict{String,Any}("template" => template), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -956,6 +1020,7 @@ function deregister_robot(fleet, robot; aws_config::AbstractAWSConfig=global_aws
         "/deregisterRobot",
         Dict{String,Any}("fleet" => fleet, "robot" => robot);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function deregister_robot(
@@ -971,6 +1036,7 @@ function deregister_robot(
             mergewith(_merge, Dict{String,Any}("fleet" => fleet, "robot" => robot), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -990,6 +1056,7 @@ function describe_deployment_job(job; aws_config::AbstractAWSConfig=global_aws_c
         "/describeDeploymentJob",
         Dict{String,Any}("job" => job);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_deployment_job(
@@ -1000,6 +1067,7 @@ function describe_deployment_job(
         "/describeDeploymentJob",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("job" => job), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1015,7 +1083,11 @@ Describes a fleet.
 """
 function describe_fleet(fleet; aws_config::AbstractAWSConfig=global_aws_config())
     return robomaker(
-        "POST", "/describeFleet", Dict{String,Any}("fleet" => fleet); aws_config=aws_config
+        "POST",
+        "/describeFleet",
+        Dict{String,Any}("fleet" => fleet);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_fleet(
@@ -1026,6 +1098,7 @@ function describe_fleet(
         "/describeFleet",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("fleet" => fleet), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1041,7 +1114,11 @@ Describes a robot.
 """
 function describe_robot(robot; aws_config::AbstractAWSConfig=global_aws_config())
     return robomaker(
-        "POST", "/describeRobot", Dict{String,Any}("robot" => robot); aws_config=aws_config
+        "POST",
+        "/describeRobot",
+        Dict{String,Any}("robot" => robot);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_robot(
@@ -1052,6 +1129,7 @@ function describe_robot(
         "/describeRobot",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("robot" => robot), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1076,6 +1154,7 @@ function describe_robot_application(
         "/describeRobotApplication",
         Dict{String,Any}("application" => application);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_robot_application(
@@ -1090,6 +1169,7 @@ function describe_robot_application(
             mergewith(_merge, Dict{String,Any}("application" => application), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1114,6 +1194,7 @@ function describe_simulation_application(
         "/describeSimulationApplication",
         Dict{String,Any}("application" => application);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_simulation_application(
@@ -1128,6 +1209,7 @@ function describe_simulation_application(
             mergewith(_merge, Dict{String,Any}("application" => application), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1147,6 +1229,7 @@ function describe_simulation_job(job; aws_config::AbstractAWSConfig=global_aws_c
         "/describeSimulationJob",
         Dict{String,Any}("job" => job);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_simulation_job(
@@ -1157,6 +1240,7 @@ function describe_simulation_job(
         "/describeSimulationJob",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("job" => job), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1178,6 +1262,7 @@ function describe_simulation_job_batch(
         "/describeSimulationJobBatch",
         Dict{String,Any}("batch" => batch);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_simulation_job_batch(
@@ -1188,6 +1273,7 @@ function describe_simulation_job_batch(
         "/describeSimulationJobBatch",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("batch" => batch), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1203,7 +1289,11 @@ Describes a world.
 """
 function describe_world(world; aws_config::AbstractAWSConfig=global_aws_config())
     return robomaker(
-        "POST", "/describeWorld", Dict{String,Any}("world" => world); aws_config=aws_config
+        "POST",
+        "/describeWorld",
+        Dict{String,Any}("world" => world);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_world(
@@ -1214,6 +1304,7 @@ function describe_world(
         "/describeWorld",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("world" => world), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1233,6 +1324,7 @@ function describe_world_export_job(job; aws_config::AbstractAWSConfig=global_aws
         "/describeWorldExportJob",
         Dict{String,Any}("job" => job);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_world_export_job(
@@ -1243,6 +1335,7 @@ function describe_world_export_job(
         "/describeWorldExportJob",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("job" => job), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1264,6 +1357,7 @@ function describe_world_generation_job(
         "/describeWorldGenerationJob",
         Dict{String,Any}("job" => job);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_world_generation_job(
@@ -1274,6 +1368,7 @@ function describe_world_generation_job(
         "/describeWorldGenerationJob",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("job" => job), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1295,6 +1390,7 @@ function describe_world_template(
         "/describeWorldTemplate",
         Dict{String,Any}("template" => template);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_world_template(
@@ -1309,6 +1405,7 @@ function describe_world_template(
             mergewith(_merge, Dict{String,Any}("template" => template), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1324,12 +1421,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"template"`: The Amazon Resource Name (arn) of the world template.
 """
 function get_world_template_body(; aws_config::AbstractAWSConfig=global_aws_config())
-    return robomaker("POST", "/getWorldTemplateBody"; aws_config=aws_config)
+    return robomaker(
+        "POST",
+        "/getWorldTemplateBody";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_world_template_body(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return robomaker("POST", "/getWorldTemplateBody", params; aws_config=aws_config)
+    return robomaker(
+        "POST",
+        "/getWorldTemplateBody",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1358,12 +1466,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   object's NextToken parameter is set to null.
 """
 function list_deployment_jobs(; aws_config::AbstractAWSConfig=global_aws_config())
-    return robomaker("POST", "/listDeploymentJobs"; aws_config=aws_config)
+    return robomaker(
+        "POST",
+        "/listDeploymentJobs";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_deployment_jobs(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return robomaker("POST", "/listDeploymentJobs", params; aws_config=aws_config)
+    return robomaker(
+        "POST",
+        "/listDeploymentJobs",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1391,12 +1510,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   purposes.
 """
 function list_fleets(; aws_config::AbstractAWSConfig=global_aws_config())
-    return robomaker("POST", "/listFleets"; aws_config=aws_config)
+    return robomaker(
+        "POST", "/listFleets"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_fleets(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return robomaker("POST", "/listFleets", params; aws_config=aws_config)
+    return robomaker(
+        "POST",
+        "/listFleets",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1425,12 +1552,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"versionQualifier"`: The version qualifier of the robot application.
 """
 function list_robot_applications(; aws_config::AbstractAWSConfig=global_aws_config())
-    return robomaker("POST", "/listRobotApplications"; aws_config=aws_config)
+    return robomaker(
+        "POST",
+        "/listRobotApplications";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_robot_applications(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return robomaker("POST", "/listRobotApplications", params; aws_config=aws_config)
+    return robomaker(
+        "POST",
+        "/listRobotApplications",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1457,12 +1595,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   NextToken parameter is set to null.
 """
 function list_robots(; aws_config::AbstractAWSConfig=global_aws_config())
-    return robomaker("POST", "/listRobots"; aws_config=aws_config)
+    return robomaker(
+        "POST", "/listRobots"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_robots(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return robomaker("POST", "/listRobots", params; aws_config=aws_config)
+    return robomaker(
+        "POST",
+        "/listRobots",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1491,12 +1637,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"versionQualifier"`: The version qualifier of the simulation application.
 """
 function list_simulation_applications(; aws_config::AbstractAWSConfig=global_aws_config())
-    return robomaker("POST", "/listSimulationApplications"; aws_config=aws_config)
+    return robomaker(
+        "POST",
+        "/listSimulationApplications";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_simulation_applications(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return robomaker("POST", "/listSimulationApplications", params; aws_config=aws_config)
+    return robomaker(
+        "POST",
+        "/listSimulationApplications",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1520,12 +1677,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   response object's NextToken parameter is set to null.
 """
 function list_simulation_job_batches(; aws_config::AbstractAWSConfig=global_aws_config())
-    return robomaker("POST", "/listSimulationJobBatches"; aws_config=aws_config)
+    return robomaker(
+        "POST",
+        "/listSimulationJobBatches";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_simulation_job_batches(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return robomaker("POST", "/listSimulationJobBatches", params; aws_config=aws_config)
+    return robomaker(
+        "POST",
+        "/listSimulationJobBatches",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1555,12 +1723,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   object's NextToken parameter is set to null.
 """
 function list_simulation_jobs(; aws_config::AbstractAWSConfig=global_aws_config())
-    return robomaker("POST", "/listSimulationJobs"; aws_config=aws_config)
+    return robomaker(
+        "POST",
+        "/listSimulationJobs";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_simulation_jobs(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return robomaker("POST", "/listSimulationJobs", params; aws_config=aws_config)
+    return robomaker(
+        "POST",
+        "/listSimulationJobs",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1576,14 +1755,25 @@ Lists all tags on a AWS RoboMaker resource.
 function list_tags_for_resource(
     resourceArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return robomaker("GET", "/tags/$(resourceArn)"; aws_config=aws_config)
+    return robomaker(
+        "GET",
+        "/tags/$(resourceArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_tags_for_resource(
     resourceArn,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return robomaker("GET", "/tags/$(resourceArn)", params; aws_config=aws_config)
+    return robomaker(
+        "GET",
+        "/tags/$(resourceArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1609,12 +1799,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   object's NextToken parameter is set to null.
 """
 function list_world_export_jobs(; aws_config::AbstractAWSConfig=global_aws_config())
-    return robomaker("POST", "/listWorldExportJobs"; aws_config=aws_config)
+    return robomaker(
+        "POST",
+        "/listWorldExportJobs";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_world_export_jobs(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return robomaker("POST", "/listWorldExportJobs", params; aws_config=aws_config)
+    return robomaker(
+        "POST",
+        "/listWorldExportJobs",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1639,12 +1840,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   response object's NextToken parameter is set to null.
 """
 function list_world_generation_jobs(; aws_config::AbstractAWSConfig=global_aws_config())
-    return robomaker("POST", "/listWorldGenerationJobs"; aws_config=aws_config)
+    return robomaker(
+        "POST",
+        "/listWorldGenerationJobs";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_world_generation_jobs(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return robomaker("POST", "/listWorldGenerationJobs", params; aws_config=aws_config)
+    return robomaker(
+        "POST",
+        "/listWorldGenerationJobs",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1668,12 +1880,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   object's NextToken parameter is set to null.
 """
 function list_world_templates(; aws_config::AbstractAWSConfig=global_aws_config())
-    return robomaker("POST", "/listWorldTemplates"; aws_config=aws_config)
+    return robomaker(
+        "POST",
+        "/listWorldTemplates";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_world_templates(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return robomaker("POST", "/listWorldTemplates", params; aws_config=aws_config)
+    return robomaker(
+        "POST",
+        "/listWorldTemplates",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1697,12 +1920,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   NextToken parameter is set to null.
 """
 function list_worlds(; aws_config::AbstractAWSConfig=global_aws_config())
-    return robomaker("POST", "/listWorlds"; aws_config=aws_config)
+    return robomaker(
+        "POST", "/listWorlds"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_worlds(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return robomaker("POST", "/listWorlds", params; aws_config=aws_config)
+    return robomaker(
+        "POST",
+        "/listWorlds",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1722,6 +1953,7 @@ function register_robot(fleet, robot; aws_config::AbstractAWSConfig=global_aws_c
         "/registerRobot",
         Dict{String,Any}("fleet" => fleet, "robot" => robot);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function register_robot(
@@ -1737,6 +1969,7 @@ function register_robot(
             mergewith(_merge, Dict{String,Any}("fleet" => fleet, "robot" => robot), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1756,6 +1989,7 @@ function restart_simulation_job(job; aws_config::AbstractAWSConfig=global_aws_co
         "/restartSimulationJob",
         Dict{String,Any}("job" => job);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function restart_simulation_job(
@@ -1766,6 +2000,7 @@ function restart_simulation_job(
         "/restartSimulationJob",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("job" => job), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1799,6 +2034,7 @@ function start_simulation_job_batch(
             "clientRequestToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_simulation_job_batch(
@@ -1820,6 +2056,7 @@ function start_simulation_job_batch(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1844,6 +2081,7 @@ function sync_deployment_job(
         "/syncDeploymentJob",
         Dict{String,Any}("clientRequestToken" => clientRequestToken, "fleet" => fleet);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function sync_deployment_job(
@@ -1865,6 +2103,7 @@ function sync_deployment_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1889,6 +2128,7 @@ function tag_resource(resourceArn, tags; aws_config::AbstractAWSConfig=global_aw
         "/tags/$(resourceArn)",
         Dict{String,Any}("tags" => tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -1902,6 +2142,7 @@ function tag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tags" => tags), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1927,6 +2168,7 @@ function untag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}("tagKeys" => tagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -1940,6 +2182,7 @@ function untag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tagKeys" => tagKeys), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1970,6 +2213,7 @@ function update_robot_application(
             "application" => application, "robotSoftwareSuite" => robotSoftwareSuite
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_robot_application(
@@ -1991,6 +2235,7 @@ function update_robot_application(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2029,6 +2274,7 @@ function update_simulation_application(
             "simulationSoftwareSuite" => simulationSoftwareSuite,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_simulation_application(
@@ -2053,6 +2299,7 @@ function update_simulation_application(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2077,6 +2324,7 @@ function update_world_template(template; aws_config::AbstractAWSConfig=global_aw
         "/updateWorldTemplate",
         Dict{String,Any}("template" => template);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_world_template(
@@ -2091,5 +2339,6 @@ function update_world_template(
             mergewith(_merge, Dict{String,Any}("template" => template), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/route53_recovery_cluster.jl
+++ b/src/services/route53_recovery_cluster.jl
@@ -28,6 +28,7 @@ function get_routing_control_state(
         "GetRoutingControlState",
         Dict{String,Any}("RoutingControlArn" => RoutingControlArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_routing_control_state(
@@ -43,6 +44,7 @@ function get_routing_control_state(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -74,6 +76,7 @@ function update_routing_control_state(
             "RoutingControlState" => RoutingControlState,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_routing_control_state(
@@ -95,6 +98,7 @@ function update_routing_control_state(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -121,6 +125,7 @@ function update_routing_control_states(
             "UpdateRoutingControlStateEntries" => UpdateRoutingControlStateEntries
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_routing_control_states(
@@ -140,5 +145,6 @@ function update_routing_control_states(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/route53_recovery_control_config.jl
+++ b/src/services/route53_recovery_control_config.jl
@@ -27,6 +27,7 @@ function create_cluster(ClusterName; aws_config::AbstractAWSConfig=global_aws_co
         "/cluster",
         Dict{String,Any}("ClusterName" => ClusterName, "ClientToken" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_cluster(
@@ -47,6 +48,7 @@ function create_cluster(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -80,6 +82,7 @@ function create_control_panel(
             "ClientToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_control_panel(
@@ -103,6 +106,7 @@ function create_control_panel(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -139,6 +143,7 @@ function create_routing_control(
             "ClientToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_routing_control(
@@ -162,6 +167,7 @@ function create_routing_control(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -191,6 +197,7 @@ function create_safety_rule(; aws_config::AbstractAWSConfig=global_aws_config())
         "/safetyrule",
         Dict{String,Any}("ClientToken" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_safety_rule(
@@ -203,6 +210,7 @@ function create_safety_rule(
             mergewith(_merge, Dict{String,Any}("ClientToken" => string(uuid4())), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -218,7 +226,10 @@ Delete a cluster.
 """
 function delete_cluster(ClusterArn; aws_config::AbstractAWSConfig=global_aws_config())
     return route53_recovery_control_config(
-        "DELETE", "/cluster/$(ClusterArn)"; aws_config=aws_config
+        "DELETE",
+        "/cluster/$(ClusterArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_cluster(
@@ -227,7 +238,11 @@ function delete_cluster(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return route53_recovery_control_config(
-        "DELETE", "/cluster/$(ClusterArn)", params; aws_config=aws_config
+        "DELETE",
+        "/cluster/$(ClusterArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -246,7 +261,10 @@ function delete_control_panel(
     ControlPanelArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return route53_recovery_control_config(
-        "DELETE", "/controlpanel/$(ControlPanelArn)"; aws_config=aws_config
+        "DELETE",
+        "/controlpanel/$(ControlPanelArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_control_panel(
@@ -255,7 +273,11 @@ function delete_control_panel(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return route53_recovery_control_config(
-        "DELETE", "/controlpanel/$(ControlPanelArn)", params; aws_config=aws_config
+        "DELETE",
+        "/controlpanel/$(ControlPanelArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -274,7 +296,10 @@ function delete_routing_control(
     RoutingControlArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return route53_recovery_control_config(
-        "DELETE", "/routingcontrol/$(RoutingControlArn)"; aws_config=aws_config
+        "DELETE",
+        "/routingcontrol/$(RoutingControlArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_routing_control(
@@ -283,7 +308,11 @@ function delete_routing_control(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return route53_recovery_control_config(
-        "DELETE", "/routingcontrol/$(RoutingControlArn)", params; aws_config=aws_config
+        "DELETE",
+        "/routingcontrol/$(RoutingControlArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -301,7 +330,10 @@ function delete_safety_rule(
     SafetyRuleArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return route53_recovery_control_config(
-        "DELETE", "/safetyrule/$(SafetyRuleArn)"; aws_config=aws_config
+        "DELETE",
+        "/safetyrule/$(SafetyRuleArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_safety_rule(
@@ -310,7 +342,11 @@ function delete_safety_rule(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return route53_recovery_control_config(
-        "DELETE", "/safetyrule/$(SafetyRuleArn)", params; aws_config=aws_config
+        "DELETE",
+        "/safetyrule/$(SafetyRuleArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -328,7 +364,10 @@ status, and Amazon Resource Name (ARN).
 """
 function describe_cluster(ClusterArn; aws_config::AbstractAWSConfig=global_aws_config())
     return route53_recovery_control_config(
-        "GET", "/cluster/$(ClusterArn)"; aws_config=aws_config
+        "GET",
+        "/cluster/$(ClusterArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_cluster(
@@ -337,7 +376,11 @@ function describe_cluster(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return route53_recovery_control_config(
-        "GET", "/cluster/$(ClusterArn)", params; aws_config=aws_config
+        "GET",
+        "/cluster/$(ClusterArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -356,7 +399,10 @@ function describe_control_panel(
     ControlPanelArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return route53_recovery_control_config(
-        "GET", "/controlpanel/$(ControlPanelArn)"; aws_config=aws_config
+        "GET",
+        "/controlpanel/$(ControlPanelArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_control_panel(
@@ -365,7 +411,11 @@ function describe_control_panel(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return route53_recovery_control_config(
-        "GET", "/controlpanel/$(ControlPanelArn)", params; aws_config=aws_config
+        "GET",
+        "/controlpanel/$(ControlPanelArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -388,7 +438,10 @@ function describe_routing_control(
     RoutingControlArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return route53_recovery_control_config(
-        "GET", "/routingcontrol/$(RoutingControlArn)"; aws_config=aws_config
+        "GET",
+        "/routingcontrol/$(RoutingControlArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_routing_control(
@@ -397,7 +450,11 @@ function describe_routing_control(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return route53_recovery_control_config(
-        "GET", "/routingcontrol/$(RoutingControlArn)", params; aws_config=aws_config
+        "GET",
+        "/routingcontrol/$(RoutingControlArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -416,7 +473,10 @@ function describe_safety_rule(
     SafetyRuleArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return route53_recovery_control_config(
-        "GET", "/safetyrule/$(SafetyRuleArn)"; aws_config=aws_config
+        "GET",
+        "/safetyrule/$(SafetyRuleArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_safety_rule(
@@ -425,7 +485,11 @@ function describe_safety_rule(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return route53_recovery_control_config(
-        "GET", "/safetyrule/$(SafetyRuleArn)", params; aws_config=aws_config
+        "GET",
+        "/safetyrule/$(SafetyRuleArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -452,6 +516,7 @@ function list_associated_route53_health_checks(
         "GET",
         "/routingcontrol/$(RoutingControlArn)/associatedRoute53HealthChecks";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_associated_route53_health_checks(
@@ -464,6 +529,7 @@ function list_associated_route53_health_checks(
         "/routingcontrol/$(RoutingControlArn)/associatedRoute53HealthChecks",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -479,12 +545,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`: The token that identifies which batch of results you want to see.
 """
 function list_clusters(; aws_config::AbstractAWSConfig=global_aws_config())
-    return route53_recovery_control_config("GET", "/cluster"; aws_config=aws_config)
+    return route53_recovery_control_config(
+        "GET", "/cluster"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_clusters(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return route53_recovery_control_config("GET", "/cluster", params; aws_config=aws_config)
+    return route53_recovery_control_config(
+        "GET", "/cluster", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -500,13 +570,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`: The token that identifies which batch of results you want to see.
 """
 function list_control_panels(; aws_config::AbstractAWSConfig=global_aws_config())
-    return route53_recovery_control_config("GET", "/controlpanels"; aws_config=aws_config)
+    return route53_recovery_control_config(
+        "GET", "/controlpanels"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_control_panels(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return route53_recovery_control_config(
-        "GET", "/controlpanels", params; aws_config=aws_config
+        "GET",
+        "/controlpanels",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -532,7 +608,10 @@ function list_routing_controls(
     ControlPanelArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return route53_recovery_control_config(
-        "GET", "/controlpanel/$(ControlPanelArn)/routingcontrols"; aws_config=aws_config
+        "GET",
+        "/controlpanel/$(ControlPanelArn)/routingcontrols";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_routing_controls(
@@ -545,6 +624,7 @@ function list_routing_controls(
         "/controlpanel/$(ControlPanelArn)/routingcontrols",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -568,7 +648,10 @@ function list_safety_rules(
     ControlPanelArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return route53_recovery_control_config(
-        "GET", "/controlpanel/$(ControlPanelArn)/safetyrules"; aws_config=aws_config
+        "GET",
+        "/controlpanel/$(ControlPanelArn)/safetyrules";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_safety_rules(
@@ -577,7 +660,11 @@ function list_safety_rules(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return route53_recovery_control_config(
-        "GET", "/controlpanel/$(ControlPanelArn)/safetyrules", params; aws_config=aws_config
+        "GET",
+        "/controlpanel/$(ControlPanelArn)/safetyrules",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -603,6 +690,7 @@ function update_control_panel(
             "ControlPanelArn" => ControlPanelArn, "ControlPanelName" => ControlPanelName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_control_panel(
@@ -625,6 +713,7 @@ function update_control_panel(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -652,6 +741,7 @@ function update_routing_control(
             "RoutingControlName" => RoutingControlName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_routing_control(
@@ -674,6 +764,7 @@ function update_routing_control(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -691,12 +782,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"GatingRuleUpdate"`:
 """
 function update_safety_rule(; aws_config::AbstractAWSConfig=global_aws_config())
-    return route53_recovery_control_config("PUT", "/safetyrule"; aws_config=aws_config)
+    return route53_recovery_control_config(
+        "PUT", "/safetyrule"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function update_safety_rule(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return route53_recovery_control_config(
-        "PUT", "/safetyrule", params; aws_config=aws_config
+        "PUT", "/safetyrule", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
     )
 end

--- a/src/services/route53_recovery_readiness.jl
+++ b/src/services/route53_recovery_readiness.jl
@@ -21,7 +21,11 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function create_cell(cellName; aws_config::AbstractAWSConfig=global_aws_config())
     return route53_recovery_readiness(
-        "POST", "/cells", Dict{String,Any}("cellName" => cellName); aws_config=aws_config
+        "POST",
+        "/cells",
+        Dict{String,Any}("cellName" => cellName);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_cell(
@@ -36,6 +40,7 @@ function create_cell(
             mergewith(_merge, Dict{String,Any}("cellName" => cellName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -57,6 +62,7 @@ function create_cross_account_authorization(
         "/crossaccountauthorizations",
         Dict{String,Any}("crossAccountAuthorization" => crossAccountAuthorization);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_cross_account_authorization(
@@ -75,6 +81,7 @@ function create_cross_account_authorization(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -102,6 +109,7 @@ function create_readiness_check(
             "readinessCheckName" => readinessCheckName, "resourceSetName" => resourceSetName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_readiness_check(
@@ -124,6 +132,7 @@ function create_readiness_check(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -149,6 +158,7 @@ function create_recovery_group(
         "/recoverygroups",
         Dict{String,Any}("recoveryGroupName" => recoveryGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_recovery_group(
@@ -165,6 +175,7 @@ function create_recovery_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -198,6 +209,7 @@ function create_resource_set(
             "resources" => resources,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_resource_set(
@@ -222,6 +234,7 @@ function create_resource_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -236,7 +249,12 @@ Deletes an existing Cell.
 
 """
 function delete_cell(cellName; aws_config::AbstractAWSConfig=global_aws_config())
-    return route53_recovery_readiness("DELETE", "/cells/$(cellName)"; aws_config=aws_config)
+    return route53_recovery_readiness(
+        "DELETE",
+        "/cells/$(cellName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_cell(
     cellName,
@@ -244,7 +262,11 @@ function delete_cell(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return route53_recovery_readiness(
-        "DELETE", "/cells/$(cellName)", params; aws_config=aws_config
+        "DELETE",
+        "/cells/$(cellName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -265,6 +287,7 @@ function delete_cross_account_authorization(
         "DELETE",
         "/crossaccountauthorizations/$(crossAccountAuthorization)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_cross_account_authorization(
@@ -277,6 +300,7 @@ function delete_cross_account_authorization(
         "/crossaccountauthorizations/$(crossAccountAuthorization)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -294,7 +318,10 @@ function delete_readiness_check(
     readinessCheckName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return route53_recovery_readiness(
-        "DELETE", "/readinesschecks/$(readinessCheckName)"; aws_config=aws_config
+        "DELETE",
+        "/readinesschecks/$(readinessCheckName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_readiness_check(
@@ -303,7 +330,11 @@ function delete_readiness_check(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return route53_recovery_readiness(
-        "DELETE", "/readinesschecks/$(readinessCheckName)", params; aws_config=aws_config
+        "DELETE",
+        "/readinesschecks/$(readinessCheckName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -321,7 +352,10 @@ function delete_recovery_group(
     recoveryGroupName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return route53_recovery_readiness(
-        "DELETE", "/recoverygroups/$(recoveryGroupName)"; aws_config=aws_config
+        "DELETE",
+        "/recoverygroups/$(recoveryGroupName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_recovery_group(
@@ -330,7 +364,11 @@ function delete_recovery_group(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return route53_recovery_readiness(
-        "DELETE", "/recoverygroups/$(recoveryGroupName)", params; aws_config=aws_config
+        "DELETE",
+        "/recoverygroups/$(recoveryGroupName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -348,7 +386,10 @@ function delete_resource_set(
     resourceSetName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return route53_recovery_readiness(
-        "DELETE", "/resourcesets/$(resourceSetName)"; aws_config=aws_config
+        "DELETE",
+        "/resourcesets/$(resourceSetName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_resource_set(
@@ -357,7 +398,11 @@ function delete_resource_set(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return route53_recovery_readiness(
-        "DELETE", "/resourcesets/$(resourceSetName)", params; aws_config=aws_config
+        "DELETE",
+        "/resourcesets/$(resourceSetName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -384,6 +429,7 @@ function get_architecture_recommendations(
         "GET",
         "/recoverygroups/$(recoveryGroupName)/architectureRecommendations";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_architecture_recommendations(
@@ -396,6 +442,7 @@ function get_architecture_recommendations(
         "/recoverygroups/$(recoveryGroupName)/architectureRecommendations",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -410,7 +457,9 @@ Returns information about a Cell.
 
 """
 function get_cell(cellName; aws_config::AbstractAWSConfig=global_aws_config())
-    return route53_recovery_readiness("GET", "/cells/$(cellName)"; aws_config=aws_config)
+    return route53_recovery_readiness(
+        "GET", "/cells/$(cellName)"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_cell(
     cellName,
@@ -418,7 +467,11 @@ function get_cell(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return route53_recovery_readiness(
-        "GET", "/cells/$(cellName)", params; aws_config=aws_config
+        "GET",
+        "/cells/$(cellName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -440,7 +493,10 @@ function get_cell_readiness_summary(
     cellName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return route53_recovery_readiness(
-        "GET", "/cellreadiness/$(cellName)"; aws_config=aws_config
+        "GET",
+        "/cellreadiness/$(cellName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_cell_readiness_summary(
@@ -449,7 +505,11 @@ function get_cell_readiness_summary(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return route53_recovery_readiness(
-        "GET", "/cellreadiness/$(cellName)", params; aws_config=aws_config
+        "GET",
+        "/cellreadiness/$(cellName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -467,7 +527,10 @@ function get_readiness_check(
     readinessCheckName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return route53_recovery_readiness(
-        "GET", "/readinesschecks/$(readinessCheckName)"; aws_config=aws_config
+        "GET",
+        "/readinesschecks/$(readinessCheckName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_readiness_check(
@@ -476,7 +539,11 @@ function get_readiness_check(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return route53_recovery_readiness(
-        "GET", "/readinesschecks/$(readinessCheckName)", params; aws_config=aws_config
+        "GET",
+        "/readinesschecks/$(readinessCheckName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -505,6 +572,7 @@ function get_readiness_check_resource_status(
         "GET",
         "/readinesschecks/$(readinessCheckName)/resource/$(resourceIdentifier)/status";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_readiness_check_resource_status(
@@ -518,6 +586,7 @@ function get_readiness_check_resource_status(
         "/readinesschecks/$(readinessCheckName)/resource/$(resourceIdentifier)/status",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -539,7 +608,10 @@ function get_readiness_check_status(
     readinessCheckName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return route53_recovery_readiness(
-        "GET", "/readinesschecks/$(readinessCheckName)/status"; aws_config=aws_config
+        "GET",
+        "/readinesschecks/$(readinessCheckName)/status";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_readiness_check_status(
@@ -552,6 +624,7 @@ function get_readiness_check_status(
         "/readinesschecks/$(readinessCheckName)/status",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -569,7 +642,10 @@ function get_recovery_group(
     recoveryGroupName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return route53_recovery_readiness(
-        "GET", "/recoverygroups/$(recoveryGroupName)"; aws_config=aws_config
+        "GET",
+        "/recoverygroups/$(recoveryGroupName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_recovery_group(
@@ -578,7 +654,11 @@ function get_recovery_group(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return route53_recovery_readiness(
-        "GET", "/recoverygroups/$(recoveryGroupName)", params; aws_config=aws_config
+        "GET",
+        "/recoverygroups/$(recoveryGroupName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -600,7 +680,10 @@ function get_recovery_group_readiness_summary(
     recoveryGroupName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return route53_recovery_readiness(
-        "GET", "/recoverygroupreadiness/$(recoveryGroupName)"; aws_config=aws_config
+        "GET",
+        "/recoverygroupreadiness/$(recoveryGroupName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_recovery_group_readiness_summary(
@@ -609,7 +692,11 @@ function get_recovery_group_readiness_summary(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return route53_recovery_readiness(
-        "GET", "/recoverygroupreadiness/$(recoveryGroupName)", params; aws_config=aws_config
+        "GET",
+        "/recoverygroupreadiness/$(recoveryGroupName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -627,7 +714,10 @@ function get_resource_set(
     resourceSetName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return route53_recovery_readiness(
-        "GET", "/resourcesets/$(resourceSetName)"; aws_config=aws_config
+        "GET",
+        "/resourcesets/$(resourceSetName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_resource_set(
@@ -636,7 +726,11 @@ function get_resource_set(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return route53_recovery_readiness(
-        "GET", "/resourcesets/$(resourceSetName)", params; aws_config=aws_config
+        "GET",
+        "/resourcesets/$(resourceSetName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -652,12 +746,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: A token used to resume pagination from the end of a previous request.
 """
 function list_cells(; aws_config::AbstractAWSConfig=global_aws_config())
-    return route53_recovery_readiness("GET", "/cells"; aws_config=aws_config)
+    return route53_recovery_readiness(
+        "GET", "/cells"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_cells(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return route53_recovery_readiness("GET", "/cells", params; aws_config=aws_config)
+    return route53_recovery_readiness(
+        "GET", "/cells", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -675,14 +773,21 @@ function list_cross_account_authorizations(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
     return route53_recovery_readiness(
-        "GET", "/crossaccountauthorizations"; aws_config=aws_config
+        "GET",
+        "/crossaccountauthorizations";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_cross_account_authorizations(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return route53_recovery_readiness(
-        "GET", "/crossaccountauthorizations", params; aws_config=aws_config
+        "GET",
+        "/crossaccountauthorizations",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -698,13 +803,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: A token used to resume pagination from the end of a previous request.
 """
 function list_readiness_checks(; aws_config::AbstractAWSConfig=global_aws_config())
-    return route53_recovery_readiness("GET", "/readinesschecks"; aws_config=aws_config)
+    return route53_recovery_readiness(
+        "GET", "/readinesschecks"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_readiness_checks(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return route53_recovery_readiness(
-        "GET", "/readinesschecks", params; aws_config=aws_config
+        "GET",
+        "/readinesschecks",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -720,13 +831,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: A token used to resume pagination from the end of a previous request.
 """
 function list_recovery_groups(; aws_config::AbstractAWSConfig=global_aws_config())
-    return route53_recovery_readiness("GET", "/recoverygroups"; aws_config=aws_config)
+    return route53_recovery_readiness(
+        "GET", "/recoverygroups"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_recovery_groups(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return route53_recovery_readiness(
-        "GET", "/recoverygroups", params; aws_config=aws_config
+        "GET",
+        "/recoverygroups",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -742,12 +859,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: A token used to resume pagination from the end of a previous request.
 """
 function list_resource_sets(; aws_config::AbstractAWSConfig=global_aws_config())
-    return route53_recovery_readiness("GET", "/resourcesets"; aws_config=aws_config)
+    return route53_recovery_readiness(
+        "GET", "/resourcesets"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_resource_sets(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return route53_recovery_readiness("GET", "/resourcesets", params; aws_config=aws_config)
+    return route53_recovery_readiness(
+        "GET",
+        "/resourcesets",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -764,12 +889,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   type.
 """
 function list_rules(; aws_config::AbstractAWSConfig=global_aws_config())
-    return route53_recovery_readiness("GET", "/rules"; aws_config=aws_config)
+    return route53_recovery_readiness(
+        "GET", "/rules"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_rules(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return route53_recovery_readiness("GET", "/rules", params; aws_config=aws_config)
+    return route53_recovery_readiness(
+        "GET", "/rules", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -786,7 +915,12 @@ Returns a list of the tags assigned to the specified resource.
 function list_tags_for_resources(
     resource_arn; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return route53_recovery_readiness("GET", "/tags/$(resource-arn)"; aws_config=aws_config)
+    return route53_recovery_readiness(
+        "GET",
+        "/tags/$(resource-arn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_tags_for_resources(
     resource_arn,
@@ -794,7 +928,11 @@ function list_tags_for_resources(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return route53_recovery_readiness(
-        "GET", "/tags/$(resource-arn)", params; aws_config=aws_config
+        "GET",
+        "/tags/$(resource-arn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -816,6 +954,7 @@ function tag_resource(resource_arn, tags; aws_config::AbstractAWSConfig=global_a
         "/tags/$(resource-arn)",
         Dict{String,Any}("tags" => tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -829,6 +968,7 @@ function tag_resource(
         "/tags/$(resource-arn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tags" => tags), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -852,6 +992,7 @@ function untag_resource(
         "/tags/$(resource-arn)",
         Dict{String,Any}("tagKeys" => tagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -865,6 +1006,7 @@ function untag_resource(
         "/tags/$(resource-arn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tagKeys" => tagKeys), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -885,6 +1027,7 @@ function update_cell(cellName, cells; aws_config::AbstractAWSConfig=global_aws_c
         "/cells/$(cellName)",
         Dict{String,Any}("cells" => cells);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_cell(
@@ -898,6 +1041,7 @@ function update_cell(
         "/cells/$(cellName)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("cells" => cells), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -920,6 +1064,7 @@ function update_readiness_check(
         "/readinesschecks/$(readinessCheckName)",
         Dict{String,Any}("resourceSetName" => resourceSetName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_readiness_check(
@@ -937,6 +1082,7 @@ function update_readiness_check(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -959,6 +1105,7 @@ function update_recovery_group(
         "/recoverygroups/$(recoveryGroupName)",
         Dict{String,Any}("cells" => cells);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_recovery_group(
@@ -972,6 +1119,7 @@ function update_recovery_group(
         "/recoverygroups/$(recoveryGroupName)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("cells" => cells), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -998,6 +1146,7 @@ function update_resource_set(
         "/resourcesets/$(resourceSetName)",
         Dict{String,Any}("resourceSetType" => resourceSetType, "resources" => resources);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_resource_set(
@@ -1020,5 +1169,6 @@ function update_resource_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/route53resolver.jl
+++ b/src/services/route53resolver.jl
@@ -52,6 +52,7 @@ function associate_firewall_rule_group(
             "VpcId" => VpcId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_firewall_rule_group(
@@ -79,6 +80,7 @@ function associate_firewall_rule_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -108,6 +110,7 @@ function associate_resolver_endpoint_ip_address(
             "IpAddress" => IpAddress, "ResolverEndpointId" => ResolverEndpointId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_resolver_endpoint_ip_address(
@@ -128,6 +131,7 @@ function associate_resolver_endpoint_ip_address(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -160,6 +164,7 @@ function associate_resolver_query_log_config(
             "ResourceId" => ResourceId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_resolver_query_log_config(
@@ -181,6 +186,7 @@ function associate_resolver_query_log_config(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -210,6 +216,7 @@ function associate_resolver_rule(
         "AssociateResolverRule",
         Dict{String,Any}("ResolverRuleId" => ResolverRuleId, "VPCId" => VPCId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_resolver_rule(
@@ -228,6 +235,7 @@ function associate_resolver_rule(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -257,6 +265,7 @@ function create_firewall_domain_list(
         "CreateFirewallDomainList",
         Dict{String,Any}("CreatorRequestId" => CreatorRequestId, "Name" => Name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_firewall_domain_list(
@@ -275,6 +284,7 @@ function create_firewall_domain_list(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -344,6 +354,7 @@ function create_firewall_rule(
             "Priority" => Priority,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_firewall_rule(
@@ -373,6 +384,7 @@ function create_firewall_rule(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -401,6 +413,7 @@ function create_firewall_rule_group(
         "CreateFirewallRuleGroup",
         Dict{String,Any}("CreatorRequestId" => CreatorRequestId, "Name" => Name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_firewall_rule_group(
@@ -419,6 +432,7 @@ function create_firewall_rule_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -470,6 +484,7 @@ function create_resolver_endpoint(
             "SecurityGroupIds" => SecurityGroupIds,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_resolver_endpoint(
@@ -495,6 +510,7 @@ function create_resolver_endpoint(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -545,6 +561,7 @@ function create_resolver_query_log_config(
             "Name" => Name,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_resolver_query_log_config(
@@ -568,6 +585,7 @@ function create_resolver_query_log_config(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -621,6 +639,7 @@ function create_resolver_rule(
             "RuleType" => RuleType,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_resolver_rule(
@@ -644,6 +663,7 @@ function create_resolver_rule(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -664,6 +684,7 @@ function delete_firewall_domain_list(
         "DeleteFirewallDomainList",
         Dict{String,Any}("FirewallDomainListId" => FirewallDomainListId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_firewall_domain_list(
@@ -681,6 +702,7 @@ function delete_firewall_domain_list(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -708,6 +730,7 @@ function delete_firewall_rule(
             "FirewallRuleGroupId" => FirewallRuleGroupId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_firewall_rule(
@@ -729,6 +752,7 @@ function delete_firewall_rule(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -750,6 +774,7 @@ function delete_firewall_rule_group(
         "DeleteFirewallRuleGroup",
         Dict{String,Any}("FirewallRuleGroupId" => FirewallRuleGroupId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_firewall_rule_group(
@@ -767,6 +792,7 @@ function delete_firewall_rule_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -790,6 +816,7 @@ function delete_resolver_endpoint(
         "DeleteResolverEndpoint",
         Dict{String,Any}("ResolverEndpointId" => ResolverEndpointId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_resolver_endpoint(
@@ -805,6 +832,7 @@ function delete_resolver_endpoint(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -836,6 +864,7 @@ function delete_resolver_query_log_config(
         "DeleteResolverQueryLogConfig",
         Dict{String,Any}("ResolverQueryLogConfigId" => ResolverQueryLogConfigId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_resolver_query_log_config(
@@ -853,6 +882,7 @@ function delete_resolver_query_log_config(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -875,6 +905,7 @@ function delete_resolver_rule(
         "DeleteResolverRule",
         Dict{String,Any}("ResolverRuleId" => ResolverRuleId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_resolver_rule(
@@ -888,6 +919,7 @@ function delete_resolver_rule(
             mergewith(_merge, Dict{String,Any}("ResolverRuleId" => ResolverRuleId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -910,6 +942,7 @@ function disassociate_firewall_rule_group(
             "FirewallRuleGroupAssociationId" => FirewallRuleGroupAssociationId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disassociate_firewall_rule_group(
@@ -929,6 +962,7 @@ function disassociate_firewall_rule_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -956,6 +990,7 @@ function disassociate_resolver_endpoint_ip_address(
             "IpAddress" => IpAddress, "ResolverEndpointId" => ResolverEndpointId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disassociate_resolver_endpoint_ip_address(
@@ -976,6 +1011,7 @@ function disassociate_resolver_endpoint_ip_address(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1007,6 +1043,7 @@ function disassociate_resolver_query_log_config(
             "ResourceId" => ResourceId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disassociate_resolver_query_log_config(
@@ -1028,6 +1065,7 @@ function disassociate_resolver_query_log_config(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1052,6 +1090,7 @@ function disassociate_resolver_rule(
         "DisassociateResolverRule",
         Dict{String,Any}("ResolverRuleId" => ResolverRuleId, "VPCId" => VPCId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disassociate_resolver_rule(
@@ -1070,6 +1109,7 @@ function disassociate_resolver_rule(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1089,6 +1129,7 @@ function get_firewall_config(ResourceId; aws_config::AbstractAWSConfig=global_aw
         "GetFirewallConfig",
         Dict{String,Any}("ResourceId" => ResourceId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_firewall_config(
@@ -1102,6 +1143,7 @@ function get_firewall_config(
             mergewith(_merge, Dict{String,Any}("ResourceId" => ResourceId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1122,6 +1164,7 @@ function get_firewall_domain_list(
         "GetFirewallDomainList",
         Dict{String,Any}("FirewallDomainListId" => FirewallDomainListId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_firewall_domain_list(
@@ -1139,6 +1182,7 @@ function get_firewall_domain_list(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1159,6 +1203,7 @@ function get_firewall_rule_group(
         "GetFirewallRuleGroup",
         Dict{String,Any}("FirewallRuleGroupId" => FirewallRuleGroupId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_firewall_rule_group(
@@ -1176,6 +1221,7 @@ function get_firewall_rule_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1200,6 +1246,7 @@ function get_firewall_rule_group_association(
             "FirewallRuleGroupAssociationId" => FirewallRuleGroupAssociationId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_firewall_rule_group_association(
@@ -1219,6 +1266,7 @@ function get_firewall_rule_group_association(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1238,7 +1286,10 @@ function get_firewall_rule_group_policy(
     Arn; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return route53resolver(
-        "GetFirewallRuleGroupPolicy", Dict{String,Any}("Arn" => Arn); aws_config=aws_config
+        "GetFirewallRuleGroupPolicy",
+        Dict{String,Any}("Arn" => Arn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_firewall_rule_group_policy(
@@ -1248,6 +1299,7 @@ function get_firewall_rule_group_policy(
         "GetFirewallRuleGroupPolicy",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Arn" => Arn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1268,6 +1320,7 @@ function get_resolver_dnssec_config(
         "GetResolverDnssecConfig",
         Dict{String,Any}("ResourceId" => ResourceId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_resolver_dnssec_config(
@@ -1281,6 +1334,7 @@ function get_resolver_dnssec_config(
             mergewith(_merge, Dict{String,Any}("ResourceId" => ResourceId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1303,6 +1357,7 @@ function get_resolver_endpoint(
         "GetResolverEndpoint",
         Dict{String,Any}("ResolverEndpointId" => ResolverEndpointId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_resolver_endpoint(
@@ -1318,6 +1373,7 @@ function get_resolver_endpoint(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1341,6 +1397,7 @@ function get_resolver_query_log_config(
         "GetResolverQueryLogConfig",
         Dict{String,Any}("ResolverQueryLogConfigId" => ResolverQueryLogConfigId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_resolver_query_log_config(
@@ -1358,6 +1415,7 @@ function get_resolver_query_log_config(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1383,6 +1441,7 @@ function get_resolver_query_log_config_association(
             "ResolverQueryLogConfigAssociationId" => ResolverQueryLogConfigAssociationId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_resolver_query_log_config_association(
@@ -1403,6 +1462,7 @@ function get_resolver_query_log_config_association(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1426,6 +1486,7 @@ function get_resolver_query_log_config_policy(
         "GetResolverQueryLogConfigPolicy",
         Dict{String,Any}("Arn" => Arn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_resolver_query_log_config_policy(
@@ -1435,6 +1496,7 @@ function get_resolver_query_log_config_policy(
         "GetResolverQueryLogConfigPolicy",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Arn" => Arn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1457,6 +1519,7 @@ function get_resolver_rule(
         "GetResolverRule",
         Dict{String,Any}("ResolverRuleId" => ResolverRuleId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_resolver_rule(
@@ -1470,6 +1533,7 @@ function get_resolver_rule(
             mergewith(_merge, Dict{String,Any}("ResolverRuleId" => ResolverRuleId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1492,6 +1556,7 @@ function get_resolver_rule_association(
         "GetResolverRuleAssociation",
         Dict{String,Any}("ResolverRuleAssociationId" => ResolverRuleAssociationId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_resolver_rule_association(
@@ -1509,6 +1574,7 @@ function get_resolver_rule_association(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1527,7 +1593,10 @@ to use.
 """
 function get_resolver_rule_policy(Arn; aws_config::AbstractAWSConfig=global_aws_config())
     return route53resolver(
-        "GetResolverRulePolicy", Dict{String,Any}("Arn" => Arn); aws_config=aws_config
+        "GetResolverRulePolicy",
+        Dict{String,Any}("Arn" => Arn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_resolver_rule_policy(
@@ -1537,6 +1606,7 @@ function get_resolver_rule_policy(
         "GetResolverRulePolicy",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Arn" => Arn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1576,6 +1646,7 @@ function import_firewall_domains(
             "Operation" => Operation,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function import_firewall_domains(
@@ -1599,6 +1670,7 @@ function import_firewall_domains(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1623,12 +1695,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   prior request in your next request.
 """
 function list_firewall_configs(; aws_config::AbstractAWSConfig=global_aws_config())
-    return route53resolver("ListFirewallConfigs"; aws_config=aws_config)
+    return route53resolver(
+        "ListFirewallConfigs"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_firewall_configs(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return route53resolver("ListFirewallConfigs", params; aws_config=aws_config)
+    return route53resolver(
+        "ListFirewallConfigs",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1653,12 +1732,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   prior request in your next request.
 """
 function list_firewall_domain_lists(; aws_config::AbstractAWSConfig=global_aws_config())
-    return route53resolver("ListFirewallDomainLists"; aws_config=aws_config)
+    return route53resolver(
+        "ListFirewallDomainLists"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_firewall_domain_lists(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return route53resolver("ListFirewallDomainLists", params; aws_config=aws_config)
+    return route53resolver(
+        "ListFirewallDomainLists",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1691,6 +1777,7 @@ function list_firewall_domains(
         "ListFirewallDomains",
         Dict{String,Any}("FirewallDomainListId" => FirewallDomainListId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_firewall_domains(
@@ -1708,6 +1795,7 @@ function list_firewall_domains(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1745,13 +1833,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function list_firewall_rule_group_associations(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return route53resolver("ListFirewallRuleGroupAssociations"; aws_config=aws_config)
+    return route53resolver(
+        "ListFirewallRuleGroupAssociations";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_firewall_rule_group_associations(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return route53resolver(
-        "ListFirewallRuleGroupAssociations", params; aws_config=aws_config
+        "ListFirewallRuleGroupAssociations",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1776,12 +1871,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   prior request in your next request.
 """
 function list_firewall_rule_groups(; aws_config::AbstractAWSConfig=global_aws_config())
-    return route53resolver("ListFirewallRuleGroups"; aws_config=aws_config)
+    return route53resolver(
+        "ListFirewallRuleGroups"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_firewall_rule_groups(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return route53resolver("ListFirewallRuleGroups", params; aws_config=aws_config)
+    return route53resolver(
+        "ListFirewallRuleGroups",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1823,6 +1925,7 @@ function list_firewall_rules(
         "ListFirewallRules",
         Dict{String,Any}("FirewallRuleGroupId" => FirewallRuleGroupId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_firewall_rules(
@@ -1840,6 +1943,7 @@ function list_firewall_rules(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1863,12 +1967,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   that value for NextToken in the request.
 """
 function list_resolver_dnssec_configs(; aws_config::AbstractAWSConfig=global_aws_config())
-    return route53resolver("ListResolverDnssecConfigs"; aws_config=aws_config)
+    return route53resolver(
+        "ListResolverDnssecConfigs"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_resolver_dnssec_configs(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return route53resolver("ListResolverDnssecConfigs", params; aws_config=aws_config)
+    return route53resolver(
+        "ListResolverDnssecConfigs",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1898,6 +2009,7 @@ function list_resolver_endpoint_ip_addresses(
         "ListResolverEndpointIpAddresses",
         Dict{String,Any}("ResolverEndpointId" => ResolverEndpointId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_resolver_endpoint_ip_addresses(
@@ -1913,6 +2025,7 @@ function list_resolver_endpoint_ip_addresses(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1938,12 +2051,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   of NextToken from the previous response.
 """
 function list_resolver_endpoints(; aws_config::AbstractAWSConfig=global_aws_config())
-    return route53resolver("ListResolverEndpoints"; aws_config=aws_config)
+    return route53resolver(
+        "ListResolverEndpoints"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_resolver_endpoints(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return route53resolver("ListResolverEndpoints", params; aws_config=aws_config)
+    return route53resolver(
+        "ListResolverEndpoints",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1993,13 +2113,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function list_resolver_query_log_config_associations(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return route53resolver("ListResolverQueryLogConfigAssociations"; aws_config=aws_config)
+    return route53resolver(
+        "ListResolverQueryLogConfigAssociations";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_resolver_query_log_config_associations(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return route53resolver(
-        "ListResolverQueryLogConfigAssociations", params; aws_config=aws_config
+        "ListResolverQueryLogConfigAssociations",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2053,12 +2180,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function list_resolver_query_log_configs(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return route53resolver("ListResolverQueryLogConfigs"; aws_config=aws_config)
+    return route53resolver(
+        "ListResolverQueryLogConfigs";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_resolver_query_log_configs(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return route53resolver("ListResolverQueryLogConfigs", params; aws_config=aws_config)
+    return route53resolver(
+        "ListResolverQueryLogConfigs",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2085,12 +2221,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function list_resolver_rule_associations(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return route53resolver("ListResolverRuleAssociations"; aws_config=aws_config)
+    return route53resolver(
+        "ListResolverRuleAssociations";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_resolver_rule_associations(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return route53resolver("ListResolverRuleAssociations", params; aws_config=aws_config)
+    return route53resolver(
+        "ListResolverRuleAssociations",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2114,12 +2259,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   previous response.
 """
 function list_resolver_rules(; aws_config::AbstractAWSConfig=global_aws_config())
-    return route53resolver("ListResolverRules"; aws_config=aws_config)
+    return route53resolver(
+        "ListResolverRules"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_resolver_rules(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return route53resolver("ListResolverRules", params; aws_config=aws_config)
+    return route53resolver(
+        "ListResolverRules", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -2149,6 +2298,7 @@ function list_tags_for_resource(
         "ListTagsForResource",
         Dict{String,Any}("ResourceArn" => ResourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags_for_resource(
@@ -2162,6 +2312,7 @@ function list_tags_for_resource(
             mergewith(_merge, Dict{String,Any}("ResourceArn" => ResourceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2188,6 +2339,7 @@ function put_firewall_rule_group_policy(
             "Arn" => Arn, "FirewallRuleGroupPolicy" => FirewallRuleGroupPolicy
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_firewall_rule_group_policy(
@@ -2208,6 +2360,7 @@ function put_firewall_rule_group_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2242,6 +2395,7 @@ function put_resolver_query_log_config_policy(
             "Arn" => Arn, "ResolverQueryLogConfigPolicy" => ResolverQueryLogConfigPolicy
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_resolver_query_log_config_policy(
@@ -2263,6 +2417,7 @@ function put_resolver_query_log_config_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2294,6 +2449,7 @@ function put_resolver_rule_policy(
         "PutResolverRulePolicy",
         Dict{String,Any}("Arn" => Arn, "ResolverRulePolicy" => ResolverRulePolicy);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_resolver_rule_policy(
@@ -2312,6 +2468,7 @@ function put_resolver_rule_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2334,6 +2491,7 @@ function tag_resource(ResourceArn, Tags; aws_config::AbstractAWSConfig=global_aw
         "TagResource",
         Dict{String,Any}("ResourceArn" => ResourceArn, "Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -2352,6 +2510,7 @@ function tag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2376,6 +2535,7 @@ function untag_resource(
         "UntagResource",
         Dict{String,Any}("ResourceArn" => ResourceArn, "TagKeys" => TagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -2394,6 +2554,7 @@ function untag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2425,6 +2586,7 @@ function update_firewall_config(
             "FirewallFailOpen" => FirewallFailOpen, "ResourceId" => ResourceId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_firewall_config(
@@ -2445,6 +2607,7 @@ function update_firewall_config(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2481,6 +2644,7 @@ function update_firewall_domains(
             "Operation" => Operation,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_firewall_domains(
@@ -2504,6 +2668,7 @@ function update_firewall_domains(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2556,6 +2721,7 @@ function update_firewall_rule(
             "FirewallRuleGroupId" => FirewallRuleGroupId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_firewall_rule(
@@ -2577,6 +2743,7 @@ function update_firewall_rule(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2612,6 +2779,7 @@ function update_firewall_rule_group_association(
             "FirewallRuleGroupAssociationId" => FirewallRuleGroupAssociationId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_firewall_rule_group_association(
@@ -2631,6 +2799,7 @@ function update_firewall_rule_group_association(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2656,6 +2825,7 @@ function update_resolver_dnssec_config(
         "UpdateResolverDnssecConfig",
         Dict{String,Any}("ResourceId" => ResourceId, "Validation" => Validation);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_resolver_dnssec_config(
@@ -2674,6 +2844,7 @@ function update_resolver_dnssec_config(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2697,6 +2868,7 @@ function update_resolver_endpoint(
         "UpdateResolverEndpoint",
         Dict{String,Any}("ResolverEndpointId" => ResolverEndpointId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_resolver_endpoint(
@@ -2712,6 +2884,7 @@ function update_resolver_endpoint(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2734,6 +2907,7 @@ function update_resolver_rule(
         "UpdateResolverRule",
         Dict{String,Any}("Config" => Config, "ResolverRuleId" => ResolverRuleId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_resolver_rule(
@@ -2752,5 +2926,6 @@ function update_resolver_rule(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/route_53.jl
+++ b/src/services/route_53.jl
@@ -25,6 +25,7 @@ function activate_key_signing_key(
         "POST",
         "/2013-04-01/keysigningkey/$(HostedZoneId)/$(Name)/activate";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function activate_key_signing_key(
@@ -38,6 +39,7 @@ function activate_key_signing_key(
         "/2013-04-01/keysigningkey/$(HostedZoneId)/$(Name)/activate",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -72,6 +74,7 @@ function associate_vpcwith_hosted_zone(
         "/2013-04-01/hostedzone/$(Id)/associatevpc",
         Dict{String,Any}("VPC" => VPC);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_vpcwith_hosted_zone(
@@ -82,6 +85,7 @@ function associate_vpcwith_hosted_zone(
         "/2013-04-01/hostedzone/$(Id)/associatevpc",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("VPC" => VPC), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -148,6 +152,7 @@ function change_resource_record_sets(
         "/2013-04-01/hostedzone/$(Id)/rrset/",
         Dict{String,Any}("ChangeBatch" => ChangeBatch);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function change_resource_record_sets(
@@ -163,6 +168,7 @@ function change_resource_record_sets(
             mergewith(_merge, Dict{String,Any}("ChangeBatch" => ChangeBatch), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -191,7 +197,10 @@ function change_tags_for_resource(
     ResourceId, ResourceType; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return route_53(
-        "POST", "/2013-04-01/tags/$(ResourceType)/$(ResourceId)"; aws_config=aws_config
+        "POST",
+        "/2013-04-01/tags/$(ResourceType)/$(ResourceId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function change_tags_for_resource(
@@ -205,6 +214,7 @@ function change_tags_for_resource(
         "/2013-04-01/tags/$(ResourceType)/$(ResourceId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -255,6 +265,7 @@ function create_health_check(
             "CallerReference" => CallerReference, "HealthCheckConfig" => HealthCheckConfig
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_health_check(
@@ -277,6 +288,7 @@ function create_health_check(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -342,6 +354,7 @@ function create_hosted_zone(
         "/2013-04-01/hostedzone",
         Dict{String,Any}("CallerReference" => CallerReference, "Name" => Name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_hosted_zone(
@@ -361,6 +374,7 @@ function create_hosted_zone(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -410,6 +424,7 @@ function create_key_signing_key(
             "Status" => Status,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_key_signing_key(
@@ -438,6 +453,7 @@ function create_key_signing_key(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -520,6 +536,7 @@ function create_query_logging_config(
             "HostedZoneId" => HostedZoneId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_query_logging_config(
@@ -542,6 +559,7 @@ function create_query_logging_config(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -593,6 +611,7 @@ function create_reusable_delegation_set(
         "/2013-04-01/delegationset",
         Dict{String,Any}("CallerReference" => CallerReference);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_reusable_delegation_set(
@@ -609,6 +628,7 @@ function create_reusable_delegation_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -636,6 +656,7 @@ function create_traffic_policy(
         "/2013-04-01/trafficpolicy",
         Dict{String,Any}("Document" => Document, "Name" => Name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_traffic_policy(
@@ -653,6 +674,7 @@ function create_traffic_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -699,6 +721,7 @@ function create_traffic_policy_instance(
             "TrafficPolicyVersion" => TrafficPolicyVersion,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_traffic_policy_instance(
@@ -727,6 +750,7 @@ function create_traffic_policy_instance(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -761,6 +785,7 @@ function create_traffic_policy_version(
         "/2013-04-01/trafficpolicy/$(Id)",
         Dict{String,Any}("Document" => Document);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_traffic_policy_version(
@@ -776,6 +801,7 @@ function create_traffic_policy_version(
             mergewith(_merge, Dict{String,Any}("Document" => Document), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -806,6 +832,7 @@ function create_vpcassociation_authorization(
         "/2013-04-01/hostedzone/$(Id)/authorizevpcassociation",
         Dict{String,Any}("VPC" => VPC);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_vpcassociation_authorization(
@@ -816,6 +843,7 @@ function create_vpcassociation_authorization(
         "/2013-04-01/hostedzone/$(Id)/authorizevpcassociation",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("VPC" => VPC), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -838,6 +866,7 @@ function deactivate_key_signing_key(
         "POST",
         "/2013-04-01/keysigningkey/$(HostedZoneId)/$(Name)/deactivate";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function deactivate_key_signing_key(
@@ -851,6 +880,7 @@ function deactivate_key_signing_key(
         "/2013-04-01/keysigningkey/$(HostedZoneId)/$(Name)/deactivate",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -877,7 +907,10 @@ function delete_health_check(
     HealthCheckId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return route_53(
-        "DELETE", "/2013-04-01/healthcheck/$(HealthCheckId)"; aws_config=aws_config
+        "DELETE",
+        "/2013-04-01/healthcheck/$(HealthCheckId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_health_check(
@@ -886,7 +919,11 @@ function delete_health_check(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return route_53(
-        "DELETE", "/2013-04-01/healthcheck/$(HealthCheckId)", params; aws_config=aws_config
+        "DELETE",
+        "/2013-04-01/healthcheck/$(HealthCheckId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -928,12 +965,23 @@ current Amazon Web Services account.
 
 """
 function delete_hosted_zone(Id; aws_config::AbstractAWSConfig=global_aws_config())
-    return route_53("DELETE", "/2013-04-01/hostedzone/$(Id)"; aws_config=aws_config)
+    return route_53(
+        "DELETE",
+        "/2013-04-01/hostedzone/$(Id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_hosted_zone(
     Id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return route_53("DELETE", "/2013-04-01/hostedzone/$(Id)", params; aws_config=aws_config)
+    return route_53(
+        "DELETE",
+        "/2013-04-01/hostedzone/$(Id)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -953,7 +1001,10 @@ function delete_key_signing_key(
     HostedZoneId, Name; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return route_53(
-        "DELETE", "/2013-04-01/keysigningkey/$(HostedZoneId)/$(Name)"; aws_config=aws_config
+        "DELETE",
+        "/2013-04-01/keysigningkey/$(HostedZoneId)/$(Name)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_key_signing_key(
@@ -967,6 +1018,7 @@ function delete_key_signing_key(
         "/2013-04-01/keysigningkey/$(HostedZoneId)/$(Name)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -984,13 +1036,22 @@ CreateQueryLoggingConfig.
 
 """
 function delete_query_logging_config(Id; aws_config::AbstractAWSConfig=global_aws_config())
-    return route_53("DELETE", "/2013-04-01/queryloggingconfig/$(Id)"; aws_config=aws_config)
+    return route_53(
+        "DELETE",
+        "/2013-04-01/queryloggingconfig/$(Id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_query_logging_config(
     Id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return route_53(
-        "DELETE", "/2013-04-01/queryloggingconfig/$(Id)", params; aws_config=aws_config
+        "DELETE",
+        "/2013-04-01/queryloggingconfig/$(Id)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1010,13 +1071,22 @@ ID of the reusable delegation set that you want to delete.
 function delete_reusable_delegation_set(
     Id; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return route_53("DELETE", "/2013-04-01/delegationset/$(Id)"; aws_config=aws_config)
+    return route_53(
+        "DELETE",
+        "/2013-04-01/delegationset/$(Id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_reusable_delegation_set(
     Id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return route_53(
-        "DELETE", "/2013-04-01/delegationset/$(Id)", params; aws_config=aws_config
+        "DELETE",
+        "/2013-04-01/delegationset/$(Id)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1040,7 +1110,10 @@ function delete_traffic_policy(
     Id, Version; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return route_53(
-        "DELETE", "/2013-04-01/trafficpolicy/$(Id)/$(Version)"; aws_config=aws_config
+        "DELETE",
+        "/2013-04-01/trafficpolicy/$(Id)/$(Version)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_traffic_policy(
@@ -1054,6 +1127,7 @@ function delete_traffic_policy(
         "/2013-04-01/trafficpolicy/$(Id)/$(Version)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1075,14 +1149,21 @@ function delete_traffic_policy_instance(
     Id; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return route_53(
-        "DELETE", "/2013-04-01/trafficpolicyinstance/$(Id)"; aws_config=aws_config
+        "DELETE",
+        "/2013-04-01/trafficpolicyinstance/$(Id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_traffic_policy_instance(
     Id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return route_53(
-        "DELETE", "/2013-04-01/trafficpolicyinstance/$(Id)", params; aws_config=aws_config
+        "DELETE",
+        "/2013-04-01/trafficpolicyinstance/$(Id)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1116,6 +1197,7 @@ function delete_vpcassociation_authorization(
         "/2013-04-01/hostedzone/$(Id)/deauthorizevpcassociation",
         Dict{String,Any}("VPC" => VPC);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_vpcassociation_authorization(
@@ -1126,6 +1208,7 @@ function delete_vpcassociation_authorization(
         "/2013-04-01/hostedzone/$(Id)/deauthorizevpcassociation",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("VPC" => VPC), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1142,14 +1225,21 @@ key-signing keys (KSKs) that are active in the hosted zone.
 """
 function disable_hosted_zone_dnssec(Id; aws_config::AbstractAWSConfig=global_aws_config())
     return route_53(
-        "POST", "/2013-04-01/hostedzone/$(Id)/disable-dnssec"; aws_config=aws_config
+        "POST",
+        "/2013-04-01/hostedzone/$(Id)/disable-dnssec";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disable_hosted_zone_dnssec(
     Id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return route_53(
-        "POST", "/2013-04-01/hostedzone/$(Id)/disable-dnssec", params; aws_config=aws_config
+        "POST",
+        "/2013-04-01/hostedzone/$(Id)/disable-dnssec",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1187,6 +1277,7 @@ function disassociate_vpcfrom_hosted_zone(
         "/2013-04-01/hostedzone/$(Id)/disassociatevpc",
         Dict{String,Any}("VPC" => VPC);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disassociate_vpcfrom_hosted_zone(
@@ -1197,6 +1288,7 @@ function disassociate_vpcfrom_hosted_zone(
         "/2013-04-01/hostedzone/$(Id)/disassociatevpc",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("VPC" => VPC), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1212,14 +1304,21 @@ Enables DNSSEC signing in a specific hosted zone.
 """
 function enable_hosted_zone_dnssec(Id; aws_config::AbstractAWSConfig=global_aws_config())
     return route_53(
-        "POST", "/2013-04-01/hostedzone/$(Id)/enable-dnssec"; aws_config=aws_config
+        "POST",
+        "/2013-04-01/hostedzone/$(Id)/enable-dnssec";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function enable_hosted_zone_dnssec(
     Id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return route_53(
-        "POST", "/2013-04-01/hostedzone/$(Id)/enable-dnssec", params; aws_config=aws_config
+        "POST",
+        "/2013-04-01/hostedzone/$(Id)/enable-dnssec",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1248,13 +1347,22 @@ navigation pane.
 
 """
 function get_account_limit(Type; aws_config::AbstractAWSConfig=global_aws_config())
-    return route_53("GET", "/2013-04-01/accountlimit/$(Type)"; aws_config=aws_config)
+    return route_53(
+        "GET",
+        "/2013-04-01/accountlimit/$(Type)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_account_limit(
     Type, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return route_53(
-        "GET", "/2013-04-01/accountlimit/$(Type)", params; aws_config=aws_config
+        "GET",
+        "/2013-04-01/accountlimit/$(Type)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1273,12 +1381,23 @@ INSYNC indicates that the changes have propagated to all Route 53 DNS servers.
 
 """
 function get_change(Id; aws_config::AbstractAWSConfig=global_aws_config())
-    return route_53("GET", "/2013-04-01/change/$(Id)"; aws_config=aws_config)
+    return route_53(
+        "GET",
+        "/2013-04-01/change/$(Id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_change(
     Id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return route_53("GET", "/2013-04-01/change/$(Id)", params; aws_config=aws_config)
+    return route_53(
+        "GET",
+        "/2013-04-01/change/$(Id)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1293,12 +1412,23 @@ Amazon Route 53 Developer Guide.
 
 """
 function get_checker_ip_ranges(; aws_config::AbstractAWSConfig=global_aws_config())
-    return route_53("GET", "/2013-04-01/checkeripranges"; aws_config=aws_config)
+    return route_53(
+        "GET",
+        "/2013-04-01/checkeripranges";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_checker_ip_ranges(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return route_53("GET", "/2013-04-01/checkeripranges", params; aws_config=aws_config)
+    return route_53(
+        "GET",
+        "/2013-04-01/checkeripranges",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1313,13 +1443,22 @@ Returns information about DNSSEC for a specific hosted zone, including the key-s
 
 """
 function get_dnssec(Id; aws_config::AbstractAWSConfig=global_aws_config())
-    return route_53("GET", "/2013-04-01/hostedzone/$(Id)/dnssec"; aws_config=aws_config)
+    return route_53(
+        "GET",
+        "/2013-04-01/hostedzone/$(Id)/dnssec";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_dnssec(
     Id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return route_53(
-        "GET", "/2013-04-01/hostedzone/$(Id)/dnssec", params; aws_config=aws_config
+        "GET",
+        "/2013-04-01/hostedzone/$(Id)/dnssec",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1352,12 +1491,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   supported subdivision codes, use the ListGeoLocations API.
 """
 function get_geo_location(; aws_config::AbstractAWSConfig=global_aws_config())
-    return route_53("GET", "/2013-04-01/geolocation"; aws_config=aws_config)
+    return route_53(
+        "GET",
+        "/2013-04-01/geolocation";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_geo_location(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return route_53("GET", "/2013-04-01/geolocation", params; aws_config=aws_config)
+    return route_53(
+        "GET",
+        "/2013-04-01/geolocation",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1374,7 +1524,10 @@ Gets information about a specified health check.
 """
 function get_health_check(HealthCheckId; aws_config::AbstractAWSConfig=global_aws_config())
     return route_53(
-        "GET", "/2013-04-01/healthcheck/$(HealthCheckId)"; aws_config=aws_config
+        "GET",
+        "/2013-04-01/healthcheck/$(HealthCheckId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_health_check(
@@ -1383,7 +1536,11 @@ function get_health_check(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return route_53(
-        "GET", "/2013-04-01/healthcheck/$(HealthCheckId)", params; aws_config=aws_config
+        "GET",
+        "/2013-04-01/healthcheck/$(HealthCheckId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1396,12 +1553,23 @@ Services account.
 
 """
 function get_health_check_count(; aws_config::AbstractAWSConfig=global_aws_config())
-    return route_53("GET", "/2013-04-01/healthcheckcount"; aws_config=aws_config)
+    return route_53(
+        "GET",
+        "/2013-04-01/healthcheckcount";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_health_check_count(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return route_53("GET", "/2013-04-01/healthcheckcount", params; aws_config=aws_config)
+    return route_53(
+        "GET",
+        "/2013-04-01/healthcheckcount",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1425,6 +1593,7 @@ function get_health_check_last_failure_reason(
         "GET",
         "/2013-04-01/healthcheck/$(HealthCheckId)/lastfailurereason";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_health_check_last_failure_reason(
@@ -1437,6 +1606,7 @@ function get_health_check_last_failure_reason(
         "/2013-04-01/healthcheck/$(HealthCheckId)/lastfailurereason",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1460,7 +1630,10 @@ function get_health_check_status(
     HealthCheckId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return route_53(
-        "GET", "/2013-04-01/healthcheck/$(HealthCheckId)/status"; aws_config=aws_config
+        "GET",
+        "/2013-04-01/healthcheck/$(HealthCheckId)/status";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_health_check_status(
@@ -1473,6 +1646,7 @@ function get_health_check_status(
         "/2013-04-01/healthcheck/$(HealthCheckId)/status",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1488,12 +1662,23 @@ the hosted zone.
 
 """
 function get_hosted_zone(Id; aws_config::AbstractAWSConfig=global_aws_config())
-    return route_53("GET", "/2013-04-01/hostedzone/$(Id)"; aws_config=aws_config)
+    return route_53(
+        "GET",
+        "/2013-04-01/hostedzone/$(Id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_hosted_zone(
     Id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return route_53("GET", "/2013-04-01/hostedzone/$(Id)", params; aws_config=aws_config)
+    return route_53(
+        "GET",
+        "/2013-04-01/hostedzone/$(Id)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1505,12 +1690,23 @@ Services account.
 
 """
 function get_hosted_zone_count(; aws_config::AbstractAWSConfig=global_aws_config())
-    return route_53("GET", "/2013-04-01/hostedzonecount"; aws_config=aws_config)
+    return route_53(
+        "GET",
+        "/2013-04-01/hostedzonecount";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_hosted_zone_count(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return route_53("GET", "/2013-04-01/hostedzonecount", params; aws_config=aws_config)
+    return route_53(
+        "GET",
+        "/2013-04-01/hostedzonecount",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1531,7 +1727,10 @@ Amazon Route 53 Developer Guide. To request a higher limit, open a case.
 """
 function get_hosted_zone_limit(Id, Type; aws_config::AbstractAWSConfig=global_aws_config())
     return route_53(
-        "GET", "/2013-04-01/hostedzonelimit/$(Id)/$(Type)"; aws_config=aws_config
+        "GET",
+        "/2013-04-01/hostedzonelimit/$(Id)/$(Type)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_hosted_zone_limit(
@@ -1541,7 +1740,11 @@ function get_hosted_zone_limit(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return route_53(
-        "GET", "/2013-04-01/hostedzonelimit/$(Id)/$(Type)", params; aws_config=aws_config
+        "GET",
+        "/2013-04-01/hostedzonelimit/$(Id)/$(Type)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1558,13 +1761,22 @@ information about DNS query logs, see CreateQueryLoggingConfig and Logging DNS Q
 
 """
 function get_query_logging_config(Id; aws_config::AbstractAWSConfig=global_aws_config())
-    return route_53("GET", "/2013-04-01/queryloggingconfig/$(Id)"; aws_config=aws_config)
+    return route_53(
+        "GET",
+        "/2013-04-01/queryloggingconfig/$(Id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_query_logging_config(
     Id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return route_53(
-        "GET", "/2013-04-01/queryloggingconfig/$(Id)", params; aws_config=aws_config
+        "GET",
+        "/2013-04-01/queryloggingconfig/$(Id)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1581,12 +1793,23 @@ servers that are assigned to the delegation set.
 
 """
 function get_reusable_delegation_set(Id; aws_config::AbstractAWSConfig=global_aws_config())
-    return route_53("GET", "/2013-04-01/delegationset/$(Id)"; aws_config=aws_config)
+    return route_53(
+        "GET",
+        "/2013-04-01/delegationset/$(Id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_reusable_delegation_set(
     Id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return route_53("GET", "/2013-04-01/delegationset/$(Id)", params; aws_config=aws_config)
+    return route_53(
+        "GET",
+        "/2013-04-01/delegationset/$(Id)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1607,7 +1830,10 @@ function get_reusable_delegation_set_limit(
     Id, Type; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return route_53(
-        "GET", "/2013-04-01/reusabledelegationsetlimit/$(Id)/$(Type)"; aws_config=aws_config
+        "GET",
+        "/2013-04-01/reusabledelegationsetlimit/$(Id)/$(Type)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_reusable_delegation_set_limit(
@@ -1621,6 +1847,7 @@ function get_reusable_delegation_set_limit(
         "/2013-04-01/reusabledelegationsetlimit/$(Id)/$(Type)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1640,7 +1867,10 @@ DeleteTrafficPolicy.
 """
 function get_traffic_policy(Id, Version; aws_config::AbstractAWSConfig=global_aws_config())
     return route_53(
-        "GET", "/2013-04-01/trafficpolicy/$(Id)/$(Version)"; aws_config=aws_config
+        "GET",
+        "/2013-04-01/trafficpolicy/$(Id)/$(Version)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_traffic_policy(
@@ -1650,7 +1880,11 @@ function get_traffic_policy(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return route_53(
-        "GET", "/2013-04-01/trafficpolicy/$(Id)/$(Version)", params; aws_config=aws_config
+        "GET",
+        "/2013-04-01/trafficpolicy/$(Id)/$(Version)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1669,13 +1903,22 @@ Route 53 console, traffic policy instances are known as policy records.
 
 """
 function get_traffic_policy_instance(Id; aws_config::AbstractAWSConfig=global_aws_config())
-    return route_53("GET", "/2013-04-01/trafficpolicyinstance/$(Id)"; aws_config=aws_config)
+    return route_53(
+        "GET",
+        "/2013-04-01/trafficpolicyinstance/$(Id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_traffic_policy_instance(
     Id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return route_53(
-        "GET", "/2013-04-01/trafficpolicyinstance/$(Id)", params; aws_config=aws_config
+        "GET",
+        "/2013-04-01/trafficpolicyinstance/$(Id)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1690,13 +1933,22 @@ Services account.
 function get_traffic_policy_instance_count(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return route_53("GET", "/2013-04-01/trafficpolicyinstancecount"; aws_config=aws_config)
+    return route_53(
+        "GET",
+        "/2013-04-01/trafficpolicyinstancecount";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_traffic_policy_instance_count(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return route_53(
-        "GET", "/2013-04-01/trafficpolicyinstancecount", params; aws_config=aws_config
+        "GET",
+        "/2013-04-01/trafficpolicyinstancecount",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1735,12 +1987,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   states), you must include both startcountrycode and startsubdivisioncode.
 """
 function list_geo_locations(; aws_config::AbstractAWSConfig=global_aws_config())
-    return route_53("GET", "/2013-04-01/geolocations"; aws_config=aws_config)
+    return route_53(
+        "GET",
+        "/2013-04-01/geolocations";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_geo_locations(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return route_53("GET", "/2013-04-01/geolocations", params; aws_config=aws_config)
+    return route_53(
+        "GET",
+        "/2013-04-01/geolocations",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1764,12 +2027,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   checks.
 """
 function list_health_checks(; aws_config::AbstractAWSConfig=global_aws_config())
-    return route_53("GET", "/2013-04-01/healthcheck"; aws_config=aws_config)
+    return route_53(
+        "GET",
+        "/2013-04-01/healthcheck";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_health_checks(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return route_53("GET", "/2013-04-01/healthcheck", params; aws_config=aws_config)
+    return route_53(
+        "GET",
+        "/2013-04-01/healthcheck",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1799,12 +2073,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   zone that Route 53 will return if you submit another request.
 """
 function list_hosted_zones(; aws_config::AbstractAWSConfig=global_aws_config())
-    return route_53("GET", "/2013-04-01/hostedzone"; aws_config=aws_config)
+    return route_53(
+        "GET",
+        "/2013-04-01/hostedzone";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_hosted_zones(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return route_53("GET", "/2013-04-01/hostedzone", params; aws_config=aws_config)
+    return route_53(
+        "GET",
+        "/2013-04-01/hostedzone",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1859,12 +2144,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   NextHostedZoneId specify the first hosted zone in the next group of maxitems hosted zones.
 """
 function list_hosted_zones_by_name(; aws_config::AbstractAWSConfig=global_aws_config())
-    return route_53("GET", "/2013-04-01/hostedzonesbyname"; aws_config=aws_config)
+    return route_53(
+        "GET",
+        "/2013-04-01/hostedzonesbyname";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_hosted_zones_by_name(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return route_53("GET", "/2013-04-01/hostedzonesbyname", params; aws_config=aws_config)
+    return route_53(
+        "GET",
+        "/2013-04-01/hostedzonesbyname",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1906,6 +2202,7 @@ function list_hosted_zones_by_vpc(
         "/2013-04-01/hostedzonesbyvpc",
         Dict{String,Any}("vpcid" => vpcid, "vpcregion" => vpcregion);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_hosted_zones_by_vpc(
@@ -1923,6 +2220,7 @@ function list_hosted_zones_by_vpc(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1954,12 +2252,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   specify that value for NextToken in the request.
 """
 function list_query_logging_configs(; aws_config::AbstractAWSConfig=global_aws_config())
-    return route_53("GET", "/2013-04-01/queryloggingconfig"; aws_config=aws_config)
+    return route_53(
+        "GET",
+        "/2013-04-01/queryloggingconfig";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_query_logging_configs(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return route_53("GET", "/2013-04-01/queryloggingconfig", params; aws_config=aws_config)
+    return route_53(
+        "GET",
+        "/2013-04-01/queryloggingconfig",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2024,13 +2333,22 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   returns an InvalidInput error.
 """
 function list_resource_record_sets(Id; aws_config::AbstractAWSConfig=global_aws_config())
-    return route_53("GET", "/2013-04-01/hostedzone/$(Id)/rrset"; aws_config=aws_config)
+    return route_53(
+        "GET",
+        "/2013-04-01/hostedzone/$(Id)/rrset";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_resource_record_sets(
     Id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return route_53(
-        "GET", "/2013-04-01/hostedzone/$(Id)/rrset", params; aws_config=aws_config
+        "GET",
+        "/2013-04-01/hostedzone/$(Id)/rrset",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2054,12 +2372,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   returns only the first 100 reusable delegation sets.
 """
 function list_reusable_delegation_sets(; aws_config::AbstractAWSConfig=global_aws_config())
-    return route_53("GET", "/2013-04-01/delegationset"; aws_config=aws_config)
+    return route_53(
+        "GET",
+        "/2013-04-01/delegationset";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_reusable_delegation_sets(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return route_53("GET", "/2013-04-01/delegationset", params; aws_config=aws_config)
+    return route_53(
+        "GET",
+        "/2013-04-01/delegationset",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2079,7 +2408,10 @@ function list_tags_for_resource(
     ResourceId, ResourceType; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return route_53(
-        "GET", "/2013-04-01/tags/$(ResourceType)/$(ResourceId)"; aws_config=aws_config
+        "GET",
+        "/2013-04-01/tags/$(ResourceType)/$(ResourceId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags_for_resource(
@@ -2093,6 +2425,7 @@ function list_tags_for_resource(
         "/2013-04-01/tags/$(ResourceType)/$(ResourceId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2123,6 +2456,7 @@ function list_tags_for_resources(
         "/2013-04-01/tags/$(ResourceType)",
         Dict{String,Any}("ResourceId" => ResourceId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags_for_resources(
@@ -2138,6 +2472,7 @@ function list_tags_for_resources(
             mergewith(_merge, Dict{String,Any}("ResourceId" => ResourceId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2165,12 +2500,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   returned in the previous response.
 """
 function list_traffic_policies(; aws_config::AbstractAWSConfig=global_aws_config())
-    return route_53("GET", "/2013-04-01/trafficpolicies"; aws_config=aws_config)
+    return route_53(
+        "GET",
+        "/2013-04-01/trafficpolicies";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_traffic_policies(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return route_53("GET", "/2013-04-01/trafficpolicies", params; aws_config=aws_config)
+    return route_53(
+        "GET",
+        "/2013-04-01/trafficpolicies",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2216,13 +2562,22 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   more traffic policy instances to get.
 """
 function list_traffic_policy_instances(; aws_config::AbstractAWSConfig=global_aws_config())
-    return route_53("GET", "/2013-04-01/trafficpolicyinstances"; aws_config=aws_config)
+    return route_53(
+        "GET",
+        "/2013-04-01/trafficpolicyinstances";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_traffic_policy_instances(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return route_53(
-        "GET", "/2013-04-01/trafficpolicyinstances", params; aws_config=aws_config
+        "GET",
+        "/2013-04-01/trafficpolicyinstances",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2272,6 +2627,7 @@ function list_traffic_policy_instances_by_hosted_zone(
         "/2013-04-01/trafficpolicyinstances/hostedzone",
         Dict{String,Any}("id" => id);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_traffic_policy_instances_by_hosted_zone(
@@ -2282,6 +2638,7 @@ function list_traffic_policy_instances_by_hosted_zone(
         "/2013-04-01/trafficpolicyinstances/hostedzone",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("id" => id), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2341,6 +2698,7 @@ function list_traffic_policy_instances_by_policy(
         "/2013-04-01/trafficpolicyinstances/trafficpolicy",
         Dict{String,Any}("id" => id, "version" => version);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_traffic_policy_instances_by_policy(
@@ -2356,6 +2714,7 @@ function list_traffic_policy_instances_by_policy(
             mergewith(_merge, Dict{String,Any}("id" => id, "version" => version), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2386,14 +2745,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function list_traffic_policy_versions(Id; aws_config::AbstractAWSConfig=global_aws_config())
     return route_53(
-        "GET", "/2013-04-01/trafficpolicies/$(Id)/versions"; aws_config=aws_config
+        "GET",
+        "/2013-04-01/trafficpolicies/$(Id)/versions";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_traffic_policy_versions(
     Id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return route_53(
-        "GET", "/2013-04-01/trafficpolicies/$(Id)/versions", params; aws_config=aws_config
+        "GET",
+        "/2013-04-01/trafficpolicies/$(Id)/versions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2424,7 +2790,10 @@ function list_vpcassociation_authorizations(
     Id; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return route_53(
-        "GET", "/2013-04-01/hostedzone/$(Id)/authorizevpcassociation"; aws_config=aws_config
+        "GET",
+        "/2013-04-01/hostedzone/$(Id)/authorizevpcassociation";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_vpcassociation_authorizations(
@@ -2435,6 +2804,7 @@ function list_vpcassociation_authorizations(
         "/2013-04-01/hostedzone/$(Id)/authorizevpcassociation",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2483,6 +2853,7 @@ function test_dnsanswer(
             "recordtype" => recordtype,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function test_dnsanswer(
@@ -2507,6 +2878,7 @@ function test_dnsanswer(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2668,7 +3040,10 @@ function update_health_check(
     HealthCheckId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return route_53(
-        "POST", "/2013-04-01/healthcheck/$(HealthCheckId)"; aws_config=aws_config
+        "POST",
+        "/2013-04-01/healthcheck/$(HealthCheckId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_health_check(
@@ -2677,7 +3052,11 @@ function update_health_check(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return route_53(
-        "POST", "/2013-04-01/healthcheck/$(HealthCheckId)", params; aws_config=aws_config
+        "POST",
+        "/2013-04-01/healthcheck/$(HealthCheckId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2696,12 +3075,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Comment, Amazon Route 53 deletes the existing value of the Comment element, if any.
 """
 function update_hosted_zone_comment(Id; aws_config::AbstractAWSConfig=global_aws_config())
-    return route_53("POST", "/2013-04-01/hostedzone/$(Id)"; aws_config=aws_config)
+    return route_53(
+        "POST",
+        "/2013-04-01/hostedzone/$(Id)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function update_hosted_zone_comment(
     Id, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return route_53("POST", "/2013-04-01/hostedzone/$(Id)", params; aws_config=aws_config)
+    return route_53(
+        "POST",
+        "/2013-04-01/hostedzone/$(Id)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2725,6 +3115,7 @@ function update_traffic_policy_comment(
         "/2013-04-01/trafficpolicy/$(Id)/$(Version)",
         Dict{String,Any}("Comment" => Comment);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_traffic_policy_comment(
@@ -2739,6 +3130,7 @@ function update_traffic_policy_comment(
         "/2013-04-01/trafficpolicy/$(Id)/$(Version)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Comment" => Comment), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2784,6 +3176,7 @@ function update_traffic_policy_instance(
             "TrafficPolicyVersion" => TrafficPolicyVersion,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_traffic_policy_instance(
@@ -2809,5 +3202,6 @@ function update_traffic_policy_instance(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/route_53_domains.jl
+++ b/src/services/route_53_domains.jl
@@ -28,6 +28,7 @@ function accept_domain_transfer_from_another_aws_account(
         "AcceptDomainTransferFromAnotherAwsAccount",
         Dict{String,Any}("DomainName" => DomainName, "Password" => Password);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function accept_domain_transfer_from_another_aws_account(
@@ -46,6 +47,7 @@ function accept_domain_transfer_from_another_aws_account(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -72,6 +74,7 @@ function cancel_domain_transfer_to_another_aws_account(
         "CancelDomainTransferToAnotherAwsAccount",
         Dict{String,Any}("DomainName" => DomainName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function cancel_domain_transfer_to_another_aws_account(
@@ -85,6 +88,7 @@ function cancel_domain_transfer_to_another_aws_account(
             mergewith(_merge, Dict{String,Any}("DomainName" => DomainName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -119,6 +123,7 @@ function check_domain_availability(
         "CheckDomainAvailability",
         Dict{String,Any}("DomainName" => DomainName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function check_domain_availability(
@@ -132,6 +137,7 @@ function check_domain_availability(
             mergewith(_merge, Dict{String,Any}("DomainName" => DomainName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -163,6 +169,7 @@ function check_domain_transferability(
         "CheckDomainTransferability",
         Dict{String,Any}("DomainName" => DomainName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function check_domain_transferability(
@@ -176,6 +183,7 @@ function check_domain_transferability(
             mergewith(_merge, Dict{String,Any}("DomainName" => DomainName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -198,6 +206,7 @@ function delete_tags_for_domain(
         "DeleteTagsForDomain",
         Dict{String,Any}("DomainName" => DomainName, "TagsToDelete" => TagsToDelete);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_tags_for_domain(
@@ -218,6 +227,7 @@ function delete_tags_for_domain(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -238,6 +248,7 @@ function disable_domain_auto_renew(
         "DisableDomainAutoRenew",
         Dict{String,Any}("DomainName" => DomainName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disable_domain_auto_renew(
@@ -251,6 +262,7 @@ function disable_domain_auto_renew(
             mergewith(_merge, Dict{String,Any}("DomainName" => DomainName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -276,6 +288,7 @@ function disable_domain_transfer_lock(
         "DisableDomainTransferLock",
         Dict{String,Any}("DomainName" => DomainName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disable_domain_transfer_lock(
@@ -289,6 +302,7 @@ function disable_domain_transfer_lock(
             mergewith(_merge, Dict{String,Any}("DomainName" => DomainName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -314,6 +328,7 @@ function enable_domain_auto_renew(
         "EnableDomainAutoRenew",
         Dict{String,Any}("DomainName" => DomainName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function enable_domain_auto_renew(
@@ -327,6 +342,7 @@ function enable_domain_auto_renew(
             mergewith(_merge, Dict{String,Any}("DomainName" => DomainName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -350,6 +366,7 @@ function enable_domain_transfer_lock(
         "EnableDomainTransferLock",
         Dict{String,Any}("DomainName" => DomainName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function enable_domain_transfer_lock(
@@ -363,6 +380,7 @@ function enable_domain_transfer_lock(
             mergewith(_merge, Dict{String,Any}("DomainName" => DomainName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -383,12 +401,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function get_contact_reachability_status(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return route_53_domains("GetContactReachabilityStatus"; aws_config=aws_config)
+    return route_53_domains(
+        "GetContactReachabilityStatus";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_contact_reachability_status(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return route_53_domains("GetContactReachabilityStatus", params; aws_config=aws_config)
+    return route_53_domains(
+        "GetContactReachabilityStatus",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -408,6 +435,7 @@ function get_domain_detail(DomainName; aws_config::AbstractAWSConfig=global_aws_
         "GetDomainDetail",
         Dict{String,Any}("DomainName" => DomainName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_domain_detail(
@@ -421,6 +449,7 @@ function get_domain_detail(
             mergewith(_merge, Dict{String,Any}("DomainName" => DomainName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -463,6 +492,7 @@ function get_domain_suggestions(
             "SuggestionCount" => SuggestionCount,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_domain_suggestions(
@@ -486,6 +516,7 @@ function get_domain_suggestions(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -507,6 +538,7 @@ function get_operation_detail(
         "GetOperationDetail",
         Dict{String,Any}("OperationId" => OperationId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_operation_detail(
@@ -520,6 +552,7 @@ function get_operation_detail(
             mergewith(_merge, Dict{String,Any}("OperationId" => OperationId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -541,12 +574,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"MaxItems"`: Number of domains to be returned. Default: 20
 """
 function list_domains(; aws_config::AbstractAWSConfig=global_aws_config())
-    return route_53_domains("ListDomains"; aws_config=aws_config)
+    return route_53_domains(
+        "ListDomains"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_domains(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return route_53_domains("ListDomains", params; aws_config=aws_config)
+    return route_53_domains(
+        "ListDomains", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -569,12 +606,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Unix time format and Coordinated Universal time (UTC).
 """
 function list_operations(; aws_config::AbstractAWSConfig=global_aws_config())
-    return route_53_domains("ListOperations"; aws_config=aws_config)
+    return route_53_domains(
+        "ListOperations"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_operations(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return route_53_domains("ListOperations", params; aws_config=aws_config)
+    return route_53_domains(
+        "ListOperations", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -594,6 +635,7 @@ function list_tags_for_domain(DomainName; aws_config::AbstractAWSConfig=global_a
         "ListTagsForDomain",
         Dict{String,Any}("DomainName" => DomainName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags_for_domain(
@@ -607,6 +649,7 @@ function list_tags_for_domain(
             mergewith(_merge, Dict{String,Any}("DomainName" => DomainName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -692,6 +735,7 @@ function register_domain(
             "TechContact" => TechContact,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function register_domain(
@@ -719,6 +763,7 @@ function register_domain(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -744,6 +789,7 @@ function reject_domain_transfer_from_another_aws_account(
         "RejectDomainTransferFromAnotherAwsAccount",
         Dict{String,Any}("DomainName" => DomainName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function reject_domain_transfer_from_another_aws_account(
@@ -757,6 +803,7 @@ function reject_domain_transfer_from_another_aws_account(
             mergewith(_merge, Dict{String,Any}("DomainName" => DomainName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -791,6 +838,7 @@ function renew_domain(
             "CurrentExpiryYear" => CurrentExpiryYear, "DomainName" => DomainName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function renew_domain(
@@ -811,6 +859,7 @@ function renew_domain(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -830,12 +879,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function resend_contact_reachability_email(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return route_53_domains("ResendContactReachabilityEmail"; aws_config=aws_config)
+    return route_53_domains(
+        "ResendContactReachabilityEmail";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function resend_contact_reachability_email(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return route_53_domains("ResendContactReachabilityEmail", params; aws_config=aws_config)
+    return route_53_domains(
+        "ResendContactReachabilityEmail",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -856,6 +914,7 @@ function retrieve_domain_auth_code(
         "RetrieveDomainAuthCode",
         Dict{String,Any}("DomainName" => DomainName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function retrieve_domain_auth_code(
@@ -869,6 +928,7 @@ function retrieve_domain_auth_code(
             mergewith(_merge, Dict{String,Any}("DomainName" => DomainName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -955,6 +1015,7 @@ function transfer_domain(
             "TechContact" => TechContact,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function transfer_domain(
@@ -982,6 +1043,7 @@ function transfer_domain(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1018,6 +1080,7 @@ function transfer_domain_to_another_aws_account(
         "TransferDomainToAnotherAwsAccount",
         Dict{String,Any}("AccountId" => AccountId, "DomainName" => DomainName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function transfer_domain_to_another_aws_account(
@@ -1036,6 +1099,7 @@ function transfer_domain_to_another_aws_account(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1065,6 +1129,7 @@ function update_domain_contact(
         "UpdateDomainContact",
         Dict{String,Any}("DomainName" => DomainName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_domain_contact(
@@ -1078,6 +1143,7 @@ function update_domain_contact(
             mergewith(_merge, Dict{String,Any}("DomainName" => DomainName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1129,6 +1195,7 @@ function update_domain_contact_privacy(
         "UpdateDomainContactPrivacy",
         Dict{String,Any}("DomainName" => DomainName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_domain_contact_privacy(
@@ -1142,6 +1209,7 @@ function update_domain_contact_privacy(
             mergewith(_merge, Dict{String,Any}("DomainName" => DomainName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1171,6 +1239,7 @@ function update_domain_nameservers(
         "UpdateDomainNameservers",
         Dict{String,Any}("DomainName" => DomainName, "Nameservers" => Nameservers);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_domain_nameservers(
@@ -1189,6 +1258,7 @@ function update_domain_nameservers(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1215,6 +1285,7 @@ function update_tags_for_domain(
         "UpdateTagsForDomain",
         Dict{String,Any}("DomainName" => DomainName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_tags_for_domain(
@@ -1228,6 +1299,7 @@ function update_tags_for_domain(
             mergewith(_merge, Dict{String,Any}("DomainName" => DomainName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1255,10 +1327,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   time (UTC).
 """
 function view_billing(; aws_config::AbstractAWSConfig=global_aws_config())
-    return route_53_domains("ViewBilling"; aws_config=aws_config)
+    return route_53_domains(
+        "ViewBilling"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function view_billing(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return route_53_domains("ViewBilling", params; aws_config=aws_config)
+    return route_53_domains(
+        "ViewBilling", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end

--- a/src/services/s3.jl
+++ b/src/services/s3.jl
@@ -51,6 +51,7 @@ function abort_multipart_upload(
         "/$(Bucket)/$(Key)",
         Dict{String,Any}("uploadId" => uploadId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function abort_multipart_upload(
@@ -67,6 +68,7 @@ function abort_multipart_upload(
             mergewith(_merge, Dict{String,Any}("uploadId" => uploadId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -138,6 +140,7 @@ function complete_multipart_upload(
         "/$(Bucket)/$(Key)",
         Dict{String,Any}("uploadId" => uploadId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function complete_multipart_upload(
@@ -154,6 +157,7 @@ function complete_multipart_upload(
             mergewith(_merge, Dict{String,Any}("uploadId" => uploadId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -376,6 +380,7 @@ function copy_object(
             "headers" => Dict{String,Any}("x-amz-copy-source" => x_amz_copy_source)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function copy_object(
@@ -398,6 +403,7 @@ function copy_object(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -469,12 +475,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"x-amz-grant-write-acp"`: Allows grantee to write the ACL for the applicable bucket.
 """
 function create_bucket(Bucket; aws_config::AbstractAWSConfig=global_aws_config())
-    return s3("PUT", "/$(Bucket)"; aws_config=aws_config)
+    return s3("PUT", "/$(Bucket)"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function create_bucket(
     Bucket, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return s3("PUT", "/$(Bucket)", params; aws_config=aws_config)
+    return s3(
+        "PUT", "/$(Bucket)", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -660,7 +668,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function create_multipart_upload(
     Bucket, Key; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return s3("POST", "/$(Bucket)/$(Key)?uploads"; aws_config=aws_config)
+    return s3(
+        "POST",
+        "/$(Bucket)/$(Key)?uploads";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function create_multipart_upload(
     Bucket,
@@ -668,7 +681,13 @@ function create_multipart_upload(
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return s3("POST", "/$(Bucket)/$(Key)?uploads", params; aws_config=aws_config)
+    return s3(
+        "POST",
+        "/$(Bucket)/$(Key)?uploads",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -689,12 +708,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Denied) error.
 """
 function delete_bucket(Bucket; aws_config::AbstractAWSConfig=global_aws_config())
-    return s3("DELETE", "/$(Bucket)"; aws_config=aws_config)
+    return s3(
+        "DELETE", "/$(Bucket)"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function delete_bucket(
     Bucket, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return s3("DELETE", "/$(Bucket)", params; aws_config=aws_config)
+    return s3(
+        "DELETE",
+        "/$(Bucket)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -729,6 +756,7 @@ function delete_bucket_analytics_configuration(
         "/$(Bucket)?analytics",
         Dict{String,Any}("id" => id);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_bucket_analytics_configuration(
@@ -742,6 +770,7 @@ function delete_bucket_analytics_configuration(
         "/$(Bucket)?analytics",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("id" => id), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -765,12 +794,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Denied) error.
 """
 function delete_bucket_cors(Bucket; aws_config::AbstractAWSConfig=global_aws_config())
-    return s3("DELETE", "/$(Bucket)?cors"; aws_config=aws_config)
+    return s3(
+        "DELETE", "/$(Bucket)?cors"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function delete_bucket_cors(
     Bucket, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return s3("DELETE", "/$(Bucket)?cors", params; aws_config=aws_config)
+    return s3(
+        "DELETE",
+        "/$(Bucket)?cors",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -797,12 +834,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Denied) error.
 """
 function delete_bucket_encryption(Bucket; aws_config::AbstractAWSConfig=global_aws_config())
-    return s3("DELETE", "/$(Bucket)?encryption"; aws_config=aws_config)
+    return s3(
+        "DELETE",
+        "/$(Bucket)?encryption";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_bucket_encryption(
     Bucket, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return s3("DELETE", "/$(Bucket)?encryption", params; aws_config=aws_config)
+    return s3(
+        "DELETE",
+        "/$(Bucket)?encryption",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -839,6 +887,7 @@ function delete_bucket_intelligent_tiering_configuration(
         "/$(Bucket)?intelligent-tiering",
         Dict{String,Any}("id" => id);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_bucket_intelligent_tiering_configuration(
@@ -852,6 +901,7 @@ function delete_bucket_intelligent_tiering_configuration(
         "/$(Bucket)?intelligent-tiering",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("id" => id), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -886,6 +936,7 @@ function delete_bucket_inventory_configuration(
         "/$(Bucket)?inventory",
         Dict{String,Any}("id" => id);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_bucket_inventory_configuration(
@@ -899,6 +950,7 @@ function delete_bucket_inventory_configuration(
         "/$(Bucket)?inventory",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("id" => id), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -927,12 +979,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Denied) error.
 """
 function delete_bucket_lifecycle(Bucket; aws_config::AbstractAWSConfig=global_aws_config())
-    return s3("DELETE", "/$(Bucket)?lifecycle"; aws_config=aws_config)
+    return s3(
+        "DELETE",
+        "/$(Bucket)?lifecycle";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_bucket_lifecycle(
     Bucket, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return s3("DELETE", "/$(Bucket)?lifecycle", params; aws_config=aws_config)
+    return s3(
+        "DELETE",
+        "/$(Bucket)?lifecycle",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -965,7 +1028,11 @@ function delete_bucket_metrics_configuration(
     Bucket, id; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return s3(
-        "DELETE", "/$(Bucket)?metrics", Dict{String,Any}("id" => id); aws_config=aws_config
+        "DELETE",
+        "/$(Bucket)?metrics",
+        Dict{String,Any}("id" => id);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_bucket_metrics_configuration(
@@ -979,6 +1046,7 @@ function delete_bucket_metrics_configuration(
         "/$(Bucket)?metrics",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("id" => id), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1005,12 +1073,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function delete_bucket_ownership_controls(
     Bucket; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return s3("DELETE", "/$(Bucket)?ownershipControls"; aws_config=aws_config)
+    return s3(
+        "DELETE",
+        "/$(Bucket)?ownershipControls";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_bucket_ownership_controls(
     Bucket, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return s3("DELETE", "/$(Bucket)?ownershipControls", params; aws_config=aws_config)
+    return s3(
+        "DELETE",
+        "/$(Bucket)?ownershipControls",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1040,12 +1119,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Denied) error.
 """
 function delete_bucket_policy(Bucket; aws_config::AbstractAWSConfig=global_aws_config())
-    return s3("DELETE", "/$(Bucket)?policy"; aws_config=aws_config)
+    return s3(
+        "DELETE",
+        "/$(Bucket)?policy";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_bucket_policy(
     Bucket, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return s3("DELETE", "/$(Bucket)?policy", params; aws_config=aws_config)
+    return s3(
+        "DELETE",
+        "/$(Bucket)?policy",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1073,12 +1163,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function delete_bucket_replication(
     Bucket; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return s3("DELETE", "/$(Bucket)?replication"; aws_config=aws_config)
+    return s3(
+        "DELETE",
+        "/$(Bucket)?replication";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_bucket_replication(
     Bucket, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return s3("DELETE", "/$(Bucket)?replication", params; aws_config=aws_config)
+    return s3(
+        "DELETE",
+        "/$(Bucket)?replication",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1100,12 +1201,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Denied) error.
 """
 function delete_bucket_tagging(Bucket; aws_config::AbstractAWSConfig=global_aws_config())
-    return s3("DELETE", "/$(Bucket)?tagging"; aws_config=aws_config)
+    return s3(
+        "DELETE",
+        "/$(Bucket)?tagging";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_bucket_tagging(
     Bucket, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return s3("DELETE", "/$(Bucket)?tagging", params; aws_config=aws_config)
+    return s3(
+        "DELETE",
+        "/$(Bucket)?tagging",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1134,12 +1246,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Denied) error.
 """
 function delete_bucket_website(Bucket; aws_config::AbstractAWSConfig=global_aws_config())
-    return s3("DELETE", "/$(Bucket)?website"; aws_config=aws_config)
+    return s3(
+        "DELETE",
+        "/$(Bucket)?website";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_bucket_website(
     Bucket, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return s3("DELETE", "/$(Bucket)?website", params; aws_config=aws_config)
+    return s3(
+        "DELETE",
+        "/$(Bucket)?website",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1192,7 +1315,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"x-amz-request-payer"`:
 """
 function delete_object(Bucket, Key; aws_config::AbstractAWSConfig=global_aws_config())
-    return s3("DELETE", "/$(Bucket)/$(Key)"; aws_config=aws_config)
+    return s3(
+        "DELETE",
+        "/$(Bucket)/$(Key)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_object(
     Bucket,
@@ -1200,7 +1328,13 @@ function delete_object(
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return s3("DELETE", "/$(Bucket)/$(Key)", params; aws_config=aws_config)
+    return s3(
+        "DELETE",
+        "/$(Bucket)/$(Key)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1239,7 +1373,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function delete_object_tagging(
     Bucket, Key; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return s3("DELETE", "/$(Bucket)/$(Key)?tagging"; aws_config=aws_config)
+    return s3(
+        "DELETE",
+        "/$(Bucket)/$(Key)?tagging";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_object_tagging(
     Bucket,
@@ -1247,7 +1386,13 @@ function delete_object_tagging(
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return s3("DELETE", "/$(Bucket)/$(Key)?tagging", params; aws_config=aws_config)
+    return s3(
+        "DELETE",
+        "/$(Bucket)/$(Key)?tagging",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1311,6 +1456,7 @@ function delete_objects(Bucket, Delete; aws_config::AbstractAWSConfig=global_aws
         "/$(Bucket)?delete",
         Dict{String,Any}("Delete" => Delete);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_objects(
@@ -1324,6 +1470,7 @@ function delete_objects(
         "/$(Bucket)?delete",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Delete" => Delete), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1350,12 +1497,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function delete_public_access_block(
     Bucket; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return s3("DELETE", "/$(Bucket)?publicAccessBlock"; aws_config=aws_config)
+    return s3(
+        "DELETE",
+        "/$(Bucket)?publicAccessBlock";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_public_access_block(
     Bucket, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return s3("DELETE", "/$(Bucket)?publicAccessBlock", params; aws_config=aws_config)
+    return s3(
+        "DELETE",
+        "/$(Bucket)?publicAccessBlock",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1389,12 +1547,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function get_bucket_accelerate_configuration(
     Bucket; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return s3("GET", "/$(Bucket)?accelerate"; aws_config=aws_config)
+    return s3(
+        "GET",
+        "/$(Bucket)?accelerate";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_bucket_accelerate_configuration(
     Bucket, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return s3("GET", "/$(Bucket)?accelerate", params; aws_config=aws_config)
+    return s3(
+        "GET",
+        "/$(Bucket)?accelerate",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1417,12 +1586,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Denied) error.
 """
 function get_bucket_acl(Bucket; aws_config::AbstractAWSConfig=global_aws_config())
-    return s3("GET", "/$(Bucket)?acl"; aws_config=aws_config)
+    return s3(
+        "GET", "/$(Bucket)?acl"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_bucket_acl(
     Bucket, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return s3("GET", "/$(Bucket)?acl", params; aws_config=aws_config)
+    return s3(
+        "GET",
+        "/$(Bucket)?acl",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1454,7 +1631,11 @@ function get_bucket_analytics_configuration(
     Bucket, id; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return s3(
-        "GET", "/$(Bucket)?analytics", Dict{String,Any}("id" => id); aws_config=aws_config
+        "GET",
+        "/$(Bucket)?analytics",
+        Dict{String,Any}("id" => id);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_bucket_analytics_configuration(
@@ -1468,6 +1649,7 @@ function get_bucket_analytics_configuration(
         "/$(Bucket)?analytics",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("id" => id), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1491,12 +1673,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Denied) error.
 """
 function get_bucket_cors(Bucket; aws_config::AbstractAWSConfig=global_aws_config())
-    return s3("GET", "/$(Bucket)?cors"; aws_config=aws_config)
+    return s3(
+        "GET", "/$(Bucket)?cors"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_bucket_cors(
     Bucket, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return s3("GET", "/$(Bucket)?cors", params; aws_config=aws_config)
+    return s3(
+        "GET",
+        "/$(Bucket)?cors",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1525,12 +1715,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Denied) error.
 """
 function get_bucket_encryption(Bucket; aws_config::AbstractAWSConfig=global_aws_config())
-    return s3("GET", "/$(Bucket)?encryption"; aws_config=aws_config)
+    return s3(
+        "GET",
+        "/$(Bucket)?encryption";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_bucket_encryption(
     Bucket, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return s3("GET", "/$(Bucket)?encryption", params; aws_config=aws_config)
+    return s3(
+        "GET",
+        "/$(Bucket)?encryption",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1567,6 +1768,7 @@ function get_bucket_intelligent_tiering_configuration(
         "/$(Bucket)?intelligent-tiering",
         Dict{String,Any}("id" => id);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_bucket_intelligent_tiering_configuration(
@@ -1580,6 +1782,7 @@ function get_bucket_intelligent_tiering_configuration(
         "/$(Bucket)?intelligent-tiering",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("id" => id), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1611,7 +1814,11 @@ function get_bucket_inventory_configuration(
     Bucket, id; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return s3(
-        "GET", "/$(Bucket)?inventory", Dict{String,Any}("id" => id); aws_config=aws_config
+        "GET",
+        "/$(Bucket)?inventory",
+        Dict{String,Any}("id" => id);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_bucket_inventory_configuration(
@@ -1625,6 +1832,7 @@ function get_bucket_inventory_configuration(
         "/$(Bucket)?inventory",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("id" => id), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1656,12 +1864,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Denied) error.
 """
 function get_bucket_lifecycle(Bucket; aws_config::AbstractAWSConfig=global_aws_config())
-    return s3("GET", "/$(Bucket)?lifecycle"; aws_config=aws_config)
+    return s3(
+        "GET",
+        "/$(Bucket)?lifecycle";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_bucket_lifecycle(
     Bucket, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return s3("GET", "/$(Bucket)?lifecycle", params; aws_config=aws_config)
+    return s3(
+        "GET",
+        "/$(Bucket)?lifecycle",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1697,12 +1916,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function get_bucket_lifecycle_configuration(
     Bucket; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return s3("GET", "/$(Bucket)?lifecycle"; aws_config=aws_config)
+    return s3(
+        "GET",
+        "/$(Bucket)?lifecycle";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_bucket_lifecycle_configuration(
     Bucket, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return s3("GET", "/$(Bucket)?lifecycle", params; aws_config=aws_config)
+    return s3(
+        "GET",
+        "/$(Bucket)?lifecycle",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1726,12 +1956,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Denied) error.
 """
 function get_bucket_location(Bucket; aws_config::AbstractAWSConfig=global_aws_config())
-    return s3("GET", "/$(Bucket)?location"; aws_config=aws_config)
+    return s3(
+        "GET", "/$(Bucket)?location"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_bucket_location(
     Bucket, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return s3("GET", "/$(Bucket)?location", params; aws_config=aws_config)
+    return s3(
+        "GET",
+        "/$(Bucket)?location",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1752,12 +1990,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Denied) error.
 """
 function get_bucket_logging(Bucket; aws_config::AbstractAWSConfig=global_aws_config())
-    return s3("GET", "/$(Bucket)?logging"; aws_config=aws_config)
+    return s3(
+        "GET", "/$(Bucket)?logging"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_bucket_logging(
     Bucket, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return s3("GET", "/$(Bucket)?logging", params; aws_config=aws_config)
+    return s3(
+        "GET",
+        "/$(Bucket)?logging",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1789,7 +2035,11 @@ function get_bucket_metrics_configuration(
     Bucket, id; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return s3(
-        "GET", "/$(Bucket)?metrics", Dict{String,Any}("id" => id); aws_config=aws_config
+        "GET",
+        "/$(Bucket)?metrics",
+        Dict{String,Any}("id" => id);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_bucket_metrics_configuration(
@@ -1803,6 +2053,7 @@ function get_bucket_metrics_configuration(
         "/$(Bucket)?metrics",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("id" => id), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1822,12 +2073,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Denied) error.
 """
 function get_bucket_notification(Bucket; aws_config::AbstractAWSConfig=global_aws_config())
-    return s3("GET", "/$(Bucket)?notification"; aws_config=aws_config)
+    return s3(
+        "GET",
+        "/$(Bucket)?notification";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_bucket_notification(
     Bucket, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return s3("GET", "/$(Bucket)?notification", params; aws_config=aws_config)
+    return s3(
+        "GET",
+        "/$(Bucket)?notification",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1855,12 +2117,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function get_bucket_notification_configuration(
     Bucket; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return s3("GET", "/$(Bucket)?notification"; aws_config=aws_config)
+    return s3(
+        "GET",
+        "/$(Bucket)?notification";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_bucket_notification_configuration(
     Bucket, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return s3("GET", "/$(Bucket)?notification", params; aws_config=aws_config)
+    return s3(
+        "GET",
+        "/$(Bucket)?notification",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1886,12 +2159,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function get_bucket_ownership_controls(
     Bucket; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return s3("GET", "/$(Bucket)?ownershipControls"; aws_config=aws_config)
+    return s3(
+        "GET",
+        "/$(Bucket)?ownershipControls";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_bucket_ownership_controls(
     Bucket, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return s3("GET", "/$(Bucket)?ownershipControls", params; aws_config=aws_config)
+    return s3(
+        "GET",
+        "/$(Bucket)?ownershipControls",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1920,12 +2204,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Denied) error.
 """
 function get_bucket_policy(Bucket; aws_config::AbstractAWSConfig=global_aws_config())
-    return s3("GET", "/$(Bucket)?policy"; aws_config=aws_config)
+    return s3(
+        "GET", "/$(Bucket)?policy"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_bucket_policy(
     Bucket, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return s3("GET", "/$(Bucket)?policy", params; aws_config=aws_config)
+    return s3(
+        "GET",
+        "/$(Bucket)?policy",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1950,12 +2242,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Denied) error.
 """
 function get_bucket_policy_status(Bucket; aws_config::AbstractAWSConfig=global_aws_config())
-    return s3("GET", "/$(Bucket)?policyStatus"; aws_config=aws_config)
+    return s3(
+        "GET",
+        "/$(Bucket)?policyStatus";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_bucket_policy_status(
     Bucket, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return s3("GET", "/$(Bucket)?policyStatus", params; aws_config=aws_config)
+    return s3(
+        "GET",
+        "/$(Bucket)?policyStatus",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1984,12 +2287,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Denied) error.
 """
 function get_bucket_replication(Bucket; aws_config::AbstractAWSConfig=global_aws_config())
-    return s3("GET", "/$(Bucket)?replication"; aws_config=aws_config)
+    return s3(
+        "GET",
+        "/$(Bucket)?replication";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_bucket_replication(
     Bucket, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return s3("GET", "/$(Bucket)?replication", params; aws_config=aws_config)
+    return s3(
+        "GET",
+        "/$(Bucket)?replication",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2012,12 +2326,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function get_bucket_request_payment(
     Bucket; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return s3("GET", "/$(Bucket)?requestPayment"; aws_config=aws_config)
+    return s3(
+        "GET",
+        "/$(Bucket)?requestPayment";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_bucket_request_payment(
     Bucket, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return s3("GET", "/$(Bucket)?requestPayment", params; aws_config=aws_config)
+    return s3(
+        "GET",
+        "/$(Bucket)?requestPayment",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2041,12 +2366,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Denied) error.
 """
 function get_bucket_tagging(Bucket; aws_config::AbstractAWSConfig=global_aws_config())
-    return s3("GET", "/$(Bucket)?tagging"; aws_config=aws_config)
+    return s3(
+        "GET", "/$(Bucket)?tagging"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_bucket_tagging(
     Bucket, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return s3("GET", "/$(Bucket)?tagging", params; aws_config=aws_config)
+    return s3(
+        "GET",
+        "/$(Bucket)?tagging",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2070,12 +2403,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Denied) error.
 """
 function get_bucket_versioning(Bucket; aws_config::AbstractAWSConfig=global_aws_config())
-    return s3("GET", "/$(Bucket)?versioning"; aws_config=aws_config)
+    return s3(
+        "GET",
+        "/$(Bucket)?versioning";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_bucket_versioning(
     Bucket, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return s3("GET", "/$(Bucket)?versioning", params; aws_config=aws_config)
+    return s3(
+        "GET",
+        "/$(Bucket)?versioning",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2101,12 +2445,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Denied) error.
 """
 function get_bucket_website(Bucket; aws_config::AbstractAWSConfig=global_aws_config())
-    return s3("GET", "/$(Bucket)?website"; aws_config=aws_config)
+    return s3(
+        "GET", "/$(Bucket)?website"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_bucket_website(
     Bucket, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return s3("GET", "/$(Bucket)?website", params; aws_config=aws_config)
+    return s3(
+        "GET",
+        "/$(Bucket)?website",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2236,7 +2588,9 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   integrity check to ensure that the encryption key was transmitted without error.
 """
 function get_object(Bucket, Key; aws_config::AbstractAWSConfig=global_aws_config())
-    return s3("GET", "/$(Bucket)/$(Key)"; aws_config=aws_config)
+    return s3(
+        "GET", "/$(Bucket)/$(Key)"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_object(
     Bucket,
@@ -2244,7 +2598,13 @@ function get_object(
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return s3("GET", "/$(Bucket)/$(Key)", params; aws_config=aws_config)
+    return s3(
+        "GET",
+        "/$(Bucket)/$(Key)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2277,7 +2637,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"x-amz-request-payer"`:
 """
 function get_object_acl(Bucket, Key; aws_config::AbstractAWSConfig=global_aws_config())
-    return s3("GET", "/$(Bucket)/$(Key)?acl"; aws_config=aws_config)
+    return s3(
+        "GET",
+        "/$(Bucket)/$(Key)?acl";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_object_acl(
     Bucket,
@@ -2285,7 +2650,13 @@ function get_object_acl(
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return s3("GET", "/$(Bucket)/$(Key)?acl", params; aws_config=aws_config)
+    return s3(
+        "GET",
+        "/$(Bucket)/$(Key)?acl",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2316,7 +2687,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function get_object_legal_hold(
     Bucket, Key; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return s3("GET", "/$(Bucket)/$(Key)?legal-hold"; aws_config=aws_config)
+    return s3(
+        "GET",
+        "/$(Bucket)/$(Key)?legal-hold";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_object_legal_hold(
     Bucket,
@@ -2324,7 +2700,13 @@ function get_object_legal_hold(
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return s3("GET", "/$(Bucket)/$(Key)?legal-hold", params; aws_config=aws_config)
+    return s3(
+        "GET",
+        "/$(Bucket)/$(Key)?legal-hold",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2353,12 +2735,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function get_object_lock_configuration(
     Bucket; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return s3("GET", "/$(Bucket)?object-lock"; aws_config=aws_config)
+    return s3(
+        "GET",
+        "/$(Bucket)?object-lock";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_object_lock_configuration(
     Bucket, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return s3("GET", "/$(Bucket)?object-lock", params; aws_config=aws_config)
+    return s3(
+        "GET",
+        "/$(Bucket)?object-lock",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2390,7 +2783,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function get_object_retention(
     Bucket, Key; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return s3("GET", "/$(Bucket)/$(Key)?retention"; aws_config=aws_config)
+    return s3(
+        "GET",
+        "/$(Bucket)/$(Key)?retention";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_object_retention(
     Bucket,
@@ -2398,7 +2796,13 @@ function get_object_retention(
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return s3("GET", "/$(Bucket)/$(Key)?retention", params; aws_config=aws_config)
+    return s3(
+        "GET",
+        "/$(Bucket)/$(Key)?retention",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2439,7 +2843,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"x-amz-request-payer"`:
 """
 function get_object_tagging(Bucket, Key; aws_config::AbstractAWSConfig=global_aws_config())
-    return s3("GET", "/$(Bucket)/$(Key)?tagging"; aws_config=aws_config)
+    return s3(
+        "GET",
+        "/$(Bucket)/$(Key)?tagging";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_object_tagging(
     Bucket,
@@ -2447,7 +2856,13 @@ function get_object_tagging(
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return s3("GET", "/$(Bucket)/$(Key)?tagging", params; aws_config=aws_config)
+    return s3(
+        "GET",
+        "/$(Bucket)/$(Key)?tagging",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2473,7 +2888,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"x-amz-request-payer"`:
 """
 function get_object_torrent(Bucket, Key; aws_config::AbstractAWSConfig=global_aws_config())
-    return s3("GET", "/$(Bucket)/$(Key)?torrent"; aws_config=aws_config)
+    return s3(
+        "GET",
+        "/$(Bucket)/$(Key)?torrent";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_object_torrent(
     Bucket,
@@ -2481,7 +2901,13 @@ function get_object_torrent(
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return s3("GET", "/$(Bucket)/$(Key)?torrent", params; aws_config=aws_config)
+    return s3(
+        "GET",
+        "/$(Bucket)/$(Key)?torrent",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2511,12 +2937,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Denied) error.
 """
 function get_public_access_block(Bucket; aws_config::AbstractAWSConfig=global_aws_config())
-    return s3("GET", "/$(Bucket)?publicAccessBlock"; aws_config=aws_config)
+    return s3(
+        "GET",
+        "/$(Bucket)?publicAccessBlock";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_public_access_block(
     Bucket, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return s3("GET", "/$(Bucket)?publicAccessBlock", params; aws_config=aws_config)
+    return s3(
+        "GET",
+        "/$(Bucket)?publicAccessBlock",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2559,12 +2996,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Denied) error.
 """
 function head_bucket(Bucket; aws_config::AbstractAWSConfig=global_aws_config())
-    return s3("HEAD", "/$(Bucket)"; aws_config=aws_config)
+    return s3("HEAD", "/$(Bucket)"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function head_bucket(
     Bucket, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return s3("HEAD", "/$(Bucket)", params; aws_config=aws_config)
+    return s3(
+        "HEAD", "/$(Bucket)", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -2652,7 +3091,9 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   integrity check to ensure that the encryption key was transmitted without error.
 """
 function head_object(Bucket, Key; aws_config::AbstractAWSConfig=global_aws_config())
-    return s3("HEAD", "/$(Bucket)/$(Key)"; aws_config=aws_config)
+    return s3(
+        "HEAD", "/$(Bucket)/$(Key)"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function head_object(
     Bucket,
@@ -2660,7 +3101,13 @@ function head_object(
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return s3("HEAD", "/$(Bucket)/$(Key)", params; aws_config=aws_config)
+    return s3(
+        "HEAD",
+        "/$(Bucket)/$(Key)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2697,12 +3144,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function list_bucket_analytics_configurations(
     Bucket; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return s3("GET", "/$(Bucket)?analytics"; aws_config=aws_config)
+    return s3(
+        "GET",
+        "/$(Bucket)?analytics";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_bucket_analytics_configurations(
     Bucket, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return s3("GET", "/$(Bucket)?analytics", params; aws_config=aws_config)
+    return s3(
+        "GET",
+        "/$(Bucket)?analytics",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2737,12 +3195,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function list_bucket_intelligent_tiering_configurations(
     Bucket; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return s3("GET", "/$(Bucket)?intelligent-tiering"; aws_config=aws_config)
+    return s3(
+        "GET",
+        "/$(Bucket)?intelligent-tiering";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_bucket_intelligent_tiering_configurations(
     Bucket, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return s3("GET", "/$(Bucket)?intelligent-tiering", params; aws_config=aws_config)
+    return s3(
+        "GET",
+        "/$(Bucket)?intelligent-tiering",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2781,12 +3250,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function list_bucket_inventory_configurations(
     Bucket; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return s3("GET", "/$(Bucket)?inventory"; aws_config=aws_config)
+    return s3(
+        "GET",
+        "/$(Bucket)?inventory";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_bucket_inventory_configurations(
     Bucket, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return s3("GET", "/$(Bucket)?inventory", params; aws_config=aws_config)
+    return s3(
+        "GET",
+        "/$(Bucket)?inventory",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2826,12 +3306,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function list_bucket_metrics_configurations(
     Bucket; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return s3("GET", "/$(Bucket)?metrics"; aws_config=aws_config)
+    return s3(
+        "GET", "/$(Bucket)?metrics"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_bucket_metrics_configurations(
     Bucket, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return s3("GET", "/$(Bucket)?metrics", params; aws_config=aws_config)
+    return s3(
+        "GET",
+        "/$(Bucket)?metrics",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2842,12 +3330,12 @@ Returns a list of all buckets owned by the authenticated sender of the request.
 
 """
 function list_buckets(; aws_config::AbstractAWSConfig=global_aws_config())
-    return s3("GET", "/"; aws_config=aws_config)
+    return s3("GET", "/"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_buckets(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return s3("GET", "/", params; aws_config=aws_config)
+    return s3("GET", "/", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 
 """
@@ -2915,12 +3403,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Denied) error.
 """
 function list_multipart_uploads(Bucket; aws_config::AbstractAWSConfig=global_aws_config())
-    return s3("GET", "/$(Bucket)?uploads"; aws_config=aws_config)
+    return s3(
+        "GET", "/$(Bucket)?uploads"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_multipart_uploads(
     Bucket, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return s3("GET", "/$(Bucket)?uploads", params; aws_config=aws_config)
+    return s3(
+        "GET",
+        "/$(Bucket)?uploads",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2965,12 +3461,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Denied) error.
 """
 function list_object_versions(Bucket; aws_config::AbstractAWSConfig=global_aws_config())
-    return s3("GET", "/$(Bucket)?versions"; aws_config=aws_config)
+    return s3(
+        "GET", "/$(Bucket)?versions"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_object_versions(
     Bucket, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return s3("GET", "/$(Bucket)?versions", params; aws_config=aws_config)
+    return s3(
+        "GET",
+        "/$(Bucket)?versions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -3018,12 +3522,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   requests.
 """
 function list_objects(Bucket; aws_config::AbstractAWSConfig=global_aws_config())
-    return s3("GET", "/$(Bucket)"; aws_config=aws_config)
+    return s3("GET", "/$(Bucket)"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_objects(
     Bucket, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return s3("GET", "/$(Bucket)", params; aws_config=aws_config)
+    return s3(
+        "GET", "/$(Bucket)", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -3082,12 +3588,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   their requests.
 """
 function list_objects_v2(Bucket; aws_config::AbstractAWSConfig=global_aws_config())
-    return s3("GET", "/$(Bucket)?list-type=2"; aws_config=aws_config)
+    return s3(
+        "GET",
+        "/$(Bucket)?list-type=2";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_objects_v2(
     Bucket, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return s3("GET", "/$(Bucket)?list-type=2", params; aws_config=aws_config)
+    return s3(
+        "GET",
+        "/$(Bucket)?list-type=2",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -3142,6 +3659,7 @@ function list_parts(
         "/$(Bucket)/$(Key)",
         Dict{String,Any}("uploadId" => uploadId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_parts(
@@ -3158,6 +3676,7 @@ function list_parts(
             mergewith(_merge, Dict{String,Any}("uploadId" => uploadId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3200,6 +3719,7 @@ function put_bucket_accelerate_configuration(
         "/$(Bucket)?accelerate",
         Dict{String,Any}("AccelerateConfiguration" => AccelerateConfiguration);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_bucket_accelerate_configuration(
@@ -3219,6 +3739,7 @@ function put_bucket_accelerate_configuration(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3305,12 +3826,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"x-amz-grant-write-acp"`: Allows grantee to write the ACL for the applicable bucket.
 """
 function put_bucket_acl(Bucket; aws_config::AbstractAWSConfig=global_aws_config())
-    return s3("PUT", "/$(Bucket)?acl"; aws_config=aws_config)
+    return s3(
+        "PUT", "/$(Bucket)?acl"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function put_bucket_acl(
     Bucket, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return s3("PUT", "/$(Bucket)?acl", params; aws_config=aws_config)
+    return s3(
+        "PUT",
+        "/$(Bucket)?acl",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -3361,6 +3890,7 @@ function put_bucket_analytics_configuration(
         "/$(Bucket)?analytics",
         Dict{String,Any}("AnalyticsConfiguration" => AnalyticsConfiguration, "id" => id);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_bucket_analytics_configuration(
@@ -3383,6 +3913,7 @@ function put_bucket_analytics_configuration(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3436,6 +3967,7 @@ function put_bucket_cors(
         "/$(Bucket)?cors",
         Dict{String,Any}("CORSConfiguration" => CORSConfiguration);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_bucket_cors(
@@ -3453,6 +3985,7 @@ function put_bucket_cors(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3503,6 +4036,7 @@ function put_bucket_encryption(
             "ServerSideEncryptionConfiguration" => ServerSideEncryptionConfiguration
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_bucket_encryption(
@@ -3524,6 +4058,7 @@ function put_bucket_encryption(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3576,6 +4111,7 @@ function put_bucket_intelligent_tiering_configuration(
             "IntelligentTieringConfiguration" => IntelligentTieringConfiguration, "id" => id
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_bucket_intelligent_tiering_configuration(
@@ -3599,6 +4135,7 @@ function put_bucket_intelligent_tiering_configuration(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3651,6 +4188,7 @@ function put_bucket_inventory_configuration(
         "/$(Bucket)?inventory",
         Dict{String,Any}("InventoryConfiguration" => InventoryConfiguration, "id" => id);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_bucket_inventory_configuration(
@@ -3673,6 +4211,7 @@ function put_bucket_inventory_configuration(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3717,12 +4256,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Denied) error.
 """
 function put_bucket_lifecycle(Bucket; aws_config::AbstractAWSConfig=global_aws_config())
-    return s3("PUT", "/$(Bucket)?lifecycle"; aws_config=aws_config)
+    return s3(
+        "PUT",
+        "/$(Bucket)?lifecycle";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function put_bucket_lifecycle(
     Bucket, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return s3("PUT", "/$(Bucket)?lifecycle", params; aws_config=aws_config)
+    return s3(
+        "PUT",
+        "/$(Bucket)?lifecycle",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -3773,12 +4323,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function put_bucket_lifecycle_configuration(
     Bucket; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return s3("PUT", "/$(Bucket)?lifecycle"; aws_config=aws_config)
+    return s3(
+        "PUT",
+        "/$(Bucket)?lifecycle";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function put_bucket_lifecycle_configuration(
     Bucket, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return s3("PUT", "/$(Bucket)?lifecycle", params; aws_config=aws_config)
+    return s3(
+        "PUT",
+        "/$(Bucket)?lifecycle",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -3833,6 +4394,7 @@ function put_bucket_logging(
         "/$(Bucket)?logging",
         Dict{String,Any}("BucketLoggingStatus" => BucketLoggingStatus);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_bucket_logging(
@@ -3852,6 +4414,7 @@ function put_bucket_logging(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3894,6 +4457,7 @@ function put_bucket_metrics_configuration(
         "/$(Bucket)?metrics",
         Dict{String,Any}("MetricsConfiguration" => MetricsConfiguration, "id" => id);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_bucket_metrics_configuration(
@@ -3916,6 +4480,7 @@ function put_bucket_metrics_configuration(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3946,6 +4511,7 @@ function put_bucket_notification(
         "/$(Bucket)?notification",
         Dict{String,Any}("NotificationConfiguration" => NotificationConfiguration);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_bucket_notification(
@@ -3965,6 +4531,7 @@ function put_bucket_notification(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4019,6 +4586,7 @@ function put_bucket_notification_configuration(
         "/$(Bucket)?notification",
         Dict{String,Any}("NotificationConfiguration" => NotificationConfiguration);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_bucket_notification_configuration(
@@ -4038,6 +4606,7 @@ function put_bucket_notification_configuration(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4074,6 +4643,7 @@ function put_bucket_ownership_controls(
         "/$(Bucket)?ownershipControls",
         Dict{String,Any}("OwnershipControls" => OwnershipControls);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_bucket_ownership_controls(
@@ -4091,6 +4661,7 @@ function put_bucket_ownership_controls(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4133,6 +4704,7 @@ function put_bucket_policy(
         "/$(Bucket)?policy",
         Dict{String,Any}("Policy" => Policy);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_bucket_policy(
@@ -4146,6 +4718,7 @@ function put_bucket_policy(
         "/$(Bucket)?policy",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Policy" => Policy), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4209,6 +4782,7 @@ function put_bucket_replication(
         "/$(Bucket)?replication",
         Dict{String,Any}("ReplicationConfiguration" => ReplicationConfiguration);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_bucket_replication(
@@ -4228,6 +4802,7 @@ function put_bucket_replication(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4264,6 +4839,7 @@ function put_bucket_request_payment(
         "/$(Bucket)?requestPayment",
         Dict{String,Any}("RequestPaymentConfiguration" => RequestPaymentConfiguration);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_bucket_request_payment(
@@ -4285,6 +4861,7 @@ function put_bucket_request_payment(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4339,6 +4916,7 @@ function put_bucket_tagging(
         "/$(Bucket)?tagging",
         Dict{String,Any}("Tagging" => Tagging);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_bucket_tagging(
@@ -4352,6 +4930,7 @@ function put_bucket_tagging(
         "/$(Bucket)?tagging",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Tagging" => Tagging), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4401,6 +4980,7 @@ function put_bucket_versioning(
         "/$(Bucket)?versioning",
         Dict{String,Any}("VersioningConfiguration" => VersioningConfiguration);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_bucket_versioning(
@@ -4420,6 +5000,7 @@ function put_bucket_versioning(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4472,6 +5053,7 @@ function put_bucket_website(
         "/$(Bucket)?website",
         Dict{String,Any}("WebsiteConfiguration" => WebsiteConfiguration);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_bucket_website(
@@ -4491,6 +5073,7 @@ function put_bucket_website(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4643,7 +5226,9 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Hosting Websites on Amazon S3 and How to Configure Website Page Redirects.
 """
 function put_object(Bucket, Key; aws_config::AbstractAWSConfig=global_aws_config())
-    return s3("PUT", "/$(Bucket)/$(Key)"; aws_config=aws_config)
+    return s3(
+        "PUT", "/$(Bucket)/$(Key)"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function put_object(
     Bucket,
@@ -4651,7 +5236,13 @@ function put_object(
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return s3("PUT", "/$(Bucket)/$(Key)", params; aws_config=aws_config)
+    return s3(
+        "PUT",
+        "/$(Bucket)/$(Key)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -4762,7 +5353,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"x-amz-request-payer"`:
 """
 function put_object_acl(Bucket, Key; aws_config::AbstractAWSConfig=global_aws_config())
-    return s3("PUT", "/$(Bucket)/$(Key)?acl"; aws_config=aws_config)
+    return s3(
+        "PUT",
+        "/$(Bucket)/$(Key)?acl";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function put_object_acl(
     Bucket,
@@ -4770,7 +5366,13 @@ function put_object_acl(
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return s3("PUT", "/$(Bucket)/$(Key)?acl", params; aws_config=aws_config)
+    return s3(
+        "PUT",
+        "/$(Bucket)/$(Key)?acl",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -4806,7 +5408,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function put_object_legal_hold(
     Bucket, Key; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return s3("PUT", "/$(Bucket)/$(Key)?legal-hold"; aws_config=aws_config)
+    return s3(
+        "PUT",
+        "/$(Bucket)/$(Key)?legal-hold";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function put_object_legal_hold(
     Bucket,
@@ -4814,7 +5421,13 @@ function put_object_legal_hold(
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return s3("PUT", "/$(Bucket)/$(Key)?legal-hold", params; aws_config=aws_config)
+    return s3(
+        "PUT",
+        "/$(Bucket)/$(Key)?legal-hold",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -4849,12 +5462,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function put_object_lock_configuration(
     Bucket; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return s3("PUT", "/$(Bucket)?object-lock"; aws_config=aws_config)
+    return s3(
+        "PUT",
+        "/$(Bucket)?object-lock";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function put_object_lock_configuration(
     Bucket, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return s3("PUT", "/$(Bucket)?object-lock", params; aws_config=aws_config)
+    return s3(
+        "PUT",
+        "/$(Bucket)?object-lock",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -4899,7 +5523,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function put_object_retention(
     Bucket, Key; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return s3("PUT", "/$(Bucket)/$(Key)?retention"; aws_config=aws_config)
+    return s3(
+        "PUT",
+        "/$(Bucket)/$(Key)?retention";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function put_object_retention(
     Bucket,
@@ -4907,7 +5536,13 @@ function put_object_retention(
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return s3("PUT", "/$(Bucket)/$(Key)?retention", params; aws_config=aws_config)
+    return s3(
+        "PUT",
+        "/$(Bucket)/$(Key)?retention",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -4967,6 +5602,7 @@ function put_object_tagging(
         "/$(Bucket)/$(Key)?tagging",
         Dict{String,Any}("Tagging" => Tagging);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_object_tagging(
@@ -4981,6 +5617,7 @@ function put_object_tagging(
         "/$(Bucket)/$(Key)?tagging",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Tagging" => Tagging), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5029,6 +5666,7 @@ function put_public_access_block(
             "PublicAccessBlockConfiguration" => PublicAccessBlockConfiguration
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_public_access_block(
@@ -5050,6 +5688,7 @@ function put_public_access_block(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5187,7 +5826,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"x-amz-request-payer"`:
 """
 function restore_object(Bucket, Key; aws_config::AbstractAWSConfig=global_aws_config())
-    return s3("POST", "/$(Bucket)/$(Key)?restore"; aws_config=aws_config)
+    return s3(
+        "POST",
+        "/$(Bucket)/$(Key)?restore";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function restore_object(
     Bucket,
@@ -5195,7 +5839,13 @@ function restore_object(
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return s3("POST", "/$(Bucket)/$(Key)?restore", params; aws_config=aws_config)
+    return s3(
+        "POST",
+        "/$(Bucket)/$(Key)?restore",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -5296,6 +5946,7 @@ function select_object_content(
             "OutputSerialization" => OutputSerialization,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function select_object_content(
@@ -5324,6 +5975,7 @@ function select_object_content(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5426,6 +6078,7 @@ function upload_part(
         "/$(Bucket)/$(Key)",
         Dict{String,Any}("partNumber" => partNumber, "uploadId" => uploadId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function upload_part(
@@ -5447,6 +6100,7 @@ function upload_part(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5598,6 +6252,7 @@ function upload_part_copy(
             "headers" => Dict{String,Any}("x-amz-copy-source" => x_amz_copy_source),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function upload_part_copy(
@@ -5624,6 +6279,7 @@ function upload_part_copy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5761,6 +6417,7 @@ function write_get_object_response(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function write_get_object_response(
@@ -5785,5 +6442,6 @@ function write_get_object_response(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/s3_control.jl
+++ b/src/services/s3_control.jl
@@ -54,6 +54,7 @@ function create_access_point(
             "headers" => Dict{String,Any}("x-amz-account-id" => x_amz_account_id),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_access_point(
@@ -77,6 +78,7 @@ function create_access_point(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -107,6 +109,7 @@ function create_access_point_for_object_lambda(
             "headers" => Dict{String,Any}("x-amz-account-id" => x_amz_account_id),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_access_point_for_object_lambda(
@@ -130,6 +133,7 @@ function create_access_point_for_object_lambda(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -176,12 +180,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   required by Amazon S3 on Outposts buckets.
 """
 function create_bucket(name; aws_config::AbstractAWSConfig=global_aws_config())
-    return s3_control("PUT", "/v20180820/bucket/$(name)"; aws_config=aws_config)
+    return s3_control(
+        "PUT",
+        "/v20180820/bucket/$(name)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function create_bucket(
     name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return s3_control("PUT", "/v20180820/bucket/$(name)", params; aws_config=aws_config)
+    return s3_control(
+        "PUT",
+        "/v20180820/bucket/$(name)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -240,6 +255,7 @@ function create_job(
             "headers" => Dict{String,Any}("x-amz-account-id" => x_amz_account_id),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_job(
@@ -272,6 +288,7 @@ function create_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -315,6 +332,7 @@ function create_multi_region_access_point(
             "headers" => Dict{String,Any}("x-amz-account-id" => x_amz_account_id),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_multi_region_access_point(
@@ -339,6 +357,7 @@ function create_multi_region_access_point(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -377,6 +396,7 @@ function delete_access_point(
             "headers" => Dict{String,Any}("x-amz-account-id" => x_amz_account_id)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_access_point(
@@ -398,6 +418,7 @@ function delete_access_point(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -425,6 +446,7 @@ function delete_access_point_for_object_lambda(
             "headers" => Dict{String,Any}("x-amz-account-id" => x_amz_account_id)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_access_point_for_object_lambda(
@@ -446,6 +468,7 @@ function delete_access_point_for_object_lambda(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -484,6 +507,7 @@ function delete_access_point_policy(
             "headers" => Dict{String,Any}("x-amz-account-id" => x_amz_account_id)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_access_point_policy(
@@ -505,6 +529,7 @@ function delete_access_point_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -532,6 +557,7 @@ function delete_access_point_policy_for_object_lambda(
             "headers" => Dict{String,Any}("x-amz-account-id" => x_amz_account_id)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_access_point_policy_for_object_lambda(
@@ -553,6 +579,7 @@ function delete_access_point_policy_for_object_lambda(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -594,6 +621,7 @@ function delete_bucket(
             "headers" => Dict{String,Any}("x-amz-account-id" => x_amz_account_id)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_bucket(
@@ -615,6 +643,7 @@ function delete_bucket(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -663,6 +692,7 @@ function delete_bucket_lifecycle_configuration(
             "headers" => Dict{String,Any}("x-amz-account-id" => x_amz_account_id)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_bucket_lifecycle_configuration(
@@ -684,6 +714,7 @@ function delete_bucket_lifecycle_configuration(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -735,6 +766,7 @@ function delete_bucket_policy(
             "headers" => Dict{String,Any}("x-amz-account-id" => x_amz_account_id)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_bucket_policy(
@@ -756,6 +788,7 @@ function delete_bucket_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -799,6 +832,7 @@ function delete_bucket_tagging(
             "headers" => Dict{String,Any}("x-amz-account-id" => x_amz_account_id)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_bucket_tagging(
@@ -820,6 +854,7 @@ function delete_bucket_tagging(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -848,6 +883,7 @@ function delete_job_tagging(
             "headers" => Dict{String,Any}("x-amz-account-id" => x_amz_account_id)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_job_tagging(
@@ -869,6 +905,7 @@ function delete_job_tagging(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -911,6 +948,7 @@ function delete_multi_region_access_point(
             "headers" => Dict{String,Any}("x-amz-account-id" => x_amz_account_id),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_multi_region_access_point(
@@ -935,6 +973,7 @@ function delete_multi_region_access_point(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -961,6 +1000,7 @@ function delete_public_access_block(
             "headers" => Dict{String,Any}("x-amz-account-id" => x_amz_account_id)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_public_access_block(
@@ -981,6 +1021,7 @@ function delete_public_access_block(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1009,6 +1050,7 @@ function delete_storage_lens_configuration(
             "headers" => Dict{String,Any}("x-amz-account-id" => x_amz_account_id)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_storage_lens_configuration(
@@ -1030,6 +1072,7 @@ function delete_storage_lens_configuration(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1058,6 +1101,7 @@ function delete_storage_lens_configuration_tagging(
             "headers" => Dict{String,Any}("x-amz-account-id" => x_amz_account_id)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_storage_lens_configuration_tagging(
@@ -1079,6 +1123,7 @@ function delete_storage_lens_configuration_tagging(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1106,6 +1151,7 @@ function describe_job(
             "headers" => Dict{String,Any}("x-amz-account-id" => x_amz_account_id)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_job(
@@ -1127,6 +1173,7 @@ function describe_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1159,6 +1206,7 @@ function describe_multi_region_access_point_operation(
             "headers" => Dict{String,Any}("x-amz-account-id" => x_amz_account_id)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_multi_region_access_point_operation(
@@ -1180,6 +1228,7 @@ function describe_multi_region_access_point_operation(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1220,6 +1269,7 @@ function get_access_point(
             "headers" => Dict{String,Any}("x-amz-account-id" => x_amz_account_id)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_access_point(
@@ -1241,6 +1291,7 @@ function get_access_point(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1269,6 +1320,7 @@ function get_access_point_configuration_for_object_lambda(
             "headers" => Dict{String,Any}("x-amz-account-id" => x_amz_account_id)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_access_point_configuration_for_object_lambda(
@@ -1290,6 +1342,7 @@ function get_access_point_configuration_for_object_lambda(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1318,6 +1371,7 @@ function get_access_point_for_object_lambda(
             "headers" => Dict{String,Any}("x-amz-account-id" => x_amz_account_id)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_access_point_for_object_lambda(
@@ -1339,6 +1393,7 @@ function get_access_point_for_object_lambda(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1373,6 +1428,7 @@ function get_access_point_policy(
             "headers" => Dict{String,Any}("x-amz-account-id" => x_amz_account_id)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_access_point_policy(
@@ -1394,6 +1450,7 @@ function get_access_point_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1421,6 +1478,7 @@ function get_access_point_policy_for_object_lambda(
             "headers" => Dict{String,Any}("x-amz-account-id" => x_amz_account_id)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_access_point_policy_for_object_lambda(
@@ -1442,6 +1500,7 @@ function get_access_point_policy_for_object_lambda(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1468,6 +1527,7 @@ function get_access_point_policy_status(
             "headers" => Dict{String,Any}("x-amz-account-id" => x_amz_account_id)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_access_point_policy_status(
@@ -1489,6 +1549,7 @@ function get_access_point_policy_status(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1514,6 +1575,7 @@ function get_access_point_policy_status_for_object_lambda(
             "headers" => Dict{String,Any}("x-amz-account-id" => x_amz_account_id)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_access_point_policy_status_for_object_lambda(
@@ -1535,6 +1597,7 @@ function get_access_point_policy_status_for_object_lambda(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1581,6 +1644,7 @@ function get_bucket(
             "headers" => Dict{String,Any}("x-amz-account-id" => x_amz_account_id)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_bucket(
@@ -1602,6 +1666,7 @@ function get_bucket(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1652,6 +1717,7 @@ function get_bucket_lifecycle_configuration(
             "headers" => Dict{String,Any}("x-amz-account-id" => x_amz_account_id)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_bucket_lifecycle_configuration(
@@ -1673,6 +1739,7 @@ function get_bucket_lifecycle_configuration(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1724,6 +1791,7 @@ function get_bucket_policy(
             "headers" => Dict{String,Any}("x-amz-account-id" => x_amz_account_id)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_bucket_policy(
@@ -1745,6 +1813,7 @@ function get_bucket_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1789,6 +1858,7 @@ function get_bucket_tagging(
             "headers" => Dict{String,Any}("x-amz-account-id" => x_amz_account_id)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_bucket_tagging(
@@ -1810,6 +1880,7 @@ function get_bucket_tagging(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1838,6 +1909,7 @@ function get_job_tagging(
             "headers" => Dict{String,Any}("x-amz-account-id" => x_amz_account_id)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_job_tagging(
@@ -1859,6 +1931,7 @@ function get_job_tagging(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1892,6 +1965,7 @@ function get_multi_region_access_point(
             "headers" => Dict{String,Any}("x-amz-account-id" => x_amz_account_id)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_multi_region_access_point(
@@ -1913,6 +1987,7 @@ function get_multi_region_access_point(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1946,6 +2021,7 @@ function get_multi_region_access_point_policy(
             "headers" => Dict{String,Any}("x-amz-account-id" => x_amz_account_id)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_multi_region_access_point_policy(
@@ -1967,6 +2043,7 @@ function get_multi_region_access_point_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2000,6 +2077,7 @@ function get_multi_region_access_point_policy_status(
             "headers" => Dict{String,Any}("x-amz-account-id" => x_amz_account_id)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_multi_region_access_point_policy_status(
@@ -2021,6 +2099,7 @@ function get_multi_region_access_point_policy_status(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2047,6 +2126,7 @@ function get_public_access_block(
             "headers" => Dict{String,Any}("x-amz-account-id" => x_amz_account_id)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_public_access_block(
@@ -2067,6 +2147,7 @@ function get_public_access_block(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2095,6 +2176,7 @@ function get_storage_lens_configuration(
             "headers" => Dict{String,Any}("x-amz-account-id" => x_amz_account_id)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_storage_lens_configuration(
@@ -2116,6 +2198,7 @@ function get_storage_lens_configuration(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2144,6 +2227,7 @@ function get_storage_lens_configuration_tagging(
             "headers" => Dict{String,Any}("x-amz-account-id" => x_amz_account_id)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_storage_lens_configuration_tagging(
@@ -2165,6 +2249,7 @@ function get_storage_lens_configuration_tagging(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2218,6 +2303,7 @@ function list_access_points(
             "headers" => Dict{String,Any}("x-amz-account-id" => x_amz_account_id)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_access_points(
@@ -2238,6 +2324,7 @@ function list_access_points(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2276,6 +2363,7 @@ function list_access_points_for_object_lambda(
             "headers" => Dict{String,Any}("x-amz-account-id" => x_amz_account_id)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_access_points_for_object_lambda(
@@ -2296,6 +2384,7 @@ function list_access_points_for_object_lambda(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2331,6 +2420,7 @@ function list_jobs(x_amz_account_id; aws_config::AbstractAWSConfig=global_aws_co
             "headers" => Dict{String,Any}("x-amz-account-id" => x_amz_account_id)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_jobs(
@@ -2351,6 +2441,7 @@ function list_jobs(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2387,6 +2478,7 @@ function list_multi_region_access_points(
             "headers" => Dict{String,Any}("x-amz-account-id" => x_amz_account_id)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_multi_region_access_points(
@@ -2407,6 +2499,7 @@ function list_multi_region_access_points(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2440,6 +2533,7 @@ function list_regional_buckets(
             "headers" => Dict{String,Any}("x-amz-account-id" => x_amz_account_id)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_regional_buckets(
@@ -2460,6 +2554,7 @@ function list_regional_buckets(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2490,6 +2585,7 @@ function list_storage_lens_configurations(
             "headers" => Dict{String,Any}("x-amz-account-id" => x_amz_account_id)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_storage_lens_configurations(
@@ -2510,6 +2606,7 @@ function list_storage_lens_configurations(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2539,6 +2636,7 @@ function put_access_point_configuration_for_object_lambda(
             "headers" => Dict{String,Any}("x-amz-account-id" => x_amz_account_id),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_access_point_configuration_for_object_lambda(
@@ -2562,6 +2660,7 @@ function put_access_point_configuration_for_object_lambda(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2608,6 +2707,7 @@ function put_access_point_policy(
             "headers" => Dict{String,Any}("x-amz-account-id" => x_amz_account_id),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_access_point_policy(
@@ -2631,6 +2731,7 @@ function put_access_point_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2661,6 +2762,7 @@ function put_access_point_policy_for_object_lambda(
             "headers" => Dict{String,Any}("x-amz-account-id" => x_amz_account_id),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_access_point_policy_for_object_lambda(
@@ -2684,6 +2786,7 @@ function put_access_point_policy_for_object_lambda(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2723,6 +2826,7 @@ function put_bucket_lifecycle_configuration(
             "headers" => Dict{String,Any}("x-amz-account-id" => x_amz_account_id)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_bucket_lifecycle_configuration(
@@ -2744,6 +2848,7 @@ function put_bucket_lifecycle_configuration(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2801,6 +2906,7 @@ function put_bucket_policy(
             "headers" => Dict{String,Any}("x-amz-account-id" => x_amz_account_id),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_bucket_policy(
@@ -2824,6 +2930,7 @@ function put_bucket_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2887,6 +2994,7 @@ function put_bucket_tagging(
             "headers" => Dict{String,Any}("x-amz-account-id" => x_amz_account_id),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_bucket_tagging(
@@ -2910,6 +3018,7 @@ function put_bucket_tagging(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2955,6 +3064,7 @@ function put_job_tagging(
             "headers" => Dict{String,Any}("x-amz-account-id" => x_amz_account_id),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_job_tagging(
@@ -2978,6 +3088,7 @@ function put_job_tagging(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3018,6 +3129,7 @@ function put_multi_region_access_point_policy(
             "headers" => Dict{String,Any}("x-amz-account-id" => x_amz_account_id),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_multi_region_access_point_policy(
@@ -3042,6 +3154,7 @@ function put_multi_region_access_point_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3073,6 +3186,7 @@ function put_public_access_block(
             "headers" => Dict{String,Any}("x-amz-account-id" => x_amz_account_id),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_public_access_block(
@@ -3095,6 +3209,7 @@ function put_public_access_block(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3132,6 +3247,7 @@ function put_storage_lens_configuration(
             "headers" => Dict{String,Any}("x-amz-account-id" => x_amz_account_id),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_storage_lens_configuration(
@@ -3155,6 +3271,7 @@ function put_storage_lens_configuration(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3191,6 +3308,7 @@ function put_storage_lens_configuration_tagging(
             "headers" => Dict{String,Any}("x-amz-account-id" => x_amz_account_id),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_storage_lens_configuration_tagging(
@@ -3214,6 +3332,7 @@ function put_storage_lens_configuration_tagging(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3243,6 +3362,7 @@ function update_job_priority(
             "headers" => Dict{String,Any}("x-amz-account-id" => x_amz_account_id),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_job_priority(
@@ -3266,6 +3386,7 @@ function update_job_priority(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3303,6 +3424,7 @@ function update_job_status(
             "headers" => Dict{String,Any}("x-amz-account-id" => x_amz_account_id),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_job_status(
@@ -3326,5 +3448,6 @@ function update_job_status(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/s3outposts.jl
+++ b/src/services/s3outposts.jl
@@ -41,6 +41,7 @@ function create_endpoint(
             "SubnetId" => SubnetId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_endpoint(
@@ -65,6 +66,7 @@ function create_endpoint(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -92,6 +94,7 @@ function delete_endpoint(
         "/S3Outposts/DeleteEndpoint",
         Dict{String,Any}("endpointId" => endpointId, "outpostId" => outpostId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_endpoint(
@@ -111,6 +114,7 @@ function delete_endpoint(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -131,10 +135,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: The next endpoint requested in the list.
 """
 function list_endpoints(; aws_config::AbstractAWSConfig=global_aws_config())
-    return s3outposts("GET", "/S3Outposts/ListEndpoints"; aws_config=aws_config)
+    return s3outposts(
+        "GET",
+        "/S3Outposts/ListEndpoints";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_endpoints(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return s3outposts("GET", "/S3Outposts/ListEndpoints", params; aws_config=aws_config)
+    return s3outposts(
+        "GET",
+        "/S3Outposts/ListEndpoints",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end

--- a/src/services/sagemaker.jl
+++ b/src/services/sagemaker.jl
@@ -36,6 +36,7 @@ function add_association(
         "AddAssociation",
         Dict{String,Any}("DestinationArn" => DestinationArn, "SourceArn" => SourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function add_association(
@@ -56,6 +57,7 @@ function add_association(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -94,6 +96,7 @@ function add_tags(ResourceArn, Tags; aws_config::AbstractAWSConfig=global_aws_co
         "AddTags",
         Dict{String,Any}("ResourceArn" => ResourceArn, "Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function add_tags(
@@ -112,6 +115,7 @@ function add_tags(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -137,6 +141,7 @@ function associate_trial_component(
             "TrialComponentName" => TrialComponentName, "TrialName" => TrialName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_trial_component(
@@ -157,6 +162,7 @@ function associate_trial_component(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -192,6 +198,7 @@ function create_action(
             "ActionName" => ActionName, "ActionType" => ActionType, "Source" => Source
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_action(
@@ -215,6 +222,7 @@ function create_action(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -263,6 +271,7 @@ function create_algorithm(
             "TrainingSpecification" => TrainingSpecification,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_algorithm(
@@ -284,6 +293,7 @@ function create_algorithm(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -326,6 +336,7 @@ function create_app(
             "UserProfileName" => UserProfileName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_app(
@@ -351,6 +362,7 @@ function create_app(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -377,6 +389,7 @@ function create_app_image_config(
         "CreateAppImageConfig",
         Dict{String,Any}("AppImageConfigName" => AppImageConfigName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_app_image_config(
@@ -392,6 +405,7 @@ function create_app_image_config(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -422,6 +436,7 @@ function create_artifact(
         "CreateArtifact",
         Dict{String,Any}("ArtifactType" => ArtifactType, "Source" => Source);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_artifact(
@@ -440,6 +455,7 @@ function create_artifact(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -495,6 +511,7 @@ function create_auto_mljob(
             "RoleArn" => RoleArn,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_auto_mljob(
@@ -520,6 +537,7 @@ function create_auto_mljob(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -555,6 +573,7 @@ function create_code_repository(
             "CodeRepositoryName" => CodeRepositoryName, "GitConfig" => GitConfig
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_code_repository(
@@ -575,6 +594,7 @@ function create_code_repository(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -643,6 +663,7 @@ function create_compilation_job(
             "StoppingCondition" => StoppingCondition,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_compilation_job(
@@ -670,6 +691,7 @@ function create_compilation_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -702,6 +724,7 @@ function create_context(
             "ContextName" => ContextName, "ContextType" => ContextType, "Source" => Source
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_context(
@@ -725,6 +748,7 @@ function create_context(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -774,6 +798,7 @@ function create_data_quality_job_definition(
             "RoleArn" => RoleArn,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_data_quality_job_definition(
@@ -803,6 +828,7 @@ function create_data_quality_job_definition(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -836,6 +862,7 @@ function create_device_fleet(
             "DeviceFleetName" => DeviceFleetName, "OutputConfig" => OutputConfig
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_device_fleet(
@@ -856,6 +883,7 @@ function create_device_fleet(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -931,6 +959,7 @@ function create_domain(
             "VpcId" => VpcId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_domain(
@@ -958,6 +987,7 @@ function create_domain(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1006,6 +1036,7 @@ function create_edge_packaging_job(
             "RoleArn" => RoleArn,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_edge_packaging_job(
@@ -1035,6 +1066,7 @@ function create_edge_packaging_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1105,6 +1137,7 @@ function create_endpoint(
             "EndpointConfigName" => EndpointConfigName, "EndpointName" => EndpointName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_endpoint(
@@ -1126,6 +1159,7 @@ function create_endpoint(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1200,6 +1234,7 @@ function create_endpoint_config(
             "ProductionVariants" => ProductionVariants,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_endpoint_config(
@@ -1221,6 +1256,7 @@ function create_endpoint_config(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1263,6 +1299,7 @@ function create_experiment(
         "CreateExperiment",
         Dict{String,Any}("ExperimentName" => ExperimentName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_experiment(
@@ -1276,6 +1313,7 @@ function create_experiment(
             mergewith(_merge, Dict{String,Any}("ExperimentName" => ExperimentName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1348,6 +1386,7 @@ function create_feature_group(
             "RecordIdentifierFeatureName" => RecordIdentifierFeatureName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_feature_group(
@@ -1373,6 +1412,7 @@ function create_feature_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1418,6 +1458,7 @@ function create_flow_definition(
             "RoleArn" => RoleArn,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_flow_definition(
@@ -1443,6 +1484,7 @@ function create_flow_definition(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1471,6 +1513,7 @@ function create_human_task_ui(
         "CreateHumanTaskUi",
         Dict{String,Any}("HumanTaskUiName" => HumanTaskUiName, "UiTemplate" => UiTemplate);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_human_task_ui(
@@ -1491,6 +1534,7 @@ function create_human_task_ui(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1551,6 +1595,7 @@ function create_hyper_parameter_tuning_job(
             "HyperParameterTuningJobName" => HyperParameterTuningJobName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_hyper_parameter_tuning_job(
@@ -1572,6 +1617,7 @@ function create_hyper_parameter_tuning_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1599,6 +1645,7 @@ function create_image(ImageName, RoleArn; aws_config::AbstractAWSConfig=global_a
         "CreateImage",
         Dict{String,Any}("ImageName" => ImageName, "RoleArn" => RoleArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_image(
@@ -1617,6 +1664,7 @@ function create_image(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1645,6 +1693,7 @@ function create_image_version(
             "BaseImage" => BaseImage, "ClientToken" => ClientToken, "ImageName" => ImageName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_image_version(
@@ -1668,6 +1717,7 @@ function create_image_version(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1797,6 +1847,7 @@ function create_labeling_job(
             "RoleArn" => RoleArn,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_labeling_job(
@@ -1826,6 +1877,7 @@ function create_labeling_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1887,6 +1939,7 @@ function create_model(
         "CreateModel",
         Dict{String,Any}("ExecutionRoleArn" => ExecutionRoleArn, "ModelName" => ModelName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_model(
@@ -1907,6 +1960,7 @@ function create_model(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1955,6 +2009,7 @@ function create_model_bias_job_definition(
             "RoleArn" => RoleArn,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_model_bias_job_definition(
@@ -1984,6 +2039,7 @@ function create_model_bias_job_definition(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2033,6 +2089,7 @@ function create_model_explainability_job_definition(
             "RoleArn" => RoleArn,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_model_explainability_job_definition(
@@ -2064,6 +2121,7 @@ function create_model_explainability_job_definition(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2117,6 +2175,7 @@ function create_model_package(; aws_config::AbstractAWSConfig=global_aws_config(
         "CreateModelPackage",
         Dict{String,Any}("ClientToken" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_model_package(
@@ -2128,6 +2187,7 @@ function create_model_package(
             mergewith(_merge, Dict{String,Any}("ClientToken" => string(uuid4())), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2154,6 +2214,7 @@ function create_model_package_group(
         "CreateModelPackageGroup",
         Dict{String,Any}("ModelPackageGroupName" => ModelPackageGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_model_package_group(
@@ -2171,6 +2232,7 @@ function create_model_package_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2220,6 +2282,7 @@ function create_model_quality_job_definition(
             "RoleArn" => RoleArn,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_model_quality_job_definition(
@@ -2249,6 +2312,7 @@ function create_model_quality_job_definition(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2282,6 +2346,7 @@ function create_monitoring_schedule(
             "MonitoringScheduleName" => MonitoringScheduleName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_monitoring_schedule(
@@ -2303,6 +2368,7 @@ function create_monitoring_schedule(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2406,6 +2472,7 @@ function create_notebook_instance(
             "RoleArn" => RoleArn,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_notebook_instance(
@@ -2429,6 +2496,7 @@ function create_notebook_instance(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2466,6 +2534,7 @@ function create_notebook_instance_lifecycle_config(
             "NotebookInstanceLifecycleConfigName" => NotebookInstanceLifecycleConfigName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_notebook_instance_lifecycle_config(
@@ -2486,6 +2555,7 @@ function create_notebook_instance_lifecycle_config(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2525,6 +2595,7 @@ function create_pipeline(
             "RoleArn" => RoleArn,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_pipeline(
@@ -2550,6 +2621,7 @@ function create_pipeline(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2590,6 +2662,7 @@ function create_presigned_domain_url(
         "CreatePresignedDomainUrl",
         Dict{String,Any}("DomainId" => DomainId, "UserProfileName" => UserProfileName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_presigned_domain_url(
@@ -2610,6 +2683,7 @@ function create_presigned_domain_url(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2648,6 +2722,7 @@ function create_presigned_notebook_instance_url(
         "CreatePresignedNotebookInstanceUrl",
         Dict{String,Any}("NotebookInstanceName" => NotebookInstanceName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_presigned_notebook_instance_url(
@@ -2665,6 +2740,7 @@ function create_presigned_notebook_instance_url(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2716,6 +2792,7 @@ function create_processing_job(
             "RoleArn" => RoleArn,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_processing_job(
@@ -2741,6 +2818,7 @@ function create_processing_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2776,6 +2854,7 @@ function create_project(
             "ServiceCatalogProvisioningDetails" => ServiceCatalogProvisioningDetails,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_project(
@@ -2798,6 +2877,7 @@ function create_project(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2834,6 +2914,7 @@ function create_studio_lifecycle_config(
             "StudioLifecycleConfigName" => StudioLifecycleConfigName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_studio_lifecycle_config(
@@ -2857,6 +2938,7 @@ function create_studio_lifecycle_config(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2996,6 +3078,7 @@ function create_training_job(
             "TrainingJobName" => TrainingJobName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_training_job(
@@ -3025,6 +3108,7 @@ function create_training_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3113,6 +3197,7 @@ function create_transform_job(
             "TransformResources" => TransformResources,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_transform_job(
@@ -3140,6 +3225,7 @@ function create_transform_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3176,6 +3262,7 @@ function create_trial(
         "CreateTrial",
         Dict{String,Any}("ExperimentName" => ExperimentName, "TrialName" => TrialName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_trial(
@@ -3196,6 +3283,7 @@ function create_trial(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3239,6 +3327,7 @@ function create_trial_component(
         "CreateTrialComponent",
         Dict{String,Any}("TrialComponentName" => TrialComponentName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_trial_component(
@@ -3254,6 +3343,7 @@ function create_trial_component(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3295,6 +3385,7 @@ function create_user_profile(
         "CreateUserProfile",
         Dict{String,Any}("DomainId" => DomainId, "UserProfileName" => UserProfileName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_user_profile(
@@ -3315,6 +3406,7 @@ function create_user_profile(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3354,6 +3446,7 @@ function create_workforce(WorkforceName; aws_config::AbstractAWSConfig=global_aw
         "CreateWorkforce",
         Dict{String,Any}("WorkforceName" => WorkforceName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_workforce(
@@ -3367,6 +3460,7 @@ function create_workforce(
             mergewith(_merge, Dict{String,Any}("WorkforceName" => WorkforceName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3417,6 +3511,7 @@ function create_workteam(
             "WorkteamName" => WorkteamName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_workteam(
@@ -3440,6 +3535,7 @@ function create_workteam(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3455,7 +3551,10 @@ Deletes an action.
 """
 function delete_action(ActionName; aws_config::AbstractAWSConfig=global_aws_config())
     return sagemaker(
-        "DeleteAction", Dict{String,Any}("ActionName" => ActionName); aws_config=aws_config
+        "DeleteAction",
+        Dict{String,Any}("ActionName" => ActionName);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_action(
@@ -3469,6 +3568,7 @@ function delete_action(
             mergewith(_merge, Dict{String,Any}("ActionName" => ActionName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3487,6 +3587,7 @@ function delete_algorithm(AlgorithmName; aws_config::AbstractAWSConfig=global_aw
         "DeleteAlgorithm",
         Dict{String,Any}("AlgorithmName" => AlgorithmName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_algorithm(
@@ -3500,6 +3601,7 @@ function delete_algorithm(
             mergewith(_merge, Dict{String,Any}("AlgorithmName" => AlgorithmName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3532,6 +3634,7 @@ function delete_app(
             "UserProfileName" => UserProfileName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_app(
@@ -3557,6 +3660,7 @@ function delete_app(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3577,6 +3681,7 @@ function delete_app_image_config(
         "DeleteAppImageConfig",
         Dict{String,Any}("AppImageConfigName" => AppImageConfigName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_app_image_config(
@@ -3592,6 +3697,7 @@ function delete_app_image_config(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3607,12 +3713,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"Source"`: The URI of the source.
 """
 function delete_artifact(; aws_config::AbstractAWSConfig=global_aws_config())
-    return sagemaker("DeleteArtifact"; aws_config=aws_config)
+    return sagemaker(
+        "DeleteArtifact"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function delete_artifact(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sagemaker("DeleteArtifact", params; aws_config=aws_config)
+    return sagemaker(
+        "DeleteArtifact", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -3633,6 +3743,7 @@ function delete_association(
         "DeleteAssociation",
         Dict{String,Any}("DestinationArn" => DestinationArn, "SourceArn" => SourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_association(
@@ -3653,6 +3764,7 @@ function delete_association(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3673,6 +3785,7 @@ function delete_code_repository(
         "DeleteCodeRepository",
         Dict{String,Any}("CodeRepositoryName" => CodeRepositoryName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_code_repository(
@@ -3688,6 +3801,7 @@ function delete_code_repository(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3706,6 +3820,7 @@ function delete_context(ContextName; aws_config::AbstractAWSConfig=global_aws_co
         "DeleteContext",
         Dict{String,Any}("ContextName" => ContextName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_context(
@@ -3719,6 +3834,7 @@ function delete_context(
             mergewith(_merge, Dict{String,Any}("ContextName" => ContextName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3739,6 +3855,7 @@ function delete_data_quality_job_definition(
         "DeleteDataQualityJobDefinition",
         Dict{String,Any}("JobDefinitionName" => JobDefinitionName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_data_quality_job_definition(
@@ -3754,6 +3871,7 @@ function delete_data_quality_job_definition(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3774,6 +3892,7 @@ function delete_device_fleet(
         "DeleteDeviceFleet",
         Dict{String,Any}("DeviceFleetName" => DeviceFleetName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_device_fleet(
@@ -3789,6 +3908,7 @@ function delete_device_fleet(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3811,7 +3931,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function delete_domain(DomainId; aws_config::AbstractAWSConfig=global_aws_config())
     return sagemaker(
-        "DeleteDomain", Dict{String,Any}("DomainId" => DomainId); aws_config=aws_config
+        "DeleteDomain",
+        Dict{String,Any}("DomainId" => DomainId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_domain(
@@ -3825,6 +3948,7 @@ function delete_domain(
             mergewith(_merge, Dict{String,Any}("DomainId" => DomainId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3845,6 +3969,7 @@ function delete_endpoint(EndpointName; aws_config::AbstractAWSConfig=global_aws_
         "DeleteEndpoint",
         Dict{String,Any}("EndpointName" => EndpointName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_endpoint(
@@ -3858,6 +3983,7 @@ function delete_endpoint(
             mergewith(_merge, Dict{String,Any}("EndpointName" => EndpointName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3884,6 +4010,7 @@ function delete_endpoint_config(
         "DeleteEndpointConfig",
         Dict{String,Any}("EndpointConfigName" => EndpointConfigName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_endpoint_config(
@@ -3899,6 +4026,7 @@ function delete_endpoint_config(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3920,6 +4048,7 @@ function delete_experiment(
         "DeleteExperiment",
         Dict{String,Any}("ExperimentName" => ExperimentName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_experiment(
@@ -3933,6 +4062,7 @@ function delete_experiment(
             mergewith(_merge, Dict{String,Any}("ExperimentName" => ExperimentName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3958,6 +4088,7 @@ function delete_feature_group(
         "DeleteFeatureGroup",
         Dict{String,Any}("FeatureGroupName" => FeatureGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_feature_group(
@@ -3973,6 +4104,7 @@ function delete_feature_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3993,6 +4125,7 @@ function delete_flow_definition(
         "DeleteFlowDefinition",
         Dict{String,Any}("FlowDefinitionName" => FlowDefinitionName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_flow_definition(
@@ -4008,6 +4141,7 @@ function delete_flow_definition(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4031,6 +4165,7 @@ function delete_human_task_ui(
         "DeleteHumanTaskUi",
         Dict{String,Any}("HumanTaskUiName" => HumanTaskUiName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_human_task_ui(
@@ -4046,6 +4181,7 @@ function delete_human_task_ui(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4062,7 +4198,10 @@ deleted.
 """
 function delete_image(ImageName; aws_config::AbstractAWSConfig=global_aws_config())
     return sagemaker(
-        "DeleteImage", Dict{String,Any}("ImageName" => ImageName); aws_config=aws_config
+        "DeleteImage",
+        Dict{String,Any}("ImageName" => ImageName);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_image(
@@ -4076,6 +4215,7 @@ function delete_image(
             mergewith(_merge, Dict{String,Any}("ImageName" => ImageName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4098,6 +4238,7 @@ function delete_image_version(
         "DeleteImageVersion",
         Dict{String,Any}("ImageName" => ImageName, "Version" => Version);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_image_version(
@@ -4116,6 +4257,7 @@ function delete_image_version(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4133,7 +4275,10 @@ inference code, or the IAM role that you specified when creating the model.
 """
 function delete_model(ModelName; aws_config::AbstractAWSConfig=global_aws_config())
     return sagemaker(
-        "DeleteModel", Dict{String,Any}("ModelName" => ModelName); aws_config=aws_config
+        "DeleteModel",
+        Dict{String,Any}("ModelName" => ModelName);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_model(
@@ -4147,6 +4292,7 @@ function delete_model(
             mergewith(_merge, Dict{String,Any}("ModelName" => ModelName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4167,6 +4313,7 @@ function delete_model_bias_job_definition(
         "DeleteModelBiasJobDefinition",
         Dict{String,Any}("JobDefinitionName" => JobDefinitionName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_model_bias_job_definition(
@@ -4182,6 +4329,7 @@ function delete_model_bias_job_definition(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4202,6 +4350,7 @@ function delete_model_explainability_job_definition(
         "DeleteModelExplainabilityJobDefinition",
         Dict{String,Any}("JobDefinitionName" => JobDefinitionName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_model_explainability_job_definition(
@@ -4217,6 +4366,7 @@ function delete_model_explainability_job_definition(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4241,6 +4391,7 @@ function delete_model_package(
         "DeleteModelPackage",
         Dict{String,Any}("ModelPackageName" => ModelPackageName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_model_package(
@@ -4256,6 +4407,7 @@ function delete_model_package(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4276,6 +4428,7 @@ function delete_model_package_group(
         "DeleteModelPackageGroup",
         Dict{String,Any}("ModelPackageGroupName" => ModelPackageGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_model_package_group(
@@ -4293,6 +4446,7 @@ function delete_model_package_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4313,6 +4467,7 @@ function delete_model_package_group_policy(
         "DeleteModelPackageGroupPolicy",
         Dict{String,Any}("ModelPackageGroupName" => ModelPackageGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_model_package_group_policy(
@@ -4330,6 +4485,7 @@ function delete_model_package_group_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4350,6 +4506,7 @@ function delete_model_quality_job_definition(
         "DeleteModelQualityJobDefinition",
         Dict{String,Any}("JobDefinitionName" => JobDefinitionName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_model_quality_job_definition(
@@ -4365,6 +4522,7 @@ function delete_model_quality_job_definition(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4386,6 +4544,7 @@ function delete_monitoring_schedule(
         "DeleteMonitoringSchedule",
         Dict{String,Any}("MonitoringScheduleName" => MonitoringScheduleName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_monitoring_schedule(
@@ -4403,6 +4562,7 @@ function delete_monitoring_schedule(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4426,6 +4586,7 @@ function delete_notebook_instance(
         "DeleteNotebookInstance",
         Dict{String,Any}("NotebookInstanceName" => NotebookInstanceName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_notebook_instance(
@@ -4443,6 +4604,7 @@ function delete_notebook_instance(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4466,6 +4628,7 @@ function delete_notebook_instance_lifecycle_config(
             "NotebookInstanceLifecycleConfigName" => NotebookInstanceLifecycleConfigName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_notebook_instance_lifecycle_config(
@@ -4486,6 +4649,7 @@ function delete_notebook_instance_lifecycle_config(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4512,6 +4676,7 @@ function delete_pipeline(
             "ClientRequestToken" => ClientRequestToken, "PipelineName" => PipelineName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_pipeline(
@@ -4533,6 +4698,7 @@ function delete_pipeline(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4551,6 +4717,7 @@ function delete_project(ProjectName; aws_config::AbstractAWSConfig=global_aws_co
         "DeleteProject",
         Dict{String,Any}("ProjectName" => ProjectName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_project(
@@ -4564,6 +4731,7 @@ function delete_project(
             mergewith(_merge, Dict{String,Any}("ProjectName" => ProjectName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4586,6 +4754,7 @@ function delete_studio_lifecycle_config(
         "DeleteStudioLifecycleConfig",
         Dict{String,Any}("StudioLifecycleConfigName" => StudioLifecycleConfigName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_studio_lifecycle_config(
@@ -4603,6 +4772,7 @@ function delete_studio_lifecycle_config(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4630,6 +4800,7 @@ function delete_tags(
         "DeleteTags",
         Dict{String,Any}("ResourceArn" => ResourceArn, "TagKeys" => TagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_tags(
@@ -4648,6 +4819,7 @@ function delete_tags(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4664,7 +4836,10 @@ first. Use the DescribeTrialComponent API to get the list of trial components.
 """
 function delete_trial(TrialName; aws_config::AbstractAWSConfig=global_aws_config())
     return sagemaker(
-        "DeleteTrial", Dict{String,Any}("TrialName" => TrialName); aws_config=aws_config
+        "DeleteTrial",
+        Dict{String,Any}("TrialName" => TrialName);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_trial(
@@ -4678,6 +4853,7 @@ function delete_trial(
             mergewith(_merge, Dict{String,Any}("TrialName" => TrialName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4700,6 +4876,7 @@ function delete_trial_component(
         "DeleteTrialComponent",
         Dict{String,Any}("TrialComponentName" => TrialComponentName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_trial_component(
@@ -4715,6 +4892,7 @@ function delete_trial_component(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4737,6 +4915,7 @@ function delete_user_profile(
         "DeleteUserProfile",
         Dict{String,Any}("DomainId" => DomainId, "UserProfileName" => UserProfileName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_user_profile(
@@ -4757,6 +4936,7 @@ function delete_user_profile(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4780,6 +4960,7 @@ function delete_workforce(WorkforceName; aws_config::AbstractAWSConfig=global_aw
         "DeleteWorkforce",
         Dict{String,Any}("WorkforceName" => WorkforceName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_workforce(
@@ -4793,6 +4974,7 @@ function delete_workforce(
             mergewith(_merge, Dict{String,Any}("WorkforceName" => WorkforceName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4811,6 +4993,7 @@ function delete_workteam(WorkteamName; aws_config::AbstractAWSConfig=global_aws_
         "DeleteWorkteam",
         Dict{String,Any}("WorkteamName" => WorkteamName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_workteam(
@@ -4824,6 +5007,7 @@ function delete_workteam(
             mergewith(_merge, Dict{String,Any}("WorkteamName" => WorkteamName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4848,6 +5032,7 @@ function deregister_devices(
             "DeviceFleetName" => DeviceFleetName, "DeviceNames" => DeviceNames
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function deregister_devices(
@@ -4868,6 +5053,7 @@ function deregister_devices(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4886,6 +5072,7 @@ function describe_action(ActionName; aws_config::AbstractAWSConfig=global_aws_co
         "DescribeAction",
         Dict{String,Any}("ActionName" => ActionName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_action(
@@ -4899,6 +5086,7 @@ function describe_action(
             mergewith(_merge, Dict{String,Any}("ActionName" => ActionName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4919,6 +5107,7 @@ function describe_algorithm(
         "DescribeAlgorithm",
         Dict{String,Any}("AlgorithmName" => AlgorithmName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_algorithm(
@@ -4932,6 +5121,7 @@ function describe_algorithm(
             mergewith(_merge, Dict{String,Any}("AlgorithmName" => AlgorithmName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4964,6 +5154,7 @@ function describe_app(
             "UserProfileName" => UserProfileName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_app(
@@ -4989,6 +5180,7 @@ function describe_app(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5009,6 +5201,7 @@ function describe_app_image_config(
         "DescribeAppImageConfig",
         Dict{String,Any}("AppImageConfigName" => AppImageConfigName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_app_image_config(
@@ -5024,6 +5217,7 @@ function describe_app_image_config(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5042,6 +5236,7 @@ function describe_artifact(ArtifactArn; aws_config::AbstractAWSConfig=global_aws
         "DescribeArtifact",
         Dict{String,Any}("ArtifactArn" => ArtifactArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_artifact(
@@ -5055,6 +5250,7 @@ function describe_artifact(
             mergewith(_merge, Dict{String,Any}("ArtifactArn" => ArtifactArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5075,6 +5271,7 @@ function describe_auto_mljob(
         "DescribeAutoMLJob",
         Dict{String,Any}("AutoMLJobName" => AutoMLJobName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_auto_mljob(
@@ -5088,6 +5285,7 @@ function describe_auto_mljob(
             mergewith(_merge, Dict{String,Any}("AutoMLJobName" => AutoMLJobName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5108,6 +5306,7 @@ function describe_code_repository(
         "DescribeCodeRepository",
         Dict{String,Any}("CodeRepositoryName" => CodeRepositoryName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_code_repository(
@@ -5123,6 +5322,7 @@ function describe_code_repository(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5146,6 +5346,7 @@ function describe_compilation_job(
         "DescribeCompilationJob",
         Dict{String,Any}("CompilationJobName" => CompilationJobName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_compilation_job(
@@ -5161,6 +5362,7 @@ function describe_compilation_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5179,6 +5381,7 @@ function describe_context(ContextName; aws_config::AbstractAWSConfig=global_aws_
         "DescribeContext",
         Dict{String,Any}("ContextName" => ContextName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_context(
@@ -5192,6 +5395,7 @@ function describe_context(
             mergewith(_merge, Dict{String,Any}("ContextName" => ContextName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5212,6 +5416,7 @@ function describe_data_quality_job_definition(
         "DescribeDataQualityJobDefinition",
         Dict{String,Any}("JobDefinitionName" => JobDefinitionName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_data_quality_job_definition(
@@ -5227,6 +5432,7 @@ function describe_data_quality_job_definition(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5251,6 +5457,7 @@ function describe_device(
         "DescribeDevice",
         Dict{String,Any}("DeviceFleetName" => DeviceFleetName, "DeviceName" => DeviceName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_device(
@@ -5271,6 +5478,7 @@ function describe_device(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5291,6 +5499,7 @@ function describe_device_fleet(
         "DescribeDeviceFleet",
         Dict{String,Any}("DeviceFleetName" => DeviceFleetName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_device_fleet(
@@ -5306,6 +5515,7 @@ function describe_device_fleet(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5321,7 +5531,10 @@ The description of the domain.
 """
 function describe_domain(DomainId; aws_config::AbstractAWSConfig=global_aws_config())
     return sagemaker(
-        "DescribeDomain", Dict{String,Any}("DomainId" => DomainId); aws_config=aws_config
+        "DescribeDomain",
+        Dict{String,Any}("DomainId" => DomainId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_domain(
@@ -5335,6 +5548,7 @@ function describe_domain(
             mergewith(_merge, Dict{String,Any}("DomainId" => DomainId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5355,6 +5569,7 @@ function describe_edge_packaging_job(
         "DescribeEdgePackagingJob",
         Dict{String,Any}("EdgePackagingJobName" => EdgePackagingJobName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_edge_packaging_job(
@@ -5372,6 +5587,7 @@ function describe_edge_packaging_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5390,6 +5606,7 @@ function describe_endpoint(EndpointName; aws_config::AbstractAWSConfig=global_aw
         "DescribeEndpoint",
         Dict{String,Any}("EndpointName" => EndpointName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_endpoint(
@@ -5403,6 +5620,7 @@ function describe_endpoint(
             mergewith(_merge, Dict{String,Any}("EndpointName" => EndpointName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5424,6 +5642,7 @@ function describe_endpoint_config(
         "DescribeEndpointConfig",
         Dict{String,Any}("EndpointConfigName" => EndpointConfigName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_endpoint_config(
@@ -5439,6 +5658,7 @@ function describe_endpoint_config(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5459,6 +5679,7 @@ function describe_experiment(
         "DescribeExperiment",
         Dict{String,Any}("ExperimentName" => ExperimentName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_experiment(
@@ -5472,6 +5693,7 @@ function describe_experiment(
             mergewith(_merge, Dict{String,Any}("ExperimentName" => ExperimentName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5497,6 +5719,7 @@ function describe_feature_group(
         "DescribeFeatureGroup",
         Dict{String,Any}("FeatureGroupName" => FeatureGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_feature_group(
@@ -5512,6 +5735,7 @@ function describe_feature_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5532,6 +5756,7 @@ function describe_flow_definition(
         "DescribeFlowDefinition",
         Dict{String,Any}("FlowDefinitionName" => FlowDefinitionName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_flow_definition(
@@ -5547,6 +5772,7 @@ function describe_flow_definition(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5568,6 +5794,7 @@ function describe_human_task_ui(
         "DescribeHumanTaskUi",
         Dict{String,Any}("HumanTaskUiName" => HumanTaskUiName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_human_task_ui(
@@ -5583,6 +5810,7 @@ function describe_human_task_ui(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5603,6 +5831,7 @@ function describe_hyper_parameter_tuning_job(
         "DescribeHyperParameterTuningJob",
         Dict{String,Any}("HyperParameterTuningJobName" => HyperParameterTuningJobName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_hyper_parameter_tuning_job(
@@ -5622,6 +5851,7 @@ function describe_hyper_parameter_tuning_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5637,7 +5867,10 @@ Describes a SageMaker image.
 """
 function describe_image(ImageName; aws_config::AbstractAWSConfig=global_aws_config())
     return sagemaker(
-        "DescribeImage", Dict{String,Any}("ImageName" => ImageName); aws_config=aws_config
+        "DescribeImage",
+        Dict{String,Any}("ImageName" => ImageName);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_image(
@@ -5651,6 +5884,7 @@ function describe_image(
             mergewith(_merge, Dict{String,Any}("ImageName" => ImageName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5674,6 +5908,7 @@ function describe_image_version(
         "DescribeImageVersion",
         Dict{String,Any}("ImageName" => ImageName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_image_version(
@@ -5687,6 +5922,7 @@ function describe_image_version(
             mergewith(_merge, Dict{String,Any}("ImageName" => ImageName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5707,6 +5943,7 @@ function describe_labeling_job(
         "DescribeLabelingJob",
         Dict{String,Any}("LabelingJobName" => LabelingJobName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_labeling_job(
@@ -5722,6 +5959,7 @@ function describe_labeling_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5737,7 +5975,10 @@ Describes a model that you created using the CreateModel API.
 """
 function describe_model(ModelName; aws_config::AbstractAWSConfig=global_aws_config())
     return sagemaker(
-        "DescribeModel", Dict{String,Any}("ModelName" => ModelName); aws_config=aws_config
+        "DescribeModel",
+        Dict{String,Any}("ModelName" => ModelName);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_model(
@@ -5751,6 +5992,7 @@ function describe_model(
             mergewith(_merge, Dict{String,Any}("ModelName" => ModelName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5772,6 +6014,7 @@ function describe_model_bias_job_definition(
         "DescribeModelBiasJobDefinition",
         Dict{String,Any}("JobDefinitionName" => JobDefinitionName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_model_bias_job_definition(
@@ -5787,6 +6030,7 @@ function describe_model_bias_job_definition(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5808,6 +6052,7 @@ function describe_model_explainability_job_definition(
         "DescribeModelExplainabilityJobDefinition",
         Dict{String,Any}("JobDefinitionName" => JobDefinitionName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_model_explainability_job_definition(
@@ -5823,6 +6068,7 @@ function describe_model_explainability_job_definition(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5848,6 +6094,7 @@ function describe_model_package(
         "DescribeModelPackage",
         Dict{String,Any}("ModelPackageName" => ModelPackageName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_model_package(
@@ -5863,6 +6110,7 @@ function describe_model_package(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5883,6 +6131,7 @@ function describe_model_package_group(
         "DescribeModelPackageGroup",
         Dict{String,Any}("ModelPackageGroupName" => ModelPackageGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_model_package_group(
@@ -5900,6 +6149,7 @@ function describe_model_package_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5921,6 +6171,7 @@ function describe_model_quality_job_definition(
         "DescribeModelQualityJobDefinition",
         Dict{String,Any}("JobDefinitionName" => JobDefinitionName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_model_quality_job_definition(
@@ -5936,6 +6187,7 @@ function describe_model_quality_job_definition(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5956,6 +6208,7 @@ function describe_monitoring_schedule(
         "DescribeMonitoringSchedule",
         Dict{String,Any}("MonitoringScheduleName" => MonitoringScheduleName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_monitoring_schedule(
@@ -5973,6 +6226,7 @@ function describe_monitoring_schedule(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5994,6 +6248,7 @@ function describe_notebook_instance(
         "DescribeNotebookInstance",
         Dict{String,Any}("NotebookInstanceName" => NotebookInstanceName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_notebook_instance(
@@ -6011,6 +6266,7 @@ function describe_notebook_instance(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6036,6 +6292,7 @@ function describe_notebook_instance_lifecycle_config(
             "NotebookInstanceLifecycleConfigName" => NotebookInstanceLifecycleConfigName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_notebook_instance_lifecycle_config(
@@ -6056,6 +6313,7 @@ function describe_notebook_instance_lifecycle_config(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6074,6 +6332,7 @@ function describe_pipeline(PipelineName; aws_config::AbstractAWSConfig=global_aw
         "DescribePipeline",
         Dict{String,Any}("PipelineName" => PipelineName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_pipeline(
@@ -6087,6 +6346,7 @@ function describe_pipeline(
             mergewith(_merge, Dict{String,Any}("PipelineName" => PipelineName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6107,6 +6367,7 @@ function describe_pipeline_definition_for_execution(
         "DescribePipelineDefinitionForExecution",
         Dict{String,Any}("PipelineExecutionArn" => PipelineExecutionArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_pipeline_definition_for_execution(
@@ -6124,6 +6385,7 @@ function describe_pipeline_definition_for_execution(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6144,6 +6406,7 @@ function describe_pipeline_execution(
         "DescribePipelineExecution",
         Dict{String,Any}("PipelineExecutionArn" => PipelineExecutionArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_pipeline_execution(
@@ -6161,6 +6424,7 @@ function describe_pipeline_execution(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6182,6 +6446,7 @@ function describe_processing_job(
         "DescribeProcessingJob",
         Dict{String,Any}("ProcessingJobName" => ProcessingJobName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_processing_job(
@@ -6197,6 +6462,7 @@ function describe_processing_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6215,6 +6481,7 @@ function describe_project(ProjectName; aws_config::AbstractAWSConfig=global_aws_
         "DescribeProject",
         Dict{String,Any}("ProjectName" => ProjectName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_project(
@@ -6228,6 +6495,7 @@ function describe_project(
             mergewith(_merge, Dict{String,Any}("ProjectName" => ProjectName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6249,6 +6517,7 @@ function describe_studio_lifecycle_config(
         "DescribeStudioLifecycleConfig",
         Dict{String,Any}("StudioLifecycleConfigName" => StudioLifecycleConfigName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_studio_lifecycle_config(
@@ -6266,6 +6535,7 @@ function describe_studio_lifecycle_config(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6287,6 +6557,7 @@ function describe_subscribed_workteam(
         "DescribeSubscribedWorkteam",
         Dict{String,Any}("WorkteamArn" => WorkteamArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_subscribed_workteam(
@@ -6300,6 +6571,7 @@ function describe_subscribed_workteam(
             mergewith(_merge, Dict{String,Any}("WorkteamArn" => WorkteamArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6324,6 +6596,7 @@ function describe_training_job(
         "DescribeTrainingJob",
         Dict{String,Any}("TrainingJobName" => TrainingJobName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_training_job(
@@ -6339,6 +6612,7 @@ function describe_training_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6359,6 +6633,7 @@ function describe_transform_job(
         "DescribeTransformJob",
         Dict{String,Any}("TransformJobName" => TransformJobName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_transform_job(
@@ -6374,6 +6649,7 @@ function describe_transform_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6389,7 +6665,10 @@ Provides a list of a trial's properties.
 """
 function describe_trial(TrialName; aws_config::AbstractAWSConfig=global_aws_config())
     return sagemaker(
-        "DescribeTrial", Dict{String,Any}("TrialName" => TrialName); aws_config=aws_config
+        "DescribeTrial",
+        Dict{String,Any}("TrialName" => TrialName);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_trial(
@@ -6403,6 +6682,7 @@ function describe_trial(
             mergewith(_merge, Dict{String,Any}("TrialName" => TrialName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6423,6 +6703,7 @@ function describe_trial_component(
         "DescribeTrialComponent",
         Dict{String,Any}("TrialComponentName" => TrialComponentName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_trial_component(
@@ -6438,6 +6719,7 @@ function describe_trial_component(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6459,6 +6741,7 @@ function describe_user_profile(
         "DescribeUserProfile",
         Dict{String,Any}("DomainId" => DomainId, "UserProfileName" => UserProfileName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_user_profile(
@@ -6479,6 +6762,7 @@ function describe_user_profile(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6504,6 +6788,7 @@ function describe_workforce(
         "DescribeWorkforce",
         Dict{String,Any}("WorkforceName" => WorkforceName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_workforce(
@@ -6517,6 +6802,7 @@ function describe_workforce(
             mergewith(_merge, Dict{String,Any}("WorkforceName" => WorkforceName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6537,6 +6823,7 @@ function describe_workteam(WorkteamName; aws_config::AbstractAWSConfig=global_aw
         "DescribeWorkteam",
         Dict{String,Any}("WorkteamName" => WorkteamName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_workteam(
@@ -6550,6 +6837,7 @@ function describe_workteam(
             mergewith(_merge, Dict{String,Any}("WorkteamName" => WorkteamName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6564,13 +6852,20 @@ projects.
 function disable_sagemaker_servicecatalog_portfolio(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sagemaker("DisableSagemakerServicecatalogPortfolio"; aws_config=aws_config)
+    return sagemaker(
+        "DisableSagemakerServicecatalogPortfolio";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function disable_sagemaker_servicecatalog_portfolio(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return sagemaker(
-        "DisableSagemakerServicecatalogPortfolio", params; aws_config=aws_config
+        "DisableSagemakerServicecatalogPortfolio",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6599,6 +6894,7 @@ function disassociate_trial_component(
             "TrialComponentName" => TrialComponentName, "TrialName" => TrialName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disassociate_trial_component(
@@ -6619,6 +6915,7 @@ function disassociate_trial_component(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6633,13 +6930,20 @@ projects.
 function enable_sagemaker_servicecatalog_portfolio(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sagemaker("EnableSagemakerServicecatalogPortfolio"; aws_config=aws_config)
+    return sagemaker(
+        "EnableSagemakerServicecatalogPortfolio";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function enable_sagemaker_servicecatalog_portfolio(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return sagemaker(
-        "EnableSagemakerServicecatalogPortfolio", params; aws_config=aws_config
+        "EnableSagemakerServicecatalogPortfolio",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6660,6 +6964,7 @@ function get_device_fleet_report(
         "GetDeviceFleetReport",
         Dict{String,Any}("DeviceFleetName" => DeviceFleetName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_device_fleet_report(
@@ -6675,6 +6980,7 @@ function get_device_fleet_report(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6698,6 +7004,7 @@ function get_model_package_group_policy(
         "GetModelPackageGroupPolicy",
         Dict{String,Any}("ModelPackageGroupName" => ModelPackageGroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_model_package_group_policy(
@@ -6715,6 +7022,7 @@ function get_model_package_group_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6729,13 +7037,20 @@ SageMaker projects.
 function get_sagemaker_servicecatalog_portfolio_status(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sagemaker("GetSagemakerServicecatalogPortfolioStatus"; aws_config=aws_config)
+    return sagemaker(
+        "GetSagemakerServicecatalogPortfolioStatus";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_sagemaker_servicecatalog_portfolio_status(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return sagemaker(
-        "GetSagemakerServicecatalogPortfolioStatus", params; aws_config=aws_config
+        "GetSagemakerServicecatalogPortfolioStatus",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6759,6 +7074,7 @@ function get_search_suggestions(Resource; aws_config::AbstractAWSConfig=global_a
         "GetSearchSuggestions",
         Dict{String,Any}("Resource" => Resource);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_search_suggestions(
@@ -6772,6 +7088,7 @@ function get_search_suggestions(
             mergewith(_merge, Dict{String,Any}("Resource" => Resource), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6797,12 +7114,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"SourceUri"`: A filter that returns only actions with the specified source URI.
 """
 function list_actions(; aws_config::AbstractAWSConfig=global_aws_config())
-    return sagemaker("ListActions"; aws_config=aws_config)
+    return sagemaker("ListActions"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_actions(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sagemaker("ListActions", params; aws_config=aws_config)
+    return sagemaker(
+        "ListActions", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -6827,12 +7146,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"SortOrder"`: The sort order for the results. The default is Ascending.
 """
 function list_algorithms(; aws_config::AbstractAWSConfig=global_aws_config())
-    return sagemaker("ListAlgorithms"; aws_config=aws_config)
+    return sagemaker(
+        "ListAlgorithms"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_algorithms(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sagemaker("ListAlgorithms", params; aws_config=aws_config)
+    return sagemaker(
+        "ListAlgorithms", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -6863,12 +7186,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"SortOrder"`: The sort order. The default value is Descending.
 """
 function list_app_image_configs(; aws_config::AbstractAWSConfig=global_aws_config())
-    return sagemaker("ListAppImageConfigs"; aws_config=aws_config)
+    return sagemaker(
+        "ListAppImageConfigs"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_app_image_configs(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sagemaker("ListAppImageConfigs", params; aws_config=aws_config)
+    return sagemaker(
+        "ListAppImageConfigs",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -6888,12 +7218,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"UserProfileNameEquals"`: A parameter to search by user profile name.
 """
 function list_apps(; aws_config::AbstractAWSConfig=global_aws_config())
-    return sagemaker("ListApps"; aws_config=aws_config)
+    return sagemaker("ListApps"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_apps(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sagemaker("ListApps", params; aws_config=aws_config)
+    return sagemaker(
+        "ListApps", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -6918,12 +7250,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"SourceUri"`: A filter that returns only artifacts with the specified source URI.
 """
 function list_artifacts(; aws_config::AbstractAWSConfig=global_aws_config())
-    return sagemaker("ListArtifacts"; aws_config=aws_config)
+    return sagemaker(
+        "ListArtifacts"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_artifacts(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sagemaker("ListArtifacts", params; aws_config=aws_config)
+    return sagemaker(
+        "ListArtifacts", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -6953,12 +7289,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"SourceType"`: A filter that returns only associations with the specified source type.
 """
 function list_associations(; aws_config::AbstractAWSConfig=global_aws_config())
-    return sagemaker("ListAssociations"; aws_config=aws_config)
+    return sagemaker(
+        "ListAssociations"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_associations(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sagemaker("ListAssociations", params; aws_config=aws_config)
+    return sagemaker(
+        "ListAssociations", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -6982,12 +7322,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"StatusEquals"`: Request a list of jobs, using a filter for status.
 """
 function list_auto_mljobs(; aws_config::AbstractAWSConfig=global_aws_config())
-    return sagemaker("ListAutoMLJobs"; aws_config=aws_config)
+    return sagemaker(
+        "ListAutoMLJobs"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_auto_mljobs(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sagemaker("ListAutoMLJobs", params; aws_config=aws_config)
+    return sagemaker(
+        "ListAutoMLJobs", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -7016,6 +7360,7 @@ function list_candidates_for_auto_mljob(
         "ListCandidatesForAutoMLJob",
         Dict{String,Any}("AutoMLJobName" => AutoMLJobName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_candidates_for_auto_mljob(
@@ -7029,6 +7374,7 @@ function list_candidates_for_auto_mljob(
             mergewith(_merge, Dict{String,Any}("AutoMLJobName" => AutoMLJobName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -7058,12 +7404,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"SortOrder"`: The sort order for results. The default is Ascending.
 """
 function list_code_repositories(; aws_config::AbstractAWSConfig=global_aws_config())
-    return sagemaker("ListCodeRepositories"; aws_config=aws_config)
+    return sagemaker(
+        "ListCodeRepositories"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_code_repositories(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sagemaker("ListCodeRepositories", params; aws_config=aws_config)
+    return sagemaker(
+        "ListCodeRepositories",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -7096,12 +7449,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   DescribeCompilationJobResponseCompilationJobStatus status.
 """
 function list_compilation_jobs(; aws_config::AbstractAWSConfig=global_aws_config())
-    return sagemaker("ListCompilationJobs"; aws_config=aws_config)
+    return sagemaker(
+        "ListCompilationJobs"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_compilation_jobs(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sagemaker("ListCompilationJobs", params; aws_config=aws_config)
+    return sagemaker(
+        "ListCompilationJobs",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -7126,12 +7486,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"SourceUri"`: A filter that returns only contexts with the specified source URI.
 """
 function list_contexts(; aws_config::AbstractAWSConfig=global_aws_config())
-    return sagemaker("ListContexts"; aws_config=aws_config)
+    return sagemaker("ListContexts"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_contexts(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sagemaker("ListContexts", params; aws_config=aws_config)
+    return sagemaker(
+        "ListContexts", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -7162,12 +7524,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function list_data_quality_job_definitions(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sagemaker("ListDataQualityJobDefinitions"; aws_config=aws_config)
+    return sagemaker(
+        "ListDataQualityJobDefinitions";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_data_quality_job_definitions(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sagemaker("ListDataQualityJobDefinitions", params; aws_config=aws_config)
+    return sagemaker(
+        "ListDataQualityJobDefinitions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -7191,12 +7562,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"SortOrder"`: What direction to sort in.
 """
 function list_device_fleets(; aws_config::AbstractAWSConfig=global_aws_config())
-    return sagemaker("ListDeviceFleets"; aws_config=aws_config)
+    return sagemaker(
+        "ListDeviceFleets"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_device_fleets(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sagemaker("ListDeviceFleets", params; aws_config=aws_config)
+    return sagemaker(
+        "ListDeviceFleets", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -7216,12 +7591,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   tokening.
 """
 function list_devices(; aws_config::AbstractAWSConfig=global_aws_config())
-    return sagemaker("ListDevices"; aws_config=aws_config)
+    return sagemaker("ListDevices"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_devices(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sagemaker("ListDevices", params; aws_config=aws_config)
+    return sagemaker(
+        "ListDevices", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -7237,12 +7614,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   it in your next request to receive the next set of results.
 """
 function list_domains(; aws_config::AbstractAWSConfig=global_aws_config())
-    return sagemaker("ListDomains"; aws_config=aws_config)
+    return sagemaker("ListDomains"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_domains(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sagemaker("ListDomains", params; aws_config=aws_config)
+    return sagemaker(
+        "ListDomains", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -7267,12 +7646,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"StatusEquals"`: The job status to filter for.
 """
 function list_edge_packaging_jobs(; aws_config::AbstractAWSConfig=global_aws_config())
-    return sagemaker("ListEdgePackagingJobs"; aws_config=aws_config)
+    return sagemaker(
+        "ListEdgePackagingJobs"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_edge_packaging_jobs(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sagemaker("ListEdgePackagingJobs", params; aws_config=aws_config)
+    return sagemaker(
+        "ListEdgePackagingJobs",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -7297,12 +7683,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"SortOrder"`: The sort order for results. The default is Descending.
 """
 function list_endpoint_configs(; aws_config::AbstractAWSConfig=global_aws_config())
-    return sagemaker("ListEndpointConfigs"; aws_config=aws_config)
+    return sagemaker(
+        "ListEndpointConfigs"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_endpoint_configs(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sagemaker("ListEndpointConfigs", params; aws_config=aws_config)
+    return sagemaker(
+        "ListEndpointConfigs",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -7333,12 +7726,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"StatusEquals"`:  A filter that returns only endpoints with the specified status.
 """
 function list_endpoints(; aws_config::AbstractAWSConfig=global_aws_config())
-    return sagemaker("ListEndpoints"; aws_config=aws_config)
+    return sagemaker(
+        "ListEndpoints"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_endpoints(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sagemaker("ListEndpoints", params; aws_config=aws_config)
+    return sagemaker(
+        "ListEndpoints", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -7362,12 +7759,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"SortOrder"`: The sort order. The default value is Descending.
 """
 function list_experiments(; aws_config::AbstractAWSConfig=global_aws_config())
-    return sagemaker("ListExperiments"; aws_config=aws_config)
+    return sagemaker(
+        "ListExperiments"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_experiments(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sagemaker("ListExperiments", params; aws_config=aws_config)
+    return sagemaker(
+        "ListExperiments", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -7392,12 +7793,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"SortOrder"`: The order in which feature groups are listed.
 """
 function list_feature_groups(; aws_config::AbstractAWSConfig=global_aws_config())
-    return sagemaker("ListFeatureGroups"; aws_config=aws_config)
+    return sagemaker(
+        "ListFeatureGroups"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_feature_groups(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sagemaker("ListFeatureGroups", params; aws_config=aws_config)
+    return sagemaker(
+        "ListFeatureGroups", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -7420,12 +7825,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Ascending or Descending order.
 """
 function list_flow_definitions(; aws_config::AbstractAWSConfig=global_aws_config())
-    return sagemaker("ListFlowDefinitions"; aws_config=aws_config)
+    return sagemaker(
+        "ListFlowDefinitions"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_flow_definitions(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sagemaker("ListFlowDefinitions", params; aws_config=aws_config)
+    return sagemaker(
+        "ListFlowDefinitions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -7448,12 +7860,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Ascending or Descending order.
 """
 function list_human_task_uis(; aws_config::AbstractAWSConfig=global_aws_config())
-    return sagemaker("ListHumanTaskUis"; aws_config=aws_config)
+    return sagemaker(
+        "ListHumanTaskUis"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_human_task_uis(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sagemaker("ListHumanTaskUis", params; aws_config=aws_config)
+    return sagemaker(
+        "ListHumanTaskUis", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -7486,12 +7902,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function list_hyper_parameter_tuning_jobs(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sagemaker("ListHyperParameterTuningJobs"; aws_config=aws_config)
+    return sagemaker(
+        "ListHyperParameterTuningJobs";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_hyper_parameter_tuning_jobs(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sagemaker("ListHyperParameterTuningJobs", params; aws_config=aws_config)
+    return sagemaker(
+        "ListHyperParameterTuningJobs",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -7526,6 +7951,7 @@ function list_image_versions(ImageName; aws_config::AbstractAWSConfig=global_aws
         "ListImageVersions",
         Dict{String,Any}("ImageName" => ImageName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_image_versions(
@@ -7539,6 +7965,7 @@ function list_image_versions(
             mergewith(_merge, Dict{String,Any}("ImageName" => ImageName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -7569,12 +7996,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"SortOrder"`: The sort order. The default value is DESCENDING.
 """
 function list_images(; aws_config::AbstractAWSConfig=global_aws_config())
-    return sagemaker("ListImages"; aws_config=aws_config)
+    return sagemaker("ListImages"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_images(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sagemaker("ListImages", params; aws_config=aws_config)
+    return sagemaker(
+        "ListImages", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -7605,12 +8034,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"StatusEquals"`: A filter that retrieves only labeling jobs with a specific status.
 """
 function list_labeling_jobs(; aws_config::AbstractAWSConfig=global_aws_config())
-    return sagemaker("ListLabelingJobs"; aws_config=aws_config)
+    return sagemaker(
+        "ListLabelingJobs"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_labeling_jobs(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sagemaker("ListLabelingJobs", params; aws_config=aws_config)
+    return sagemaker(
+        "ListLabelingJobs", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -7646,6 +8079,7 @@ function list_labeling_jobs_for_workteam(
         "ListLabelingJobsForWorkteam",
         Dict{String,Any}("WorkteamArn" => WorkteamArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_labeling_jobs_for_workteam(
@@ -7659,6 +8093,7 @@ function list_labeling_jobs_for_workteam(
             mergewith(_merge, Dict{String,Any}("WorkteamArn" => WorkteamArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -7688,12 +8123,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function list_model_bias_job_definitions(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sagemaker("ListModelBiasJobDefinitions"; aws_config=aws_config)
+    return sagemaker(
+        "ListModelBiasJobDefinitions";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_model_bias_job_definitions(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sagemaker("ListModelBiasJobDefinitions", params; aws_config=aws_config)
+    return sagemaker(
+        "ListModelBiasJobDefinitions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -7723,12 +8167,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function list_model_explainability_job_definitions(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sagemaker("ListModelExplainabilityJobDefinitions"; aws_config=aws_config)
+    return sagemaker(
+        "ListModelExplainabilityJobDefinitions";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_model_explainability_job_definitions(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sagemaker("ListModelExplainabilityJobDefinitions", params; aws_config=aws_config)
+    return sagemaker(
+        "ListModelExplainabilityJobDefinitions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -7753,12 +8206,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"SortOrder"`: The sort order for results. The default is Ascending.
 """
 function list_model_package_groups(; aws_config::AbstractAWSConfig=global_aws_config())
-    return sagemaker("ListModelPackageGroups"; aws_config=aws_config)
+    return sagemaker(
+        "ListModelPackageGroups"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_model_package_groups(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sagemaker("ListModelPackageGroups", params; aws_config=aws_config)
+    return sagemaker(
+        "ListModelPackageGroups",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -7791,12 +8251,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"SortOrder"`: The sort order for the results. The default is Ascending.
 """
 function list_model_packages(; aws_config::AbstractAWSConfig=global_aws_config())
-    return sagemaker("ListModelPackages"; aws_config=aws_config)
+    return sagemaker(
+        "ListModelPackages"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_model_packages(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sagemaker("ListModelPackages", params; aws_config=aws_config)
+    return sagemaker(
+        "ListModelPackages", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -7826,12 +8290,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function list_model_quality_job_definitions(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sagemaker("ListModelQualityJobDefinitions"; aws_config=aws_config)
+    return sagemaker(
+        "ListModelQualityJobDefinitions";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_model_quality_job_definitions(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sagemaker("ListModelQualityJobDefinitions", params; aws_config=aws_config)
+    return sagemaker(
+        "ListModelQualityJobDefinitions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -7856,12 +8329,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"SortOrder"`: The sort order for results. The default is Descending.
 """
 function list_models(; aws_config::AbstractAWSConfig=global_aws_config())
-    return sagemaker("ListModels"; aws_config=aws_config)
+    return sagemaker("ListModels"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_models(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sagemaker("ListModels", params; aws_config=aws_config)
+    return sagemaker(
+        "ListModels", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -7897,12 +8372,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"StatusEquals"`: A filter that retrieves only jobs with a specific status.
 """
 function list_monitoring_executions(; aws_config::AbstractAWSConfig=global_aws_config())
-    return sagemaker("ListMonitoringExecutions"; aws_config=aws_config)
+    return sagemaker(
+        "ListMonitoringExecutions"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_monitoring_executions(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sagemaker("ListMonitoringExecutions", params; aws_config=aws_config)
+    return sagemaker(
+        "ListMonitoringExecutions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -7939,12 +8421,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   specified time.
 """
 function list_monitoring_schedules(; aws_config::AbstractAWSConfig=global_aws_config())
-    return sagemaker("ListMonitoringSchedules"; aws_config=aws_config)
+    return sagemaker(
+        "ListMonitoringSchedules"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_monitoring_schedules(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sagemaker("ListMonitoringSchedules", params; aws_config=aws_config)
+    return sagemaker(
+        "ListMonitoringSchedules",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -7976,12 +8465,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function list_notebook_instance_lifecycle_configs(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sagemaker("ListNotebookInstanceLifecycleConfigs"; aws_config=aws_config)
+    return sagemaker(
+        "ListNotebookInstanceLifecycleConfigs";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_notebook_instance_lifecycle_configs(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sagemaker("ListNotebookInstanceLifecycleConfigs", params; aws_config=aws_config)
+    return sagemaker(
+        "ListNotebookInstanceLifecycleConfigs",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -8023,12 +8521,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"StatusEquals"`: A filter that returns only notebook instances with the specified status.
 """
 function list_notebook_instances(; aws_config::AbstractAWSConfig=global_aws_config())
-    return sagemaker("ListNotebookInstances"; aws_config=aws_config)
+    return sagemaker(
+        "ListNotebookInstances"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_notebook_instances(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sagemaker("ListNotebookInstances", params; aws_config=aws_config)
+    return sagemaker(
+        "ListNotebookInstances",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -8047,12 +8552,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"SortOrder"`: The field by which to sort results. The default is CreatedTime.
 """
 function list_pipeline_execution_steps(; aws_config::AbstractAWSConfig=global_aws_config())
-    return sagemaker("ListPipelineExecutionSteps"; aws_config=aws_config)
+    return sagemaker(
+        "ListPipelineExecutionSteps"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_pipeline_execution_steps(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sagemaker("ListPipelineExecutionSteps", params; aws_config=aws_config)
+    return sagemaker(
+        "ListPipelineExecutionSteps",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -8084,6 +8596,7 @@ function list_pipeline_executions(
         "ListPipelineExecutions",
         Dict{String,Any}("PipelineName" => PipelineName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_pipeline_executions(
@@ -8097,6 +8610,7 @@ function list_pipeline_executions(
             mergewith(_merge, Dict{String,Any}("PipelineName" => PipelineName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -8123,6 +8637,7 @@ function list_pipeline_parameters_for_execution(
         "ListPipelineParametersForExecution",
         Dict{String,Any}("PipelineExecutionArn" => PipelineExecutionArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_pipeline_parameters_for_execution(
@@ -8140,6 +8655,7 @@ function list_pipeline_parameters_for_execution(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -8164,12 +8680,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"SortOrder"`: The sort order for results.
 """
 function list_pipelines(; aws_config::AbstractAWSConfig=global_aws_config())
-    return sagemaker("ListPipelines"; aws_config=aws_config)
+    return sagemaker(
+        "ListPipelines"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_pipelines(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sagemaker("ListPipelines", params; aws_config=aws_config)
+    return sagemaker(
+        "ListPipelines", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -8199,12 +8719,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"StatusEquals"`: A filter that retrieves only processing jobs with a specific status.
 """
 function list_processing_jobs(; aws_config::AbstractAWSConfig=global_aws_config())
-    return sagemaker("ListProcessingJobs"; aws_config=aws_config)
+    return sagemaker(
+        "ListProcessingJobs"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_processing_jobs(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sagemaker("ListProcessingJobs", params; aws_config=aws_config)
+    return sagemaker(
+        "ListProcessingJobs", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -8229,12 +8753,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"SortOrder"`: The sort order for results. The default is Ascending.
 """
 function list_projects(; aws_config::AbstractAWSConfig=global_aws_config())
-    return sagemaker("ListProjects"; aws_config=aws_config)
+    return sagemaker("ListProjects"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_projects(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sagemaker("ListProjects", params; aws_config=aws_config)
+    return sagemaker(
+        "ListProjects", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -8266,12 +8792,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"SortOrder"`: The sort order. The default value is Descending.
 """
 function list_studio_lifecycle_configs(; aws_config::AbstractAWSConfig=global_aws_config())
-    return sagemaker("ListStudioLifecycleConfigs"; aws_config=aws_config)
+    return sagemaker(
+        "ListStudioLifecycleConfigs"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_studio_lifecycle_configs(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sagemaker("ListStudioLifecycleConfigs", params; aws_config=aws_config)
+    return sagemaker(
+        "ListStudioLifecycleConfigs",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -8292,12 +8825,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   use the token in the next request.
 """
 function list_subscribed_workteams(; aws_config::AbstractAWSConfig=global_aws_config())
-    return sagemaker("ListSubscribedWorkteams"; aws_config=aws_config)
+    return sagemaker(
+        "ListSubscribedWorkteams"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_subscribed_workteams(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sagemaker("ListSubscribedWorkteams", params; aws_config=aws_config)
+    return sagemaker(
+        "ListSubscribedWorkteams",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -8319,7 +8859,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function list_tags(ResourceArn; aws_config::AbstractAWSConfig=global_aws_config())
     return sagemaker(
-        "ListTags", Dict{String,Any}("ResourceArn" => ResourceArn); aws_config=aws_config
+        "ListTags",
+        Dict{String,Any}("ResourceArn" => ResourceArn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags(
@@ -8333,6 +8876,7 @@ function list_tags(
             mergewith(_merge, Dict{String,Any}("ResourceArn" => ResourceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -8371,12 +8915,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"StatusEquals"`: A filter that retrieves only training jobs with a specific status.
 """
 function list_training_jobs(; aws_config::AbstractAWSConfig=global_aws_config())
-    return sagemaker("ListTrainingJobs"; aws_config=aws_config)
+    return sagemaker(
+        "ListTrainingJobs"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_training_jobs(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sagemaker("ListTrainingJobs", params; aws_config=aws_config)
+    return sagemaker(
+        "ListTrainingJobs", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -8409,6 +8957,7 @@ function list_training_jobs_for_hyper_parameter_tuning_job(
         "ListTrainingJobsForHyperParameterTuningJob",
         Dict{String,Any}("HyperParameterTuningJobName" => HyperParameterTuningJobName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_training_jobs_for_hyper_parameter_tuning_job(
@@ -8428,6 +8977,7 @@ function list_training_jobs_for_hyper_parameter_tuning_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -8459,12 +9009,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"StatusEquals"`: A filter that retrieves only transform jobs with a specific status.
 """
 function list_transform_jobs(; aws_config::AbstractAWSConfig=global_aws_config())
-    return sagemaker("ListTransformJobs"; aws_config=aws_config)
+    return sagemaker(
+        "ListTransformJobs"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_transform_jobs(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sagemaker("ListTransformJobs", params; aws_config=aws_config)
+    return sagemaker(
+        "ListTransformJobs", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -8496,12 +9050,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   trial. If you specify TrialName, you can't filter by ExperimentName or SourceArn.
 """
 function list_trial_components(; aws_config::AbstractAWSConfig=global_aws_config())
-    return sagemaker("ListTrialComponents"; aws_config=aws_config)
+    return sagemaker(
+        "ListTrialComponents"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_trial_components(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sagemaker("ListTrialComponents", params; aws_config=aws_config)
+    return sagemaker(
+        "ListTrialComponents",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -8530,12 +9091,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   specified trial component.
 """
 function list_trials(; aws_config::AbstractAWSConfig=global_aws_config())
-    return sagemaker("ListTrials"; aws_config=aws_config)
+    return sagemaker("ListTrials"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_trials(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sagemaker("ListTrials", params; aws_config=aws_config)
+    return sagemaker(
+        "ListTrials", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -8555,12 +9118,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"UserProfileNameContains"`: A parameter by which to filter the results.
 """
 function list_user_profiles(; aws_config::AbstractAWSConfig=global_aws_config())
-    return sagemaker("ListUserProfiles"; aws_config=aws_config)
+    return sagemaker(
+        "ListUserProfiles"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_user_profiles(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sagemaker("ListUserProfiles", params; aws_config=aws_config)
+    return sagemaker(
+        "ListUserProfiles", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -8580,12 +9147,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"SortOrder"`: Sort workforces in ascending or descending order.
 """
 function list_workforces(; aws_config::AbstractAWSConfig=global_aws_config())
-    return sagemaker("ListWorkforces"; aws_config=aws_config)
+    return sagemaker(
+        "ListWorkforces"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_workforces(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sagemaker("ListWorkforces", params; aws_config=aws_config)
+    return sagemaker(
+        "ListWorkforces", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -8607,12 +9178,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"SortOrder"`: The sort order for results. The default is Ascending.
 """
 function list_workteams(; aws_config::AbstractAWSConfig=global_aws_config())
-    return sagemaker("ListWorkteams"; aws_config=aws_config)
+    return sagemaker(
+        "ListWorkteams"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_workteams(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sagemaker("ListWorkteams", params; aws_config=aws_config)
+    return sagemaker(
+        "ListWorkteams", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -8638,6 +9213,7 @@ function put_model_package_group_policy(
             "ResourcePolicy" => ResourcePolicy,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_model_package_group_policy(
@@ -8659,6 +9235,7 @@ function put_model_package_group_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -8683,6 +9260,7 @@ function register_devices(
         "RegisterDevices",
         Dict{String,Any}("DeviceFleetName" => DeviceFleetName, "Devices" => Devices);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function register_devices(
@@ -8703,6 +9281,7 @@ function register_devices(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -8731,6 +9310,7 @@ function render_ui_template(
         "RenderUiTemplate",
         Dict{String,Any}("RoleArn" => RoleArn, "Task" => Task);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function render_ui_template(
@@ -8747,6 +9327,7 @@ function render_ui_template(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -8774,6 +9355,7 @@ function retry_pipeline_execution(
             "PipelineExecutionArn" => PipelineExecutionArn,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function retry_pipeline_execution(
@@ -8795,6 +9377,7 @@ function retry_pipeline_execution(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -8827,7 +9410,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function search(Resource; aws_config::AbstractAWSConfig=global_aws_config())
     return sagemaker(
-        "Search", Dict{String,Any}("Resource" => Resource); aws_config=aws_config
+        "Search",
+        Dict{String,Any}("Resource" => Resource);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function search(
@@ -8841,6 +9427,7 @@ function search(
             mergewith(_merge, Dict{String,Any}("Resource" => Resource), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -8870,6 +9457,7 @@ function send_pipeline_execution_step_failure(
             "CallbackToken" => CallbackToken, "ClientRequestToken" => string(uuid4())
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function send_pipeline_execution_step_failure(
@@ -8890,6 +9478,7 @@ function send_pipeline_execution_step_failure(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -8920,6 +9509,7 @@ function send_pipeline_execution_step_success(
             "CallbackToken" => CallbackToken, "ClientRequestToken" => string(uuid4())
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function send_pipeline_execution_step_success(
@@ -8940,6 +9530,7 @@ function send_pipeline_execution_step_success(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -8961,6 +9552,7 @@ function start_monitoring_schedule(
         "StartMonitoringSchedule",
         Dict{String,Any}("MonitoringScheduleName" => MonitoringScheduleName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_monitoring_schedule(
@@ -8978,6 +9570,7 @@ function start_monitoring_schedule(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -9001,6 +9594,7 @@ function start_notebook_instance(
         "StartNotebookInstance",
         Dict{String,Any}("NotebookInstanceName" => NotebookInstanceName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_notebook_instance(
@@ -9018,6 +9612,7 @@ function start_notebook_instance(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -9047,6 +9642,7 @@ function start_pipeline_execution(
             "ClientRequestToken" => ClientRequestToken, "PipelineName" => PipelineName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_pipeline_execution(
@@ -9068,6 +9664,7 @@ function start_pipeline_execution(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -9086,6 +9683,7 @@ function stop_auto_mljob(AutoMLJobName; aws_config::AbstractAWSConfig=global_aws
         "StopAutoMLJob",
         Dict{String,Any}("AutoMLJobName" => AutoMLJobName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function stop_auto_mljob(
@@ -9099,6 +9697,7 @@ function stop_auto_mljob(
             mergewith(_merge, Dict{String,Any}("AutoMLJobName" => AutoMLJobName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -9123,6 +9722,7 @@ function stop_compilation_job(
         "StopCompilationJob",
         Dict{String,Any}("CompilationJobName" => CompilationJobName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function stop_compilation_job(
@@ -9138,6 +9738,7 @@ function stop_compilation_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -9158,6 +9759,7 @@ function stop_edge_packaging_job(
         "StopEdgePackagingJob",
         Dict{String,Any}("EdgePackagingJobName" => EdgePackagingJobName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function stop_edge_packaging_job(
@@ -9175,6 +9777,7 @@ function stop_edge_packaging_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -9199,6 +9802,7 @@ function stop_hyper_parameter_tuning_job(
         "StopHyperParameterTuningJob",
         Dict{String,Any}("HyperParameterTuningJobName" => HyperParameterTuningJobName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function stop_hyper_parameter_tuning_job(
@@ -9218,6 +9822,7 @@ function stop_hyper_parameter_tuning_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -9239,6 +9844,7 @@ function stop_labeling_job(
         "StopLabelingJob",
         Dict{String,Any}("LabelingJobName" => LabelingJobName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function stop_labeling_job(
@@ -9254,6 +9860,7 @@ function stop_labeling_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -9274,6 +9881,7 @@ function stop_monitoring_schedule(
         "StopMonitoringSchedule",
         Dict{String,Any}("MonitoringScheduleName" => MonitoringScheduleName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function stop_monitoring_schedule(
@@ -9291,6 +9899,7 @@ function stop_monitoring_schedule(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -9317,6 +9926,7 @@ function stop_notebook_instance(
         "StopNotebookInstance",
         Dict{String,Any}("NotebookInstanceName" => NotebookInstanceName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function stop_notebook_instance(
@@ -9334,6 +9944,7 @@ function stop_notebook_instance(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -9374,6 +9985,7 @@ function stop_pipeline_execution(
             "PipelineExecutionArn" => PipelineExecutionArn,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function stop_pipeline_execution(
@@ -9395,6 +10007,7 @@ function stop_pipeline_execution(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -9415,6 +10028,7 @@ function stop_processing_job(
         "StopProcessingJob",
         Dict{String,Any}("ProcessingJobName" => ProcessingJobName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function stop_processing_job(
@@ -9430,6 +10044,7 @@ function stop_processing_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -9454,6 +10069,7 @@ function stop_training_job(
         "StopTrainingJob",
         Dict{String,Any}("TrainingJobName" => TrainingJobName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function stop_training_job(
@@ -9469,6 +10085,7 @@ function stop_training_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -9492,6 +10109,7 @@ function stop_transform_job(
         "StopTransformJob",
         Dict{String,Any}("TransformJobName" => TransformJobName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function stop_transform_job(
@@ -9507,6 +10125,7 @@ function stop_transform_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -9528,7 +10147,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function update_action(ActionName; aws_config::AbstractAWSConfig=global_aws_config())
     return sagemaker(
-        "UpdateAction", Dict{String,Any}("ActionName" => ActionName); aws_config=aws_config
+        "UpdateAction",
+        Dict{String,Any}("ActionName" => ActionName);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_action(
@@ -9542,6 +10164,7 @@ function update_action(
             mergewith(_merge, Dict{String,Any}("ActionName" => ActionName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -9565,6 +10188,7 @@ function update_app_image_config(
         "UpdateAppImageConfig",
         Dict{String,Any}("AppImageConfigName" => AppImageConfigName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_app_image_config(
@@ -9580,6 +10204,7 @@ function update_app_image_config(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -9603,6 +10228,7 @@ function update_artifact(ArtifactArn; aws_config::AbstractAWSConfig=global_aws_c
         "UpdateArtifact",
         Dict{String,Any}("ArtifactArn" => ArtifactArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_artifact(
@@ -9616,6 +10242,7 @@ function update_artifact(
             mergewith(_merge, Dict{String,Any}("ArtifactArn" => ArtifactArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -9643,6 +10270,7 @@ function update_code_repository(
         "UpdateCodeRepository",
         Dict{String,Any}("CodeRepositoryName" => CodeRepositoryName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_code_repository(
@@ -9658,6 +10286,7 @@ function update_code_repository(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -9681,6 +10310,7 @@ function update_context(ContextName; aws_config::AbstractAWSConfig=global_aws_co
         "UpdateContext",
         Dict{String,Any}("ContextName" => ContextName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_context(
@@ -9694,6 +10324,7 @@ function update_context(
             mergewith(_merge, Dict{String,Any}("ContextName" => ContextName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -9725,6 +10356,7 @@ function update_device_fleet(
             "DeviceFleetName" => DeviceFleetName, "OutputConfig" => OutputConfig
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_device_fleet(
@@ -9745,6 +10377,7 @@ function update_device_fleet(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -9766,6 +10399,7 @@ function update_devices(
         "UpdateDevices",
         Dict{String,Any}("DeviceFleetName" => DeviceFleetName, "Devices" => Devices);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_devices(
@@ -9786,6 +10420,7 @@ function update_devices(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -9804,7 +10439,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function update_domain(DomainId; aws_config::AbstractAWSConfig=global_aws_config())
     return sagemaker(
-        "UpdateDomain", Dict{String,Any}("DomainId" => DomainId); aws_config=aws_config
+        "UpdateDomain",
+        Dict{String,Any}("DomainId" => DomainId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_domain(
@@ -9818,6 +10456,7 @@ function update_domain(
             mergewith(_merge, Dict{String,Any}("DomainId" => DomainId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -9865,6 +10504,7 @@ function update_endpoint(
             "EndpointConfigName" => EndpointConfigName, "EndpointName" => EndpointName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_endpoint(
@@ -9886,6 +10526,7 @@ function update_endpoint(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -9916,6 +10557,7 @@ function update_endpoint_weights_and_capacities(
             "EndpointName" => EndpointName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_endpoint_weights_and_capacities(
@@ -9937,6 +10579,7 @@ function update_endpoint_weights_and_capacities(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -9963,6 +10606,7 @@ function update_experiment(
         "UpdateExperiment",
         Dict{String,Any}("ExperimentName" => ExperimentName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_experiment(
@@ -9976,6 +10620,7 @@ function update_experiment(
             mergewith(_merge, Dict{String,Any}("ExperimentName" => ExperimentName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -10000,7 +10645,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function update_image(ImageName; aws_config::AbstractAWSConfig=global_aws_config())
     return sagemaker(
-        "UpdateImage", Dict{String,Any}("ImageName" => ImageName); aws_config=aws_config
+        "UpdateImage",
+        Dict{String,Any}("ImageName" => ImageName);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_image(
@@ -10014,6 +10662,7 @@ function update_image(
             mergewith(_merge, Dict{String,Any}("ImageName" => ImageName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -10041,6 +10690,7 @@ function update_model_package(
             "ModelPackageArn" => ModelPackageArn,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_model_package(
@@ -10062,6 +10712,7 @@ function update_model_package(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -10090,6 +10741,7 @@ function update_monitoring_schedule(
             "MonitoringScheduleName" => MonitoringScheduleName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_monitoring_schedule(
@@ -10111,6 +10763,7 @@ function update_monitoring_schedule(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -10184,6 +10837,7 @@ function update_notebook_instance(
         "UpdateNotebookInstance",
         Dict{String,Any}("NotebookInstanceName" => NotebookInstanceName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_notebook_instance(
@@ -10201,6 +10855,7 @@ function update_notebook_instance(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -10231,6 +10886,7 @@ function update_notebook_instance_lifecycle_config(
             "NotebookInstanceLifecycleConfigName" => NotebookInstanceLifecycleConfigName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_notebook_instance_lifecycle_config(
@@ -10251,6 +10907,7 @@ function update_notebook_instance_lifecycle_config(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -10275,6 +10932,7 @@ function update_pipeline(PipelineName; aws_config::AbstractAWSConfig=global_aws_
         "UpdatePipeline",
         Dict{String,Any}("PipelineName" => PipelineName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_pipeline(
@@ -10288,6 +10946,7 @@ function update_pipeline(
             mergewith(_merge, Dict{String,Any}("PipelineName" => PipelineName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -10312,6 +10971,7 @@ function update_pipeline_execution(
         "UpdatePipelineExecution",
         Dict{String,Any}("PipelineExecutionArn" => PipelineExecutionArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_pipeline_execution(
@@ -10329,6 +10989,7 @@ function update_pipeline_execution(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -10356,6 +11017,7 @@ function update_training_job(
         "UpdateTrainingJob",
         Dict{String,Any}("TrainingJobName" => TrainingJobName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_training_job(
@@ -10371,6 +11033,7 @@ function update_training_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -10390,7 +11053,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function update_trial(TrialName; aws_config::AbstractAWSConfig=global_aws_config())
     return sagemaker(
-        "UpdateTrial", Dict{String,Any}("TrialName" => TrialName); aws_config=aws_config
+        "UpdateTrial",
+        Dict{String,Any}("TrialName" => TrialName);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_trial(
@@ -10404,6 +11070,7 @@ function update_trial(
             mergewith(_merge, Dict{String,Any}("TrialName" => TrialName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -10440,6 +11107,7 @@ function update_trial_component(
         "UpdateTrialComponent",
         Dict{String,Any}("TrialComponentName" => TrialComponentName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_trial_component(
@@ -10455,6 +11123,7 @@ function update_trial_component(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -10479,6 +11148,7 @@ function update_user_profile(
         "UpdateUserProfile",
         Dict{String,Any}("DomainId" => DomainId, "UserProfileName" => UserProfileName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_user_profile(
@@ -10499,6 +11169,7 @@ function update_user_profile(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -10536,6 +11207,7 @@ function update_workforce(WorkforceName; aws_config::AbstractAWSConfig=global_aw
         "UpdateWorkforce",
         Dict{String,Any}("WorkforceName" => WorkforceName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_workforce(
@@ -10549,6 +11221,7 @@ function update_workforce(
             mergewith(_merge, Dict{String,Any}("WorkforceName" => WorkforceName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -10588,6 +11261,7 @@ function update_workteam(WorkteamName; aws_config::AbstractAWSConfig=global_aws_
         "UpdateWorkteam",
         Dict{String,Any}("WorkteamName" => WorkteamName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_workteam(
@@ -10601,5 +11275,6 @@ function update_workteam(
             mergewith(_merge, Dict{String,Any}("WorkteamName" => WorkteamName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/sagemaker_a2i_runtime.jl
+++ b/src/services/sagemaker_a2i_runtime.jl
@@ -17,7 +17,10 @@ operation will return a ResourceNotFoundException.
 """
 function delete_human_loop(HumanLoopName; aws_config::AbstractAWSConfig=global_aws_config())
     return sagemaker_a2i_runtime(
-        "DELETE", "/human-loops/$(HumanLoopName)"; aws_config=aws_config
+        "DELETE",
+        "/human-loops/$(HumanLoopName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_human_loop(
@@ -26,7 +29,11 @@ function delete_human_loop(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return sagemaker_a2i_runtime(
-        "DELETE", "/human-loops/$(HumanLoopName)", params; aws_config=aws_config
+        "DELETE",
+        "/human-loops/$(HumanLoopName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -45,7 +52,10 @@ function describe_human_loop(
     HumanLoopName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return sagemaker_a2i_runtime(
-        "GET", "/human-loops/$(HumanLoopName)"; aws_config=aws_config
+        "GET",
+        "/human-loops/$(HumanLoopName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_human_loop(
@@ -54,7 +64,11 @@ function describe_human_loop(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return sagemaker_a2i_runtime(
-        "GET", "/human-loops/$(HumanLoopName)", params; aws_config=aws_config
+        "GET",
+        "/human-loops/$(HumanLoopName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -89,6 +103,7 @@ function list_human_loops(
         "/human-loops",
         Dict{String,Any}("FlowDefinitionArn" => FlowDefinitionArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_human_loops(
@@ -105,6 +120,7 @@ function list_human_loops(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -140,6 +156,7 @@ function start_human_loop(
             "HumanLoopName" => HumanLoopName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_human_loop(
@@ -164,6 +181,7 @@ function start_human_loop(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -183,6 +201,7 @@ function stop_human_loop(HumanLoopName; aws_config::AbstractAWSConfig=global_aws
         "/human-loops/stop",
         Dict{String,Any}("HumanLoopName" => HumanLoopName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function stop_human_loop(
@@ -197,5 +216,6 @@ function stop_human_loop(
             mergewith(_merge, Dict{String,Any}("HumanLoopName" => HumanLoopName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/sagemaker_edge.jl
+++ b/src/services/sagemaker_edge.jl
@@ -23,6 +23,7 @@ function get_device_registration(
         "/GetDeviceRegistration",
         Dict{String,Any}("DeviceFleetName" => DeviceFleetName, "DeviceName" => DeviceName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_device_registration(
@@ -44,6 +45,7 @@ function get_device_registration(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -79,6 +81,7 @@ function send_heartbeat(
             "DeviceName" => DeviceName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function send_heartbeat(
@@ -103,5 +106,6 @@ function send_heartbeat(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/sagemaker_featurestore_runtime.jl
+++ b/src/services/sagemaker_featurestore_runtime.jl
@@ -21,6 +21,7 @@ function batch_get_record(Identifiers; aws_config::AbstractAWSConfig=global_aws_
         "/BatchGetRecord",
         Dict{String,Any}("Identifiers" => Identifiers);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_get_record(
@@ -35,6 +36,7 @@ function batch_get_record(
             mergewith(_merge, Dict{String,Any}("Identifiers" => Identifiers), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -68,6 +70,7 @@ function delete_record(
             "RecordIdentifierValueAsString" => RecordIdentifierValueAsString,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_record(
@@ -91,6 +94,7 @@ function delete_record(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -122,6 +126,7 @@ function get_record(
         "/FeatureGroup/$(FeatureGroupName)",
         Dict{String,Any}("RecordIdentifierValueAsString" => RecordIdentifierValueAsString);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_record(
@@ -143,6 +148,7 @@ function get_record(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -172,6 +178,7 @@ function put_record(
         "/FeatureGroup/$(FeatureGroupName)",
         Dict{String,Any}("Record" => Record);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_record(
@@ -185,5 +192,6 @@ function put_record(
         "/FeatureGroup/$(FeatureGroupName)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Record" => Record), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/sagemaker_runtime.jl
+++ b/src/services/sagemaker_runtime.jl
@@ -67,6 +67,7 @@ function invoke_endpoint(
         "/endpoints/$(EndpointName)/invocations",
         Dict{String,Any}("Body" => Body);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function invoke_endpoint(
@@ -80,6 +81,7 @@ function invoke_endpoint(
         "/endpoints/$(EndpointName)/invocations",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Body" => Body), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -140,6 +142,7 @@ function invoke_endpoint_async(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function invoke_endpoint_async(
@@ -164,5 +167,6 @@ function invoke_endpoint_async(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/savingsplans.jl
+++ b/src/services/savingsplans.jl
@@ -38,6 +38,7 @@ function create_savings_plan(
             "clientToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_savings_plan(
@@ -61,6 +62,7 @@ function create_savings_plan(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -82,6 +84,7 @@ function delete_queued_savings_plan(
         "/DeleteQueuedSavingsPlan",
         Dict{String,Any}("savingsPlanId" => savingsPlanId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_queued_savings_plan(
@@ -96,6 +99,7 @@ function delete_queued_savings_plan(
             mergewith(_merge, Dict{String,Any}("savingsPlanId" => savingsPlanId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -123,6 +127,7 @@ function describe_savings_plan_rates(
         "/DescribeSavingsPlanRates",
         Dict{String,Any}("savingsPlanId" => savingsPlanId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_savings_plan_rates(
@@ -137,6 +142,7 @@ function describe_savings_plan_rates(
             mergewith(_merge, Dict{String,Any}("savingsPlanId" => savingsPlanId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -157,12 +163,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"states"`: The states.
 """
 function describe_savings_plans(; aws_config::AbstractAWSConfig=global_aws_config())
-    return savingsplans("POST", "/DescribeSavingsPlans"; aws_config=aws_config)
+    return savingsplans(
+        "POST",
+        "/DescribeSavingsPlans";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_savings_plans(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return savingsplans("POST", "/DescribeSavingsPlans", params; aws_config=aws_config)
+    return savingsplans(
+        "POST",
+        "/DescribeSavingsPlans",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -188,13 +205,22 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_savings_plans_offering_rates(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return savingsplans("POST", "/DescribeSavingsPlansOfferingRates"; aws_config=aws_config)
+    return savingsplans(
+        "POST",
+        "/DescribeSavingsPlansOfferingRates";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_savings_plans_offering_rates(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return savingsplans(
-        "POST", "/DescribeSavingsPlansOfferingRates", params; aws_config=aws_config
+        "POST",
+        "/DescribeSavingsPlansOfferingRates",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -224,13 +250,22 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_savings_plans_offerings(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return savingsplans("POST", "/DescribeSavingsPlansOfferings"; aws_config=aws_config)
+    return savingsplans(
+        "POST",
+        "/DescribeSavingsPlansOfferings";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_savings_plans_offerings(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return savingsplans(
-        "POST", "/DescribeSavingsPlansOfferings", params; aws_config=aws_config
+        "POST",
+        "/DescribeSavingsPlansOfferings",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -252,6 +287,7 @@ function list_tags_for_resource(
         "/ListTagsForResource",
         Dict{String,Any}("resourceArn" => resourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags_for_resource(
@@ -266,6 +302,7 @@ function list_tags_for_resource(
             mergewith(_merge, Dict{String,Any}("resourceArn" => resourceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -287,6 +324,7 @@ function tag_resource(resourceArn, tags; aws_config::AbstractAWSConfig=global_aw
         "/TagResource",
         Dict{String,Any}("resourceArn" => resourceArn, "tags" => tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -306,6 +344,7 @@ function tag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -328,6 +367,7 @@ function untag_resource(
         "/UntagResource",
         Dict{String,Any}("resourceArn" => resourceArn, "tagKeys" => tagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -347,5 +387,6 @@ function untag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/schemas.jl
+++ b/src/services/schemas.jl
@@ -26,6 +26,7 @@ function create_discoverer(SourceArn; aws_config::AbstractAWSConfig=global_aws_c
         "/v1/discoverers",
         Dict{String,Any}("SourceArn" => SourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_discoverer(
@@ -40,6 +41,7 @@ function create_discoverer(
             mergewith(_merge, Dict{String,Any}("SourceArn" => SourceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -58,7 +60,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"tags"`: Tags to associate with the registry.
 """
 function create_registry(registryName; aws_config::AbstractAWSConfig=global_aws_config())
-    return schemas("POST", "/v1/registries/name/$(registryName)"; aws_config=aws_config)
+    return schemas(
+        "POST",
+        "/v1/registries/name/$(registryName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function create_registry(
     registryName,
@@ -66,7 +73,11 @@ function create_registry(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return schemas(
-        "POST", "/v1/registries/name/$(registryName)", params; aws_config=aws_config
+        "POST",
+        "/v1/registries/name/$(registryName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -99,6 +110,7 @@ function create_schema(
         "/v1/registries/name/$(registryName)/schemas/name/$(schemaName)",
         Dict{String,Any}("Content" => Content, "Type" => Type);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_schema(
@@ -118,6 +130,7 @@ function create_schema(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -132,7 +145,12 @@ Deletes a discoverer.
 
 """
 function delete_discoverer(discovererId; aws_config::AbstractAWSConfig=global_aws_config())
-    return schemas("DELETE", "/v1/discoverers/id/$(discovererId)"; aws_config=aws_config)
+    return schemas(
+        "DELETE",
+        "/v1/discoverers/id/$(discovererId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_discoverer(
     discovererId,
@@ -140,7 +158,11 @@ function delete_discoverer(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return schemas(
-        "DELETE", "/v1/discoverers/id/$(discovererId)", params; aws_config=aws_config
+        "DELETE",
+        "/v1/discoverers/id/$(discovererId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -155,7 +177,12 @@ Deletes a Registry.
 
 """
 function delete_registry(registryName; aws_config::AbstractAWSConfig=global_aws_config())
-    return schemas("DELETE", "/v1/registries/name/$(registryName)"; aws_config=aws_config)
+    return schemas(
+        "DELETE",
+        "/v1/registries/name/$(registryName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_registry(
     registryName,
@@ -163,7 +190,11 @@ function delete_registry(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return schemas(
-        "DELETE", "/v1/registries/name/$(registryName)", params; aws_config=aws_config
+        "DELETE",
+        "/v1/registries/name/$(registryName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -178,12 +209,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"registryName"`: The name of the registry.
 """
 function delete_resource_policy(; aws_config::AbstractAWSConfig=global_aws_config())
-    return schemas("DELETE", "/v1/policy"; aws_config=aws_config)
+    return schemas(
+        "DELETE", "/v1/policy"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function delete_resource_policy(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return schemas("DELETE", "/v1/policy", params; aws_config=aws_config)
+    return schemas(
+        "DELETE",
+        "/v1/policy",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -204,6 +243,7 @@ function delete_schema(
         "DELETE",
         "/v1/registries/name/$(registryName)/schemas/name/$(schemaName)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_schema(
@@ -217,6 +257,7 @@ function delete_schema(
         "/v1/registries/name/$(registryName)/schemas/name/$(schemaName)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -242,6 +283,7 @@ function delete_schema_version(
         "DELETE",
         "/v1/registries/name/$(registryName)/schemas/name/$(schemaName)/version/$(schemaVersion)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_schema_version(
@@ -256,6 +298,7 @@ function delete_schema_version(
         "/v1/registries/name/$(registryName)/schemas/name/$(schemaName)/version/$(schemaVersion)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -281,6 +324,7 @@ function describe_code_binding(
         "GET",
         "/v1/registries/name/$(registryName)/schemas/name/$(schemaName)/language/$(language)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_code_binding(
@@ -295,6 +339,7 @@ function describe_code_binding(
         "/v1/registries/name/$(registryName)/schemas/name/$(schemaName)/language/$(language)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -311,7 +356,12 @@ Describes the discoverer.
 function describe_discoverer(
     discovererId; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return schemas("GET", "/v1/discoverers/id/$(discovererId)"; aws_config=aws_config)
+    return schemas(
+        "GET",
+        "/v1/discoverers/id/$(discovererId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_discoverer(
     discovererId,
@@ -319,7 +369,11 @@ function describe_discoverer(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return schemas(
-        "GET", "/v1/discoverers/id/$(discovererId)", params; aws_config=aws_config
+        "GET",
+        "/v1/discoverers/id/$(discovererId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -334,7 +388,12 @@ Describes the registry.
 
 """
 function describe_registry(registryName; aws_config::AbstractAWSConfig=global_aws_config())
-    return schemas("GET", "/v1/registries/name/$(registryName)"; aws_config=aws_config)
+    return schemas(
+        "GET",
+        "/v1/registries/name/$(registryName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_registry(
     registryName,
@@ -342,7 +401,11 @@ function describe_registry(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return schemas(
-        "GET", "/v1/registries/name/$(registryName)", params; aws_config=aws_config
+        "GET",
+        "/v1/registries/name/$(registryName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -367,6 +430,7 @@ function describe_schema(
         "GET",
         "/v1/registries/name/$(registryName)/schemas/name/$(schemaName)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_schema(
@@ -380,6 +444,7 @@ function describe_schema(
         "/v1/registries/name/$(registryName)/schemas/name/$(schemaName)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -406,6 +471,7 @@ function export_schema(
         "/v1/registries/name/$(registryName)/schemas/name/$(schemaName)/export",
         Dict{String,Any}("type" => type);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function export_schema(
@@ -420,6 +486,7 @@ function export_schema(
         "/v1/registries/name/$(registryName)/schemas/name/$(schemaName)/export",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("type" => type), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -445,6 +512,7 @@ function get_code_binding_source(
         "GET",
         "/v1/registries/name/$(registryName)/schemas/name/$(schemaName)/language/$(language)/source";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_code_binding_source(
@@ -459,6 +527,7 @@ function get_code_binding_source(
         "/v1/registries/name/$(registryName)/schemas/name/$(schemaName)/language/$(language)/source",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -483,6 +552,7 @@ function get_discovered_schema(
         "/v1/discover",
         Dict{String,Any}("Events" => Events, "Type" => Type);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_discovered_schema(
@@ -498,6 +568,7 @@ function get_discovered_schema(
             mergewith(_merge, Dict{String,Any}("Events" => Events, "Type" => Type), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -512,12 +583,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"registryName"`: The name of the registry.
 """
 function get_resource_policy(; aws_config::AbstractAWSConfig=global_aws_config())
-    return schemas("GET", "/v1/policy"; aws_config=aws_config)
+    return schemas(
+        "GET", "/v1/policy"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_resource_policy(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return schemas("GET", "/v1/policy", params; aws_config=aws_config)
+    return schemas(
+        "GET", "/v1/policy", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -538,12 +613,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   with the specified prefix.
 """
 function list_discoverers(; aws_config::AbstractAWSConfig=global_aws_config())
-    return schemas("GET", "/v1/discoverers"; aws_config=aws_config)
+    return schemas(
+        "GET", "/v1/discoverers"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_discoverers(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return schemas("GET", "/v1/discoverers", params; aws_config=aws_config)
+    return schemas(
+        "GET",
+        "/v1/discoverers",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -564,12 +647,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   the ones provided by AWS.
 """
 function list_registries(; aws_config::AbstractAWSConfig=global_aws_config())
-    return schemas("GET", "/v1/registries"; aws_config=aws_config)
+    return schemas(
+        "GET", "/v1/registries"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_registries(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return schemas("GET", "/v1/registries", params; aws_config=aws_config)
+    return schemas(
+        "GET",
+        "/v1/registries",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -596,6 +687,7 @@ function list_schema_versions(
         "GET",
         "/v1/registries/name/$(registryName)/schemas/name/$(schemaName)/versions";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_schema_versions(
@@ -609,6 +701,7 @@ function list_schema_versions(
         "/v1/registries/name/$(registryName)/schemas/name/$(schemaName)/versions",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -632,7 +725,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function list_schemas(registryName; aws_config::AbstractAWSConfig=global_aws_config())
     return schemas(
-        "GET", "/v1/registries/name/$(registryName)/schemas"; aws_config=aws_config
+        "GET",
+        "/v1/registries/name/$(registryName)/schemas";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_schemas(
@@ -641,7 +737,11 @@ function list_schemas(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return schemas(
-        "GET", "/v1/registries/name/$(registryName)/schemas", params; aws_config=aws_config
+        "GET",
+        "/v1/registries/name/$(registryName)/schemas",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -658,14 +758,25 @@ Get tags for resource.
 function list_tags_for_resource(
     resource_arn; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return schemas("GET", "/tags/$(resource-arn)"; aws_config=aws_config)
+    return schemas(
+        "GET",
+        "/tags/$(resource-arn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_tags_for_resource(
     resource_arn,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return schemas("GET", "/tags/$(resource-arn)", params; aws_config=aws_config)
+    return schemas(
+        "GET",
+        "/tags/$(resource-arn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -690,6 +801,7 @@ function put_code_binding(
         "POST",
         "/v1/registries/name/$(registryName)/schemas/name/$(schemaName)/language/$(language)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_code_binding(
@@ -704,6 +816,7 @@ function put_code_binding(
         "/v1/registries/name/$(registryName)/schemas/name/$(schemaName)/language/$(language)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -723,7 +836,11 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function put_resource_policy(Policy; aws_config::AbstractAWSConfig=global_aws_config())
     return schemas(
-        "PUT", "/v1/policy", Dict{String,Any}("Policy" => Policy); aws_config=aws_config
+        "PUT",
+        "/v1/policy",
+        Dict{String,Any}("Policy" => Policy);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_resource_policy(
@@ -734,6 +851,7 @@ function put_resource_policy(
         "/v1/policy",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Policy" => Policy), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -763,6 +881,7 @@ function search_schemas(
         "/v1/registries/name/$(registryName)/schemas/search",
         Dict{String,Any}("keywords" => keywords);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function search_schemas(
@@ -778,6 +897,7 @@ function search_schemas(
             mergewith(_merge, Dict{String,Any}("keywords" => keywords), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -793,7 +913,10 @@ Starts the discoverer
 """
 function start_discoverer(discovererId; aws_config::AbstractAWSConfig=global_aws_config())
     return schemas(
-        "POST", "/v1/discoverers/id/$(discovererId)/start"; aws_config=aws_config
+        "POST",
+        "/v1/discoverers/id/$(discovererId)/start";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_discoverer(
@@ -802,7 +925,11 @@ function start_discoverer(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return schemas(
-        "POST", "/v1/discoverers/id/$(discovererId)/start", params; aws_config=aws_config
+        "POST",
+        "/v1/discoverers/id/$(discovererId)/start",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -817,7 +944,12 @@ Stops the discoverer
 
 """
 function stop_discoverer(discovererId; aws_config::AbstractAWSConfig=global_aws_config())
-    return schemas("POST", "/v1/discoverers/id/$(discovererId)/stop"; aws_config=aws_config)
+    return schemas(
+        "POST",
+        "/v1/discoverers/id/$(discovererId)/stop";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function stop_discoverer(
     discovererId,
@@ -825,7 +957,11 @@ function stop_discoverer(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return schemas(
-        "POST", "/v1/discoverers/id/$(discovererId)/stop", params; aws_config=aws_config
+        "POST",
+        "/v1/discoverers/id/$(discovererId)/stop",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -846,6 +982,7 @@ function tag_resource(resource_arn, tags; aws_config::AbstractAWSConfig=global_a
         "/tags/$(resource-arn)",
         Dict{String,Any}("tags" => tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -859,6 +996,7 @@ function tag_resource(
         "/tags/$(resource-arn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tags" => tags), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -881,6 +1019,7 @@ function untag_resource(
         "/tags/$(resource-arn)",
         Dict{String,Any}("tagKeys" => tagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -894,6 +1033,7 @@ function untag_resource(
         "/tags/$(resource-arn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tagKeys" => tagKeys), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -913,7 +1053,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"Description"`: The description of the discoverer to update.
 """
 function update_discoverer(discovererId; aws_config::AbstractAWSConfig=global_aws_config())
-    return schemas("PUT", "/v1/discoverers/id/$(discovererId)"; aws_config=aws_config)
+    return schemas(
+        "PUT",
+        "/v1/discoverers/id/$(discovererId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function update_discoverer(
     discovererId,
@@ -921,7 +1066,11 @@ function update_discoverer(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return schemas(
-        "PUT", "/v1/discoverers/id/$(discovererId)", params; aws_config=aws_config
+        "PUT",
+        "/v1/discoverers/id/$(discovererId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -939,7 +1088,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"Description"`: The description of the registry to update.
 """
 function update_registry(registryName; aws_config::AbstractAWSConfig=global_aws_config())
-    return schemas("PUT", "/v1/registries/name/$(registryName)"; aws_config=aws_config)
+    return schemas(
+        "PUT",
+        "/v1/registries/name/$(registryName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function update_registry(
     registryName,
@@ -947,7 +1101,11 @@ function update_registry(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return schemas(
-        "PUT", "/v1/registries/name/$(registryName)", params; aws_config=aws_config
+        "PUT",
+        "/v1/registries/name/$(registryName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -976,6 +1134,7 @@ function update_schema(
         "/v1/registries/name/$(registryName)/schemas/name/$(schemaName)",
         Dict{String,Any}("ClientTokenId" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_schema(
@@ -991,5 +1150,6 @@ function update_schema(
             mergewith(_merge, Dict{String,Any}("ClientTokenId" => string(uuid4())), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/secrets_manager.jl
+++ b/src/services/secrets_manager.jl
@@ -50,6 +50,7 @@ function cancel_rotate_secret(SecretId; aws_config::AbstractAWSConfig=global_aws
         "CancelRotateSecret",
         Dict{String,Any}("SecretId" => SecretId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function cancel_rotate_secret(
@@ -63,6 +64,7 @@ function cancel_rotate_secret(
             mergewith(_merge, Dict{String,Any}("SecretId" => SecretId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -206,6 +208,7 @@ function create_secret(Name; aws_config::AbstractAWSConfig=global_aws_config())
         "CreateSecret",
         Dict{String,Any}("Name" => Name, "ClientRequestToken" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_secret(
@@ -221,6 +224,7 @@ function create_secret(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -258,6 +262,7 @@ function delete_resource_policy(SecretId; aws_config::AbstractAWSConfig=global_a
         "DeleteResourcePolicy",
         Dict{String,Any}("SecretId" => SecretId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_resource_policy(
@@ -271,6 +276,7 @@ function delete_resource_policy(
             mergewith(_merge, Dict{String,Any}("SecretId" => SecretId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -336,7 +342,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function delete_secret(SecretId; aws_config::AbstractAWSConfig=global_aws_config())
     return secrets_manager(
-        "DeleteSecret", Dict{String,Any}("SecretId" => SecretId); aws_config=aws_config
+        "DeleteSecret",
+        Dict{String,Any}("SecretId" => SecretId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_secret(
@@ -350,6 +359,7 @@ function delete_secret(
             mergewith(_merge, Dict{String,Any}("SecretId" => SecretId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -385,7 +395,10 @@ the Amazon Web Services account, use ListSecrets.
 """
 function describe_secret(SecretId; aws_config::AbstractAWSConfig=global_aws_config())
     return secrets_manager(
-        "DescribeSecret", Dict{String,Any}("SecretId" => SecretId); aws_config=aws_config
+        "DescribeSecret",
+        Dict{String,Any}("SecretId" => SecretId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_secret(
@@ -399,6 +412,7 @@ function describe_secret(
             mergewith(_merge, Dict{String,Any}("SecretId" => SecretId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -441,12 +455,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   True and the operation requires at least one of every character type.
 """
 function get_random_password(; aws_config::AbstractAWSConfig=global_aws_config())
-    return secrets_manager("GetRandomPassword"; aws_config=aws_config)
+    return secrets_manager(
+        "GetRandomPassword"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_random_password(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return secrets_manager("GetRandomPassword", params; aws_config=aws_config)
+    return secrets_manager(
+        "GetRandomPassword", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -482,7 +500,10 @@ ListSecrets.
 """
 function get_resource_policy(SecretId; aws_config::AbstractAWSConfig=global_aws_config())
     return secrets_manager(
-        "GetResourcePolicy", Dict{String,Any}("SecretId" => SecretId); aws_config=aws_config
+        "GetResourcePolicy",
+        Dict{String,Any}("SecretId" => SecretId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_resource_policy(
@@ -496,6 +517,7 @@ function get_resource_policy(
             mergewith(_merge, Dict{String,Any}("SecretId" => SecretId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -545,7 +567,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function get_secret_value(SecretId; aws_config::AbstractAWSConfig=global_aws_config())
     return secrets_manager(
-        "GetSecretValue", Dict{String,Any}("SecretId" => SecretId); aws_config=aws_config
+        "GetSecretValue",
+        Dict{String,Any}("SecretId" => SecretId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_secret_value(
@@ -559,6 +584,7 @@ function get_secret_value(
             mergewith(_merge, Dict{String,Any}("SecretId" => SecretId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -619,6 +645,7 @@ function list_secret_version_ids(
         "ListSecretVersionIds",
         Dict{String,Any}("SecretId" => SecretId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_secret_version_ids(
@@ -632,6 +659,7 @@ function list_secret_version_ids(
             mergewith(_merge, Dict{String,Any}("SecretId" => SecretId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -669,12 +697,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"SortOrder"`: Lists secrets in the requested order.
 """
 function list_secrets(; aws_config::AbstractAWSConfig=global_aws_config())
-    return secrets_manager("ListSecrets"; aws_config=aws_config)
+    return secrets_manager(
+        "ListSecrets"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_secrets(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return secrets_manager("ListSecrets", params; aws_config=aws_config)
+    return secrets_manager(
+        "ListSecrets", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -729,6 +761,7 @@ function put_resource_policy(
         "PutResourcePolicy",
         Dict{String,Any}("ResourcePolicy" => ResourcePolicy, "SecretId" => SecretId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_resource_policy(
@@ -749,6 +782,7 @@ function put_resource_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -865,6 +899,7 @@ function put_secret_value(SecretId; aws_config::AbstractAWSConfig=global_aws_con
         "PutSecretValue",
         Dict{String,Any}("SecretId" => SecretId, "ClientRequestToken" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_secret_value(
@@ -884,6 +919,7 @@ function put_secret_value(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -907,6 +943,7 @@ function remove_regions_from_replication(
             "RemoveReplicaRegions" => RemoveReplicaRegions, "SecretId" => SecretId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function remove_regions_from_replication(
@@ -927,6 +964,7 @@ function remove_regions_from_replication(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -953,6 +991,7 @@ function replicate_secret_to_regions(
         "ReplicateSecretToRegions",
         Dict{String,Any}("AddReplicaRegions" => AddReplicaRegions, "SecretId" => SecretId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function replicate_secret_to_regions(
@@ -973,6 +1012,7 @@ function replicate_secret_to_regions(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1005,7 +1045,10 @@ operations    To delete a secret, use DeleteSecret.
 """
 function restore_secret(SecretId; aws_config::AbstractAWSConfig=global_aws_config())
     return secrets_manager(
-        "RestoreSecret", Dict{String,Any}("SecretId" => SecretId); aws_config=aws_config
+        "RestoreSecret",
+        Dict{String,Any}("SecretId" => SecretId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function restore_secret(
@@ -1019,6 +1062,7 @@ function restore_secret(
             mergewith(_merge, Dict{String,Any}("SecretId" => SecretId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1096,6 +1140,7 @@ function rotate_secret(SecretId; aws_config::AbstractAWSConfig=global_aws_config
         "RotateSecret",
         Dict{String,Any}("SecretId" => SecretId, "ClientRequestToken" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function rotate_secret(
@@ -1115,6 +1160,7 @@ function rotate_secret(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1136,6 +1182,7 @@ function stop_replication_to_replica(
         "StopReplicationToReplica",
         Dict{String,Any}("SecretId" => SecretId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function stop_replication_to_replica(
@@ -1149,6 +1196,7 @@ function stop_replication_to_replica(
             mergewith(_merge, Dict{String,Any}("SecretId" => SecretId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1204,6 +1252,7 @@ function tag_resource(SecretId, Tags; aws_config::AbstractAWSConfig=global_aws_c
         "TagResource",
         Dict{String,Any}("SecretId" => SecretId, "Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -1220,6 +1269,7 @@ function tag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1267,6 +1317,7 @@ function untag_resource(
         "UntagResource",
         Dict{String,Any}("SecretId" => SecretId, "TagKeys" => TagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -1285,6 +1336,7 @@ function untag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1403,6 +1455,7 @@ function update_secret(SecretId; aws_config::AbstractAWSConfig=global_aws_config
         "UpdateSecret",
         Dict{String,Any}("SecretId" => SecretId, "ClientRequestToken" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_secret(
@@ -1422,6 +1475,7 @@ function update_secret(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1484,6 +1538,7 @@ function update_secret_version_stage(
         "UpdateSecretVersionStage",
         Dict{String,Any}("SecretId" => SecretId, "VersionStage" => VersionStage);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_secret_version_stage(
@@ -1502,6 +1557,7 @@ function update_secret_version_stage(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1551,6 +1607,7 @@ function validate_resource_policy(
         "ValidateResourcePolicy",
         Dict{String,Any}("ResourcePolicy" => ResourcePolicy);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function validate_resource_policy(
@@ -1564,5 +1621,6 @@ function validate_resource_policy(
             mergewith(_merge, Dict{String,Any}("ResourcePolicy" => ResourcePolicy), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/securityhub.jl
+++ b/src/services/securityhub.jl
@@ -31,6 +31,7 @@ function accept_administrator_invitation(
             "AdministratorId" => AdministratorId, "InvitationId" => InvitationId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function accept_administrator_invitation(
@@ -52,6 +53,7 @@ function accept_administrator_invitation(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -86,6 +88,7 @@ function accept_invitation(
         "/master",
         Dict{String,Any}("InvitationId" => InvitationId, "MasterId" => MasterId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function accept_invitation(
@@ -105,6 +108,7 @@ function accept_invitation(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -127,6 +131,7 @@ function batch_disable_standards(
         "/standards/deregister",
         Dict{String,Any}("StandardsSubscriptionArns" => StandardsSubscriptionArns);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_disable_standards(
@@ -145,6 +150,7 @@ function batch_disable_standards(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -168,6 +174,7 @@ function batch_enable_standards(
         "/standards/register",
         Dict{String,Any}("StandardsSubscriptionRequests" => StandardsSubscriptionRequests);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_enable_standards(
@@ -188,6 +195,7 @@ function batch_enable_standards(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -216,6 +224,7 @@ function batch_import_findings(Findings; aws_config::AbstractAWSConfig=global_aw
         "/findings/import",
         Dict{String,Any}("Findings" => Findings);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_import_findings(
@@ -230,6 +239,7 @@ function batch_import_findings(
             mergewith(_merge, Dict{String,Any}("Findings" => Findings), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -287,6 +297,7 @@ function batch_update_findings(
         "/findings/batchupdate",
         Dict{String,Any}("FindingIdentifiers" => FindingIdentifiers);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_update_findings(
@@ -303,6 +314,7 @@ function batch_update_findings(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -327,6 +339,7 @@ function create_action_target(
         "/actionTargets",
         Dict{String,Any}("Description" => Description, "Id" => Id, "Name" => Name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_action_target(
@@ -347,6 +360,7 @@ function create_action_target(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -378,6 +392,7 @@ function create_insight(
             "Filters" => Filters, "GroupByAttribute" => GroupByAttribute, "Name" => Name
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_insight(
@@ -402,6 +417,7 @@ function create_insight(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -443,6 +459,7 @@ function create_members(AccountDetails; aws_config::AbstractAWSConfig=global_aws
         "/members",
         Dict{String,Any}("AccountDetails" => AccountDetails);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_members(
@@ -457,6 +474,7 @@ function create_members(
             mergewith(_merge, Dict{String,Any}("AccountDetails" => AccountDetails), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -478,6 +496,7 @@ function decline_invitations(AccountIds; aws_config::AbstractAWSConfig=global_aw
         "/invitations/decline",
         Dict{String,Any}("AccountIds" => AccountIds);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function decline_invitations(
@@ -492,6 +511,7 @@ function decline_invitations(
             mergewith(_merge, Dict{String,Any}("AccountIds" => AccountIds), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -510,7 +530,12 @@ the custom action.
 function delete_action_target(
     ActionTargetArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return securityhub("DELETE", "/actionTargets/$(ActionTargetArn)"; aws_config=aws_config)
+    return securityhub(
+        "DELETE",
+        "/actionTargets/$(ActionTargetArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_action_target(
     ActionTargetArn,
@@ -518,7 +543,11 @@ function delete_action_target(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return securityhub(
-        "DELETE", "/actionTargets/$(ActionTargetArn)", params; aws_config=aws_config
+        "DELETE",
+        "/actionTargets/$(ActionTargetArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -533,14 +562,25 @@ Deletes the insight specified by the InsightArn.
 
 """
 function delete_insight(InsightArn; aws_config::AbstractAWSConfig=global_aws_config())
-    return securityhub("DELETE", "/insights/$(InsightArn)"; aws_config=aws_config)
+    return securityhub(
+        "DELETE",
+        "/insights/$(InsightArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_insight(
     InsightArn,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return securityhub("DELETE", "/insights/$(InsightArn)", params; aws_config=aws_config)
+    return securityhub(
+        "DELETE",
+        "/insights/$(InsightArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -561,6 +601,7 @@ function delete_invitations(AccountIds; aws_config::AbstractAWSConfig=global_aws
         "/invitations/delete",
         Dict{String,Any}("AccountIds" => AccountIds);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_invitations(
@@ -575,6 +616,7 @@ function delete_invitations(
             mergewith(_merge, Dict{String,Any}("AccountIds" => AccountIds), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -596,6 +638,7 @@ function delete_members(AccountIds; aws_config::AbstractAWSConfig=global_aws_con
         "/members/delete",
         Dict{String,Any}("AccountIds" => AccountIds);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_members(
@@ -610,6 +653,7 @@ function delete_members(
             mergewith(_merge, Dict{String,Any}("AccountIds" => AccountIds), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -630,12 +674,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   value returned from the previous response.
 """
 function describe_action_targets(; aws_config::AbstractAWSConfig=global_aws_config())
-    return securityhub("POST", "/actionTargets/get"; aws_config=aws_config)
+    return securityhub(
+        "POST", "/actionTargets/get"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_action_targets(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return securityhub("POST", "/actionTargets/get", params; aws_config=aws_config)
+    return securityhub(
+        "POST",
+        "/actionTargets/get",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -650,12 +702,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"HubArn"`: The ARN of the Hub resource to retrieve.
 """
 function describe_hub(; aws_config::AbstractAWSConfig=global_aws_config())
-    return securityhub("GET", "/accounts"; aws_config=aws_config)
+    return securityhub(
+        "GET", "/accounts"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_hub(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return securityhub("GET", "/accounts", params; aws_config=aws_config)
+    return securityhub(
+        "GET", "/accounts", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -669,12 +725,23 @@ called from a Security Hub administrator account.
 function describe_organization_configuration(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return securityhub("GET", "/organization/configuration"; aws_config=aws_config)
+    return securityhub(
+        "GET",
+        "/organization/configuration";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_organization_configuration(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return securityhub("GET", "/organization/configuration", params; aws_config=aws_config)
+    return securityhub(
+        "GET",
+        "/organization/configuration",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -696,12 +763,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"ProductArn"`: The ARN of the integration to return.
 """
 function describe_products(; aws_config::AbstractAWSConfig=global_aws_config())
-    return securityhub("GET", "/products"; aws_config=aws_config)
+    return securityhub(
+        "GET", "/products"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_products(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return securityhub("GET", "/products", params; aws_config=aws_config)
+    return securityhub(
+        "GET", "/products", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -720,12 +791,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   returned from the previous response.
 """
 function describe_standards(; aws_config::AbstractAWSConfig=global_aws_config())
-    return securityhub("GET", "/standards"; aws_config=aws_config)
+    return securityhub(
+        "GET", "/standards"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_standards(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return securityhub("GET", "/standards", params; aws_config=aws_config)
+    return securityhub(
+        "GET", "/standards", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -753,7 +828,10 @@ function describe_standards_controls(
     StandardsSubscriptionArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return securityhub(
-        "GET", "/standards/controls/$(StandardsSubscriptionArn)"; aws_config=aws_config
+        "GET",
+        "/standards/controls/$(StandardsSubscriptionArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_standards_controls(
@@ -766,6 +844,7 @@ function describe_standards_controls(
         "/standards/controls/$(StandardsSubscriptionArn)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -785,7 +864,10 @@ function disable_import_findings_for_product(
     ProductSubscriptionArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return securityhub(
-        "DELETE", "/productSubscriptions/$(ProductSubscriptionArn)"; aws_config=aws_config
+        "DELETE",
+        "/productSubscriptions/$(ProductSubscriptionArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disable_import_findings_for_product(
@@ -798,6 +880,7 @@ function disable_import_findings_for_product(
         "/productSubscriptions/$(ProductSubscriptionArn)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -821,6 +904,7 @@ function disable_organization_admin_account(
         "/organization/admin/disable",
         Dict{String,Any}("AdminAccountId" => AdminAccountId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disable_organization_admin_account(
@@ -835,6 +919,7 @@ function disable_organization_admin_account(
             mergewith(_merge, Dict{String,Any}("AdminAccountId" => AdminAccountId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -853,12 +938,20 @@ you must export them before you disable Security Hub.
 
 """
 function disable_security_hub(; aws_config::AbstractAWSConfig=global_aws_config())
-    return securityhub("DELETE", "/accounts"; aws_config=aws_config)
+    return securityhub(
+        "DELETE", "/accounts"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function disable_security_hub(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return securityhub("DELETE", "/accounts", params; aws_config=aws_config)
+    return securityhub(
+        "DELETE",
+        "/accounts",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -873,12 +966,23 @@ organization accounts, only the administrator account can disassociate a member 
 function disassociate_from_administrator_account(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return securityhub("POST", "/administrator/disassociate"; aws_config=aws_config)
+    return securityhub(
+        "POST",
+        "/administrator/disassociate";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function disassociate_from_administrator_account(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return securityhub("POST", "/administrator/disassociate", params; aws_config=aws_config)
+    return securityhub(
+        "POST",
+        "/administrator/disassociate",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -900,12 +1004,23 @@ disassociate a member account.
 function disassociate_from_master_account(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return securityhub("POST", "/master/disassociate"; aws_config=aws_config)
+    return securityhub(
+        "POST",
+        "/master/disassociate";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function disassociate_from_master_account(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return securityhub("POST", "/master/disassociate", params; aws_config=aws_config)
+    return securityhub(
+        "POST",
+        "/master/disassociate",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -927,6 +1042,7 @@ function disassociate_members(AccountIds; aws_config::AbstractAWSConfig=global_a
         "/members/disassociate",
         Dict{String,Any}("AccountIds" => AccountIds);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disassociate_members(
@@ -941,6 +1057,7 @@ function disassociate_members(
             mergewith(_merge, Dict{String,Any}("AccountIds" => AccountIds), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -964,6 +1081,7 @@ function enable_import_findings_for_product(
         "/productSubscriptions",
         Dict{String,Any}("ProductArn" => ProductArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function enable_import_findings_for_product(
@@ -978,6 +1096,7 @@ function enable_import_findings_for_product(
             mergewith(_merge, Dict{String,Any}("ProductArn" => ProductArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1001,6 +1120,7 @@ function enable_organization_admin_account(
         "/organization/admin/enable",
         Dict{String,Any}("AdminAccountId" => AdminAccountId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function enable_organization_admin_account(
@@ -1015,6 +1135,7 @@ function enable_organization_admin_account(
             mergewith(_merge, Dict{String,Any}("AdminAccountId" => AdminAccountId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1043,12 +1164,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"Tags"`: The tags to add to the hub resource when you enable Security Hub.
 """
 function enable_security_hub(; aws_config::AbstractAWSConfig=global_aws_config())
-    return securityhub("POST", "/accounts"; aws_config=aws_config)
+    return securityhub(
+        "POST", "/accounts"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function enable_security_hub(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return securityhub("POST", "/accounts", params; aws_config=aws_config)
+    return securityhub(
+        "POST", "/accounts", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1061,12 +1186,20 @@ accounts that were invited manually.
 
 """
 function get_administrator_account(; aws_config::AbstractAWSConfig=global_aws_config())
-    return securityhub("GET", "/administrator"; aws_config=aws_config)
+    return securityhub(
+        "GET", "/administrator"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_administrator_account(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return securityhub("GET", "/administrator", params; aws_config=aws_config)
+    return securityhub(
+        "GET",
+        "/administrator",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1086,12 +1219,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   standards to retrieve.
 """
 function get_enabled_standards(; aws_config::AbstractAWSConfig=global_aws_config())
-    return securityhub("POST", "/standards/get"; aws_config=aws_config)
+    return securityhub(
+        "POST", "/standards/get"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_enabled_standards(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return securityhub("POST", "/standards/get", params; aws_config=aws_config)
+    return securityhub(
+        "POST",
+        "/standards/get",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1114,12 +1255,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"SortCriteria"`: The finding attributes used to sort the list of returned findings.
 """
 function get_findings(; aws_config::AbstractAWSConfig=global_aws_config())
-    return securityhub("POST", "/findings"; aws_config=aws_config)
+    return securityhub(
+        "POST", "/findings"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_findings(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return securityhub("POST", "/findings", params; aws_config=aws_config)
+    return securityhub(
+        "POST", "/findings", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1133,7 +1278,12 @@ Lists the results of the Security Hub insight specified by the insight ARN.
 
 """
 function get_insight_results(InsightArn; aws_config::AbstractAWSConfig=global_aws_config())
-    return securityhub("GET", "/insights/results/$(InsightArn)"; aws_config=aws_config)
+    return securityhub(
+        "GET",
+        "/insights/results/$(InsightArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_insight_results(
     InsightArn,
@@ -1141,7 +1291,11 @@ function get_insight_results(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return securityhub(
-        "GET", "/insights/results/$(InsightArn)", params; aws_config=aws_config
+        "GET",
+        "/insights/results/$(InsightArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1163,12 +1317,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   from the previous response.
 """
 function get_insights(; aws_config::AbstractAWSConfig=global_aws_config())
-    return securityhub("POST", "/insights/get"; aws_config=aws_config)
+    return securityhub(
+        "POST", "/insights/get"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_insights(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return securityhub("POST", "/insights/get", params; aws_config=aws_config)
+    return securityhub(
+        "POST",
+        "/insights/get",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1180,12 +1342,20 @@ member account, not including the currently accepted invitation.
 
 """
 function get_invitations_count(; aws_config::AbstractAWSConfig=global_aws_config())
-    return securityhub("GET", "/invitations/count"; aws_config=aws_config)
+    return securityhub(
+        "GET", "/invitations/count"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_invitations_count(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return securityhub("GET", "/invitations/count", params; aws_config=aws_config)
+    return securityhub(
+        "GET",
+        "/invitations/count",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1203,12 +1373,16 @@ managed using Organizations and accounts that were invited manually.
 
 """
 function get_master_account(; aws_config::AbstractAWSConfig=global_aws_config())
-    return securityhub("GET", "/master"; aws_config=aws_config)
+    return securityhub(
+        "GET", "/master"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_master_account(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return securityhub("GET", "/master", params; aws_config=aws_config)
+    return securityhub(
+        "GET", "/master", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1232,6 +1406,7 @@ function get_members(AccountIds; aws_config::AbstractAWSConfig=global_aws_config
         "/members/get",
         Dict{String,Any}("AccountIds" => AccountIds);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_members(
@@ -1246,6 +1421,7 @@ function get_members(
             mergewith(_merge, Dict{String,Any}("AccountIds" => AccountIds), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1272,6 +1448,7 @@ function invite_members(AccountIds; aws_config::AbstractAWSConfig=global_aws_con
         "/members/invite",
         Dict{String,Any}("AccountIds" => AccountIds);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function invite_members(
@@ -1286,6 +1463,7 @@ function invite_members(
             mergewith(_merge, Dict{String,Any}("AccountIds" => AccountIds), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1307,12 +1485,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function list_enabled_products_for_import(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return securityhub("GET", "/productSubscriptions"; aws_config=aws_config)
+    return securityhub(
+        "GET",
+        "/productSubscriptions";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_enabled_products_for_import(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return securityhub("GET", "/productSubscriptions", params; aws_config=aws_config)
+    return securityhub(
+        "GET",
+        "/productSubscriptions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1333,12 +1522,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   returned from the previous response.
 """
 function list_invitations(; aws_config::AbstractAWSConfig=global_aws_config())
-    return securityhub("GET", "/invitations"; aws_config=aws_config)
+    return securityhub(
+        "GET", "/invitations"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_invitations(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return securityhub("GET", "/invitations", params; aws_config=aws_config)
+    return securityhub(
+        "GET",
+        "/invitations",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1363,12 +1560,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   the response includes all existing member accounts.
 """
 function list_members(; aws_config::AbstractAWSConfig=global_aws_config())
-    return securityhub("GET", "/members"; aws_config=aws_config)
+    return securityhub(
+        "GET", "/members"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_members(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return securityhub("GET", "/members", params; aws_config=aws_config)
+    return securityhub(
+        "GET", "/members", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1389,12 +1590,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function list_organization_admin_accounts(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return securityhub("GET", "/organization/admin"; aws_config=aws_config)
+    return securityhub(
+        "GET", "/organization/admin"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_organization_admin_accounts(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return securityhub("GET", "/organization/admin", params; aws_config=aws_config)
+    return securityhub(
+        "GET",
+        "/organization/admin",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1410,14 +1619,25 @@ Returns a list of tags associated with a resource.
 function list_tags_for_resource(
     ResourceArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return securityhub("GET", "/tags/$(ResourceArn)"; aws_config=aws_config)
+    return securityhub(
+        "GET",
+        "/tags/$(ResourceArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_tags_for_resource(
     ResourceArn,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return securityhub("GET", "/tags/$(ResourceArn)", params; aws_config=aws_config)
+    return securityhub(
+        "GET",
+        "/tags/$(ResourceArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1439,6 +1659,7 @@ function tag_resource(ResourceArn, Tags; aws_config::AbstractAWSConfig=global_aw
         "/tags/$(ResourceArn)",
         Dict{String,Any}("Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -1452,6 +1673,7 @@ function tag_resource(
         "/tags/$(ResourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Tags" => Tags), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1475,6 +1697,7 @@ function untag_resource(
         "/tags/$(ResourceArn)",
         Dict{String,Any}("tagKeys" => tagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -1488,6 +1711,7 @@ function untag_resource(
         "/tags/$(ResourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tagKeys" => tagKeys), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1508,7 +1732,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function update_action_target(
     ActionTargetArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return securityhub("PATCH", "/actionTargets/$(ActionTargetArn)"; aws_config=aws_config)
+    return securityhub(
+        "PATCH",
+        "/actionTargets/$(ActionTargetArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function update_action_target(
     ActionTargetArn,
@@ -1516,7 +1745,11 @@ function update_action_target(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return securityhub(
-        "PATCH", "/actionTargets/$(ActionTargetArn)", params; aws_config=aws_config
+        "PATCH",
+        "/actionTargets/$(ActionTargetArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1538,7 +1771,11 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function update_findings(Filters; aws_config::AbstractAWSConfig=global_aws_config())
     return securityhub(
-        "PATCH", "/findings", Dict{String,Any}("Filters" => Filters); aws_config=aws_config
+        "PATCH",
+        "/findings",
+        Dict{String,Any}("Filters" => Filters);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_findings(
@@ -1549,6 +1786,7 @@ function update_findings(
         "/findings",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Filters" => Filters), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1568,14 +1806,25 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"Name"`: The updated name for the insight.
 """
 function update_insight(InsightArn; aws_config::AbstractAWSConfig=global_aws_config())
-    return securityhub("PATCH", "/insights/$(InsightArn)"; aws_config=aws_config)
+    return securityhub(
+        "PATCH",
+        "/insights/$(InsightArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function update_insight(
     InsightArn,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return securityhub("PATCH", "/insights/$(InsightArn)", params; aws_config=aws_config)
+    return securityhub(
+        "PATCH",
+        "/insights/$(InsightArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1599,6 +1848,7 @@ function update_organization_configuration(
         "/organization/configuration",
         Dict{String,Any}("AutoEnable" => AutoEnable);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_organization_configuration(
@@ -1613,6 +1863,7 @@ function update_organization_configuration(
             mergewith(_merge, Dict{String,Any}("AutoEnable" => AutoEnable), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1631,12 +1882,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function update_security_hub_configuration(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return securityhub("PATCH", "/accounts"; aws_config=aws_config)
+    return securityhub(
+        "PATCH", "/accounts"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function update_security_hub_configuration(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return securityhub("PATCH", "/accounts", params; aws_config=aws_config)
+    return securityhub(
+        "PATCH", "/accounts", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1658,7 +1913,10 @@ function update_standards_control(
     StandardsControlArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return securityhub(
-        "PATCH", "/standards/control/$(StandardsControlArn)"; aws_config=aws_config
+        "PATCH",
+        "/standards/control/$(StandardsControlArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_standards_control(
@@ -1667,6 +1925,10 @@ function update_standards_control(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return securityhub(
-        "PATCH", "/standards/control/$(StandardsControlArn)", params; aws_config=aws_config
+        "PATCH",
+        "/standards/control/$(StandardsControlArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/serverlessapplicationrepository.jl
+++ b/src/services/serverlessapplicationrepository.jl
@@ -63,6 +63,7 @@ function create_application(
         "/applications",
         Dict{String,Any}("author" => author, "description" => description, "name" => name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_application(
@@ -85,6 +86,7 @@ function create_application(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -114,6 +116,7 @@ function create_application_version(
         "PUT",
         "/applications/$(applicationId)/versions/$(semanticVersion)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_application_version(
@@ -127,6 +130,7 @@ function create_application_version(
         "/applications/$(applicationId)/versions/$(semanticVersion)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -215,6 +219,7 @@ function create_cloud_formation_change_set(
         "/applications/$(applicationId)/changesets",
         Dict{String,Any}("stackName" => stackName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_cloud_formation_change_set(
@@ -230,6 +235,7 @@ function create_cloud_formation_change_set(
             mergewith(_merge, Dict{String,Any}("stackName" => stackName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -251,7 +257,10 @@ function create_cloud_formation_template(
     applicationId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return serverlessapplicationrepository(
-        "POST", "/applications/$(applicationId)/templates"; aws_config=aws_config
+        "POST",
+        "/applications/$(applicationId)/templates";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_cloud_formation_template(
@@ -260,7 +269,11 @@ function create_cloud_formation_template(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return serverlessapplicationrepository(
-        "POST", "/applications/$(applicationId)/templates", params; aws_config=aws_config
+        "POST",
+        "/applications/$(applicationId)/templates",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -278,7 +291,10 @@ function delete_application(
     applicationId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return serverlessapplicationrepository(
-        "DELETE", "/applications/$(applicationId)"; aws_config=aws_config
+        "DELETE",
+        "/applications/$(applicationId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_application(
@@ -287,7 +303,11 @@ function delete_application(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return serverlessapplicationrepository(
-        "DELETE", "/applications/$(applicationId)", params; aws_config=aws_config
+        "DELETE",
+        "/applications/$(applicationId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -306,7 +326,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function get_application(applicationId; aws_config::AbstractAWSConfig=global_aws_config())
     return serverlessapplicationrepository(
-        "GET", "/applications/$(applicationId)"; aws_config=aws_config
+        "GET",
+        "/applications/$(applicationId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_application(
@@ -315,7 +338,11 @@ function get_application(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return serverlessapplicationrepository(
-        "GET", "/applications/$(applicationId)", params; aws_config=aws_config
+        "GET",
+        "/applications/$(applicationId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -333,7 +360,10 @@ function get_application_policy(
     applicationId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return serverlessapplicationrepository(
-        "GET", "/applications/$(applicationId)/policy"; aws_config=aws_config
+        "GET",
+        "/applications/$(applicationId)/policy";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_application_policy(
@@ -342,7 +372,11 @@ function get_application_policy(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return serverlessapplicationrepository(
-        "GET", "/applications/$(applicationId)/policy", params; aws_config=aws_config
+        "GET",
+        "/applications/$(applicationId)/policy",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -365,6 +399,7 @@ function get_cloud_formation_template(
         "GET",
         "/applications/$(applicationId)/templates/$(templateId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_cloud_formation_template(
@@ -378,6 +413,7 @@ function get_cloud_formation_template(
         "/applications/$(applicationId)/templates/$(templateId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -400,7 +436,10 @@ function list_application_dependencies(
     applicationId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return serverlessapplicationrepository(
-        "GET", "/applications/$(applicationId)/dependencies"; aws_config=aws_config
+        "GET",
+        "/applications/$(applicationId)/dependencies";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_application_dependencies(
@@ -409,7 +448,11 @@ function list_application_dependencies(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return serverlessapplicationrepository(
-        "GET", "/applications/$(applicationId)/dependencies", params; aws_config=aws_config
+        "GET",
+        "/applications/$(applicationId)/dependencies",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -431,7 +474,10 @@ function list_application_versions(
     applicationId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return serverlessapplicationrepository(
-        "GET", "/applications/$(applicationId)/versions"; aws_config=aws_config
+        "GET",
+        "/applications/$(applicationId)/versions";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_application_versions(
@@ -440,7 +486,11 @@ function list_application_versions(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return serverlessapplicationrepository(
-        "GET", "/applications/$(applicationId)/versions", params; aws_config=aws_config
+        "GET",
+        "/applications/$(applicationId)/versions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -456,13 +506,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: A token to specify where to start paginating.
 """
 function list_applications(; aws_config::AbstractAWSConfig=global_aws_config())
-    return serverlessapplicationrepository("GET", "/applications"; aws_config=aws_config)
+    return serverlessapplicationrepository(
+        "GET", "/applications"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_applications(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return serverlessapplicationrepository(
-        "GET", "/applications", params; aws_config=aws_config
+        "GET",
+        "/applications",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -489,6 +545,7 @@ function put_application_policy(
         "/applications/$(applicationId)/policy",
         Dict{String,Any}("statements" => statements);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_application_policy(
@@ -504,6 +561,7 @@ function put_application_policy(
             mergewith(_merge, Dict{String,Any}("statements" => statements), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -527,6 +585,7 @@ function unshare_application(
         "/applications/$(applicationId)/unshare",
         Dict{String,Any}("organizationId" => organizationId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function unshare_application(
@@ -542,6 +601,7 @@ function unshare_application(
             mergewith(_merge, Dict{String,Any}("organizationId" => organizationId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -572,7 +632,10 @@ function update_application(
     applicationId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return serverlessapplicationrepository(
-        "PATCH", "/applications/$(applicationId)"; aws_config=aws_config
+        "PATCH",
+        "/applications/$(applicationId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_application(
@@ -581,6 +644,10 @@ function update_application(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return serverlessapplicationrepository(
-        "PATCH", "/applications/$(applicationId)", params; aws_config=aws_config
+        "PATCH",
+        "/applications/$(applicationId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/service_catalog.jl
+++ b/src/services/service_catalog.jl
@@ -31,6 +31,7 @@ function accept_portfolio_share(
         "AcceptPortfolioShare",
         Dict{String,Any}("PortfolioId" => PortfolioId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function accept_portfolio_share(
@@ -44,6 +45,7 @@ function accept_portfolio_share(
             mergewith(_merge, Dict{String,Any}("PortfolioId" => PortfolioId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -65,6 +67,7 @@ function associate_budget_with_resource(
         "AssociateBudgetWithResource",
         Dict{String,Any}("BudgetName" => BudgetName, "ResourceId" => ResourceId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_budget_with_resource(
@@ -83,6 +86,7 @@ function associate_budget_with_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -116,6 +120,7 @@ function associate_principal_with_portfolio(
             "PrincipalType" => PrincipalType,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_principal_with_portfolio(
@@ -139,6 +144,7 @@ function associate_principal_with_portfolio(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -166,6 +172,7 @@ function associate_product_with_portfolio(
         "AssociateProductWithPortfolio",
         Dict{String,Any}("PortfolioId" => PortfolioId, "ProductId" => ProductId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_product_with_portfolio(
@@ -184,6 +191,7 @@ function associate_product_with_portfolio(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -218,6 +226,7 @@ function associate_service_action_with_provisioning_artifact(
             "ServiceActionId" => ServiceActionId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_service_action_with_provisioning_artifact(
@@ -241,6 +250,7 @@ function associate_service_action_with_provisioning_artifact(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -262,6 +272,7 @@ function associate_tag_option_with_resource(
         "AssociateTagOptionWithResource",
         Dict{String,Any}("ResourceId" => ResourceId, "TagOptionId" => TagOptionId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_tag_option_with_resource(
@@ -280,6 +291,7 @@ function associate_tag_option_with_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -305,6 +317,7 @@ function batch_associate_service_action_with_provisioning_artifact(
         "BatchAssociateServiceActionWithProvisioningArtifact",
         Dict{String,Any}("ServiceActionAssociations" => ServiceActionAssociations);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_associate_service_action_with_provisioning_artifact(
@@ -322,6 +335,7 @@ function batch_associate_service_action_with_provisioning_artifact(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -347,6 +361,7 @@ function batch_disassociate_service_action_from_provisioning_artifact(
         "BatchDisassociateServiceActionFromProvisioningArtifact",
         Dict{String,Any}("ServiceActionAssociations" => ServiceActionAssociations);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_disassociate_service_action_from_provisioning_artifact(
@@ -364,6 +379,7 @@ function batch_disassociate_service_action_from_provisioning_artifact(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -405,6 +421,7 @@ function copy_product(
             "IdempotencyToken" => IdempotencyToken, "SourceProductArn" => SourceProductArn
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function copy_product(
@@ -426,6 +443,7 @@ function copy_product(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -491,6 +509,7 @@ function create_constraint(
             "Type" => Type,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_constraint(
@@ -518,6 +537,7 @@ function create_constraint(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -555,6 +575,7 @@ function create_portfolio(
             "ProviderName" => ProviderName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_portfolio(
@@ -578,6 +599,7 @@ function create_portfolio(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -618,6 +640,7 @@ function create_portfolio_share(
         "CreatePortfolioShare",
         Dict{String,Any}("PortfolioId" => PortfolioId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_portfolio_share(
@@ -631,6 +654,7 @@ function create_portfolio_share(
             mergewith(_merge, Dict{String,Any}("PortfolioId" => PortfolioId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -682,6 +706,7 @@ function create_product(
             "ProvisioningArtifactParameters" => ProvisioningArtifactParameters,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_product(
@@ -709,6 +734,7 @@ function create_product(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -769,6 +795,7 @@ function create_provisioned_product_plan(
             "ProvisioningArtifactId" => ProvisioningArtifactId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_provisioned_product_plan(
@@ -798,6 +825,7 @@ function create_provisioned_product_plan(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -837,6 +865,7 @@ function create_provisioning_artifact(
             "ProductId" => ProductId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_provisioning_artifact(
@@ -860,6 +889,7 @@ function create_provisioning_artifact(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -908,6 +938,7 @@ function create_service_action(
             "Name" => Name,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_service_action(
@@ -933,6 +964,7 @@ function create_service_action(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -952,6 +984,7 @@ function create_tag_option(Key, Value; aws_config::AbstractAWSConfig=global_aws_
         "CreateTagOption",
         Dict{String,Any}("Key" => Key, "Value" => Value);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_tag_option(
@@ -966,6 +999,7 @@ function create_tag_option(
             mergewith(_merge, Dict{String,Any}("Key" => Key, "Value" => Value), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -985,7 +1019,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function delete_constraint(Id; aws_config::AbstractAWSConfig=global_aws_config())
     return service_catalog(
-        "DeleteConstraint", Dict{String,Any}("Id" => Id); aws_config=aws_config
+        "DeleteConstraint",
+        Dict{String,Any}("Id" => Id);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_constraint(
@@ -995,6 +1032,7 @@ function delete_constraint(
         "DeleteConstraint",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Id" => Id), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1016,7 +1054,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function delete_portfolio(Id; aws_config::AbstractAWSConfig=global_aws_config())
     return service_catalog(
-        "DeletePortfolio", Dict{String,Any}("Id" => Id); aws_config=aws_config
+        "DeletePortfolio",
+        Dict{String,Any}("Id" => Id);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_portfolio(
@@ -1026,6 +1067,7 @@ function delete_portfolio(
         "DeletePortfolio",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Id" => Id), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1055,6 +1097,7 @@ function delete_portfolio_share(
         "DeletePortfolioShare",
         Dict{String,Any}("PortfolioId" => PortfolioId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_portfolio_share(
@@ -1068,6 +1111,7 @@ function delete_portfolio_share(
             mergewith(_merge, Dict{String,Any}("PortfolioId" => PortfolioId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1088,7 +1132,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function delete_product(Id; aws_config::AbstractAWSConfig=global_aws_config())
     return service_catalog(
-        "DeleteProduct", Dict{String,Any}("Id" => Id); aws_config=aws_config
+        "DeleteProduct",
+        Dict{String,Any}("Id" => Id);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_product(
@@ -1098,6 +1145,7 @@ function delete_product(
         "DeleteProduct",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Id" => Id), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1124,6 +1172,7 @@ function delete_provisioned_product_plan(
         "DeleteProvisionedProductPlan",
         Dict{String,Any}("PlanId" => PlanId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_provisioned_product_plan(
@@ -1133,6 +1182,7 @@ function delete_provisioned_product_plan(
         "DeleteProvisionedProductPlan",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("PlanId" => PlanId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1163,6 +1213,7 @@ function delete_provisioning_artifact(
             "ProductId" => ProductId, "ProvisioningArtifactId" => ProvisioningArtifactId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_provisioning_artifact(
@@ -1184,6 +1235,7 @@ function delete_provisioning_artifact(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1203,7 +1255,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function delete_service_action(Id; aws_config::AbstractAWSConfig=global_aws_config())
     return service_catalog(
-        "DeleteServiceAction", Dict{String,Any}("Id" => Id); aws_config=aws_config
+        "DeleteServiceAction",
+        Dict{String,Any}("Id" => Id);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_service_action(
@@ -1213,6 +1268,7 @@ function delete_service_action(
         "DeleteServiceAction",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Id" => Id), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1229,7 +1285,10 @@ product or portfolio.
 """
 function delete_tag_option(Id; aws_config::AbstractAWSConfig=global_aws_config())
     return service_catalog(
-        "DeleteTagOption", Dict{String,Any}("Id" => Id); aws_config=aws_config
+        "DeleteTagOption",
+        Dict{String,Any}("Id" => Id);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_tag_option(
@@ -1239,6 +1298,7 @@ function delete_tag_option(
         "DeleteTagOption",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Id" => Id), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1258,7 +1318,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function describe_constraint(Id; aws_config::AbstractAWSConfig=global_aws_config())
     return service_catalog(
-        "DescribeConstraint", Dict{String,Any}("Id" => Id); aws_config=aws_config
+        "DescribeConstraint",
+        Dict{String,Any}("Id" => Id);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_constraint(
@@ -1268,6 +1331,7 @@ function describe_constraint(
         "DescribeConstraint",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Id" => Id), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1293,6 +1357,7 @@ function describe_copy_product_status(
         "DescribeCopyProductStatus",
         Dict{String,Any}("CopyProductToken" => CopyProductToken);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_copy_product_status(
@@ -1308,6 +1373,7 @@ function describe_copy_product_status(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1328,7 +1394,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function describe_portfolio(Id; aws_config::AbstractAWSConfig=global_aws_config())
     return service_catalog(
-        "DescribePortfolio", Dict{String,Any}("Id" => Id); aws_config=aws_config
+        "DescribePortfolio",
+        Dict{String,Any}("Id" => Id);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_portfolio(
@@ -1338,6 +1407,7 @@ function describe_portfolio(
         "DescribePortfolio",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Id" => Id), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1360,6 +1430,7 @@ function describe_portfolio_share_status(
         "DescribePortfolioShareStatus",
         Dict{String,Any}("PortfolioShareToken" => PortfolioShareToken);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_portfolio_share_status(
@@ -1377,6 +1448,7 @@ function describe_portfolio_share_status(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1412,6 +1484,7 @@ function describe_portfolio_shares(
         "DescribePortfolioShares",
         Dict{String,Any}("PortfolioId" => PortfolioId, "Type" => Type);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_portfolio_shares(
@@ -1430,6 +1503,7 @@ function describe_portfolio_shares(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1447,12 +1521,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"Name"`: The product name.
 """
 function describe_product(; aws_config::AbstractAWSConfig=global_aws_config())
-    return service_catalog("DescribeProduct"; aws_config=aws_config)
+    return service_catalog(
+        "DescribeProduct"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_product(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return service_catalog("DescribeProduct", params; aws_config=aws_config)
+    return service_catalog(
+        "DescribeProduct", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1475,12 +1553,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   associated with the product. Otherwise only local TagOptions will be returned.
 """
 function describe_product_as_admin(; aws_config::AbstractAWSConfig=global_aws_config())
-    return service_catalog("DescribeProductAsAdmin"; aws_config=aws_config)
+    return service_catalog(
+        "DescribeProductAsAdmin"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_product_as_admin(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return service_catalog("DescribeProductAsAdmin", params; aws_config=aws_config)
+    return service_catalog(
+        "DescribeProductAsAdmin",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1499,7 +1584,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function describe_product_view(Id; aws_config::AbstractAWSConfig=global_aws_config())
     return service_catalog(
-        "DescribeProductView", Dict{String,Any}("Id" => Id); aws_config=aws_config
+        "DescribeProductView",
+        Dict{String,Any}("Id" => Id);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_product_view(
@@ -1509,6 +1597,7 @@ function describe_product_view(
         "DescribeProductView",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Id" => Id), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1530,12 +1619,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   InvalidParametersException will occur.
 """
 function describe_provisioned_product(; aws_config::AbstractAWSConfig=global_aws_config())
-    return service_catalog("DescribeProvisionedProduct"; aws_config=aws_config)
+    return service_catalog(
+        "DescribeProvisionedProduct"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_provisioned_product(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return service_catalog("DescribeProvisionedProduct", params; aws_config=aws_config)
+    return service_catalog(
+        "DescribeProvisionedProduct",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1562,6 +1658,7 @@ function describe_provisioned_product_plan(
         "DescribeProvisionedProductPlan",
         Dict{String,Any}("PlanId" => PlanId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_provisioned_product_plan(
@@ -1571,6 +1668,7 @@ function describe_provisioned_product_plan(
         "DescribeProvisionedProductPlan",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("PlanId" => PlanId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1592,12 +1690,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"Verbose"`: Indicates whether a verbose level of detail is enabled.
 """
 function describe_provisioning_artifact(; aws_config::AbstractAWSConfig=global_aws_config())
-    return service_catalog("DescribeProvisioningArtifact"; aws_config=aws_config)
+    return service_catalog(
+        "DescribeProvisioningArtifact";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_provisioning_artifact(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return service_catalog("DescribeProvisioningArtifact", params; aws_config=aws_config)
+    return service_catalog(
+        "DescribeProvisioningArtifact",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1631,12 +1738,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_provisioning_parameters(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return service_catalog("DescribeProvisioningParameters"; aws_config=aws_config)
+    return service_catalog(
+        "DescribeProvisioningParameters";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_provisioning_parameters(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return service_catalog("DescribeProvisioningParameters", params; aws_config=aws_config)
+    return service_catalog(
+        "DescribeProvisioningParameters",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1665,7 +1781,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function describe_record(Id; aws_config::AbstractAWSConfig=global_aws_config())
     return service_catalog(
-        "DescribeRecord", Dict{String,Any}("Id" => Id); aws_config=aws_config
+        "DescribeRecord",
+        Dict{String,Any}("Id" => Id);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_record(
@@ -1675,6 +1794,7 @@ function describe_record(
         "DescribeRecord",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Id" => Id), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1694,7 +1814,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function describe_service_action(Id; aws_config::AbstractAWSConfig=global_aws_config())
     return service_catalog(
-        "DescribeServiceAction", Dict{String,Any}("Id" => Id); aws_config=aws_config
+        "DescribeServiceAction",
+        Dict{String,Any}("Id" => Id);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_service_action(
@@ -1704,6 +1827,7 @@ function describe_service_action(
         "DescribeServiceAction",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Id" => Id), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1733,6 +1857,7 @@ function describe_service_action_execution_parameters(
             "ServiceActionId" => ServiceActionId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_service_action_execution_parameters(
@@ -1754,6 +1879,7 @@ function describe_service_action_execution_parameters(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1769,7 +1895,10 @@ Gets information about the specified TagOption.
 """
 function describe_tag_option(Id; aws_config::AbstractAWSConfig=global_aws_config())
     return service_catalog(
-        "DescribeTagOption", Dict{String,Any}("Id" => Id); aws_config=aws_config
+        "DescribeTagOption",
+        Dict{String,Any}("Id" => Id);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_tag_option(
@@ -1779,6 +1908,7 @@ function describe_tag_option(
         "DescribeTagOption",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Id" => Id), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1798,12 +1928,21 @@ DisableAWSOrganizationsAccess.
 function disable_awsorganizations_access(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return service_catalog("DisableAWSOrganizationsAccess"; aws_config=aws_config)
+    return service_catalog(
+        "DisableAWSOrganizationsAccess";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function disable_awsorganizations_access(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return service_catalog("DisableAWSOrganizationsAccess", params; aws_config=aws_config)
+    return service_catalog(
+        "DisableAWSOrganizationsAccess",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1825,6 +1964,7 @@ function disassociate_budget_from_resource(
         "DisassociateBudgetFromResource",
         Dict{String,Any}("BudgetName" => BudgetName, "ResourceId" => ResourceId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disassociate_budget_from_resource(
@@ -1843,6 +1983,7 @@ function disassociate_budget_from_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1868,6 +2009,7 @@ function disassociate_principal_from_portfolio(
         "DisassociatePrincipalFromPortfolio",
         Dict{String,Any}("PortfolioId" => PortfolioId, "PrincipalARN" => PrincipalARN);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disassociate_principal_from_portfolio(
@@ -1888,6 +2030,7 @@ function disassociate_principal_from_portfolio(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1914,6 +2057,7 @@ function disassociate_product_from_portfolio(
         "DisassociateProductFromPortfolio",
         Dict{String,Any}("PortfolioId" => PortfolioId, "ProductId" => ProductId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disassociate_product_from_portfolio(
@@ -1932,6 +2076,7 @@ function disassociate_product_from_portfolio(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1967,6 +2112,7 @@ function disassociate_service_action_from_provisioning_artifact(
             "ServiceActionId" => ServiceActionId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disassociate_service_action_from_provisioning_artifact(
@@ -1990,6 +2136,7 @@ function disassociate_service_action_from_provisioning_artifact(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2011,6 +2158,7 @@ function disassociate_tag_option_from_resource(
         "DisassociateTagOptionFromResource",
         Dict{String,Any}("ResourceId" => ResourceId, "TagOptionId" => TagOptionId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disassociate_tag_option_from_resource(
@@ -2029,6 +2177,7 @@ function disassociate_tag_option_from_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2046,12 +2195,21 @@ authorized to invoke EnableAWSOrganizationsAccess.
 
 """
 function enable_awsorganizations_access(; aws_config::AbstractAWSConfig=global_aws_config())
-    return service_catalog("EnableAWSOrganizationsAccess"; aws_config=aws_config)
+    return service_catalog(
+        "EnableAWSOrganizationsAccess";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function enable_awsorganizations_access(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return service_catalog("EnableAWSOrganizationsAccess", params; aws_config=aws_config)
+    return service_catalog(
+        "EnableAWSOrganizationsAccess",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2078,6 +2236,7 @@ function execute_provisioned_product_plan(
         "ExecuteProvisionedProductPlan",
         Dict{String,Any}("IdempotencyToken" => IdempotencyToken, "PlanId" => PlanId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function execute_provisioned_product_plan(
@@ -2098,6 +2257,7 @@ function execute_provisioned_product_plan(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2136,6 +2296,7 @@ function execute_provisioned_product_service_action(
             "ServiceActionId" => ServiceActionId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function execute_provisioned_product_service_action(
@@ -2159,6 +2320,7 @@ function execute_provisioned_product_service_action(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2173,12 +2335,21 @@ called by the management account in the organization or by a delegated admin.
 function get_awsorganizations_access_status(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return service_catalog("GetAWSOrganizationsAccessStatus"; aws_config=aws_config)
+    return service_catalog(
+        "GetAWSOrganizationsAccessStatus";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_awsorganizations_access_status(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return service_catalog("GetAWSOrganizationsAccessStatus", params; aws_config=aws_config)
+    return service_catalog(
+        "GetAWSOrganizationsAccessStatus",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2205,12 +2376,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function get_provisioned_product_outputs(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return service_catalog("GetProvisionedProductOutputs"; aws_config=aws_config)
+    return service_catalog(
+        "GetProvisionedProductOutputs";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_provisioned_product_outputs(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return service_catalog("GetProvisionedProductOutputs", params; aws_config=aws_config)
+    return service_catalog(
+        "GetProvisionedProductOutputs",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2263,6 +2443,7 @@ function import_as_provisioned_product(
             "ProvisioningArtifactId" => ProvisioningArtifactId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function import_as_provisioned_product(
@@ -2290,6 +2471,7 @@ function import_as_provisioned_product(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2312,12 +2494,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   List imported portfolios
 """
 function list_accepted_portfolio_shares(; aws_config::AbstractAWSConfig=global_aws_config())
-    return service_catalog("ListAcceptedPortfolioShares"; aws_config=aws_config)
+    return service_catalog(
+        "ListAcceptedPortfolioShares";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_accepted_portfolio_shares(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return service_catalog("ListAcceptedPortfolioShares", params; aws_config=aws_config)
+    return service_catalog(
+        "ListAcceptedPortfolioShares",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2344,6 +2535,7 @@ function list_budgets_for_resource(
         "ListBudgetsForResource",
         Dict{String,Any}("ResourceId" => ResourceId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_budgets_for_resource(
@@ -2357,6 +2549,7 @@ function list_budgets_for_resource(
             mergewith(_merge, Dict{String,Any}("ResourceId" => ResourceId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2385,6 +2578,7 @@ function list_constraints_for_portfolio(
         "ListConstraintsForPortfolio",
         Dict{String,Any}("PortfolioId" => PortfolioId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_constraints_for_portfolio(
@@ -2398,6 +2592,7 @@ function list_constraints_for_portfolio(
             mergewith(_merge, Dict{String,Any}("PortfolioId" => PortfolioId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2422,7 +2617,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function list_launch_paths(ProductId; aws_config::AbstractAWSConfig=global_aws_config())
     return service_catalog(
-        "ListLaunchPaths", Dict{String,Any}("ProductId" => ProductId); aws_config=aws_config
+        "ListLaunchPaths",
+        Dict{String,Any}("ProductId" => ProductId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_launch_paths(
@@ -2436,6 +2634,7 @@ function list_launch_paths(
             mergewith(_merge, Dict{String,Any}("ProductId" => ProductId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2471,6 +2670,7 @@ function list_organization_portfolio_access(
             "OrganizationNodeType" => OrganizationNodeType, "PortfolioId" => PortfolioId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_organization_portfolio_access(
@@ -2492,6 +2692,7 @@ function list_organization_portfolio_access(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2523,6 +2724,7 @@ function list_portfolio_access(
         "ListPortfolioAccess",
         Dict{String,Any}("PortfolioId" => PortfolioId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_portfolio_access(
@@ -2536,6 +2738,7 @@ function list_portfolio_access(
             mergewith(_merge, Dict{String,Any}("PortfolioId" => PortfolioId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2554,12 +2757,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   results, use null.
 """
 function list_portfolios(; aws_config::AbstractAWSConfig=global_aws_config())
-    return service_catalog("ListPortfolios"; aws_config=aws_config)
+    return service_catalog(
+        "ListPortfolios"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_portfolios(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return service_catalog("ListPortfolios", params; aws_config=aws_config)
+    return service_catalog(
+        "ListPortfolios", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -2586,6 +2793,7 @@ function list_portfolios_for_product(
         "ListPortfoliosForProduct",
         Dict{String,Any}("ProductId" => ProductId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_portfolios_for_product(
@@ -2599,6 +2807,7 @@ function list_portfolios_for_product(
             mergewith(_merge, Dict{String,Any}("ProductId" => ProductId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2626,6 +2835,7 @@ function list_principals_for_portfolio(
         "ListPrincipalsForPortfolio",
         Dict{String,Any}("PortfolioId" => PortfolioId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_principals_for_portfolio(
@@ -2639,6 +2849,7 @@ function list_principals_for_portfolio(
             mergewith(_merge, Dict{String,Any}("PortfolioId" => PortfolioId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2660,12 +2871,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"ProvisionProductId"`: The product identifier.
 """
 function list_provisioned_product_plans(; aws_config::AbstractAWSConfig=global_aws_config())
-    return service_catalog("ListProvisionedProductPlans"; aws_config=aws_config)
+    return service_catalog(
+        "ListProvisionedProductPlans";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_provisioned_product_plans(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return service_catalog("ListProvisionedProductPlans", params; aws_config=aws_config)
+    return service_catalog(
+        "ListProvisionedProductPlans",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2689,6 +2909,7 @@ function list_provisioning_artifacts(
         "ListProvisioningArtifacts",
         Dict{String,Any}("ProductId" => ProductId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_provisioning_artifacts(
@@ -2702,6 +2923,7 @@ function list_provisioning_artifacts(
             mergewith(_merge, Dict{String,Any}("ProductId" => ProductId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2730,6 +2952,7 @@ function list_provisioning_artifacts_for_service_action(
         "ListProvisioningArtifactsForServiceAction",
         Dict{String,Any}("ServiceActionId" => ServiceActionId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_provisioning_artifacts_for_service_action(
@@ -2745,6 +2968,7 @@ function list_provisioning_artifacts_for_service_action(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2765,12 +2989,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"SearchFilter"`: The search filter to scope the results.
 """
 function list_record_history(; aws_config::AbstractAWSConfig=global_aws_config())
-    return service_catalog("ListRecordHistory"; aws_config=aws_config)
+    return service_catalog(
+        "ListRecordHistory"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_record_history(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return service_catalog("ListRecordHistory", params; aws_config=aws_config)
+    return service_catalog(
+        "ListRecordHistory", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -2796,6 +3024,7 @@ function list_resources_for_tag_option(
         "ListResourcesForTagOption",
         Dict{String,Any}("TagOptionId" => TagOptionId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_resources_for_tag_option(
@@ -2809,6 +3038,7 @@ function list_resources_for_tag_option(
             mergewith(_merge, Dict{String,Any}("TagOptionId" => TagOptionId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2827,12 +3057,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   results, use null.
 """
 function list_service_actions(; aws_config::AbstractAWSConfig=global_aws_config())
-    return service_catalog("ListServiceActions"; aws_config=aws_config)
+    return service_catalog(
+        "ListServiceActions"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_service_actions(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return service_catalog("ListServiceActions", params; aws_config=aws_config)
+    return service_catalog(
+        "ListServiceActions", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -2864,6 +3098,7 @@ function list_service_actions_for_provisioning_artifact(
             "ProductId" => ProductId, "ProvisioningArtifactId" => ProvisioningArtifactId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_service_actions_for_provisioning_artifact(
@@ -2885,6 +3120,7 @@ function list_service_actions_for_provisioning_artifact(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2914,6 +3150,7 @@ function list_stack_instances_for_provisioned_product(
         "ListStackInstancesForProvisionedProduct",
         Dict{String,Any}("ProvisionedProductId" => ProvisionedProductId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_stack_instances_for_provisioned_product(
@@ -2931,6 +3168,7 @@ function list_stack_instances_for_provisioned_product(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2949,12 +3187,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   results, use null.
 """
 function list_tag_options(; aws_config::AbstractAWSConfig=global_aws_config())
-    return service_catalog("ListTagOptions"; aws_config=aws_config)
+    return service_catalog(
+        "ListTagOptions"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_tag_options(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return service_catalog("ListTagOptions", params; aws_config=aws_config)
+    return service_catalog(
+        "ListTagOptions", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -3007,6 +3249,7 @@ function provision_product(
             "ProvisionedProductName" => ProvisionedProductName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function provision_product(
@@ -3028,6 +3271,7 @@ function provision_product(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3058,6 +3302,7 @@ function reject_portfolio_share(
         "RejectPortfolioShare",
         Dict{String,Any}("PortfolioId" => PortfolioId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function reject_portfolio_share(
@@ -3071,6 +3316,7 @@ function reject_portfolio_share(
             mergewith(_merge, Dict{String,Any}("PortfolioId" => PortfolioId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3091,12 +3337,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   results, use null.
 """
 function scan_provisioned_products(; aws_config::AbstractAWSConfig=global_aws_config())
-    return service_catalog("ScanProvisionedProducts"; aws_config=aws_config)
+    return service_catalog(
+        "ScanProvisionedProducts"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function scan_provisioned_products(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return service_catalog("ScanProvisionedProducts", params; aws_config=aws_config)
+    return service_catalog(
+        "ScanProvisionedProducts",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -3118,12 +3371,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"SortOrder"`: The sort order. If no value is specified, the results are not sorted.
 """
 function search_products(; aws_config::AbstractAWSConfig=global_aws_config())
-    return service_catalog("SearchProducts"; aws_config=aws_config)
+    return service_catalog(
+        "SearchProducts"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function search_products(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return service_catalog("SearchProducts", params; aws_config=aws_config)
+    return service_catalog(
+        "SearchProducts", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -3147,12 +3404,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"SortOrder"`: The sort order. If no value is specified, the results are not sorted.
 """
 function search_products_as_admin(; aws_config::AbstractAWSConfig=global_aws_config())
-    return service_catalog("SearchProductsAsAdmin"; aws_config=aws_config)
+    return service_catalog(
+        "SearchProductsAsAdmin"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function search_products_as_admin(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return service_catalog("SearchProductsAsAdmin", params; aws_config=aws_config)
+    return service_catalog(
+        "SearchProductsAsAdmin",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -3179,12 +3443,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"SortOrder"`: The sort order. If no value is specified, the results are not sorted.
 """
 function search_provisioned_products(; aws_config::AbstractAWSConfig=global_aws_config())
-    return service_catalog("SearchProvisionedProducts"; aws_config=aws_config)
+    return service_catalog(
+        "SearchProvisionedProducts"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function search_provisioned_products(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return service_catalog("SearchProvisionedProducts", params; aws_config=aws_config)
+    return service_catalog(
+        "SearchProvisionedProducts",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -3223,6 +3494,7 @@ function terminate_provisioned_product(
         "TerminateProvisionedProduct",
         Dict{String,Any}("TerminateToken" => TerminateToken);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function terminate_provisioned_product(
@@ -3236,6 +3508,7 @@ function terminate_provisioned_product(
             mergewith(_merge, Dict{String,Any}("TerminateToken" => TerminateToken), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3279,7 +3552,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function update_constraint(Id; aws_config::AbstractAWSConfig=global_aws_config())
     return service_catalog(
-        "UpdateConstraint", Dict{String,Any}("Id" => Id); aws_config=aws_config
+        "UpdateConstraint",
+        Dict{String,Any}("Id" => Id);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_constraint(
@@ -3289,6 +3565,7 @@ function update_constraint(
         "UpdateConstraint",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Id" => Id), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3313,7 +3590,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function update_portfolio(Id; aws_config::AbstractAWSConfig=global_aws_config())
     return service_catalog(
-        "UpdatePortfolio", Dict{String,Any}("Id" => Id); aws_config=aws_config
+        "UpdatePortfolio",
+        Dict{String,Any}("Id" => Id);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_portfolio(
@@ -3323,6 +3603,7 @@ function update_portfolio(
         "UpdatePortfolio",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Id" => Id), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3362,6 +3643,7 @@ function update_portfolio_share(
         "UpdatePortfolioShare",
         Dict{String,Any}("PortfolioId" => PortfolioId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_portfolio_share(
@@ -3375,6 +3657,7 @@ function update_portfolio_share(
             mergewith(_merge, Dict{String,Any}("PortfolioId" => PortfolioId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3403,7 +3686,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function update_product(Id; aws_config::AbstractAWSConfig=global_aws_config())
     return service_catalog(
-        "UpdateProduct", Dict{String,Any}("Id" => Id); aws_config=aws_config
+        "UpdateProduct",
+        Dict{String,Any}("Id" => Id);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_product(
@@ -3413,6 +3699,7 @@ function update_product(
         "UpdateProduct",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Id" => Id), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3461,6 +3748,7 @@ function update_provisioned_product(
         "UpdateProvisionedProduct",
         Dict{String,Any}("UpdateToken" => UpdateToken);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_provisioned_product(
@@ -3474,6 +3762,7 @@ function update_provisioned_product(
             mergewith(_merge, Dict{String,Any}("UpdateToken" => UpdateToken), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3525,6 +3814,7 @@ function update_provisioned_product_properties(
             "ProvisionedProductProperties" => ProvisionedProductProperties,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_provisioned_product_properties(
@@ -3548,6 +3838,7 @@ function update_provisioned_product_properties(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3586,6 +3877,7 @@ function update_provisioning_artifact(
             "ProductId" => ProductId, "ProvisioningArtifactId" => ProvisioningArtifactId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_provisioning_artifact(
@@ -3607,6 +3899,7 @@ function update_provisioning_artifact(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3629,7 +3922,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function update_service_action(Id; aws_config::AbstractAWSConfig=global_aws_config())
     return service_catalog(
-        "UpdateServiceAction", Dict{String,Any}("Id" => Id); aws_config=aws_config
+        "UpdateServiceAction",
+        Dict{String,Any}("Id" => Id);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_service_action(
@@ -3639,6 +3935,7 @@ function update_service_action(
         "UpdateServiceAction",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Id" => Id), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3658,7 +3955,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function update_tag_option(Id; aws_config::AbstractAWSConfig=global_aws_config())
     return service_catalog(
-        "UpdateTagOption", Dict{String,Any}("Id" => Id); aws_config=aws_config
+        "UpdateTagOption",
+        Dict{String,Any}("Id" => Id);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_tag_option(
@@ -3668,5 +3968,6 @@ function update_tag_option(
         "UpdateTagOption",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Id" => Id), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/service_catalog_appregistry.jl
+++ b/src/services/service_catalog_appregistry.jl
@@ -25,6 +25,7 @@ function associate_attribute_group(
         "PUT",
         "/applications/$(application)/attribute-groups/$(attributeGroup)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_attribute_group(
@@ -38,6 +39,7 @@ function associate_attribute_group(
         "/applications/$(application)/attribute-groups/$(attributeGroup)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -61,6 +63,7 @@ function associate_resource(
         "PUT",
         "/applications/$(application)/resources/$(resourceType)/$(resource)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_resource(
@@ -75,6 +78,7 @@ function associate_resource(
         "/applications/$(application)/resources/$(resourceType)/$(resource)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -107,6 +111,7 @@ function create_application(
         "/applications",
         Dict{String,Any}("clientToken" => clientToken, "name" => name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_application(
@@ -126,6 +131,7 @@ function create_application(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -163,6 +169,7 @@ function create_attribute_group(
             "attributes" => attributes, "clientToken" => clientToken, "name" => name
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_attribute_group(
@@ -185,6 +192,7 @@ function create_attribute_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -202,7 +210,10 @@ application.
 """
 function delete_application(application; aws_config::AbstractAWSConfig=global_aws_config())
     return service_catalog_appregistry(
-        "DELETE", "/applications/$(application)"; aws_config=aws_config
+        "DELETE",
+        "/applications/$(application)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_application(
@@ -211,7 +222,11 @@ function delete_application(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return service_catalog_appregistry(
-        "DELETE", "/applications/$(application)", params; aws_config=aws_config
+        "DELETE",
+        "/applications/$(application)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -230,7 +245,10 @@ function delete_attribute_group(
     attributeGroup; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return service_catalog_appregistry(
-        "DELETE", "/attribute-groups/$(attributeGroup)"; aws_config=aws_config
+        "DELETE",
+        "/attribute-groups/$(attributeGroup)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_attribute_group(
@@ -239,7 +257,11 @@ function delete_attribute_group(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return service_catalog_appregistry(
-        "DELETE", "/attribute-groups/$(attributeGroup)", params; aws_config=aws_config
+        "DELETE",
+        "/attribute-groups/$(attributeGroup)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -264,6 +286,7 @@ function disassociate_attribute_group(
         "DELETE",
         "/applications/$(application)/attribute-groups/$(attributeGroup)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disassociate_attribute_group(
@@ -277,6 +300,7 @@ function disassociate_attribute_group(
         "/applications/$(application)/attribute-groups/$(attributeGroup)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -300,6 +324,7 @@ function disassociate_resource(
         "DELETE",
         "/applications/$(application)/resources/$(resourceType)/$(resource)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disassociate_resource(
@@ -314,6 +339,7 @@ function disassociate_resource(
         "/applications/$(application)/resources/$(resourceType)/$(resource)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -333,7 +359,10 @@ avoiding the ABA addressing problem.
 """
 function get_application(application; aws_config::AbstractAWSConfig=global_aws_config())
     return service_catalog_appregistry(
-        "GET", "/applications/$(application)"; aws_config=aws_config
+        "GET",
+        "/applications/$(application)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_application(
@@ -342,7 +371,11 @@ function get_application(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return service_catalog_appregistry(
-        "GET", "/applications/$(application)", params; aws_config=aws_config
+        "GET",
+        "/applications/$(application)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -365,6 +398,7 @@ function get_associated_resource(
         "GET",
         "/applications/$(application)/resources/$(resourceType)/$(resource)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_associated_resource(
@@ -379,6 +413,7 @@ function get_associated_resource(
         "/applications/$(application)/resources/$(resourceType)/$(resource)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -398,7 +433,10 @@ function get_attribute_group(
     attributeGroup; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return service_catalog_appregistry(
-        "GET", "/attribute-groups/$(attributeGroup)"; aws_config=aws_config
+        "GET",
+        "/attribute-groups/$(attributeGroup)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_attribute_group(
@@ -407,7 +445,11 @@ function get_attribute_group(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return service_catalog_appregistry(
-        "GET", "/attribute-groups/$(attributeGroup)", params; aws_config=aws_config
+        "GET",
+        "/attribute-groups/$(attributeGroup)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -425,13 +467,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   call.
 """
 function list_applications(; aws_config::AbstractAWSConfig=global_aws_config())
-    return service_catalog_appregistry("GET", "/applications"; aws_config=aws_config)
+    return service_catalog_appregistry(
+        "GET", "/applications"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_applications(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return service_catalog_appregistry(
-        "GET", "/applications", params; aws_config=aws_config
+        "GET",
+        "/applications",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -456,7 +504,10 @@ function list_associated_attribute_groups(
     application; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return service_catalog_appregistry(
-        "GET", "/applications/$(application)/attribute-groups"; aws_config=aws_config
+        "GET",
+        "/applications/$(application)/attribute-groups";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_associated_attribute_groups(
@@ -469,6 +520,7 @@ function list_associated_attribute_groups(
         "/applications/$(application)/attribute-groups",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -492,7 +544,10 @@ function list_associated_resources(
     application; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return service_catalog_appregistry(
-        "GET", "/applications/$(application)/resources"; aws_config=aws_config
+        "GET",
+        "/applications/$(application)/resources";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_associated_resources(
@@ -501,7 +556,11 @@ function list_associated_resources(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return service_catalog_appregistry(
-        "GET", "/applications/$(application)/resources", params; aws_config=aws_config
+        "GET",
+        "/applications/$(application)/resources",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -519,13 +578,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   call.
 """
 function list_attribute_groups(; aws_config::AbstractAWSConfig=global_aws_config())
-    return service_catalog_appregistry("GET", "/attribute-groups"; aws_config=aws_config)
+    return service_catalog_appregistry(
+        "GET", "/attribute-groups"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_attribute_groups(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return service_catalog_appregistry(
-        "GET", "/attribute-groups", params; aws_config=aws_config
+        "GET",
+        "/attribute-groups",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -542,7 +607,12 @@ Lists all of the tags on the resource.
 function list_tags_for_resource(
     resourceArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return service_catalog_appregistry("GET", "/tags/$(resourceArn)"; aws_config=aws_config)
+    return service_catalog_appregistry(
+        "GET",
+        "/tags/$(resourceArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_tags_for_resource(
     resourceArn,
@@ -550,7 +620,11 @@ function list_tags_for_resource(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return service_catalog_appregistry(
-        "GET", "/tags/$(resourceArn)", params; aws_config=aws_config
+        "GET",
+        "/tags/$(resourceArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -573,7 +647,10 @@ function sync_resource(
     resource, resourceType; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return service_catalog_appregistry(
-        "POST", "/sync/$(resourceType)/$(resource)"; aws_config=aws_config
+        "POST",
+        "/sync/$(resourceType)/$(resource)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function sync_resource(
@@ -583,7 +660,11 @@ function sync_resource(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return service_catalog_appregistry(
-        "POST", "/sync/$(resourceType)/$(resource)", params; aws_config=aws_config
+        "POST",
+        "/sync/$(resourceType)/$(resource)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -607,6 +688,7 @@ function tag_resource(resourceArn, tags; aws_config::AbstractAWSConfig=global_aw
         "/tags/$(resourceArn)",
         Dict{String,Any}("tags" => tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -620,6 +702,7 @@ function tag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tags" => tags), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -643,6 +726,7 @@ function untag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}("tagKeys" => tagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -656,6 +740,7 @@ function untag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tagKeys" => tagKeys), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -676,7 +761,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function update_application(application; aws_config::AbstractAWSConfig=global_aws_config())
     return service_catalog_appregistry(
-        "PATCH", "/applications/$(application)"; aws_config=aws_config
+        "PATCH",
+        "/applications/$(application)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_application(
@@ -685,7 +773,11 @@ function update_application(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return service_catalog_appregistry(
-        "PATCH", "/applications/$(application)", params; aws_config=aws_config
+        "PATCH",
+        "/applications/$(application)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -711,7 +803,10 @@ function update_attribute_group(
     attributeGroup; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return service_catalog_appregistry(
-        "PATCH", "/attribute-groups/$(attributeGroup)"; aws_config=aws_config
+        "PATCH",
+        "/attribute-groups/$(attributeGroup)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_attribute_group(
@@ -720,6 +815,10 @@ function update_attribute_group(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return service_catalog_appregistry(
-        "PATCH", "/attribute-groups/$(attributeGroup)", params; aws_config=aws_config
+        "PATCH",
+        "/attribute-groups/$(attributeGroup)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/service_quotas.jl
+++ b/src/services/service_quotas.jl
@@ -17,12 +17,21 @@ your template.
 function associate_service_quota_template(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return service_quotas("AssociateServiceQuotaTemplate"; aws_config=aws_config)
+    return service_quotas(
+        "AssociateServiceQuotaTemplate";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function associate_service_quota_template(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return service_quotas("AssociateServiceQuotaTemplate", params; aws_config=aws_config)
+    return service_quotas(
+        "AssociateServiceQuotaTemplate",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -46,6 +55,7 @@ function delete_service_quota_increase_request_from_template(
             "AwsRegion" => AwsRegion, "QuotaCode" => QuotaCode, "ServiceCode" => ServiceCode
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_service_quota_increase_request_from_template(
@@ -69,6 +79,7 @@ function delete_service_quota_increase_request_from_template(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -84,12 +95,21 @@ quota request template does not apply its quota increase requests.
 function disassociate_service_quota_template(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return service_quotas("DisassociateServiceQuotaTemplate"; aws_config=aws_config)
+    return service_quotas(
+        "DisassociateServiceQuotaTemplate";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function disassociate_service_quota_template(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return service_quotas("DisassociateServiceQuotaTemplate", params; aws_config=aws_config)
+    return service_quotas(
+        "DisassociateServiceQuotaTemplate",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -102,13 +122,20 @@ Retrieves the status of the association for the quota request template.
 function get_association_for_service_quota_template(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return service_quotas("GetAssociationForServiceQuotaTemplate"; aws_config=aws_config)
+    return service_quotas(
+        "GetAssociationForServiceQuotaTemplate";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_association_for_service_quota_template(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return service_quotas(
-        "GetAssociationForServiceQuotaTemplate", params; aws_config=aws_config
+        "GetAssociationForServiceQuotaTemplate",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -131,6 +158,7 @@ function get_awsdefault_service_quota(
         "GetAWSDefaultServiceQuota",
         Dict{String,Any}("QuotaCode" => QuotaCode, "ServiceCode" => ServiceCode);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_awsdefault_service_quota(
@@ -149,6 +177,7 @@ function get_awsdefault_service_quota(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -169,6 +198,7 @@ function get_requested_service_quota_change(
         "GetRequestedServiceQuotaChange",
         Dict{String,Any}("RequestId" => RequestId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_requested_service_quota_change(
@@ -182,6 +212,7 @@ function get_requested_service_quota_change(
             mergewith(_merge, Dict{String,Any}("RequestId" => RequestId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -205,6 +236,7 @@ function get_service_quota(
         "GetServiceQuota",
         Dict{String,Any}("QuotaCode" => QuotaCode, "ServiceCode" => ServiceCode);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_service_quota(
@@ -223,6 +255,7 @@ function get_service_quota(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -248,6 +281,7 @@ function get_service_quota_increase_request_from_template(
             "AwsRegion" => AwsRegion, "QuotaCode" => QuotaCode, "ServiceCode" => ServiceCode
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_service_quota_increase_request_from_template(
@@ -271,6 +305,7 @@ function get_service_quota_increase_request_from_template(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -297,6 +332,7 @@ function list_awsdefault_service_quotas(
         "ListAWSDefaultServiceQuotas",
         Dict{String,Any}("ServiceCode" => ServiceCode);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_awsdefault_service_quotas(
@@ -310,6 +346,7 @@ function list_awsdefault_service_quotas(
             mergewith(_merge, Dict{String,Any}("ServiceCode" => ServiceCode), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -330,13 +367,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function list_requested_service_quota_change_history(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return service_quotas("ListRequestedServiceQuotaChangeHistory"; aws_config=aws_config)
+    return service_quotas(
+        "ListRequestedServiceQuotaChangeHistory";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_requested_service_quota_change_history(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return service_quotas(
-        "ListRequestedServiceQuotaChangeHistory", params; aws_config=aws_config
+        "ListRequestedServiceQuotaChangeHistory",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -364,6 +408,7 @@ function list_requested_service_quota_change_history_by_quota(
         "ListRequestedServiceQuotaChangeHistoryByQuota",
         Dict{String,Any}("QuotaCode" => QuotaCode, "ServiceCode" => ServiceCode);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_requested_service_quota_change_history_by_quota(
@@ -382,6 +427,7 @@ function list_requested_service_quota_change_history_by_quota(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -403,14 +449,19 @@ function list_service_quota_increase_requests_in_template(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
     return service_quotas(
-        "ListServiceQuotaIncreaseRequestsInTemplate"; aws_config=aws_config
+        "ListServiceQuotaIncreaseRequestsInTemplate";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_service_quota_increase_requests_in_template(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return service_quotas(
-        "ListServiceQuotaIncreaseRequestsInTemplate", params; aws_config=aws_config
+        "ListServiceQuotaIncreaseRequestsInTemplate",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -436,6 +487,7 @@ function list_service_quotas(ServiceCode; aws_config::AbstractAWSConfig=global_a
         "ListServiceQuotas",
         Dict{String,Any}("ServiceCode" => ServiceCode);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_service_quotas(
@@ -449,6 +501,7 @@ function list_service_quotas(
             mergewith(_merge, Dict{String,Any}("ServiceCode" => ServiceCode), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -465,12 +518,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`: The token for the next page of results.
 """
 function list_services(; aws_config::AbstractAWSConfig=global_aws_config())
-    return service_quotas("ListServices"; aws_config=aws_config)
+    return service_quotas(
+        "ListServices"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_services(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return service_quotas("ListServices", params; aws_config=aws_config)
+    return service_quotas(
+        "ListServices", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -493,6 +550,7 @@ function list_tags_for_resource(
         "ListTagsForResource",
         Dict{String,Any}("ResourceARN" => ResourceARN);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags_for_resource(
@@ -506,6 +564,7 @@ function list_tags_for_resource(
             mergewith(_merge, Dict{String,Any}("ResourceARN" => ResourceARN), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -538,6 +597,7 @@ function put_service_quota_increase_request_into_template(
             "ServiceCode" => ServiceCode,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_service_quota_increase_request_into_template(
@@ -563,6 +623,7 @@ function put_service_quota_increase_request_into_template(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -589,6 +650,7 @@ function request_service_quota_increase(
             "ServiceCode" => ServiceCode,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function request_service_quota_increase(
@@ -612,6 +674,7 @@ function request_service_quota_increase(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -634,6 +697,7 @@ function tag_resource(ResourceARN, Tags; aws_config::AbstractAWSConfig=global_aw
         "TagResource",
         Dict{String,Any}("ResourceARN" => ResourceARN, "Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -652,6 +716,7 @@ function tag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -676,6 +741,7 @@ function untag_resource(
         "UntagResource",
         Dict{String,Any}("ResourceARN" => ResourceARN, "TagKeys" => TagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -694,5 +760,6 @@ function untag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/servicediscovery.jl
+++ b/src/services/servicediscovery.jl
@@ -31,6 +31,7 @@ function create_http_namespace(Name; aws_config::AbstractAWSConfig=global_aws_co
         "CreateHttpNamespace",
         Dict{String,Any}("Name" => Name, "CreatorRequestId" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_http_namespace(
@@ -46,6 +47,7 @@ function create_http_namespace(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -87,6 +89,7 @@ function create_private_dns_namespace(
             "Name" => Name, "Vpc" => Vpc, "CreatorRequestId" => string(uuid4())
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_private_dns_namespace(
@@ -107,6 +110,7 @@ function create_private_dns_namespace(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -143,6 +147,7 @@ function create_public_dns_namespace(
         "CreatePublicDnsNamespace",
         Dict{String,Any}("Name" => Name, "CreatorRequestId" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_public_dns_namespace(
@@ -158,6 +163,7 @@ function create_public_dns_namespace(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -219,6 +225,7 @@ function create_service(Name; aws_config::AbstractAWSConfig=global_aws_config())
         "CreateService",
         Dict{String,Any}("Name" => Name, "CreatorRequestId" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_service(
@@ -234,6 +241,7 @@ function create_service(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -250,7 +258,10 @@ services, the request fails.
 """
 function delete_namespace(Id; aws_config::AbstractAWSConfig=global_aws_config())
     return servicediscovery(
-        "DeleteNamespace", Dict{String,Any}("Id" => Id); aws_config=aws_config
+        "DeleteNamespace",
+        Dict{String,Any}("Id" => Id);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_namespace(
@@ -260,6 +271,7 @@ function delete_namespace(
         "DeleteNamespace",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Id" => Id), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -276,7 +288,10 @@ instances, the request fails.
 """
 function delete_service(Id; aws_config::AbstractAWSConfig=global_aws_config())
     return servicediscovery(
-        "DeleteService", Dict{String,Any}("Id" => Id); aws_config=aws_config
+        "DeleteService",
+        Dict{String,Any}("Id" => Id);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_service(
@@ -286,6 +301,7 @@ function delete_service(
         "DeleteService",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Id" => Id), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -308,6 +324,7 @@ function deregister_instance(
         "DeregisterInstance",
         Dict{String,Any}("InstanceId" => InstanceId, "ServiceId" => ServiceId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function deregister_instance(
@@ -326,6 +343,7 @@ function deregister_instance(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -370,6 +388,7 @@ function discover_instances(
         "DiscoverInstances",
         Dict{String,Any}("NamespaceName" => NamespaceName, "ServiceName" => ServiceName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function discover_instances(
@@ -390,6 +409,7 @@ function discover_instances(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -411,6 +431,7 @@ function get_instance(
         "GetInstance",
         Dict{String,Any}("InstanceId" => InstanceId, "ServiceId" => ServiceId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_instance(
@@ -429,6 +450,7 @@ function get_instance(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -465,6 +487,7 @@ function get_instances_health_status(
         "GetInstancesHealthStatus",
         Dict{String,Any}("ServiceId" => ServiceId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_instances_health_status(
@@ -478,6 +501,7 @@ function get_instances_health_status(
             mergewith(_merge, Dict{String,Any}("ServiceId" => ServiceId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -493,7 +517,10 @@ Gets information about a namespace.
 """
 function get_namespace(Id; aws_config::AbstractAWSConfig=global_aws_config())
     return servicediscovery(
-        "GetNamespace", Dict{String,Any}("Id" => Id); aws_config=aws_config
+        "GetNamespace",
+        Dict{String,Any}("Id" => Id);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_namespace(
@@ -503,6 +530,7 @@ function get_namespace(
         "GetNamespace",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Id" => Id), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -523,6 +551,7 @@ function get_operation(OperationId; aws_config::AbstractAWSConfig=global_aws_con
         "GetOperation",
         Dict{String,Any}("OperationId" => OperationId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_operation(
@@ -536,6 +565,7 @@ function get_operation(
             mergewith(_merge, Dict{String,Any}("OperationId" => OperationId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -551,7 +581,10 @@ Gets the settings for a specified service.
 """
 function get_service(Id; aws_config::AbstractAWSConfig=global_aws_config())
     return servicediscovery(
-        "GetService", Dict{String,Any}("Id" => Id); aws_config=aws_config
+        "GetService",
+        Dict{String,Any}("Id" => Id);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_service(
@@ -561,6 +594,7 @@ function get_service(
         "GetService",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Id" => Id), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -586,7 +620,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function list_instances(ServiceId; aws_config::AbstractAWSConfig=global_aws_config())
     return servicediscovery(
-        "ListInstances", Dict{String,Any}("ServiceId" => ServiceId); aws_config=aws_config
+        "ListInstances",
+        Dict{String,Any}("ServiceId" => ServiceId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_instances(
@@ -600,6 +637,7 @@ function list_instances(
             mergewith(_merge, Dict{String,Any}("ServiceId" => ServiceId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -626,12 +664,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   match the criteria.
 """
 function list_namespaces(; aws_config::AbstractAWSConfig=global_aws_config())
-    return servicediscovery("ListNamespaces"; aws_config=aws_config)
+    return servicediscovery(
+        "ListNamespaces"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_namespaces(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return servicediscovery("ListNamespaces", params; aws_config=aws_config)
+    return servicediscovery(
+        "ListNamespaces", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -658,12 +700,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   match the criteria.
 """
 function list_operations(; aws_config::AbstractAWSConfig=global_aws_config())
-    return servicediscovery("ListOperations"; aws_config=aws_config)
+    return servicediscovery(
+        "ListOperations"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_operations(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return servicediscovery("ListOperations", params; aws_config=aws_config)
+    return servicediscovery(
+        "ListOperations", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -690,12 +736,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   criteria.
 """
 function list_services(; aws_config::AbstractAWSConfig=global_aws_config())
-    return servicediscovery("ListServices"; aws_config=aws_config)
+    return servicediscovery(
+        "ListServices"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_services(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return servicediscovery("ListServices", params; aws_config=aws_config)
+    return servicediscovery(
+        "ListServices", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -716,6 +766,7 @@ function list_tags_for_resource(
         "ListTagsForResource",
         Dict{String,Any}("ResourceARN" => ResourceARN);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags_for_resource(
@@ -729,6 +780,7 @@ function list_tags_for_resource(
             mergewith(_merge, Dict{String,Any}("ResourceARN" => ResourceARN), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -829,6 +881,7 @@ function register_instance(
             "CreatorRequestId" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function register_instance(
@@ -853,6 +906,7 @@ function register_instance(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -875,6 +929,7 @@ function tag_resource(ResourceARN, Tags; aws_config::AbstractAWSConfig=global_aw
         "TagResource",
         Dict{String,Any}("ResourceARN" => ResourceARN, "Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -893,6 +948,7 @@ function tag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -915,6 +971,7 @@ function untag_resource(
         "UntagResource",
         Dict{String,Any}("ResourceARN" => ResourceARN, "TagKeys" => TagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -933,6 +990,7 @@ function untag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -961,6 +1019,7 @@ function update_http_namespace(
             "Id" => Id, "Namespace" => Namespace, "UpdaterRequestId" => string(uuid4())
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_http_namespace(
@@ -983,6 +1042,7 @@ function update_http_namespace(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1012,6 +1072,7 @@ function update_instance_custom_health_status(
             "InstanceId" => InstanceId, "ServiceId" => ServiceId, "Status" => Status
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_instance_custom_health_status(
@@ -1033,6 +1094,7 @@ function update_instance_custom_health_status(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1061,6 +1123,7 @@ function update_private_dns_namespace(
             "Id" => Id, "Namespace" => Namespace, "UpdaterRequestId" => string(uuid4())
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_private_dns_namespace(
@@ -1083,6 +1146,7 @@ function update_private_dns_namespace(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1111,6 +1175,7 @@ function update_public_dns_namespace(
             "Id" => Id, "Namespace" => Namespace, "UpdaterRequestId" => string(uuid4())
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_public_dns_namespace(
@@ -1133,6 +1198,7 @@ function update_public_dns_namespace(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1161,6 +1227,7 @@ function update_service(Id, Service; aws_config::AbstractAWSConfig=global_aws_co
         "UpdateService",
         Dict{String,Any}("Id" => Id, "Service" => Service);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_service(
@@ -1175,5 +1242,6 @@ function update_service(
             mergewith(_merge, Dict{String,Any}("Id" => Id, "Service" => Service), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/ses.jl
+++ b/src/services/ses.jl
@@ -29,6 +29,7 @@ function clone_receipt_rule_set(
             "OriginalRuleSetName" => OriginalRuleSetName, "RuleSetName" => RuleSetName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function clone_receipt_rule_set(
@@ -50,6 +51,7 @@ function clone_receipt_rule_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -72,6 +74,7 @@ function create_configuration_set(
         "CreateConfigurationSet",
         Dict{String,Any}("ConfigurationSet" => ConfigurationSet);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_configuration_set(
@@ -87,6 +90,7 @@ function create_configuration_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -121,6 +125,7 @@ function create_configuration_set_event_destination(
             "EventDestination" => EventDestination,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_configuration_set_event_destination(
@@ -142,6 +147,7 @@ function create_configuration_set_event_destination(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -171,6 +177,7 @@ function create_configuration_set_tracking_options(
             "TrackingOptions" => TrackingOptions,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_configuration_set_tracking_options(
@@ -192,6 +199,7 @@ function create_configuration_set_tracking_options(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -237,6 +245,7 @@ function create_custom_verification_email_template(
             "TemplateSubject" => TemplateSubject,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_custom_verification_email_template(
@@ -266,6 +275,7 @@ function create_custom_verification_email_template(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -283,7 +293,10 @@ the Amazon SES Developer Guide. You can execute this operation no more than once
 """
 function create_receipt_filter(Filter; aws_config::AbstractAWSConfig=global_aws_config())
     return ses(
-        "CreateReceiptFilter", Dict{String,Any}("Filter" => Filter); aws_config=aws_config
+        "CreateReceiptFilter",
+        Dict{String,Any}("Filter" => Filter);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_receipt_filter(
@@ -293,6 +306,7 @@ function create_receipt_filter(
         "CreateReceiptFilter",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Filter" => Filter), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -320,6 +334,7 @@ function create_receipt_rule(
         "CreateReceiptRule",
         Dict{String,Any}("Rule" => Rule, "RuleSetName" => RuleSetName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_receipt_rule(
@@ -338,6 +353,7 @@ function create_receipt_rule(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -361,6 +377,7 @@ function create_receipt_rule_set(
         "CreateReceiptRuleSet",
         Dict{String,Any}("RuleSetName" => RuleSetName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_receipt_rule_set(
@@ -374,6 +391,7 @@ function create_receipt_rule_set(
             mergewith(_merge, Dict{String,Any}("RuleSetName" => RuleSetName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -392,7 +410,10 @@ Developer Guide. You can execute this operation no more than once per second.
 """
 function create_template(Template; aws_config::AbstractAWSConfig=global_aws_config())
     return ses(
-        "CreateTemplate", Dict{String,Any}("Template" => Template); aws_config=aws_config
+        "CreateTemplate",
+        Dict{String,Any}("Template" => Template);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_template(
@@ -406,6 +427,7 @@ function create_template(
             mergewith(_merge, Dict{String,Any}("Template" => Template), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -428,6 +450,7 @@ function delete_configuration_set(
         "DeleteConfigurationSet",
         Dict{String,Any}("ConfigurationSetName" => ConfigurationSetName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_configuration_set(
@@ -445,6 +468,7 @@ function delete_configuration_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -475,6 +499,7 @@ function delete_configuration_set_event_destination(
             "EventDestinationName" => EventDestinationName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_configuration_set_event_destination(
@@ -496,6 +521,7 @@ function delete_configuration_set_event_destination(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -523,6 +549,7 @@ function delete_configuration_set_tracking_options(
         "DeleteConfigurationSetTrackingOptions",
         Dict{String,Any}("ConfigurationSetName" => ConfigurationSetName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_configuration_set_tracking_options(
@@ -540,6 +567,7 @@ function delete_configuration_set_tracking_options(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -563,6 +591,7 @@ function delete_custom_verification_email_template(
         "DeleteCustomVerificationEmailTemplate",
         Dict{String,Any}("TemplateName" => TemplateName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_custom_verification_email_template(
@@ -576,6 +605,7 @@ function delete_custom_verification_email_template(
             mergewith(_merge, Dict{String,Any}("TemplateName" => TemplateName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -592,7 +622,10 @@ identities. You can execute this operation no more than once per second.
 """
 function delete_identity(Identity; aws_config::AbstractAWSConfig=global_aws_config())
     return ses(
-        "DeleteIdentity", Dict{String,Any}("Identity" => Identity); aws_config=aws_config
+        "DeleteIdentity",
+        Dict{String,Any}("Identity" => Identity);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_identity(
@@ -606,6 +639,7 @@ function delete_identity(
             mergewith(_merge, Dict{String,Any}("Identity" => Identity), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -637,6 +671,7 @@ function delete_identity_policy(
         "DeleteIdentityPolicy",
         Dict{String,Any}("Identity" => Identity, "PolicyName" => PolicyName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_identity_policy(
@@ -655,6 +690,7 @@ function delete_identity_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -677,6 +713,7 @@ function delete_receipt_filter(
         "DeleteReceiptFilter",
         Dict{String,Any}("FilterName" => FilterName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_receipt_filter(
@@ -690,6 +727,7 @@ function delete_receipt_filter(
             mergewith(_merge, Dict{String,Any}("FilterName" => FilterName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -713,6 +751,7 @@ function delete_receipt_rule(
         "DeleteReceiptRule",
         Dict{String,Any}("RuleName" => RuleName, "RuleSetName" => RuleSetName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_receipt_rule(
@@ -731,6 +770,7 @@ function delete_receipt_rule(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -754,6 +794,7 @@ function delete_receipt_rule_set(
         "DeleteReceiptRuleSet",
         Dict{String,Any}("RuleSetName" => RuleSetName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_receipt_rule_set(
@@ -767,6 +808,7 @@ function delete_receipt_rule_set(
             mergewith(_merge, Dict{String,Any}("RuleSetName" => RuleSetName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -785,6 +827,7 @@ function delete_template(TemplateName; aws_config::AbstractAWSConfig=global_aws_
         "DeleteTemplate",
         Dict{String,Any}("TemplateName" => TemplateName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_template(
@@ -798,6 +841,7 @@ function delete_template(
             mergewith(_merge, Dict{String,Any}("TemplateName" => TemplateName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -818,6 +862,7 @@ function delete_verified_email_address(
         "DeleteVerifiedEmailAddress",
         Dict{String,Any}("EmailAddress" => EmailAddress);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_verified_email_address(
@@ -831,6 +876,7 @@ function delete_verified_email_address(
             mergewith(_merge, Dict{String,Any}("EmailAddress" => EmailAddress), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -846,12 +892,21 @@ can execute this operation no more than once per second.
 function describe_active_receipt_rule_set(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ses("DescribeActiveReceiptRuleSet"; aws_config=aws_config)
+    return ses(
+        "DescribeActiveReceiptRuleSet";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_active_receipt_rule_set(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ses("DescribeActiveReceiptRuleSet", params; aws_config=aws_config)
+    return ses(
+        "DescribeActiveReceiptRuleSet",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -876,6 +931,7 @@ function describe_configuration_set(
         "DescribeConfigurationSet",
         Dict{String,Any}("ConfigurationSetName" => ConfigurationSetName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_configuration_set(
@@ -893,6 +949,7 @@ function describe_configuration_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -916,6 +973,7 @@ function describe_receipt_rule(
         "DescribeReceiptRule",
         Dict{String,Any}("RuleName" => RuleName, "RuleSetName" => RuleSetName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_receipt_rule(
@@ -934,6 +992,7 @@ function describe_receipt_rule(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -956,6 +1015,7 @@ function describe_receipt_rule_set(
         "DescribeReceiptRuleSet",
         Dict{String,Any}("RuleSetName" => RuleSetName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_receipt_rule_set(
@@ -969,6 +1029,7 @@ function describe_receipt_rule_set(
             mergewith(_merge, Dict{String,Any}("RuleSetName" => RuleSetName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -981,12 +1042,19 @@ execute this operation no more than once per second.
 
 """
 function get_account_sending_enabled(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ses("GetAccountSendingEnabled"; aws_config=aws_config)
+    return ses(
+        "GetAccountSendingEnabled"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_account_sending_enabled(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ses("GetAccountSendingEnabled", params; aws_config=aws_config)
+    return ses(
+        "GetAccountSendingEnabled",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1010,6 +1078,7 @@ function get_custom_verification_email_template(
         "GetCustomVerificationEmailTemplate",
         Dict{String,Any}("TemplateName" => TemplateName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_custom_verification_email_template(
@@ -1023,6 +1092,7 @@ function get_custom_verification_email_template(
             mergewith(_merge, Dict{String,Any}("TemplateName" => TemplateName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1055,6 +1125,7 @@ function get_identity_dkim_attributes(
         "GetIdentityDkimAttributes",
         Dict{String,Any}("Identities" => Identities);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_identity_dkim_attributes(
@@ -1068,6 +1139,7 @@ function get_identity_dkim_attributes(
             mergewith(_merge, Dict{String,Any}("Identities" => Identities), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1090,6 +1162,7 @@ function get_identity_mail_from_domain_attributes(
         "GetIdentityMailFromDomainAttributes",
         Dict{String,Any}("Identities" => Identities);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_identity_mail_from_domain_attributes(
@@ -1103,6 +1176,7 @@ function get_identity_mail_from_domain_attributes(
             mergewith(_merge, Dict{String,Any}("Identities" => Identities), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1129,6 +1203,7 @@ function get_identity_notification_attributes(
         "GetIdentityNotificationAttributes",
         Dict{String,Any}("Identities" => Identities);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_identity_notification_attributes(
@@ -1142,6 +1217,7 @@ function get_identity_notification_attributes(
             mergewith(_merge, Dict{String,Any}("Identities" => Identities), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1174,6 +1250,7 @@ function get_identity_policies(
         "GetIdentityPolicies",
         Dict{String,Any}("Identity" => Identity, "PolicyNames" => PolicyNames);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_identity_policies(
@@ -1192,6 +1269,7 @@ function get_identity_policies(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1226,6 +1304,7 @@ function get_identity_verification_attributes(
         "GetIdentityVerificationAttributes",
         Dict{String,Any}("Identities" => Identities);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_identity_verification_attributes(
@@ -1239,6 +1318,7 @@ function get_identity_verification_attributes(
             mergewith(_merge, Dict{String,Any}("Identities" => Identities), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1251,12 +1331,14 @@ more than once per second.
 
 """
 function get_send_quota(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ses("GetSendQuota"; aws_config=aws_config)
+    return ses("GetSendQuota"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function get_send_quota(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ses("GetSendQuota", params; aws_config=aws_config)
+    return ses(
+        "GetSendQuota", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1270,12 +1352,14 @@ than once per second.
 
 """
 function get_send_statistics(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ses("GetSendStatistics"; aws_config=aws_config)
+    return ses("GetSendStatistics"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function get_send_statistics(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ses("GetSendStatistics", params; aws_config=aws_config)
+    return ses(
+        "GetSendStatistics", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1294,6 +1378,7 @@ function get_template(TemplateName; aws_config::AbstractAWSConfig=global_aws_con
         "GetTemplate",
         Dict{String,Any}("TemplateName" => TemplateName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_template(
@@ -1307,6 +1392,7 @@ function get_template(
             mergewith(_merge, Dict{String,Any}("TemplateName" => TemplateName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1330,12 +1416,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   the position of the configuration set in the configuration set list.
 """
 function list_configuration_sets(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ses("ListConfigurationSets"; aws_config=aws_config)
+    return ses(
+        "ListConfigurationSets"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_configuration_sets(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ses("ListConfigurationSets", params; aws_config=aws_config)
+    return ses(
+        "ListConfigurationSets",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1359,12 +1452,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function list_custom_verification_email_templates(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ses("ListCustomVerificationEmailTemplates"; aws_config=aws_config)
+    return ses(
+        "ListCustomVerificationEmailTemplates";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_custom_verification_email_templates(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ses("ListCustomVerificationEmailTemplates", params; aws_config=aws_config)
+    return ses(
+        "ListCustomVerificationEmailTemplates",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1385,12 +1487,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`: The token to use for pagination.
 """
 function list_identities(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ses("ListIdentities"; aws_config=aws_config)
+    return ses("ListIdentities"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_identities(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ses("ListIdentities", params; aws_config=aws_config)
+    return ses(
+        "ListIdentities", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1418,6 +1522,7 @@ function list_identity_policies(Identity; aws_config::AbstractAWSConfig=global_a
         "ListIdentityPolicies",
         Dict{String,Any}("Identity" => Identity);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_identity_policies(
@@ -1431,6 +1536,7 @@ function list_identity_policies(
             mergewith(_merge, Dict{String,Any}("Identity" => Identity), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1444,12 +1550,14 @@ can execute this operation no more than once per second.
 
 """
 function list_receipt_filters(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ses("ListReceiptFilters"; aws_config=aws_config)
+    return ses("ListReceiptFilters"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_receipt_filters(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ses("ListReceiptFilters", params; aws_config=aws_config)
+    return ses(
+        "ListReceiptFilters", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1468,12 +1576,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   the position in the receipt rule set list.
 """
 function list_receipt_rule_sets(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ses("ListReceiptRuleSets"; aws_config=aws_config)
+    return ses(
+        "ListReceiptRuleSets"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_receipt_rule_sets(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ses("ListReceiptRuleSets", params; aws_config=aws_config)
+    return ses(
+        "ListReceiptRuleSets",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1492,12 +1607,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   position in the list of email templates.
 """
 function list_templates(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ses("ListTemplates"; aws_config=aws_config)
+    return ses("ListTemplates"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_templates(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ses("ListTemplates", params; aws_config=aws_config)
+    return ses(
+        "ListTemplates", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1509,12 +1626,19 @@ associated with your account.
 
 """
 function list_verified_email_addresses(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ses("ListVerifiedEmailAddresses"; aws_config=aws_config)
+    return ses(
+        "ListVerifiedEmailAddresses"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_verified_email_addresses(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ses("ListVerifiedEmailAddresses", params; aws_config=aws_config)
+    return ses(
+        "ListVerifiedEmailAddresses",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1539,6 +1663,7 @@ function put_configuration_set_delivery_options(
         "PutConfigurationSetDeliveryOptions",
         Dict{String,Any}("ConfigurationSetName" => ConfigurationSetName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_configuration_set_delivery_options(
@@ -1556,6 +1681,7 @@ function put_configuration_set_delivery_options(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1591,6 +1717,7 @@ function put_identity_policy(
             "Identity" => Identity, "Policy" => Policy, "PolicyName" => PolicyName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_identity_policy(
@@ -1612,6 +1739,7 @@ function put_identity_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1638,6 +1766,7 @@ function reorder_receipt_rule_set(
         "ReorderReceiptRuleSet",
         Dict{String,Any}("RuleNames" => RuleNames, "RuleSetName" => RuleSetName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function reorder_receipt_rule_set(
@@ -1656,6 +1785,7 @@ function reorder_receipt_rule_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1702,6 +1832,7 @@ function send_bounce(
             "OriginalMessageId" => OriginalMessageId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function send_bounce(
@@ -1725,6 +1856,7 @@ function send_bounce(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1817,6 +1949,7 @@ function send_bulk_templated_email(
             "Destinations" => Destinations, "Source" => Source, "Template" => Template
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function send_bulk_templated_email(
@@ -1840,6 +1973,7 @@ function send_bulk_templated_email(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1871,6 +2005,7 @@ function send_custom_verification_email(
         "SendCustomVerificationEmail",
         Dict{String,Any}("EmailAddress" => EmailAddress, "TemplateName" => TemplateName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function send_custom_verification_email(
@@ -1891,6 +2026,7 @@ function send_custom_verification_email(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1978,6 +2114,7 @@ function send_email(
             "Destination" => Destination, "Message" => Message, "Source" => Source
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function send_email(
@@ -1999,6 +2136,7 @@ function send_email(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2115,7 +2253,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function send_raw_email(RawMessage; aws_config::AbstractAWSConfig=global_aws_config())
     return ses(
-        "SendRawEmail", Dict{String,Any}("RawMessage" => RawMessage); aws_config=aws_config
+        "SendRawEmail",
+        Dict{String,Any}("RawMessage" => RawMessage);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function send_raw_email(
@@ -2129,6 +2270,7 @@ function send_raw_email(
             mergewith(_merge, Dict{String,Any}("RawMessage" => RawMessage), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2232,6 +2374,7 @@ function send_templated_email(
             "TemplateData" => TemplateData,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function send_templated_email(
@@ -2257,6 +2400,7 @@ function send_templated_email(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2275,12 +2419,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   null disables all email receiving.
 """
 function set_active_receipt_rule_set(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ses("SetActiveReceiptRuleSet"; aws_config=aws_config)
+    return ses(
+        "SetActiveReceiptRuleSet"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function set_active_receipt_rule_set(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ses("SetActiveReceiptRuleSet", params; aws_config=aws_config)
+    return ses(
+        "SetActiveReceiptRuleSet",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2311,6 +2462,7 @@ function set_identity_dkim_enabled(
         "SetIdentityDkimEnabled",
         Dict{String,Any}("DkimEnabled" => DkimEnabled, "Identity" => Identity);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function set_identity_dkim_enabled(
@@ -2329,6 +2481,7 @@ function set_identity_dkim_enabled(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2362,6 +2515,7 @@ function set_identity_feedback_forwarding_enabled(
         "SetIdentityFeedbackForwardingEnabled",
         Dict{String,Any}("ForwardingEnabled" => ForwardingEnabled, "Identity" => Identity);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function set_identity_feedback_forwarding_enabled(
@@ -2382,6 +2536,7 @@ function set_identity_feedback_forwarding_enabled(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2417,6 +2572,7 @@ function set_identity_headers_in_notifications_enabled(
             "NotificationType" => NotificationType,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function set_identity_headers_in_notifications_enabled(
@@ -2440,6 +2596,7 @@ function set_identity_headers_in_notifications_enabled(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2480,6 +2637,7 @@ function set_identity_mail_from_domain(
         "SetIdentityMailFromDomain",
         Dict{String,Any}("Identity" => Identity);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function set_identity_mail_from_domain(
@@ -2493,6 +2651,7 @@ function set_identity_mail_from_domain(
             mergewith(_merge, Dict{String,Any}("Identity" => Identity), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2530,6 +2689,7 @@ function set_identity_notification_topic(
         "SetIdentityNotificationTopic",
         Dict{String,Any}("Identity" => Identity, "NotificationType" => NotificationType);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function set_identity_notification_topic(
@@ -2550,6 +2710,7 @@ function set_identity_notification_topic(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2577,6 +2738,7 @@ function set_receipt_rule_position(
         "SetReceiptRulePosition",
         Dict{String,Any}("RuleName" => RuleName, "RuleSetName" => RuleSetName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function set_receipt_rule_position(
@@ -2595,6 +2757,7 @@ function set_receipt_rule_position(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2619,6 +2782,7 @@ function test_render_template(
         "TestRenderTemplate",
         Dict{String,Any}("TemplateData" => TemplateData, "TemplateName" => TemplateName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function test_render_template(
@@ -2639,6 +2803,7 @@ function test_render_template(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2658,12 +2823,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   account in the current AWS Region.
 """
 function update_account_sending_enabled(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ses("UpdateAccountSendingEnabled"; aws_config=aws_config)
+    return ses(
+        "UpdateAccountSendingEnabled";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function update_account_sending_enabled(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ses("UpdateAccountSendingEnabled", params; aws_config=aws_config)
+    return ses(
+        "UpdateAccountSendingEnabled",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2698,6 +2872,7 @@ function update_configuration_set_event_destination(
             "EventDestination" => EventDestination,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_configuration_set_event_destination(
@@ -2719,6 +2894,7 @@ function update_configuration_set_event_destination(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2747,6 +2923,7 @@ function update_configuration_set_reputation_metrics_enabled(
             "ConfigurationSetName" => ConfigurationSetName, "Enabled" => Enabled
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_configuration_set_reputation_metrics_enabled(
@@ -2767,6 +2944,7 @@ function update_configuration_set_reputation_metrics_enabled(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2795,6 +2973,7 @@ function update_configuration_set_sending_enabled(
             "ConfigurationSetName" => ConfigurationSetName, "Enabled" => Enabled
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_configuration_set_sending_enabled(
@@ -2815,6 +2994,7 @@ function update_configuration_set_sending_enabled(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2844,6 +3024,7 @@ function update_configuration_set_tracking_options(
             "TrackingOptions" => TrackingOptions,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_configuration_set_tracking_options(
@@ -2865,6 +3046,7 @@ function update_configuration_set_tracking_options(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2900,6 +3082,7 @@ function update_custom_verification_email_template(
         "UpdateCustomVerificationEmailTemplate",
         Dict{String,Any}("TemplateName" => TemplateName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_custom_verification_email_template(
@@ -2913,6 +3096,7 @@ function update_custom_verification_email_template(
             mergewith(_merge, Dict{String,Any}("TemplateName" => TemplateName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2935,6 +3119,7 @@ function update_receipt_rule(
         "UpdateReceiptRule",
         Dict{String,Any}("Rule" => Rule, "RuleSetName" => RuleSetName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_receipt_rule(
@@ -2953,6 +3138,7 @@ function update_receipt_rule(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2970,7 +3156,10 @@ Developer Guide. You can execute this operation no more than once per second.
 """
 function update_template(Template; aws_config::AbstractAWSConfig=global_aws_config())
     return ses(
-        "UpdateTemplate", Dict{String,Any}("Template" => Template); aws_config=aws_config
+        "UpdateTemplate",
+        Dict{String,Any}("Template" => Template);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_template(
@@ -2984,6 +3173,7 @@ function update_template(
             mergewith(_merge, Dict{String,Any}("Template" => Template), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3014,7 +3204,10 @@ operation no more than once per second.
 """
 function verify_domain_dkim(Domain; aws_config::AbstractAWSConfig=global_aws_config())
     return ses(
-        "VerifyDomainDkim", Dict{String,Any}("Domain" => Domain); aws_config=aws_config
+        "VerifyDomainDkim",
+        Dict{String,Any}("Domain" => Domain);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function verify_domain_dkim(
@@ -3024,6 +3217,7 @@ function verify_domain_dkim(
         "VerifyDomainDkim",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Domain" => Domain), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3042,7 +3236,10 @@ this operation no more than once per second.
 """
 function verify_domain_identity(Domain; aws_config::AbstractAWSConfig=global_aws_config())
     return ses(
-        "VerifyDomainIdentity", Dict{String,Any}("Domain" => Domain); aws_config=aws_config
+        "VerifyDomainIdentity",
+        Dict{String,Any}("Domain" => Domain);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function verify_domain_identity(
@@ -3052,6 +3249,7 @@ function verify_domain_identity(
         "VerifyDomainIdentity",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Domain" => Domain), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3072,6 +3270,7 @@ function verify_email_address(
         "VerifyEmailAddress",
         Dict{String,Any}("EmailAddress" => EmailAddress);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function verify_email_address(
@@ -3085,6 +3284,7 @@ function verify_email_address(
             mergewith(_merge, Dict{String,Any}("EmailAddress" => EmailAddress), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3108,6 +3308,7 @@ function verify_email_identity(
         "VerifyEmailIdentity",
         Dict{String,Any}("EmailAddress" => EmailAddress);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function verify_email_identity(
@@ -3121,5 +3322,6 @@ function verify_email_identity(
             mergewith(_merge, Dict{String,Any}("EmailAddress" => EmailAddress), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/sesv2.jl
+++ b/src/services/sesv2.jl
@@ -39,6 +39,7 @@ function create_configuration_set(
         "/v2/email/configuration-sets",
         Dict{String,Any}("ConfigurationSetName" => ConfigurationSetName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_configuration_set(
@@ -57,6 +58,7 @@ function create_configuration_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -93,6 +95,7 @@ function create_configuration_set_event_destination(
             "EventDestinationName" => EventDestinationName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_configuration_set_event_destination(
@@ -116,6 +119,7 @@ function create_configuration_set_event_destination(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -146,6 +150,7 @@ function create_contact(
         "/v2/email/contact-lists/$(ContactListName)/contacts",
         Dict{String,Any}("EmailAddress" => EmailAddress);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_contact(
@@ -161,6 +166,7 @@ function create_contact(
             mergewith(_merge, Dict{String,Any}("EmailAddress" => EmailAddress), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -188,6 +194,7 @@ function create_contact_list(
         "/v2/email/contact-lists",
         Dict{String,Any}("ContactListName" => ContactListName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_contact_list(
@@ -204,6 +211,7 @@ function create_contact_list(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -250,6 +258,7 @@ function create_custom_verification_email_template(
             "TemplateSubject" => TemplateSubject,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_custom_verification_email_template(
@@ -280,6 +289,7 @@ function create_custom_verification_email_template(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -308,6 +318,7 @@ function create_dedicated_ip_pool(
         "/v2/email/dedicated-ip-pools",
         Dict{String,Any}("PoolName" => PoolName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_dedicated_ip_pool(
@@ -322,6 +333,7 @@ function create_dedicated_ip_pool(
             mergewith(_merge, Dict{String,Any}("PoolName" => PoolName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -358,6 +370,7 @@ function create_deliverability_test_report(
         "/v2/email/deliverability-dashboard/test",
         Dict{String,Any}("Content" => Content, "FromEmailAddress" => FromEmailAddress);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_deliverability_test_report(
@@ -379,6 +392,7 @@ function create_deliverability_test_report(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -431,6 +445,7 @@ function create_email_identity(
         "/v2/email/identities",
         Dict{String,Any}("EmailIdentity" => EmailIdentity);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_email_identity(
@@ -445,6 +460,7 @@ function create_email_identity(
             mergewith(_merge, Dict{String,Any}("EmailIdentity" => EmailIdentity), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -476,6 +492,7 @@ function create_email_identity_policy(
         "/v2/email/identities/$(EmailIdentity)/policies/$(PolicyName)",
         Dict{String,Any}("Policy" => Policy);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_email_identity_policy(
@@ -490,6 +507,7 @@ function create_email_identity_policy(
         "/v2/email/identities/$(EmailIdentity)/policies/$(PolicyName)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Policy" => Policy), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -517,6 +535,7 @@ function create_email_template(
             "TemplateContent" => TemplateContent, "TemplateName" => TemplateName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_email_template(
@@ -538,6 +557,7 @@ function create_email_template(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -562,6 +582,7 @@ function create_import_job(
             "ImportDataSource" => ImportDataSource, "ImportDestination" => ImportDestination
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_import_job(
@@ -584,6 +605,7 @@ function create_import_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -608,6 +630,7 @@ function delete_configuration_set(
         "DELETE",
         "/v2/email/configuration-sets/$(ConfigurationSetName)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_configuration_set(
@@ -620,6 +643,7 @@ function delete_configuration_set(
         "/v2/email/configuration-sets/$(ConfigurationSetName)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -648,6 +672,7 @@ function delete_configuration_set_event_destination(
         "DELETE",
         "/v2/email/configuration-sets/$(ConfigurationSetName)/event-destinations/$(EventDestinationName)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_configuration_set_event_destination(
@@ -661,6 +686,7 @@ function delete_configuration_set_event_destination(
         "/v2/email/configuration-sets/$(ConfigurationSetName)/event-destinations/$(EventDestinationName)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -683,6 +709,7 @@ function delete_contact(
         "DELETE",
         "/v2/email/contact-lists/$(ContactListName)/contacts/$(EmailAddress)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_contact(
@@ -696,6 +723,7 @@ function delete_contact(
         "/v2/email/contact-lists/$(ContactListName)/contacts/$(EmailAddress)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -713,7 +741,10 @@ function delete_contact_list(
     ContactListName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return sesv2(
-        "DELETE", "/v2/email/contact-lists/$(ContactListName)"; aws_config=aws_config
+        "DELETE",
+        "/v2/email/contact-lists/$(ContactListName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_contact_list(
@@ -726,6 +757,7 @@ function delete_contact_list(
         "/v2/email/contact-lists/$(ContactListName)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -749,6 +781,7 @@ function delete_custom_verification_email_template(
         "DELETE",
         "/v2/email/custom-verification-email-templates/$(TemplateName)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_custom_verification_email_template(
@@ -761,6 +794,7 @@ function delete_custom_verification_email_template(
         "/v2/email/custom-verification-email-templates/$(TemplateName)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -778,7 +812,10 @@ function delete_dedicated_ip_pool(
     PoolName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return sesv2(
-        "DELETE", "/v2/email/dedicated-ip-pools/$(PoolName)"; aws_config=aws_config
+        "DELETE",
+        "/v2/email/dedicated-ip-pools/$(PoolName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_dedicated_ip_pool(
@@ -787,7 +824,11 @@ function delete_dedicated_ip_pool(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return sesv2(
-        "DELETE", "/v2/email/dedicated-ip-pools/$(PoolName)", params; aws_config=aws_config
+        "DELETE",
+        "/v2/email/dedicated-ip-pools/$(PoolName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -805,7 +846,12 @@ Deletes an email identity. An identity can be either an email address or a domai
 function delete_email_identity(
     EmailIdentity; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sesv2("DELETE", "/v2/email/identities/$(EmailIdentity)"; aws_config=aws_config)
+    return sesv2(
+        "DELETE",
+        "/v2/email/identities/$(EmailIdentity)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_email_identity(
     EmailIdentity,
@@ -813,7 +859,11 @@ function delete_email_identity(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return sesv2(
-        "DELETE", "/v2/email/identities/$(EmailIdentity)", params; aws_config=aws_config
+        "DELETE",
+        "/v2/email/identities/$(EmailIdentity)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -842,6 +892,7 @@ function delete_email_identity_policy(
         "DELETE",
         "/v2/email/identities/$(EmailIdentity)/policies/$(PolicyName)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_email_identity_policy(
@@ -855,6 +906,7 @@ function delete_email_identity_policy(
         "/v2/email/identities/$(EmailIdentity)/policies/$(PolicyName)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -871,7 +923,12 @@ Deletes an email template. You can execute this operation no more than once per 
 function delete_email_template(
     TemplateName; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sesv2("DELETE", "/v2/email/templates/$(TemplateName)"; aws_config=aws_config)
+    return sesv2(
+        "DELETE",
+        "/v2/email/templates/$(TemplateName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_email_template(
     TemplateName,
@@ -879,7 +936,11 @@ function delete_email_template(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return sesv2(
-        "DELETE", "/v2/email/templates/$(TemplateName)", params; aws_config=aws_config
+        "DELETE",
+        "/v2/email/templates/$(TemplateName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -898,7 +959,10 @@ function delete_suppressed_destination(
     EmailAddress; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return sesv2(
-        "DELETE", "/v2/email/suppression/addresses/$(EmailAddress)"; aws_config=aws_config
+        "DELETE",
+        "/v2/email/suppression/addresses/$(EmailAddress)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_suppressed_destination(
@@ -911,6 +975,7 @@ function delete_suppressed_destination(
         "/v2/email/suppression/addresses/$(EmailAddress)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -923,12 +988,20 @@ account in the current AWS Region.
 
 """
 function get_account(; aws_config::AbstractAWSConfig=global_aws_config())
-    return sesv2("GET", "/v2/email/account"; aws_config=aws_config)
+    return sesv2(
+        "GET", "/v2/email/account"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_account(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sesv2("GET", "/v2/email/account", params; aws_config=aws_config)
+    return sesv2(
+        "GET",
+        "/v2/email/account",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -951,6 +1024,7 @@ function get_blacklist_reports(
         "/v2/email/deliverability-dashboard/blacklist-report",
         Dict{String,Any}("BlacklistItemNames" => BlacklistItemNames);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_blacklist_reports(
@@ -967,6 +1041,7 @@ function get_blacklist_reports(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -990,7 +1065,10 @@ function get_configuration_set(
     ConfigurationSetName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return sesv2(
-        "GET", "/v2/email/configuration-sets/$(ConfigurationSetName)"; aws_config=aws_config
+        "GET",
+        "/v2/email/configuration-sets/$(ConfigurationSetName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_configuration_set(
@@ -1003,6 +1081,7 @@ function get_configuration_set(
         "/v2/email/configuration-sets/$(ConfigurationSetName)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1029,6 +1108,7 @@ function get_configuration_set_event_destinations(
         "GET",
         "/v2/email/configuration-sets/$(ConfigurationSetName)/event-destinations";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_configuration_set_event_destinations(
@@ -1041,6 +1121,7 @@ function get_configuration_set_event_destinations(
         "/v2/email/configuration-sets/$(ConfigurationSetName)/event-destinations",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1062,6 +1143,7 @@ function get_contact(
         "GET",
         "/v2/email/contact-lists/$(ContactListName)/contacts/$(EmailAddress)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_contact(
@@ -1075,6 +1157,7 @@ function get_contact(
         "/v2/email/contact-lists/$(ContactListName)/contacts/$(EmailAddress)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1092,7 +1175,12 @@ present in the list.
 function get_contact_list(
     ContactListName; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sesv2("GET", "/v2/email/contact-lists/$(ContactListName)"; aws_config=aws_config)
+    return sesv2(
+        "GET",
+        "/v2/email/contact-lists/$(ContactListName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_contact_list(
     ContactListName,
@@ -1100,7 +1188,11 @@ function get_contact_list(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return sesv2(
-        "GET", "/v2/email/contact-lists/$(ContactListName)", params; aws_config=aws_config
+        "GET",
+        "/v2/email/contact-lists/$(ContactListName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1125,6 +1217,7 @@ function get_custom_verification_email_template(
         "GET",
         "/v2/email/custom-verification-email-templates/$(TemplateName)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_custom_verification_email_template(
@@ -1137,6 +1230,7 @@ function get_custom_verification_email_template(
         "/v2/email/custom-verification-email-templates/$(TemplateName)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1154,12 +1248,23 @@ address.
 
 """
 function get_dedicated_ip(IP; aws_config::AbstractAWSConfig=global_aws_config())
-    return sesv2("GET", "/v2/email/dedicated-ips/$(IP)"; aws_config=aws_config)
+    return sesv2(
+        "GET",
+        "/v2/email/dedicated-ips/$(IP)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_dedicated_ip(
     IP, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sesv2("GET", "/v2/email/dedicated-ips/$(IP)", params; aws_config=aws_config)
+    return sesv2(
+        "GET",
+        "/v2/email/dedicated-ips/$(IP)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1178,12 +1283,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"PoolName"`: The name of the IP pool that the dedicated IP address is associated with.
 """
 function get_dedicated_ips(; aws_config::AbstractAWSConfig=global_aws_config())
-    return sesv2("GET", "/v2/email/dedicated-ips"; aws_config=aws_config)
+    return sesv2(
+        "GET",
+        "/v2/email/dedicated-ips";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_dedicated_ips(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sesv2("GET", "/v2/email/dedicated-ips", params; aws_config=aws_config)
+    return sesv2(
+        "GET",
+        "/v2/email/dedicated-ips",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1202,12 +1318,23 @@ and cost of a Deliverability dashboard subscription, see Amazon SES Pricing.
 function get_deliverability_dashboard_options(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sesv2("GET", "/v2/email/deliverability-dashboard"; aws_config=aws_config)
+    return sesv2(
+        "GET",
+        "/v2/email/deliverability-dashboard";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_deliverability_dashboard_options(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sesv2("GET", "/v2/email/deliverability-dashboard", params; aws_config=aws_config)
+    return sesv2(
+        "GET",
+        "/v2/email/deliverability-dashboard",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1227,6 +1354,7 @@ function get_deliverability_test_report(
         "GET",
         "/v2/email/deliverability-dashboard/test-reports/$(ReportId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_deliverability_test_report(
@@ -1239,6 +1367,7 @@ function get_deliverability_test_report(
         "/v2/email/deliverability-dashboard/test-reports/$(ReportId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1262,6 +1391,7 @@ function get_domain_deliverability_campaign(
         "GET",
         "/v2/email/deliverability-dashboard/campaigns/$(CampaignId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_domain_deliverability_campaign(
@@ -1274,6 +1404,7 @@ function get_domain_deliverability_campaign(
         "/v2/email/deliverability-dashboard/campaigns/$(CampaignId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1300,6 +1431,7 @@ function get_domain_statistics_report(
         "/v2/email/deliverability-dashboard/statistics-report/$(Domain)",
         Dict{String,Any}("EndDate" => EndDate, "StartDate" => StartDate);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_domain_statistics_report(
@@ -1320,6 +1452,7 @@ function get_domain_statistics_report(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1338,7 +1471,12 @@ Mail-From settings.
 function get_email_identity(
     EmailIdentity; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sesv2("GET", "/v2/email/identities/$(EmailIdentity)"; aws_config=aws_config)
+    return sesv2(
+        "GET",
+        "/v2/email/identities/$(EmailIdentity)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_email_identity(
     EmailIdentity,
@@ -1346,7 +1484,11 @@ function get_email_identity(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return sesv2(
-        "GET", "/v2/email/identities/$(EmailIdentity)", params; aws_config=aws_config
+        "GET",
+        "/v2/email/identities/$(EmailIdentity)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1370,7 +1512,10 @@ function get_email_identity_policies(
     EmailIdentity; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return sesv2(
-        "GET", "/v2/email/identities/$(EmailIdentity)/policies"; aws_config=aws_config
+        "GET",
+        "/v2/email/identities/$(EmailIdentity)/policies";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_email_identity_policies(
@@ -1383,6 +1528,7 @@ function get_email_identity_policies(
         "/v2/email/identities/$(EmailIdentity)/policies",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1398,7 +1544,12 @@ the template you specify. You can execute this operation no more than once per s
 
 """
 function get_email_template(TemplateName; aws_config::AbstractAWSConfig=global_aws_config())
-    return sesv2("GET", "/v2/email/templates/$(TemplateName)"; aws_config=aws_config)
+    return sesv2(
+        "GET",
+        "/v2/email/templates/$(TemplateName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_email_template(
     TemplateName,
@@ -1406,7 +1557,11 @@ function get_email_template(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return sesv2(
-        "GET", "/v2/email/templates/$(TemplateName)", params; aws_config=aws_config
+        "GET",
+        "/v2/email/templates/$(TemplateName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1421,12 +1576,23 @@ Provides information about an import job.
 
 """
 function get_import_job(JobId; aws_config::AbstractAWSConfig=global_aws_config())
-    return sesv2("GET", "/v2/email/import-jobs/$(JobId)"; aws_config=aws_config)
+    return sesv2(
+        "GET",
+        "/v2/email/import-jobs/$(JobId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_import_job(
     JobId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sesv2("GET", "/v2/email/import-jobs/$(JobId)", params; aws_config=aws_config)
+    return sesv2(
+        "GET",
+        "/v2/email/import-jobs/$(JobId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1444,7 +1610,10 @@ function get_suppressed_destination(
     EmailAddress; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return sesv2(
-        "GET", "/v2/email/suppression/addresses/$(EmailAddress)"; aws_config=aws_config
+        "GET",
+        "/v2/email/suppression/addresses/$(EmailAddress)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_suppressed_destination(
@@ -1457,6 +1626,7 @@ function get_suppressed_destination(
         "/v2/email/suppression/addresses/$(EmailAddress)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1479,12 +1649,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   response includes a NextToken element, which you can use to obtain additional results.
 """
 function list_configuration_sets(; aws_config::AbstractAWSConfig=global_aws_config())
-    return sesv2("GET", "/v2/email/configuration-sets"; aws_config=aws_config)
+    return sesv2(
+        "GET",
+        "/v2/email/configuration-sets";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_configuration_sets(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sesv2("GET", "/v2/email/configuration-sets", params; aws_config=aws_config)
+    return sesv2(
+        "GET",
+        "/v2/email/configuration-sets",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1505,12 +1686,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   to retrieve additional lists.
 """
 function list_contact_lists(; aws_config::AbstractAWSConfig=global_aws_config())
-    return sesv2("GET", "/v2/email/contact-lists"; aws_config=aws_config)
+    return sesv2(
+        "GET",
+        "/v2/email/contact-lists";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_contact_lists(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sesv2("GET", "/v2/email/contact-lists", params; aws_config=aws_config)
+    return sesv2(
+        "GET",
+        "/v2/email/contact-lists",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1536,7 +1728,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function list_contacts(ContactListName; aws_config::AbstractAWSConfig=global_aws_config())
     return sesv2(
-        "GET", "/v2/email/contact-lists/$(ContactListName)/contacts"; aws_config=aws_config
+        "GET",
+        "/v2/email/contact-lists/$(ContactListName)/contacts";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_contacts(
@@ -1549,6 +1744,7 @@ function list_contacts(
         "/v2/email/contact-lists/$(ContactListName)/contacts",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1576,7 +1772,10 @@ function list_custom_verification_email_templates(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
     return sesv2(
-        "GET", "/v2/email/custom-verification-email-templates"; aws_config=aws_config
+        "GET",
+        "/v2/email/custom-verification-email-templates";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_custom_verification_email_templates(
@@ -1587,6 +1786,7 @@ function list_custom_verification_email_templates(
         "/v2/email/custom-verification-email-templates",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1605,12 +1805,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   response includes a NextToken element, which you can use to obtain additional results.
 """
 function list_dedicated_ip_pools(; aws_config::AbstractAWSConfig=global_aws_config())
-    return sesv2("GET", "/v2/email/dedicated-ip-pools"; aws_config=aws_config)
+    return sesv2(
+        "GET",
+        "/v2/email/dedicated-ip-pools";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_dedicated_ip_pools(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sesv2("GET", "/v2/email/dedicated-ip-pools", params; aws_config=aws_config)
+    return sesv2(
+        "GET",
+        "/v2/email/dedicated-ip-pools",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1635,7 +1846,10 @@ function list_deliverability_test_reports(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
     return sesv2(
-        "GET", "/v2/email/deliverability-dashboard/test-reports"; aws_config=aws_config
+        "GET",
+        "/v2/email/deliverability-dashboard/test-reports";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_deliverability_test_reports(
@@ -1646,6 +1860,7 @@ function list_deliverability_test_reports(
         "/v2/email/deliverability-dashboard/test-reports",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1683,6 +1898,7 @@ function list_domain_deliverability_campaigns(
         "/v2/email/deliverability-dashboard/domains/$(SubscribedDomain)/campaigns",
         Dict{String,Any}("EndDate" => EndDate, "StartDate" => StartDate);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_domain_deliverability_campaigns(
@@ -1703,6 +1919,7 @@ function list_domain_deliverability_campaigns(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1725,12 +1942,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   value you specify has to be at least 0, and can be no more than 1000.
 """
 function list_email_identities(; aws_config::AbstractAWSConfig=global_aws_config())
-    return sesv2("GET", "/v2/email/identities"; aws_config=aws_config)
+    return sesv2(
+        "GET",
+        "/v2/email/identities";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_email_identities(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sesv2("GET", "/v2/email/identities", params; aws_config=aws_config)
+    return sesv2(
+        "GET",
+        "/v2/email/identities",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1750,12 +1978,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   value you specify has to be at least 1, and can be no more than 10.
 """
 function list_email_templates(; aws_config::AbstractAWSConfig=global_aws_config())
-    return sesv2("GET", "/v2/email/templates"; aws_config=aws_config)
+    return sesv2(
+        "GET", "/v2/email/templates"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_email_templates(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sesv2("GET", "/v2/email/templates", params; aws_config=aws_config)
+    return sesv2(
+        "GET",
+        "/v2/email/templates",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1777,12 +2013,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   additional addresses.
 """
 function list_import_jobs(; aws_config::AbstractAWSConfig=global_aws_config())
-    return sesv2("GET", "/v2/email/import-jobs"; aws_config=aws_config)
+    return sesv2(
+        "GET",
+        "/v2/email/import-jobs";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_import_jobs(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sesv2("GET", "/v2/email/import-jobs", params; aws_config=aws_config)
+    return sesv2(
+        "GET",
+        "/v2/email/import-jobs",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1808,12 +2055,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   specify should be in Unix time format.
 """
 function list_suppressed_destinations(; aws_config::AbstractAWSConfig=global_aws_config())
-    return sesv2("GET", "/v2/email/suppression/addresses"; aws_config=aws_config)
+    return sesv2(
+        "GET",
+        "/v2/email/suppression/addresses";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_suppressed_destinations(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sesv2("GET", "/v2/email/suppression/addresses", params; aws_config=aws_config)
+    return sesv2(
+        "GET",
+        "/v2/email/suppression/addresses",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1839,6 +2097,7 @@ function list_tags_for_resource(
         "/v2/email/tags",
         Dict{String,Any}("ResourceArn" => ResourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags_for_resource(
@@ -1853,6 +2112,7 @@ function list_tags_for_resource(
             mergewith(_merge, Dict{String,Any}("ResourceArn" => ResourceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1871,13 +2131,22 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function put_account_dedicated_ip_warmup_attributes(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sesv2("PUT", "/v2/email/account/dedicated-ips/warmup"; aws_config=aws_config)
+    return sesv2(
+        "PUT",
+        "/v2/email/account/dedicated-ips/warmup";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function put_account_dedicated_ip_warmup_attributes(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return sesv2(
-        "PUT", "/v2/email/account/dedicated-ips/warmup", params; aws_config=aws_config
+        "PUT",
+        "/v2/email/account/dedicated-ips/warmup",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1922,6 +2191,7 @@ function put_account_details(
             "WebsiteURL" => WebsiteURL,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_account_details(
@@ -1946,6 +2216,7 @@ function put_account_details(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1963,12 +2234,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   ability to send email.
 """
 function put_account_sending_attributes(; aws_config::AbstractAWSConfig=global_aws_config())
-    return sesv2("PUT", "/v2/email/account/sending"; aws_config=aws_config)
+    return sesv2(
+        "PUT",
+        "/v2/email/account/sending";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function put_account_sending_attributes(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sesv2("PUT", "/v2/email/account/sending", params; aws_config=aws_config)
+    return sesv2(
+        "PUT",
+        "/v2/email/account/sending",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1989,12 +2271,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function put_account_suppression_attributes(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sesv2("PUT", "/v2/email/account/suppression"; aws_config=aws_config)
+    return sesv2(
+        "PUT",
+        "/v2/email/account/suppression";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function put_account_suppression_attributes(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sesv2("PUT", "/v2/email/account/suppression", params; aws_config=aws_config)
+    return sesv2(
+        "PUT",
+        "/v2/email/account/suppression",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2024,6 +2317,7 @@ function put_configuration_set_delivery_options(
         "PUT",
         "/v2/email/configuration-sets/$(ConfigurationSetName)/delivery-options";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_configuration_set_delivery_options(
@@ -2036,6 +2330,7 @@ function put_configuration_set_delivery_options(
         "/v2/email/configuration-sets/$(ConfigurationSetName)/delivery-options",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2063,6 +2358,7 @@ function put_configuration_set_reputation_options(
         "PUT",
         "/v2/email/configuration-sets/$(ConfigurationSetName)/reputation-options";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_configuration_set_reputation_options(
@@ -2075,6 +2371,7 @@ function put_configuration_set_reputation_options(
         "/v2/email/configuration-sets/$(ConfigurationSetName)/reputation-options",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2101,6 +2398,7 @@ function put_configuration_set_sending_options(
         "PUT",
         "/v2/email/configuration-sets/$(ConfigurationSetName)/sending";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_configuration_set_sending_options(
@@ -2113,6 +2411,7 @@ function put_configuration_set_sending_options(
         "/v2/email/configuration-sets/$(ConfigurationSetName)/sending",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2142,6 +2441,7 @@ function put_configuration_set_suppression_options(
         "PUT",
         "/v2/email/configuration-sets/$(ConfigurationSetName)/suppression-options";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_configuration_set_suppression_options(
@@ -2154,6 +2454,7 @@ function put_configuration_set_suppression_options(
         "/v2/email/configuration-sets/$(ConfigurationSetName)/suppression-options",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2178,6 +2479,7 @@ function put_configuration_set_tracking_options(
         "PUT",
         "/v2/email/configuration-sets/$(ConfigurationSetName)/tracking-options";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_configuration_set_tracking_options(
@@ -2190,6 +2492,7 @@ function put_configuration_set_tracking_options(
         "/v2/email/configuration-sets/$(ConfigurationSetName)/tracking-options",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2217,6 +2520,7 @@ function put_dedicated_ip_in_pool(
         "/v2/email/dedicated-ips/$(IP)/pool",
         Dict{String,Any}("DestinationPoolName" => DestinationPoolName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_dedicated_ip_in_pool(
@@ -2236,6 +2540,7 @@ function put_dedicated_ip_in_pool(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2259,6 +2564,7 @@ function put_dedicated_ip_warmup_attributes(
         "/v2/email/dedicated-ips/$(IP)/warmup",
         Dict{String,Any}("WarmupPercentage" => WarmupPercentage);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_dedicated_ip_warmup_attributes(
@@ -2276,6 +2582,7 @@ function put_dedicated_ip_warmup_attributes(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2308,6 +2615,7 @@ function put_deliverability_dashboard_option(
         "/v2/email/deliverability-dashboard",
         Dict{String,Any}("DashboardEnabled" => DashboardEnabled);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_deliverability_dashboard_option(
@@ -2324,6 +2632,7 @@ function put_deliverability_dashboard_option(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2349,6 +2658,7 @@ function put_email_identity_configuration_set_attributes(
         "PUT",
         "/v2/email/identities/$(EmailIdentity)/configuration-set";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_email_identity_configuration_set_attributes(
@@ -2361,6 +2671,7 @@ function put_email_identity_configuration_set_attributes(
         "/v2/email/identities/$(EmailIdentity)/configuration-set",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2382,7 +2693,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function put_email_identity_dkim_attributes(
     EmailIdentity; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sesv2("PUT", "/v2/email/identities/$(EmailIdentity)/dkim"; aws_config=aws_config)
+    return sesv2(
+        "PUT",
+        "/v2/email/identities/$(EmailIdentity)/dkim";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function put_email_identity_dkim_attributes(
     EmailIdentity,
@@ -2390,7 +2706,11 @@ function put_email_identity_dkim_attributes(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return sesv2(
-        "PUT", "/v2/email/identities/$(EmailIdentity)/dkim", params; aws_config=aws_config
+        "PUT",
+        "/v2/email/identities/$(EmailIdentity)/dkim",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2428,6 +2748,7 @@ function put_email_identity_dkim_signing_attributes(
         "/v1/email/identities/$(EmailIdentity)/dkim/signing",
         Dict{String,Any}("SigningAttributesOrigin" => SigningAttributesOrigin);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_email_identity_dkim_signing_attributes(
@@ -2447,6 +2768,7 @@ function put_email_identity_dkim_signing_attributes(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2481,7 +2803,10 @@ function put_email_identity_feedback_attributes(
     EmailIdentity; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return sesv2(
-        "PUT", "/v2/email/identities/$(EmailIdentity)/feedback"; aws_config=aws_config
+        "PUT",
+        "/v2/email/identities/$(EmailIdentity)/feedback";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_email_identity_feedback_attributes(
@@ -2494,6 +2819,7 @@ function put_email_identity_feedback_attributes(
         "/v2/email/identities/$(EmailIdentity)/feedback",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2524,7 +2850,10 @@ function put_email_identity_mail_from_attributes(
     EmailIdentity; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return sesv2(
-        "PUT", "/v2/email/identities/$(EmailIdentity)/mail-from"; aws_config=aws_config
+        "PUT",
+        "/v2/email/identities/$(EmailIdentity)/mail-from";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_email_identity_mail_from_attributes(
@@ -2537,6 +2866,7 @@ function put_email_identity_mail_from_attributes(
         "/v2/email/identities/$(EmailIdentity)/mail-from",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2561,6 +2891,7 @@ function put_suppressed_destination(
         "/v2/email/suppression/addresses",
         Dict{String,Any}("EmailAddress" => EmailAddress, "Reason" => Reason);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_suppressed_destination(
@@ -2580,6 +2911,7 @@ function put_suppressed_destination(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2637,6 +2969,7 @@ function send_bulk_email(
             "BulkEmailEntries" => BulkEmailEntries, "DefaultContent" => DefaultContent
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function send_bulk_email(
@@ -2659,6 +2992,7 @@ function send_bulk_email(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2691,6 +3025,7 @@ function send_custom_verification_email(
         "/v2/email/outbound-custom-verification-emails",
         Dict{String,Any}("EmailAddress" => EmailAddress, "TemplateName" => TemplateName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function send_custom_verification_email(
@@ -2712,6 +3047,7 @@ function send_custom_verification_email(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2777,6 +3113,7 @@ function send_email(Content; aws_config::AbstractAWSConfig=global_aws_config())
         "/v2/email/outbound-emails",
         Dict{String,Any}("Content" => Content);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function send_email(
@@ -2787,6 +3124,7 @@ function send_email(
         "/v2/email/outbound-emails",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Content" => Content), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2815,6 +3153,7 @@ function tag_resource(ResourceArn, Tags; aws_config::AbstractAWSConfig=global_aw
         "/v2/email/tags",
         Dict{String,Any}("ResourceArn" => ResourceArn, "Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -2834,6 +3173,7 @@ function tag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2859,6 +3199,7 @@ function test_render_email_template(
         "/v2/email/templates/$(TemplateName)/render",
         Dict{String,Any}("TemplateData" => TemplateData);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function test_render_email_template(
@@ -2874,6 +3215,7 @@ function test_render_email_template(
             mergewith(_merge, Dict{String,Any}("TemplateData" => TemplateData), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2901,6 +3243,7 @@ function untag_resource(
         "/v2/email/tags",
         Dict{String,Any}("ResourceArn" => ResourceArn, "TagKeys" => TagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -2920,6 +3263,7 @@ function untag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2951,6 +3295,7 @@ function update_configuration_set_event_destination(
         "/v2/email/configuration-sets/$(ConfigurationSetName)/event-destinations/$(EventDestinationName)",
         Dict{String,Any}("EventDestination" => EventDestination);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_configuration_set_event_destination(
@@ -2969,6 +3314,7 @@ function update_configuration_set_event_destination(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2998,6 +3344,7 @@ function update_contact(
         "PUT",
         "/v2/email/contact-lists/$(ContactListName)/contacts/$(EmailAddress)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_contact(
@@ -3011,6 +3358,7 @@ function update_contact(
         "/v2/email/contact-lists/$(ContactListName)/contacts/$(EmailAddress)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3032,7 +3380,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function update_contact_list(
     ContactListName; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sesv2("PUT", "/v2/email/contact-lists/$(ContactListName)"; aws_config=aws_config)
+    return sesv2(
+        "PUT",
+        "/v2/email/contact-lists/$(ContactListName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function update_contact_list(
     ContactListName,
@@ -3040,7 +3393,11 @@ function update_contact_list(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return sesv2(
-        "PUT", "/v2/email/contact-lists/$(ContactListName)", params; aws_config=aws_config
+        "PUT",
+        "/v2/email/contact-lists/$(ContactListName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3087,6 +3444,7 @@ function update_custom_verification_email_template(
             "TemplateSubject" => TemplateSubject,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_custom_verification_email_template(
@@ -3116,6 +3474,7 @@ function update_custom_verification_email_template(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3148,6 +3507,7 @@ function update_email_identity_policy(
         "/v2/email/identities/$(EmailIdentity)/policies/$(PolicyName)",
         Dict{String,Any}("Policy" => Policy);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_email_identity_policy(
@@ -3162,6 +3522,7 @@ function update_email_identity_policy(
         "/v2/email/identities/$(EmailIdentity)/policies/$(PolicyName)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Policy" => Policy), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3187,6 +3548,7 @@ function update_email_template(
         "/v2/email/templates/$(TemplateName)",
         Dict{String,Any}("TemplateContent" => TemplateContent);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_email_template(
@@ -3204,5 +3566,6 @@ function update_email_template(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/sfn.jl
+++ b/src/services/sfn.jl
@@ -36,7 +36,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   digits, white space, or these symbols: _ . : / = + - @.
 """
 function create_activity(name; aws_config::AbstractAWSConfig=global_aws_config())
-    return sfn("CreateActivity", Dict{String,Any}("name" => name); aws_config=aws_config)
+    return sfn(
+        "CreateActivity",
+        Dict{String,Any}("name" => name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function create_activity(
     name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -45,6 +50,7 @@ function create_activity(
         "CreateActivity",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("name" => name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -94,6 +100,7 @@ function create_state_machine(
         "CreateStateMachine",
         Dict{String,Any}("definition" => definition, "name" => name, "roleArn" => roleArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_state_machine(
@@ -115,6 +122,7 @@ function create_state_machine(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -133,6 +141,7 @@ function delete_activity(activityArn; aws_config::AbstractAWSConfig=global_aws_c
         "DeleteActivity",
         Dict{String,Any}("activityArn" => activityArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_activity(
@@ -146,6 +155,7 @@ function delete_activity(
             mergewith(_merge, Dict{String,Any}("activityArn" => activityArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -169,6 +179,7 @@ function delete_state_machine(
         "DeleteStateMachine",
         Dict{String,Any}("stateMachineArn" => stateMachineArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_state_machine(
@@ -184,6 +195,7 @@ function delete_state_machine(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -203,6 +215,7 @@ function describe_activity(activityArn; aws_config::AbstractAWSConfig=global_aws
         "DescribeActivity",
         Dict{String,Any}("activityArn" => activityArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_activity(
@@ -216,6 +229,7 @@ function describe_activity(
             mergewith(_merge, Dict{String,Any}("activityArn" => activityArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -236,6 +250,7 @@ function describe_execution(executionArn; aws_config::AbstractAWSConfig=global_a
         "DescribeExecution",
         Dict{String,Any}("executionArn" => executionArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_execution(
@@ -249,6 +264,7 @@ function describe_execution(
             mergewith(_merge, Dict{String,Any}("executionArn" => executionArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -270,6 +286,7 @@ function describe_state_machine(
         "DescribeStateMachine",
         Dict{String,Any}("stateMachineArn" => stateMachineArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_state_machine(
@@ -285,6 +302,7 @@ function describe_state_machine(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -308,6 +326,7 @@ function describe_state_machine_for_execution(
         "DescribeStateMachineForExecution",
         Dict{String,Any}("executionArn" => executionArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_state_machine_for_execution(
@@ -321,6 +340,7 @@ function describe_state_machine_for_execution(
             mergewith(_merge, Dict{String,Any}("executionArn" => executionArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -353,6 +373,7 @@ function get_activity_task(activityArn; aws_config::AbstractAWSConfig=global_aws
         "GetActivityTask",
         Dict{String,Any}("activityArn" => activityArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_activity_task(
@@ -366,6 +387,7 @@ function get_activity_task(
             mergewith(_merge, Dict{String,Any}("activityArn" => activityArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -407,6 +429,7 @@ function get_execution_history(
         "GetExecutionHistory",
         Dict{String,Any}("executionArn" => executionArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_execution_history(
@@ -420,6 +443,7 @@ function get_execution_history(
             mergewith(_merge, Dict{String,Any}("executionArn" => executionArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -447,12 +471,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   HTTP 400 InvalidToken error.
 """
 function list_activities(; aws_config::AbstractAWSConfig=global_aws_config())
-    return sfn("ListActivities"; aws_config=aws_config)
+    return sfn("ListActivities"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_activities(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sfn("ListActivities", params; aws_config=aws_config)
+    return sfn(
+        "ListActivities", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -491,6 +517,7 @@ function list_executions(stateMachineArn; aws_config::AbstractAWSConfig=global_a
         "ListExecutions",
         Dict{String,Any}("stateMachineArn" => stateMachineArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_executions(
@@ -506,6 +533,7 @@ function list_executions(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -533,12 +561,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   HTTP 400 InvalidToken error.
 """
 function list_state_machines(; aws_config::AbstractAWSConfig=global_aws_config())
-    return sfn("ListStateMachines"; aws_config=aws_config)
+    return sfn("ListStateMachines"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_state_machines(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sfn("ListStateMachines", params; aws_config=aws_config)
+    return sfn(
+        "ListStateMachines", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -560,6 +590,7 @@ function list_tags_for_resource(
         "ListTagsForResource",
         Dict{String,Any}("resourceArn" => resourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags_for_resource(
@@ -573,6 +604,7 @@ function list_tags_for_resource(
             mergewith(_merge, Dict{String,Any}("resourceArn" => resourceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -595,7 +627,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function send_task_failure(taskToken; aws_config::AbstractAWSConfig=global_aws_config())
     return sfn(
-        "SendTaskFailure", Dict{String,Any}("taskToken" => taskToken); aws_config=aws_config
+        "SendTaskFailure",
+        Dict{String,Any}("taskToken" => taskToken);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function send_task_failure(
@@ -609,6 +644,7 @@ function send_task_failure(
             mergewith(_merge, Dict{String,Any}("taskToken" => taskToken), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -638,6 +674,7 @@ function send_task_heartbeat(taskToken; aws_config::AbstractAWSConfig=global_aws
         "SendTaskHeartbeat",
         Dict{String,Any}("taskToken" => taskToken);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function send_task_heartbeat(
@@ -651,6 +688,7 @@ function send_task_heartbeat(
             mergewith(_merge, Dict{String,Any}("taskToken" => taskToken), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -676,6 +714,7 @@ function send_task_success(
         "SendTaskSuccess",
         Dict{String,Any}("output" => output, "taskToken" => taskToken);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function send_task_success(
@@ -694,6 +733,7 @@ function send_task_success(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -730,6 +770,7 @@ function start_execution(stateMachineArn; aws_config::AbstractAWSConfig=global_a
         "StartExecution",
         Dict{String,Any}("stateMachineArn" => stateMachineArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_execution(
@@ -745,6 +786,7 @@ function start_execution(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -774,6 +816,7 @@ function start_sync_execution(
         "StartSyncExecution",
         Dict{String,Any}("stateMachineArn" => stateMachineArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_sync_execution(
@@ -789,6 +832,7 @@ function start_sync_execution(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -811,6 +855,7 @@ function stop_execution(executionArn; aws_config::AbstractAWSConfig=global_aws_c
         "StopExecution",
         Dict{String,Any}("executionArn" => executionArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function stop_execution(
@@ -824,6 +869,7 @@ function stop_execution(
             mergewith(_merge, Dict{String,Any}("executionArn" => executionArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -848,6 +894,7 @@ function tag_resource(resourceArn, tags; aws_config::AbstractAWSConfig=global_aw
         "TagResource",
         Dict{String,Any}("resourceArn" => resourceArn, "tags" => tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -866,6 +913,7 @@ function tag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -888,6 +936,7 @@ function untag_resource(
         "UntagResource",
         Dict{String,Any}("resourceArn" => resourceArn, "tagKeys" => tagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -906,6 +955,7 @@ function untag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -939,6 +989,7 @@ function update_state_machine(
         "UpdateStateMachine",
         Dict{String,Any}("stateMachineArn" => stateMachineArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_state_machine(
@@ -954,5 +1005,6 @@ function update_state_machine(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/shield.jl
+++ b/src/services/shield.jl
@@ -25,6 +25,7 @@ function associate_drtlog_bucket(
         "AssociateDRTLogBucket",
         Dict{String,Any}("LogBucket" => LogBucket);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_drtlog_bucket(
@@ -38,6 +39,7 @@ function associate_drtlog_bucket(
             mergewith(_merge, Dict{String,Any}("LogBucket" => LogBucket), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -72,7 +74,10 @@ plan or the Enterprise Support plan.
 """
 function associate_drtrole(RoleArn; aws_config::AbstractAWSConfig=global_aws_config())
     return shield(
-        "AssociateDRTRole", Dict{String,Any}("RoleArn" => RoleArn); aws_config=aws_config
+        "AssociateDRTRole",
+        Dict{String,Any}("RoleArn" => RoleArn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_drtrole(
@@ -82,6 +87,7 @@ function associate_drtrole(
         "AssociateDRTRole",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("RoleArn" => RoleArn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -111,6 +117,7 @@ function associate_health_check(
             "HealthCheckArn" => HealthCheckArn, "ProtectionId" => ProtectionId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_health_check(
@@ -131,6 +138,7 @@ function associate_health_check(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -165,6 +173,7 @@ function associate_proactive_engagement_details(
         "AssociateProactiveEngagementDetails",
         Dict{String,Any}("EmergencyContactList" => EmergencyContactList);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_proactive_engagement_details(
@@ -182,6 +191,7 @@ function associate_proactive_engagement_details(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -221,6 +231,7 @@ function create_protection(
         "CreateProtection",
         Dict{String,Any}("Name" => Name, "ResourceArn" => ResourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_protection(
@@ -239,6 +250,7 @@ function create_protection(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -291,6 +303,7 @@ function create_protection_group(
             "ProtectionGroupId" => ProtectionGroupId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_protection_group(
@@ -314,6 +327,7 @@ function create_protection_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -327,12 +341,16 @@ period. You can change this by submitting an UpdateSubscription request.
 
 """
 function create_subscription(; aws_config::AbstractAWSConfig=global_aws_config())
-    return shield("CreateSubscription"; aws_config=aws_config)
+    return shield(
+        "CreateSubscription"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function create_subscription(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return shield("CreateSubscription", params; aws_config=aws_config)
+    return shield(
+        "CreateSubscription", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -350,6 +368,7 @@ function delete_protection(ProtectionId; aws_config::AbstractAWSConfig=global_aw
         "DeleteProtection",
         Dict{String,Any}("ProtectionId" => ProtectionId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_protection(
@@ -363,6 +382,7 @@ function delete_protection(
             mergewith(_merge, Dict{String,Any}("ProtectionId" => ProtectionId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -385,6 +405,7 @@ function delete_protection_group(
         "DeleteProtectionGroup",
         Dict{String,Any}("ProtectionGroupId" => ProtectionGroupId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_protection_group(
@@ -400,6 +421,7 @@ function delete_protection_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -412,12 +434,16 @@ commitment. You cannot delete a subscription prior to the completion of that com
 
 """
 function delete_subscription(; aws_config::AbstractAWSConfig=global_aws_config())
-    return shield("DeleteSubscription"; aws_config=aws_config)
+    return shield(
+        "DeleteSubscription"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function delete_subscription(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return shield("DeleteSubscription", params; aws_config=aws_config)
+    return shield(
+        "DeleteSubscription", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -432,7 +458,10 @@ Describes the details of a DDoS attack.
 """
 function describe_attack(AttackId; aws_config::AbstractAWSConfig=global_aws_config())
     return shield(
-        "DescribeAttack", Dict{String,Any}("AttackId" => AttackId); aws_config=aws_config
+        "DescribeAttack",
+        Dict{String,Any}("AttackId" => AttackId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_attack(
@@ -446,6 +475,7 @@ function describe_attack(
             mergewith(_merge, Dict{String,Any}("AttackId" => AttackId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -464,12 +494,19 @@ indicates the period covered by the attack statistics data items.
 
 """
 function describe_attack_statistics(; aws_config::AbstractAWSConfig=global_aws_config())
-    return shield("DescribeAttackStatistics"; aws_config=aws_config)
+    return shield(
+        "DescribeAttackStatistics"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_attack_statistics(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return shield("DescribeAttackStatistics", params; aws_config=aws_config)
+    return shield(
+        "DescribeAttackStatistics",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -481,12 +518,16 @@ Returns the current role and list of Amazon S3 log buckets used by the Shield Re
 
 """
 function describe_drtaccess(; aws_config::AbstractAWSConfig=global_aws_config())
-    return shield("DescribeDRTAccess"; aws_config=aws_config)
+    return shield(
+        "DescribeDRTAccess"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_drtaccess(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return shield("DescribeDRTAccess", params; aws_config=aws_config)
+    return shield(
+        "DescribeDRTAccess", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -501,12 +542,21 @@ initiate proactive customer support.
 function describe_emergency_contact_settings(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return shield("DescribeEmergencyContactSettings"; aws_config=aws_config)
+    return shield(
+        "DescribeEmergencyContactSettings";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_emergency_contact_settings(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return shield("DescribeEmergencyContactSettings", params; aws_config=aws_config)
+    return shield(
+        "DescribeEmergencyContactSettings",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -525,12 +575,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   must provide either the ResourceArn or the ProtectionID, but not both.
 """
 function describe_protection(; aws_config::AbstractAWSConfig=global_aws_config())
-    return shield("DescribeProtection"; aws_config=aws_config)
+    return shield(
+        "DescribeProtection"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_protection(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return shield("DescribeProtection", params; aws_config=aws_config)
+    return shield(
+        "DescribeProtection", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -552,6 +606,7 @@ function describe_protection_group(
         "DescribeProtectionGroup",
         Dict{String,Any}("ProtectionGroupId" => ProtectionGroupId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_protection_group(
@@ -567,6 +622,7 @@ function describe_protection_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -578,12 +634,19 @@ Provides details about the Shield Advanced subscription for an account.
 
 """
 function describe_subscription(; aws_config::AbstractAWSConfig=global_aws_config())
-    return shield("DescribeSubscription"; aws_config=aws_config)
+    return shield(
+        "DescribeSubscription"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_subscription(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return shield("DescribeSubscription", params; aws_config=aws_config)
+    return shield(
+        "DescribeSubscription",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -595,12 +658,19 @@ escalations to the SRT and to initiate proactive customer support.
 
 """
 function disable_proactive_engagement(; aws_config::AbstractAWSConfig=global_aws_config())
-    return shield("DisableProactiveEngagement"; aws_config=aws_config)
+    return shield(
+        "DisableProactiveEngagement"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function disable_proactive_engagement(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return shield("DisableProactiveEngagement", params; aws_config=aws_config)
+    return shield(
+        "DisableProactiveEngagement",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -625,6 +695,7 @@ function disassociate_drtlog_bucket(
         "DisassociateDRTLogBucket",
         Dict{String,Any}("LogBucket" => LogBucket);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disassociate_drtlog_bucket(
@@ -638,6 +709,7 @@ function disassociate_drtlog_bucket(
             mergewith(_merge, Dict{String,Any}("LogBucket" => LogBucket), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -653,12 +725,19 @@ submit a DisassociateDRTRole request to remove this access.
 
 """
 function disassociate_drtrole(; aws_config::AbstractAWSConfig=global_aws_config())
-    return shield("DisassociateDRTRole"; aws_config=aws_config)
+    return shield(
+        "DisassociateDRTRole"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function disassociate_drtrole(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return shield("DisassociateDRTRole", params; aws_config=aws_config)
+    return shield(
+        "DisassociateDRTRole",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -688,6 +767,7 @@ function disassociate_health_check(
             "HealthCheckArn" => HealthCheckArn, "ProtectionId" => ProtectionId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disassociate_health_check(
@@ -708,6 +788,7 @@ function disassociate_health_check(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -720,12 +801,19 @@ escalations to the SRT and to initiate proactive customer support.
 
 """
 function enable_proactive_engagement(; aws_config::AbstractAWSConfig=global_aws_config())
-    return shield("EnableProactiveEngagement"; aws_config=aws_config)
+    return shield(
+        "EnableProactiveEngagement"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function enable_proactive_engagement(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return shield("EnableProactiveEngagement", params; aws_config=aws_config)
+    return shield(
+        "EnableProactiveEngagement",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -736,12 +824,19 @@ Returns the SubscriptionState, either Active or Inactive.
 
 """
 function get_subscription_state(; aws_config::AbstractAWSConfig=global_aws_config())
-    return shield("GetSubscriptionState"; aws_config=aws_config)
+    return shield(
+        "GetSubscriptionState"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_subscription_state(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return shield("GetSubscriptionState", params; aws_config=aws_config)
+    return shield(
+        "GetSubscriptionState",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -770,12 +865,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   time in seconds. However any valid timestamp format is allowed.
 """
 function list_attacks(; aws_config::AbstractAWSConfig=global_aws_config())
-    return shield("ListAttacks"; aws_config=aws_config)
+    return shield("ListAttacks"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_attacks(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return shield("ListAttacks", params; aws_config=aws_config)
+    return shield(
+        "ListAttacks", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -796,12 +893,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   null if this is the first call.
 """
 function list_protection_groups(; aws_config::AbstractAWSConfig=global_aws_config())
-    return shield("ListProtectionGroups"; aws_config=aws_config)
+    return shield(
+        "ListProtectionGroups"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_protection_groups(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return shield("ListProtectionGroups", params; aws_config=aws_config)
+    return shield(
+        "ListProtectionGroups",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -822,12 +926,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   ListProtections. Pass null if this is the first call.
 """
 function list_protections(; aws_config::AbstractAWSConfig=global_aws_config())
-    return shield("ListProtections"; aws_config=aws_config)
+    return shield("ListProtections"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_protections(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return shield("ListProtections", params; aws_config=aws_config)
+    return shield(
+        "ListProtections", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -859,6 +965,7 @@ function list_resources_in_protection_group(
         "ListResourcesInProtectionGroup",
         Dict{String,Any}("ProtectionGroupId" => ProtectionGroupId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_resources_in_protection_group(
@@ -874,6 +981,7 @@ function list_resources_in_protection_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -895,6 +1003,7 @@ function list_tags_for_resource(
         "ListTagsForResource",
         Dict{String,Any}("ResourceARN" => ResourceARN);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags_for_resource(
@@ -908,6 +1017,7 @@ function list_tags_for_resource(
             mergewith(_merge, Dict{String,Any}("ResourceARN" => ResourceARN), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -928,6 +1038,7 @@ function tag_resource(ResourceARN, Tags; aws_config::AbstractAWSConfig=global_aw
         "TagResource",
         Dict{String,Any}("ResourceARN" => ResourceARN, "Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -946,6 +1057,7 @@ function tag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -968,6 +1080,7 @@ function untag_resource(
         "UntagResource",
         Dict{String,Any}("ResourceARN" => ResourceARN, "TagKeys" => TagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -986,6 +1099,7 @@ function untag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1007,12 +1121,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function update_emergency_contact_settings(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return shield("UpdateEmergencyContactSettings"; aws_config=aws_config)
+    return shield(
+        "UpdateEmergencyContactSettings";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function update_emergency_contact_settings(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return shield("UpdateEmergencyContactSettings", params; aws_config=aws_config)
+    return shield(
+        "UpdateEmergencyContactSettings",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1063,6 +1186,7 @@ function update_protection_group(
             "ProtectionGroupId" => ProtectionGroupId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_protection_group(
@@ -1086,6 +1210,7 @@ function update_protection_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1105,10 +1230,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   for AutoRenew remains unchanged.
 """
 function update_subscription(; aws_config::AbstractAWSConfig=global_aws_config())
-    return shield("UpdateSubscription"; aws_config=aws_config)
+    return shield(
+        "UpdateSubscription"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function update_subscription(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return shield("UpdateSubscription", params; aws_config=aws_config)
+    return shield(
+        "UpdateSubscription", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end

--- a/src/services/signer.jl
+++ b/src/services/signer.jl
@@ -36,6 +36,7 @@ function add_profile_permission(
             "action" => action, "principal" => principal, "statementId" => statementId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function add_profile_permission(
@@ -61,6 +62,7 @@ function add_profile_permission(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -79,7 +81,12 @@ and is deleted two years after cancelation.
 function cancel_signing_profile(
     profileName; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return signer("DELETE", "/signing-profiles/$(profileName)"; aws_config=aws_config)
+    return signer(
+        "DELETE",
+        "/signing-profiles/$(profileName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function cancel_signing_profile(
     profileName,
@@ -87,7 +94,11 @@ function cancel_signing_profile(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return signer(
-        "DELETE", "/signing-profiles/$(profileName)", params; aws_config=aws_config
+        "DELETE",
+        "/signing-profiles/$(profileName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -103,12 +114,23 @@ jobId value that is returned by the StartSigningJob operation.
 
 """
 function describe_signing_job(jobId; aws_config::AbstractAWSConfig=global_aws_config())
-    return signer("GET", "/signing-jobs/$(jobId)"; aws_config=aws_config)
+    return signer(
+        "GET",
+        "/signing-jobs/$(jobId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_signing_job(
     jobId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return signer("GET", "/signing-jobs/$(jobId)", params; aws_config=aws_config)
+    return signer(
+        "GET",
+        "/signing-jobs/$(jobId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -122,14 +144,25 @@ Returns information on a specific signing platform.
 
 """
 function get_signing_platform(platformId; aws_config::AbstractAWSConfig=global_aws_config())
-    return signer("GET", "/signing-platforms/$(platformId)"; aws_config=aws_config)
+    return signer(
+        "GET",
+        "/signing-platforms/$(platformId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_signing_platform(
     platformId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return signer("GET", "/signing-platforms/$(platformId)", params; aws_config=aws_config)
+    return signer(
+        "GET",
+        "/signing-platforms/$(platformId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -146,14 +179,25 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"profileOwner"`: The AWS account ID of the profile owner.
 """
 function get_signing_profile(profileName; aws_config::AbstractAWSConfig=global_aws_config())
-    return signer("GET", "/signing-profiles/$(profileName)"; aws_config=aws_config)
+    return signer(
+        "GET",
+        "/signing-profiles/$(profileName)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_signing_profile(
     profileName,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return signer("GET", "/signing-profiles/$(profileName)", params; aws_config=aws_config)
+    return signer(
+        "GET",
+        "/signing-profiles/$(profileName)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -173,7 +217,10 @@ function list_profile_permissions(
     profileName; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return signer(
-        "GET", "/signing-profiles/$(profileName)/permissions"; aws_config=aws_config
+        "GET",
+        "/signing-profiles/$(profileName)/permissions";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_profile_permissions(
@@ -182,7 +229,11 @@ function list_profile_permissions(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return signer(
-        "GET", "/signing-profiles/$(profileName)/permissions", params; aws_config=aws_config
+        "GET",
+        "/signing-profiles/$(profileName)/permissions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -219,12 +270,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"status"`: A status value with which to filter your results.
 """
 function list_signing_jobs(; aws_config::AbstractAWSConfig=global_aws_config())
-    return signer("GET", "/signing-jobs"; aws_config=aws_config)
+    return signer(
+        "GET", "/signing-jobs"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_signing_jobs(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return signer("GET", "/signing-jobs", params; aws_config=aws_config)
+    return signer(
+        "GET",
+        "/signing-jobs",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -249,12 +308,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"target"`: The validation template that is used by the target signing platform.
 """
 function list_signing_platforms(; aws_config::AbstractAWSConfig=global_aws_config())
-    return signer("GET", "/signing-platforms"; aws_config=aws_config)
+    return signer(
+        "GET", "/signing-platforms"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_signing_platforms(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return signer("GET", "/signing-platforms", params; aws_config=aws_config)
+    return signer(
+        "GET",
+        "/signing-platforms",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -281,12 +348,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   list.
 """
 function list_signing_profiles(; aws_config::AbstractAWSConfig=global_aws_config())
-    return signer("GET", "/signing-profiles"; aws_config=aws_config)
+    return signer(
+        "GET", "/signing-profiles"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_signing_profiles(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return signer("GET", "/signing-profiles", params; aws_config=aws_config)
+    return signer(
+        "GET",
+        "/signing-profiles",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -302,14 +377,25 @@ Returns a list of the tags associated with a signing profile resource.
 function list_tags_for_resource(
     resourceArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return signer("GET", "/tags/$(resourceArn)"; aws_config=aws_config)
+    return signer(
+        "GET",
+        "/tags/$(resourceArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_tags_for_resource(
     resourceArn,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return signer("GET", "/tags/$(resourceArn)", params; aws_config=aws_config)
+    return signer(
+        "GET",
+        "/tags/$(resourceArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -345,6 +431,7 @@ function put_signing_profile(
         "/signing-profiles/$(profileName)",
         Dict{String,Any}("platformId" => platformId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_signing_profile(
@@ -360,6 +447,7 @@ function put_signing_profile(
             mergewith(_merge, Dict{String,Any}("platformId" => platformId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -384,6 +472,7 @@ function remove_profile_permission(
         "/signing-profiles/$(profileName)/permissions/$(statementId)",
         Dict{String,Any}("revisionId" => revisionId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function remove_profile_permission(
@@ -400,6 +489,7 @@ function remove_profile_permission(
             mergewith(_merge, Dict{String,Any}("revisionId" => revisionId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -424,6 +514,7 @@ function revoke_signature(jobId, reason; aws_config::AbstractAWSConfig=global_aw
         "/signing-jobs/$(jobId)/revoke",
         Dict{String,Any}("reason" => reason);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function revoke_signature(
@@ -437,6 +528,7 @@ function revoke_signature(
         "/signing-jobs/$(jobId)/revoke",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("reason" => reason), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -472,6 +564,7 @@ function revoke_signing_profile(
             "reason" => reason,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function revoke_signing_profile(
@@ -497,6 +590,7 @@ function revoke_signing_profile(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -546,6 +640,7 @@ function start_signing_job(
             "source" => source,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_signing_job(
@@ -572,6 +667,7 @@ function start_signing_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -595,6 +691,7 @@ function tag_resource(resourceArn, tags; aws_config::AbstractAWSConfig=global_aw
         "/tags/$(resourceArn)",
         Dict{String,Any}("tags" => tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -608,6 +705,7 @@ function tag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tags" => tags), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -631,6 +729,7 @@ function untag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}("tagKeys" => tagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -644,5 +743,6 @@ function untag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tagKeys" => tagKeys), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/simpledb.jl
+++ b/src/services/simpledb.jl
@@ -37,6 +37,7 @@ function batch_delete_attributes(
         "BatchDeleteAttributes",
         Dict{String,Any}("DomainName" => DomainName, "Item" => Item);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_delete_attributes(
@@ -53,6 +54,7 @@ function batch_delete_attributes(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -105,6 +107,7 @@ function batch_put_attributes(
         "BatchPutAttributes",
         Dict{String,Any}("DomainName" => DomainName, "Item" => Item);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_put_attributes(
@@ -121,6 +124,7 @@ function batch_put_attributes(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -142,7 +146,10 @@ additional domains, go to  http://aws.amazon.com/contact-us/simpledb-limit-reque
 """
 function create_domain(DomainName; aws_config::AbstractAWSConfig=global_aws_config())
     return simpledb(
-        "CreateDomain", Dict{String,Any}("DomainName" => DomainName); aws_config=aws_config
+        "CreateDomain",
+        Dict{String,Any}("DomainName" => DomainName);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_domain(
@@ -156,6 +163,7 @@ function create_domain(
             mergewith(_merge, Dict{String,Any}("DomainName" => DomainName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -192,6 +200,7 @@ function delete_attributes(
         "DeleteAttributes",
         Dict{String,Any}("DomainName" => DomainName, "ItemName" => ItemName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_attributes(
@@ -210,6 +219,7 @@ function delete_attributes(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -228,7 +238,10 @@ multiple times using the same domain name will not result in an error response.
 """
 function delete_domain(DomainName; aws_config::AbstractAWSConfig=global_aws_config())
     return simpledb(
-        "DeleteDomain", Dict{String,Any}("DomainName" => DomainName); aws_config=aws_config
+        "DeleteDomain",
+        Dict{String,Any}("DomainName" => DomainName);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_domain(
@@ -242,6 +255,7 @@ function delete_domain(
             mergewith(_merge, Dict{String,Any}("DomainName" => DomainName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -261,6 +275,7 @@ function domain_metadata(DomainName; aws_config::AbstractAWSConfig=global_aws_co
         "DomainMetadata",
         Dict{String,Any}("DomainName" => DomainName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function domain_metadata(
@@ -274,6 +289,7 @@ function domain_metadata(
             mergewith(_merge, Dict{String,Any}("DomainName" => DomainName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -307,6 +323,7 @@ function get_attributes(
         "GetAttributes",
         Dict{String,Any}("DomainName" => DomainName, "ItemName" => ItemName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_attributes(
@@ -325,6 +342,7 @@ function get_attributes(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -346,12 +364,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   names.
 """
 function list_domains(; aws_config::AbstractAWSConfig=global_aws_config())
-    return simpledb("ListDomains"; aws_config=aws_config)
+    return simpledb("ListDomains"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_domains(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return simpledb("ListDomains", params; aws_config=aws_config)
+    return simpledb(
+        "ListDomains", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -402,6 +422,7 @@ function put_attributes(
             "Attribute" => Attribute, "DomainName" => DomainName, "ItemName" => ItemName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_attributes(
@@ -425,6 +446,7 @@ function put_attributes(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -458,6 +480,7 @@ function select(SelectExpression; aws_config::AbstractAWSConfig=global_aws_confi
         "Select",
         Dict{String,Any}("SelectExpression" => SelectExpression);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function select(
@@ -473,5 +496,6 @@ function select(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/sms.jl
+++ b/src/services/sms.jl
@@ -23,12 +23,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"tags"`: The tags to be associated with the application.
 """
 function create_app(; aws_config::AbstractAWSConfig=global_aws_config())
-    return sms("CreateApp"; aws_config=aws_config)
+    return sms("CreateApp"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function create_app(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sms("CreateApp", params; aws_config=aws_config)
+    return sms("CreateApp", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 
 """
@@ -67,6 +67,7 @@ function create_replication_job(
             "seedReplicationTime" => seedReplicationTime, "serverId" => serverId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_replication_job(
@@ -87,6 +88,7 @@ function create_replication_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -106,12 +108,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   application while deleting the application.
 """
 function delete_app(; aws_config::AbstractAWSConfig=global_aws_config())
-    return sms("DeleteApp"; aws_config=aws_config)
+    return sms("DeleteApp"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function delete_app(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sms("DeleteApp", params; aws_config=aws_config)
+    return sms("DeleteApp", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 
 """
@@ -127,12 +129,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function delete_app_launch_configuration(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sms("DeleteAppLaunchConfiguration"; aws_config=aws_config)
+    return sms(
+        "DeleteAppLaunchConfiguration";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_app_launch_configuration(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sms("DeleteAppLaunchConfiguration", params; aws_config=aws_config)
+    return sms(
+        "DeleteAppLaunchConfiguration",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -148,12 +159,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function delete_app_replication_configuration(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sms("DeleteAppReplicationConfiguration"; aws_config=aws_config)
+    return sms(
+        "DeleteAppReplicationConfiguration";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_app_replication_configuration(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sms("DeleteAppReplicationConfiguration", params; aws_config=aws_config)
+    return sms(
+        "DeleteAppReplicationConfiguration",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -173,6 +193,7 @@ function delete_app_validation_configuration(
         "DeleteAppValidationConfiguration",
         Dict{String,Any}("appId" => appId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_app_validation_configuration(
@@ -182,6 +203,7 @@ function delete_app_validation_configuration(
         "DeleteAppValidationConfiguration",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("appId" => appId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -204,6 +226,7 @@ function delete_replication_job(
         "DeleteReplicationJob",
         Dict{String,Any}("replicationJobId" => replicationJobId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_replication_job(
@@ -219,6 +242,7 @@ function delete_replication_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -230,12 +254,19 @@ Deletes all servers from your server catalog.
 
 """
 function delete_server_catalog(; aws_config::AbstractAWSConfig=global_aws_config())
-    return sms("DeleteServerCatalog"; aws_config=aws_config)
+    return sms(
+        "DeleteServerCatalog"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function delete_server_catalog(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sms("DeleteServerCatalog", params; aws_config=aws_config)
+    return sms(
+        "DeleteServerCatalog",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -256,6 +287,7 @@ function disassociate_connector(
         "DisassociateConnector",
         Dict{String,Any}("connectorId" => connectorId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disassociate_connector(
@@ -269,6 +301,7 @@ function disassociate_connector(
             mergewith(_merge, Dict{String,Any}("connectorId" => connectorId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -285,12 +318,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"changesetFormat"`: The format for the change set.
 """
 function generate_change_set(; aws_config::AbstractAWSConfig=global_aws_config())
-    return sms("GenerateChangeSet"; aws_config=aws_config)
+    return sms("GenerateChangeSet"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function generate_change_set(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sms("GenerateChangeSet", params; aws_config=aws_config)
+    return sms(
+        "GenerateChangeSet", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -306,12 +341,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"templateFormat"`: The format for generating the AWS CloudFormation template.
 """
 function generate_template(; aws_config::AbstractAWSConfig=global_aws_config())
-    return sms("GenerateTemplate"; aws_config=aws_config)
+    return sms("GenerateTemplate"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function generate_template(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sms("GenerateTemplate", params; aws_config=aws_config)
+    return sms(
+        "GenerateTemplate", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -325,12 +362,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"appId"`: The ID of the application.
 """
 function get_app(; aws_config::AbstractAWSConfig=global_aws_config())
-    return sms("GetApp"; aws_config=aws_config)
+    return sms("GetApp"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function get_app(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sms("GetApp", params; aws_config=aws_config)
+    return sms("GetApp", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 
 """
@@ -344,12 +381,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"appId"`: The ID of the application.
 """
 function get_app_launch_configuration(; aws_config::AbstractAWSConfig=global_aws_config())
-    return sms("GetAppLaunchConfiguration"; aws_config=aws_config)
+    return sms(
+        "GetAppLaunchConfiguration"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_app_launch_configuration(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sms("GetAppLaunchConfiguration", params; aws_config=aws_config)
+    return sms(
+        "GetAppLaunchConfiguration",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -366,12 +410,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function get_app_replication_configuration(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sms("GetAppReplicationConfiguration"; aws_config=aws_config)
+    return sms(
+        "GetAppReplicationConfiguration";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_app_replication_configuration(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sms("GetAppReplicationConfiguration", params; aws_config=aws_config)
+    return sms(
+        "GetAppReplicationConfiguration",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -391,6 +444,7 @@ function get_app_validation_configuration(
         "GetAppValidationConfiguration",
         Dict{String,Any}("appId" => appId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_app_validation_configuration(
@@ -400,6 +454,7 @@ function get_app_validation_configuration(
         "GetAppValidationConfiguration",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("appId" => appId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -415,7 +470,10 @@ Retrieves output from validating an application.
 """
 function get_app_validation_output(appId; aws_config::AbstractAWSConfig=global_aws_config())
     return sms(
-        "GetAppValidationOutput", Dict{String,Any}("appId" => appId); aws_config=aws_config
+        "GetAppValidationOutput",
+        Dict{String,Any}("appId" => appId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_app_validation_output(
@@ -425,6 +483,7 @@ function get_app_validation_output(
         "GetAppValidationOutput",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("appId" => appId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -442,12 +501,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: The token for the next set of results.
 """
 function get_connectors(; aws_config::AbstractAWSConfig=global_aws_config())
-    return sms("GetConnectors"; aws_config=aws_config)
+    return sms("GetConnectors"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function get_connectors(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sms("GetConnectors", params; aws_config=aws_config)
+    return sms(
+        "GetConnectors", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -465,12 +526,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"replicationJobId"`: The ID of the replication job.
 """
 function get_replication_jobs(; aws_config::AbstractAWSConfig=global_aws_config())
-    return sms("GetReplicationJobs"; aws_config=aws_config)
+    return sms("GetReplicationJobs"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function get_replication_jobs(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sms("GetReplicationJobs", params; aws_config=aws_config)
+    return sms(
+        "GetReplicationJobs", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -496,6 +559,7 @@ function get_replication_runs(
         "GetReplicationRuns",
         Dict{String,Any}("replicationJobId" => replicationJobId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_replication_runs(
@@ -511,6 +575,7 @@ function get_replication_runs(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -530,12 +595,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"vmServerAddressList"`: The server addresses.
 """
 function get_servers(; aws_config::AbstractAWSConfig=global_aws_config())
-    return sms("GetServers"; aws_config=aws_config)
+    return sms("GetServers"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function get_servers(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sms("GetServers", params; aws_config=aws_config)
+    return sms("GetServers", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 
 """
@@ -551,12 +616,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   provide must have the policy and trust policy described in the AWS Migration Hub User Guide.
 """
 function import_app_catalog(; aws_config::AbstractAWSConfig=global_aws_config())
-    return sms("ImportAppCatalog"; aws_config=aws_config)
+    return sms("ImportAppCatalog"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function import_app_catalog(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sms("ImportAppCatalog", params; aws_config=aws_config)
+    return sms(
+        "ImportAppCatalog", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -569,12 +636,19 @@ retrieve all the servers.
 
 """
 function import_server_catalog(; aws_config::AbstractAWSConfig=global_aws_config())
-    return sms("ImportServerCatalog"; aws_config=aws_config)
+    return sms(
+        "ImportServerCatalog"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function import_server_catalog(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sms("ImportServerCatalog", params; aws_config=aws_config)
+    return sms(
+        "ImportServerCatalog",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -588,12 +662,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"appId"`: The ID of the application.
 """
 function launch_app(; aws_config::AbstractAWSConfig=global_aws_config())
-    return sms("LaunchApp"; aws_config=aws_config)
+    return sms("LaunchApp"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function launch_app(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sms("LaunchApp", params; aws_config=aws_config)
+    return sms("LaunchApp", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 
 """
@@ -611,12 +685,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: The token for the next set of results.
 """
 function list_apps(; aws_config::AbstractAWSConfig=global_aws_config())
-    return sms("ListApps"; aws_config=aws_config)
+    return sms("ListApps"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_apps(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sms("ListApps", params; aws_config=aws_config)
+    return sms("ListApps", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 
 """
@@ -639,6 +713,7 @@ function notify_app_validation_output(
         "NotifyAppValidationOutput",
         Dict{String,Any}("appId" => appId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function notify_app_validation_output(
@@ -648,6 +723,7 @@ function notify_app_validation_output(
         "NotifyAppValidationOutput",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("appId" => appId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -668,12 +744,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   server groups in the application.
 """
 function put_app_launch_configuration(; aws_config::AbstractAWSConfig=global_aws_config())
-    return sms("PutAppLaunchConfiguration"; aws_config=aws_config)
+    return sms(
+        "PutAppLaunchConfiguration"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function put_app_launch_configuration(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sms("PutAppLaunchConfiguration", params; aws_config=aws_config)
+    return sms(
+        "PutAppLaunchConfiguration",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -691,12 +774,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function put_app_replication_configuration(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sms("PutAppReplicationConfiguration"; aws_config=aws_config)
+    return sms(
+        "PutAppReplicationConfiguration";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function put_app_replication_configuration(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sms("PutAppReplicationConfiguration", params; aws_config=aws_config)
+    return sms(
+        "PutAppReplicationConfiguration",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -720,6 +812,7 @@ function put_app_validation_configuration(
         "PutAppValidationConfiguration",
         Dict{String,Any}("appId" => appId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_app_validation_configuration(
@@ -729,6 +822,7 @@ function put_app_validation_configuration(
         "PutAppValidationConfiguration",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("appId" => appId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -744,12 +838,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"appId"`: The ID of the application.
 """
 function start_app_replication(; aws_config::AbstractAWSConfig=global_aws_config())
-    return sms("StartAppReplication"; aws_config=aws_config)
+    return sms(
+        "StartAppReplication"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function start_app_replication(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sms("StartAppReplication", params; aws_config=aws_config)
+    return sms(
+        "StartAppReplication",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -772,6 +873,7 @@ function start_on_demand_app_replication(
         "StartOnDemandAppReplication",
         Dict{String,Any}("appId" => appId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_on_demand_app_replication(
@@ -781,6 +883,7 @@ function start_on_demand_app_replication(
         "StartOnDemandAppReplication",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("appId" => appId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -807,6 +910,7 @@ function start_on_demand_replication_run(
         "StartOnDemandReplicationRun",
         Dict{String,Any}("replicationJobId" => replicationJobId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_on_demand_replication_run(
@@ -822,6 +926,7 @@ function start_on_demand_replication_run(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -837,12 +942,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"appId"`: The ID of the application.
 """
 function stop_app_replication(; aws_config::AbstractAWSConfig=global_aws_config())
-    return sms("StopAppReplication"; aws_config=aws_config)
+    return sms("StopAppReplication"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function stop_app_replication(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sms("StopAppReplication", params; aws_config=aws_config)
+    return sms(
+        "StopAppReplication", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -856,12 +963,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"appId"`: The ID of the application.
 """
 function terminate_app(; aws_config::AbstractAWSConfig=global_aws_config())
-    return sms("TerminateApp"; aws_config=aws_config)
+    return sms("TerminateApp"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function terminate_app(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sms("TerminateApp", params; aws_config=aws_config)
+    return sms(
+        "TerminateApp", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -880,12 +989,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"tags"`: The tags to associate with the application.
 """
 function update_app(; aws_config::AbstractAWSConfig=global_aws_config())
-    return sms("UpdateApp"; aws_config=aws_config)
+    return sms("UpdateApp"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function update_app(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sms("UpdateApp", params; aws_config=aws_config)
+    return sms("UpdateApp", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 
 """
@@ -921,6 +1030,7 @@ function update_replication_job(
         "UpdateReplicationJob",
         Dict{String,Any}("replicationJobId" => replicationJobId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_replication_job(
@@ -936,5 +1046,6 @@ function update_replication_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/snow_device_management.jl
+++ b/src/services/snow_device_management.jl
@@ -18,13 +18,22 @@ it's processed from the queue before the CancelTask operation changes the task's
 
 """
 function cancel_task(taskId; aws_config::AbstractAWSConfig=global_aws_config())
-    return snow_device_management("POST", "/task/$(taskId)/cancel"; aws_config=aws_config)
+    return snow_device_management(
+        "POST",
+        "/task/$(taskId)/cancel";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function cancel_task(
     taskId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return snow_device_management(
-        "POST", "/task/$(taskId)/cancel", params; aws_config=aws_config
+        "POST",
+        "/task/$(taskId)/cancel",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -54,6 +63,7 @@ function create_task(command, targets; aws_config::AbstractAWSConfig=global_aws_
             "command" => command, "targets" => targets, "clientToken" => string(uuid4())
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_task(
@@ -77,6 +87,7 @@ function create_task(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -93,7 +104,10 @@ addresses, and lock status.
 """
 function describe_device(managedDeviceId; aws_config::AbstractAWSConfig=global_aws_config())
     return snow_device_management(
-        "POST", "/managed-device/$(managedDeviceId)/describe"; aws_config=aws_config
+        "POST",
+        "/managed-device/$(managedDeviceId)/describe";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_device(
@@ -102,7 +116,11 @@ function describe_device(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return snow_device_management(
-        "POST", "/managed-device/$(managedDeviceId)/describe", params; aws_config=aws_config
+        "POST",
+        "/managed-device/$(managedDeviceId)/describe",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -127,6 +145,7 @@ function describe_device_ec2_instances(
         "/managed-device/$(managedDeviceId)/resources/ec2/describe",
         Dict{String,Any}("instanceIds" => instanceIds);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_device_ec2_instances(
@@ -142,6 +161,7 @@ function describe_device_ec2_instances(
             mergewith(_merge, Dict{String,Any}("instanceIds" => instanceIds), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -160,7 +180,10 @@ function describe_execution(
     managedDeviceId, taskId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return snow_device_management(
-        "POST", "/task/$(taskId)/execution/$(managedDeviceId)"; aws_config=aws_config
+        "POST",
+        "/task/$(taskId)/execution/$(managedDeviceId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_execution(
@@ -174,6 +197,7 @@ function describe_execution(
         "/task/$(taskId)/execution/$(managedDeviceId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -188,12 +212,20 @@ Checks the metadata for a given task on a device.
 
 """
 function describe_task(taskId; aws_config::AbstractAWSConfig=global_aws_config())
-    return snow_device_management("POST", "/task/$(taskId)"; aws_config=aws_config)
+    return snow_device_management(
+        "POST", "/task/$(taskId)"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_task(
     taskId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return snow_device_management("POST", "/task/$(taskId)", params; aws_config=aws_config)
+    return snow_device_management(
+        "POST",
+        "/task/$(taskId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -216,7 +248,10 @@ function list_device_resources(
     managedDeviceId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return snow_device_management(
-        "GET", "/managed-device/$(managedDeviceId)/resources"; aws_config=aws_config
+        "GET",
+        "/managed-device/$(managedDeviceId)/resources";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_device_resources(
@@ -225,7 +260,11 @@ function list_device_resources(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return snow_device_management(
-        "GET", "/managed-device/$(managedDeviceId)/resources", params; aws_config=aws_config
+        "GET",
+        "/managed-device/$(managedDeviceId)/resources",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -244,12 +283,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: A pagination token to continue to the next page of results.
 """
 function list_devices(; aws_config::AbstractAWSConfig=global_aws_config())
-    return snow_device_management("GET", "/managed-devices"; aws_config=aws_config)
+    return snow_device_management(
+        "GET", "/managed-devices"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_devices(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return snow_device_management("GET", "/managed-devices", params; aws_config=aws_config)
+    return snow_device_management(
+        "GET",
+        "/managed-devices",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -269,7 +316,11 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function list_executions(taskId; aws_config::AbstractAWSConfig=global_aws_config())
     return snow_device_management(
-        "GET", "/executions", Dict{String,Any}("taskId" => taskId); aws_config=aws_config
+        "GET",
+        "/executions",
+        Dict{String,Any}("taskId" => taskId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_executions(
@@ -280,6 +331,7 @@ function list_executions(
         "/executions",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("taskId" => taskId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -296,7 +348,12 @@ Returns a list of tags for a managed device or task.
 function list_tags_for_resource(
     resourceArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return snow_device_management("GET", "/tags/$(resourceArn)"; aws_config=aws_config)
+    return snow_device_management(
+        "GET",
+        "/tags/$(resourceArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_tags_for_resource(
     resourceArn,
@@ -304,7 +361,11 @@ function list_tags_for_resource(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return snow_device_management(
-        "GET", "/tags/$(resourceArn)", params; aws_config=aws_config
+        "GET",
+        "/tags/$(resourceArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -321,12 +382,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"state"`: A structure used to filter the list of tasks.
 """
 function list_tasks(; aws_config::AbstractAWSConfig=global_aws_config())
-    return snow_device_management("GET", "/tasks"; aws_config=aws_config)
+    return snow_device_management(
+        "GET", "/tasks"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_tasks(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return snow_device_management("GET", "/tasks", params; aws_config=aws_config)
+    return snow_device_management(
+        "GET", "/tasks", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -347,6 +412,7 @@ function tag_resource(resourceArn, tags; aws_config::AbstractAWSConfig=global_aw
         "/tags/$(resourceArn)",
         Dict{String,Any}("tags" => tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -360,6 +426,7 @@ function tag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tags" => tags), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -383,6 +450,7 @@ function untag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}("tagKeys" => tagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -396,5 +464,6 @@ function untag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tagKeys" => tagKeys), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/snowball.jl
+++ b/src/services/snowball.jl
@@ -18,7 +18,10 @@ status. You'll have at least an hour after creating a cluster job to cancel it.
 """
 function cancel_cluster(ClusterId; aws_config::AbstractAWSConfig=global_aws_config())
     return snowball(
-        "CancelCluster", Dict{String,Any}("ClusterId" => ClusterId); aws_config=aws_config
+        "CancelCluster",
+        Dict{String,Any}("ClusterId" => ClusterId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function cancel_cluster(
@@ -32,6 +35,7 @@ function cancel_cluster(
             mergewith(_merge, Dict{String,Any}("ClusterId" => ClusterId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -49,7 +53,12 @@ as part of the response element data returned.
 
 """
 function cancel_job(JobId; aws_config::AbstractAWSConfig=global_aws_config())
-    return snowball("CancelJob", Dict{String,Any}("JobId" => JobId); aws_config=aws_config)
+    return snowball(
+        "CancelJob",
+        Dict{String,Any}("JobId" => JobId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function cancel_job(
     JobId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -58,6 +67,7 @@ function cancel_job(
         "CancelJob",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("JobId" => JobId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -76,7 +86,10 @@ exception is thrown.
 """
 function create_address(Address; aws_config::AbstractAWSConfig=global_aws_config())
     return snowball(
-        "CreateAddress", Dict{String,Any}("Address" => Address); aws_config=aws_config
+        "CreateAddress",
+        Dict{String,Any}("Address" => Address);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_address(
@@ -86,6 +99,7 @@ function create_address(
         "CreateAddress",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Address" => Address), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -172,6 +186,7 @@ function create_cluster(
             "SnowballType" => SnowballType,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_cluster(
@@ -201,6 +216,7 @@ function create_cluster(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -292,12 +308,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"TaxDocuments"`: The tax documents required in your AWS Region.
 """
 function create_job(; aws_config::AbstractAWSConfig=global_aws_config())
-    return snowball("CreateJob"; aws_config=aws_config)
+    return snowball("CreateJob"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function create_job(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return snowball("CreateJob", params; aws_config=aws_config)
+    return snowball(
+        "CreateJob", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -325,6 +343,7 @@ function create_long_term_pricing(
         "CreateLongTermPricing",
         Dict{String,Any}("LongTermPricingType" => LongTermPricingType);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_long_term_pricing(
@@ -342,6 +361,7 @@ function create_long_term_pricing(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -368,6 +388,7 @@ function create_return_shipping_label(
         "CreateReturnShippingLabel",
         Dict{String,Any}("JobId" => JobId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_return_shipping_label(
@@ -377,6 +398,7 @@ function create_return_shipping_label(
         "CreateReturnShippingLabel",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("JobId" => JobId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -393,7 +415,10 @@ Address object.
 """
 function describe_address(AddressId; aws_config::AbstractAWSConfig=global_aws_config())
     return snowball(
-        "DescribeAddress", Dict{String,Any}("AddressId" => AddressId); aws_config=aws_config
+        "DescribeAddress",
+        Dict{String,Any}("AddressId" => AddressId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_address(
@@ -407,6 +432,7 @@ function describe_address(
             mergewith(_merge, Dict{String,Any}("AddressId" => AddressId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -426,12 +452,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   starting point for your list of returned addresses.
 """
 function describe_addresses(; aws_config::AbstractAWSConfig=global_aws_config())
-    return snowball("DescribeAddresses"; aws_config=aws_config)
+    return snowball(
+        "DescribeAddresses"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_addresses(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return snowball("DescribeAddresses", params; aws_config=aws_config)
+    return snowball(
+        "DescribeAddresses", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -447,7 +477,10 @@ status, and other important metadata.
 """
 function describe_cluster(ClusterId; aws_config::AbstractAWSConfig=global_aws_config())
     return snowball(
-        "DescribeCluster", Dict{String,Any}("ClusterId" => ClusterId); aws_config=aws_config
+        "DescribeCluster",
+        Dict{String,Any}("ClusterId" => ClusterId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_cluster(
@@ -461,6 +494,7 @@ function describe_cluster(
             mergewith(_merge, Dict{String,Any}("ClusterId" => ClusterId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -478,7 +512,10 @@ other important metadata.
 """
 function describe_job(JobId; aws_config::AbstractAWSConfig=global_aws_config())
     return snowball(
-        "DescribeJob", Dict{String,Any}("JobId" => JobId); aws_config=aws_config
+        "DescribeJob",
+        Dict{String,Any}("JobId" => JobId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_job(
@@ -488,6 +525,7 @@ function describe_job(
         "DescribeJob",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("JobId" => JobId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -509,6 +547,7 @@ function describe_return_shipping_label(
         "DescribeReturnShippingLabel",
         Dict{String,Any}("JobId" => JobId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_return_shipping_label(
@@ -518,6 +557,7 @@ function describe_return_shipping_label(
         "DescribeReturnShippingLabel",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("JobId" => JobId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -545,7 +585,10 @@ after the job is created.
 """
 function get_job_manifest(JobId; aws_config::AbstractAWSConfig=global_aws_config())
     return snowball(
-        "GetJobManifest", Dict{String,Any}("JobId" => JobId); aws_config=aws_config
+        "GetJobManifest",
+        Dict{String,Any}("JobId" => JobId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_job_manifest(
@@ -555,6 +598,7 @@ function get_job_manifest(
         "GetJobManifest",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("JobId" => JobId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -578,7 +622,10 @@ from gaining access to the Snow device associated with that job.
 """
 function get_job_unlock_code(JobId; aws_config::AbstractAWSConfig=global_aws_config())
     return snowball(
-        "GetJobUnlockCode", Dict{String,Any}("JobId" => JobId); aws_config=aws_config
+        "GetJobUnlockCode",
+        Dict{String,Any}("JobId" => JobId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_job_unlock_code(
@@ -588,6 +635,7 @@ function get_job_unlock_code(
         "GetJobUnlockCode",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("JobId" => JobId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -602,12 +650,16 @@ limit, contact AWS Support.
 
 """
 function get_snowball_usage(; aws_config::AbstractAWSConfig=global_aws_config())
-    return snowball("GetSnowballUsage"; aws_config=aws_config)
+    return snowball(
+        "GetSnowballUsage"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_snowball_usage(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return snowball("GetSnowballUsage", params; aws_config=aws_config)
+    return snowball(
+        "GetSnowballUsage", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -623,7 +675,10 @@ Returns an Amazon S3 presigned URL for an update file associated with a specifie
 """
 function get_software_updates(JobId; aws_config::AbstractAWSConfig=global_aws_config())
     return snowball(
-        "GetSoftwareUpdates", Dict{String,Any}("JobId" => JobId); aws_config=aws_config
+        "GetSoftwareUpdates",
+        Dict{String,Any}("JobId" => JobId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_software_updates(
@@ -633,6 +688,7 @@ function get_software_updates(
         "GetSoftwareUpdates",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("JobId" => JobId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -657,7 +713,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function list_cluster_jobs(ClusterId; aws_config::AbstractAWSConfig=global_aws_config())
     return snowball(
-        "ListClusterJobs", Dict{String,Any}("ClusterId" => ClusterId); aws_config=aws_config
+        "ListClusterJobs",
+        Dict{String,Any}("ClusterId" => ClusterId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_cluster_jobs(
@@ -671,6 +730,7 @@ function list_cluster_jobs(
             mergewith(_merge, Dict{String,Any}("ClusterId" => ClusterId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -689,12 +749,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   starting point for your returned list.
 """
 function list_clusters(; aws_config::AbstractAWSConfig=global_aws_config())
-    return snowball("ListClusters"; aws_config=aws_config)
+    return snowball("ListClusters"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_clusters(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return snowball("ListClusters", params; aws_config=aws_config)
+    return snowball(
+        "ListClusters", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -715,12 +777,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   your list of returned images.
 """
 function list_compatible_images(; aws_config::AbstractAWSConfig=global_aws_config())
-    return snowball("ListCompatibleImages"; aws_config=aws_config)
+    return snowball(
+        "ListCompatibleImages"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_compatible_images(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return snowball("ListCompatibleImages", params; aws_config=aws_config)
+    return snowball(
+        "ListCompatibleImages",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -740,12 +809,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   point for your returned list.
 """
 function list_jobs(; aws_config::AbstractAWSConfig=global_aws_config())
-    return snowball("ListJobs"; aws_config=aws_config)
+    return snowball("ListJobs"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_jobs(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return snowball("ListJobs", params; aws_config=aws_config)
+    return snowball(
+        "ListJobs", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -761,12 +832,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   next list of ListLongTermPricing to return.
 """
 function list_long_term_pricing(; aws_config::AbstractAWSConfig=global_aws_config())
-    return snowball("ListLongTermPricing"; aws_config=aws_config)
+    return snowball(
+        "ListLongTermPricing"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_long_term_pricing(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return snowball("ListLongTermPricing", params; aws_config=aws_config)
+    return snowball(
+        "ListLongTermPricing",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -802,7 +880,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function update_cluster(ClusterId; aws_config::AbstractAWSConfig=global_aws_config())
     return snowball(
-        "UpdateCluster", Dict{String,Any}("ClusterId" => ClusterId); aws_config=aws_config
+        "UpdateCluster",
+        Dict{String,Any}("ClusterId" => ClusterId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_cluster(
@@ -816,6 +897,7 @@ function update_cluster(
             mergewith(_merge, Dict{String,Any}("ClusterId" => ClusterId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -856,7 +938,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   (Snow Family Devices and Capacity) in the Snowcone User Guide.
 """
 function update_job(JobId; aws_config::AbstractAWSConfig=global_aws_config())
-    return snowball("UpdateJob", Dict{String,Any}("JobId" => JobId); aws_config=aws_config)
+    return snowball(
+        "UpdateJob",
+        Dict{String,Any}("JobId" => JobId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function update_job(
     JobId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -865,6 +952,7 @@ function update_job(
         "UpdateJob",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("JobId" => JobId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -889,6 +977,7 @@ function update_job_shipment_state(
         "UpdateJobShipmentState",
         Dict{String,Any}("JobId" => JobId, "ShipmentState" => ShipmentState);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_job_shipment_state(
@@ -907,6 +996,7 @@ function update_job_shipment_state(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -934,6 +1024,7 @@ function update_long_term_pricing(
         "UpdateLongTermPricing",
         Dict{String,Any}("LongTermPricingId" => LongTermPricingId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_long_term_pricing(
@@ -949,5 +1040,6 @@ function update_long_term_pricing(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/sns.jl
+++ b/src/services/sns.jl
@@ -37,6 +37,7 @@ function add_permission(
             "TopicArn" => TopicArn,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function add_permission(
@@ -62,6 +63,7 @@ function add_permission(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -84,6 +86,7 @@ function check_if_phone_number_is_opted_out(
         "CheckIfPhoneNumberIsOptedOut",
         Dict{String,Any}("phoneNumber" => phoneNumber);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function check_if_phone_number_is_opted_out(
@@ -97,6 +100,7 @@ function check_if_phone_number_is_opted_out(
             mergewith(_merge, Dict{String,Any}("phoneNumber" => phoneNumber), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -127,6 +131,7 @@ function confirm_subscription(
         "ConfirmSubscription",
         Dict{String,Any}("Token" => Token, "TopicArn" => TopicArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function confirm_subscription(
@@ -143,6 +148,7 @@ function confirm_subscription(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -181,6 +187,7 @@ function create_platform_application(
             "Attributes" => Attributes, "Name" => Name, "Platform" => Platform
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_platform_application(
@@ -202,6 +209,7 @@ function create_platform_application(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -244,6 +252,7 @@ function create_platform_endpoint(
             "PlatformApplicationArn" => PlatformApplicationArn, "Token" => Token
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_platform_endpoint(
@@ -264,6 +273,7 @@ function create_platform_endpoint(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -295,6 +305,7 @@ function create_smssandbox_phone_number(
         "CreateSMSSandboxPhoneNumber",
         Dict{String,Any}("PhoneNumber" => PhoneNumber);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_smssandbox_phone_number(
@@ -308,6 +319,7 @@ function create_smssandbox_phone_number(
             mergewith(_merge, Dict{String,Any}("PhoneNumber" => PhoneNumber), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -352,7 +364,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   you must have the sns:CreateTopic and sns:TagResource permissions.
 """
 function create_topic(Name; aws_config::AbstractAWSConfig=global_aws_config())
-    return sns("CreateTopic", Dict{String,Any}("Name" => Name); aws_config=aws_config)
+    return sns(
+        "CreateTopic",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function create_topic(
     Name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -361,6 +378,7 @@ function create_topic(
         "CreateTopic",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -382,6 +400,7 @@ function delete_endpoint(EndpointArn; aws_config::AbstractAWSConfig=global_aws_c
         "DeleteEndpoint",
         Dict{String,Any}("EndpointArn" => EndpointArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_endpoint(
@@ -395,6 +414,7 @@ function delete_endpoint(
             mergewith(_merge, Dict{String,Any}("EndpointArn" => EndpointArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -418,6 +438,7 @@ function delete_platform_application(
         "DeletePlatformApplication",
         Dict{String,Any}("PlatformApplicationArn" => PlatformApplicationArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_platform_application(
@@ -435,6 +456,7 @@ function delete_platform_application(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -461,6 +483,7 @@ function delete_smssandbox_phone_number(
         "DeleteSMSSandboxPhoneNumber",
         Dict{String,Any}("PhoneNumber" => PhoneNumber);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_smssandbox_phone_number(
@@ -474,6 +497,7 @@ function delete_smssandbox_phone_number(
             mergewith(_merge, Dict{String,Any}("PhoneNumber" => PhoneNumber), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -491,7 +515,10 @@ idempotent, so deleting a topic that does not exist does not result in an error.
 """
 function delete_topic(TopicArn; aws_config::AbstractAWSConfig=global_aws_config())
     return sns(
-        "DeleteTopic", Dict{String,Any}("TopicArn" => TopicArn); aws_config=aws_config
+        "DeleteTopic",
+        Dict{String,Any}("TopicArn" => TopicArn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_topic(
@@ -505,6 +532,7 @@ function delete_topic(
             mergewith(_merge, Dict{String,Any}("TopicArn" => TopicArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -527,6 +555,7 @@ function get_endpoint_attributes(
         "GetEndpointAttributes",
         Dict{String,Any}("EndpointArn" => EndpointArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_endpoint_attributes(
@@ -540,6 +569,7 @@ function get_endpoint_attributes(
             mergewith(_merge, Dict{String,Any}("EndpointArn" => EndpointArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -563,6 +593,7 @@ function get_platform_application_attributes(
         "GetPlatformApplicationAttributes",
         Dict{String,Any}("PlatformApplicationArn" => PlatformApplicationArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_platform_application_attributes(
@@ -580,6 +611,7 @@ function get_platform_application_attributes(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -597,12 +629,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   parameter, Amazon SNS returns all SMS attributes.
 """
 function get_smsattributes(; aws_config::AbstractAWSConfig=global_aws_config())
-    return sns("GetSMSAttributes"; aws_config=aws_config)
+    return sns("GetSMSAttributes"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function get_smsattributes(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sns("GetSMSAttributes", params; aws_config=aws_config)
+    return sns(
+        "GetSMSAttributes", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -619,12 +653,19 @@ messages without restrictions, see SMS sandbox in the Amazon SNS Developer Guide
 
 """
 function get_smssandbox_account_status(; aws_config::AbstractAWSConfig=global_aws_config())
-    return sns("GetSMSSandboxAccountStatus"; aws_config=aws_config)
+    return sns(
+        "GetSMSSandboxAccountStatus"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_smssandbox_account_status(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sns("GetSMSSandboxAccountStatus", params; aws_config=aws_config)
+    return sns(
+        "GetSMSSandboxAccountStatus",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -644,6 +685,7 @@ function get_subscription_attributes(
         "GetSubscriptionAttributes",
         Dict{String,Any}("SubscriptionArn" => SubscriptionArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_subscription_attributes(
@@ -659,6 +701,7 @@ function get_subscription_attributes(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -678,6 +721,7 @@ function get_topic_attributes(TopicArn; aws_config::AbstractAWSConfig=global_aws
         "GetTopicAttributes",
         Dict{String,Any}("TopicArn" => TopicArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_topic_attributes(
@@ -691,6 +735,7 @@ function get_topic_attributes(
             mergewith(_merge, Dict{String,Any}("TopicArn" => TopicArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -724,6 +769,7 @@ function list_endpoints_by_platform_application(
         "ListEndpointsByPlatformApplication",
         Dict{String,Any}("PlatformApplicationArn" => PlatformApplicationArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_endpoints_by_platform_application(
@@ -741,6 +787,7 @@ function list_endpoints_by_platform_application(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -758,12 +805,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`: Token that the previous ListOriginationNumbers request returns.
 """
 function list_origination_numbers(; aws_config::AbstractAWSConfig=global_aws_config())
-    return sns("ListOriginationNumbers"; aws_config=aws_config)
+    return sns(
+        "ListOriginationNumbers"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_origination_numbers(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sns("ListOriginationNumbers", params; aws_config=aws_config)
+    return sns(
+        "ListOriginationNumbers",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -783,12 +837,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   action to retrieve additional records that are available after the first page of results.
 """
 function list_phone_numbers_opted_out(; aws_config::AbstractAWSConfig=global_aws_config())
-    return sns("ListPhoneNumbersOptedOut"; aws_config=aws_config)
+    return sns(
+        "ListPhoneNumbersOptedOut"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_phone_numbers_opted_out(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sns("ListPhoneNumbersOptedOut", params; aws_config=aws_config)
+    return sns(
+        "ListPhoneNumbersOptedOut",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -810,12 +871,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   retrieve additional records that are available after the first page results.
 """
 function list_platform_applications(; aws_config::AbstractAWSConfig=global_aws_config())
-    return sns("ListPlatformApplications"; aws_config=aws_config)
+    return sns(
+        "ListPlatformApplications"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_platform_applications(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sns("ListPlatformApplications", params; aws_config=aws_config)
+    return sns(
+        "ListPlatformApplications",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -837,12 +905,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`: Token that the previous ListSMSSandboxPhoneNumbersInput request returns.
 """
 function list_smssandbox_phone_numbers(; aws_config::AbstractAWSConfig=global_aws_config())
-    return sns("ListSMSSandboxPhoneNumbers"; aws_config=aws_config)
+    return sns(
+        "ListSMSSandboxPhoneNumbers"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_smssandbox_phone_numbers(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sns("ListSMSSandboxPhoneNumbers", params; aws_config=aws_config)
+    return sns(
+        "ListSMSSandboxPhoneNumbers",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -859,12 +934,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`: Token returned by the previous ListSubscriptions request.
 """
 function list_subscriptions(; aws_config::AbstractAWSConfig=global_aws_config())
-    return sns("ListSubscriptions"; aws_config=aws_config)
+    return sns("ListSubscriptions"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_subscriptions(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sns("ListSubscriptions", params; aws_config=aws_config)
+    return sns(
+        "ListSubscriptions", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -890,6 +967,7 @@ function list_subscriptions_by_topic(
         "ListSubscriptionsByTopic",
         Dict{String,Any}("TopicArn" => TopicArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_subscriptions_by_topic(
@@ -903,6 +981,7 @@ function list_subscriptions_by_topic(
             mergewith(_merge, Dict{String,Any}("TopicArn" => TopicArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -924,6 +1003,7 @@ function list_tags_for_resource(
         "ListTagsForResource",
         Dict{String,Any}("ResourceArn" => ResourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags_for_resource(
@@ -937,6 +1017,7 @@ function list_tags_for_resource(
             mergewith(_merge, Dict{String,Any}("ResourceArn" => ResourceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -954,12 +1035,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`: Token returned by the previous ListTopics request.
 """
 function list_topics(; aws_config::AbstractAWSConfig=global_aws_config())
-    return sns("ListTopics"; aws_config=aws_config)
+    return sns("ListTopics"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_topics(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sns("ListTopics", params; aws_config=aws_config)
+    return sns("ListTopics", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 
 """
@@ -978,6 +1059,7 @@ function opt_in_phone_number(phoneNumber; aws_config::AbstractAWSConfig=global_a
         "OptInPhoneNumber",
         Dict{String,Any}("phoneNumber" => phoneNumber);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function opt_in_phone_number(
@@ -991,6 +1073,7 @@ function opt_in_phone_number(
             mergewith(_merge, Dict{String,Any}("phoneNumber" => phoneNumber), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1072,7 +1155,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   TopicArn parameter, you must specify a value for the PhoneNumber or TargetArn parameters.
 """
 function publish(Message; aws_config::AbstractAWSConfig=global_aws_config())
-    return sns("Publish", Dict{String,Any}("Message" => Message); aws_config=aws_config)
+    return sns(
+        "Publish",
+        Dict{String,Any}("Message" => Message);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function publish(
     Message, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -1081,6 +1169,7 @@ function publish(
         "Publish",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Message" => Message), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1102,6 +1191,7 @@ function remove_permission(
         "RemovePermission",
         Dict{String,Any}("Label" => Label, "TopicArn" => TopicArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function remove_permission(
@@ -1118,6 +1208,7 @@ function remove_permission(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1149,6 +1240,7 @@ function set_endpoint_attributes(
         "SetEndpointAttributes",
         Dict{String,Any}("Attributes" => Attributes, "EndpointArn" => EndpointArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function set_endpoint_attributes(
@@ -1167,6 +1259,7 @@ function set_endpoint_attributes(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1209,6 +1302,7 @@ function set_platform_application_attributes(
             "Attributes" => Attributes, "PlatformApplicationArn" => PlatformApplicationArn
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function set_platform_application_attributes(
@@ -1230,6 +1324,7 @@ function set_platform_application_attributes(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1288,6 +1383,7 @@ function set_smsattributes(attributes; aws_config::AbstractAWSConfig=global_aws_
         "SetSMSAttributes",
         Dict{String,Any}("attributes" => attributes);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function set_smsattributes(
@@ -1301,6 +1397,7 @@ function set_smsattributes(
             mergewith(_merge, Dict{String,Any}("attributes" => attributes), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1344,6 +1441,7 @@ function set_subscription_attributes(
             "AttributeName" => AttributeName, "SubscriptionArn" => SubscriptionArn
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function set_subscription_attributes(
@@ -1364,6 +1462,7 @@ function set_subscription_attributes(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1404,6 +1503,7 @@ function set_topic_attributes(
         "SetTopicAttributes",
         Dict{String,Any}("AttributeName" => AttributeName, "TopicArn" => TopicArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function set_topic_attributes(
@@ -1422,6 +1522,7 @@ function set_topic_attributes(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1489,6 +1590,7 @@ function subscribe(Protocol, TopicArn; aws_config::AbstractAWSConfig=global_aws_
         "Subscribe",
         Dict{String,Any}("Protocol" => Protocol, "TopicArn" => TopicArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function subscribe(
@@ -1507,6 +1609,7 @@ function subscribe(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1533,6 +1636,7 @@ function tag_resource(ResourceArn, Tags; aws_config::AbstractAWSConfig=global_aw
         "TagResource",
         Dict{String,Any}("ResourceArn" => ResourceArn, "Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -1551,6 +1655,7 @@ function tag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1574,6 +1679,7 @@ function unsubscribe(SubscriptionArn; aws_config::AbstractAWSConfig=global_aws_c
         "Unsubscribe",
         Dict{String,Any}("SubscriptionArn" => SubscriptionArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function unsubscribe(
@@ -1589,6 +1695,7 @@ function unsubscribe(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1611,6 +1718,7 @@ function untag_resource(
         "UntagResource",
         Dict{String,Any}("ResourceArn" => ResourceArn, "TagKeys" => TagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -1629,6 +1737,7 @@ function untag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1659,6 +1768,7 @@ function verify_smssandbox_phone_number(
             "OneTimePassword" => OneTimePassword, "PhoneNumber" => PhoneNumber
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function verify_smssandbox_phone_number(
@@ -1679,5 +1789,6 @@ function verify_smssandbox_phone_number(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/sqs.jl
+++ b/src/services/sqs.jl
@@ -68,6 +68,7 @@ function add_permission(
             "QueueUrl" => QueueUrl,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function add_permission(
@@ -93,6 +94,7 @@ function add_permission(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -154,6 +156,7 @@ function change_message_visibility(
             "VisibilityTimeout" => VisibilityTimeout,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function change_message_visibility(
@@ -177,6 +180,7 @@ function change_message_visibility(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -218,6 +222,7 @@ function change_message_visibility_batch(
             "QueueUrl" => QueueUrl,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function change_message_visibility_batch(
@@ -240,6 +245,7 @@ function change_message_visibility_batch(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -373,7 +379,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function create_queue(QueueName; aws_config::AbstractAWSConfig=global_aws_config())
     return sqs(
-        "CreateQueue", Dict{String,Any}("QueueName" => QueueName); aws_config=aws_config
+        "CreateQueue",
+        Dict{String,Any}("QueueName" => QueueName);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_queue(
@@ -387,6 +396,7 @@ function create_queue(
             mergewith(_merge, Dict{String,Any}("QueueName" => QueueName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -423,6 +433,7 @@ function delete_message(
         "DeleteMessage",
         Dict{String,Any}("QueueUrl" => QueueUrl, "ReceiptHandle" => ReceiptHandle);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_message(
@@ -441,6 +452,7 @@ function delete_message(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -479,6 +491,7 @@ function delete_message_batch(
             "QueueUrl" => QueueUrl,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_message_batch(
@@ -500,6 +513,7 @@ function delete_message_batch(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -524,7 +538,10 @@ user name in the Amazon SQS Developer Guide.
 """
 function delete_queue(QueueUrl; aws_config::AbstractAWSConfig=global_aws_config())
     return sqs(
-        "DeleteQueue", Dict{String,Any}("QueueUrl" => QueueUrl); aws_config=aws_config
+        "DeleteQueue",
+        Dict{String,Any}("QueueUrl" => QueueUrl);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_queue(
@@ -538,6 +555,7 @@ function delete_queue(
             mergewith(_merge, Dict{String,Any}("QueueUrl" => QueueUrl), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -632,6 +650,7 @@ function get_queue_attributes(QueueUrl; aws_config::AbstractAWSConfig=global_aws
         "GetQueueAttributes",
         Dict{String,Any}("QueueUrl" => QueueUrl);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_queue_attributes(
@@ -645,6 +664,7 @@ function get_queue_attributes(
             mergewith(_merge, Dict{String,Any}("QueueUrl" => QueueUrl), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -669,7 +689,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function get_queue_url(QueueName; aws_config::AbstractAWSConfig=global_aws_config())
     return sqs(
-        "GetQueueUrl", Dict{String,Any}("QueueName" => QueueName); aws_config=aws_config
+        "GetQueueUrl",
+        Dict{String,Any}("QueueName" => QueueName);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_queue_url(
@@ -683,6 +706,7 @@ function get_queue_url(
             mergewith(_merge, Dict{String,Any}("QueueName" => QueueName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -716,6 +740,7 @@ function list_dead_letter_source_queues(
         "ListDeadLetterSourceQueues",
         Dict{String,Any}("QueueUrl" => QueueUrl);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_dead_letter_source_queues(
@@ -729,6 +754,7 @@ function list_dead_letter_source_queues(
             mergewith(_merge, Dict{String,Any}("QueueUrl" => QueueUrl), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -747,7 +773,10 @@ permissions to a role and a user name in the Amazon SQS Developer Guide.
 """
 function list_queue_tags(QueueUrl; aws_config::AbstractAWSConfig=global_aws_config())
     return sqs(
-        "ListQueueTags", Dict{String,Any}("QueueUrl" => QueueUrl); aws_config=aws_config
+        "ListQueueTags",
+        Dict{String,Any}("QueueUrl" => QueueUrl);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_queue_tags(
@@ -761,6 +790,7 @@ function list_queue_tags(
             mergewith(_merge, Dict{String,Any}("QueueUrl" => QueueUrl), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -789,12 +819,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   case-sensitive.
 """
 function list_queues(; aws_config::AbstractAWSConfig=global_aws_config())
-    return sqs("ListQueues"; aws_config=aws_config)
+    return sqs("ListQueues"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_queues(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sqs("ListQueues", params; aws_config=aws_config)
+    return sqs("ListQueues", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 
 """
@@ -815,7 +845,10 @@ PurgeQueue might be deleted while the queue is being purged.
 """
 function purge_queue(QueueUrl; aws_config::AbstractAWSConfig=global_aws_config())
     return sqs(
-        "PurgeQueue", Dict{String,Any}("QueueUrl" => QueueUrl); aws_config=aws_config
+        "PurgeQueue",
+        Dict{String,Any}("QueueUrl" => QueueUrl);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function purge_queue(
@@ -829,6 +862,7 @@ function purge_queue(
             mergewith(_merge, Dict{String,Any}("QueueUrl" => QueueUrl), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -935,7 +969,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function receive_message(QueueUrl; aws_config::AbstractAWSConfig=global_aws_config())
     return sqs(
-        "ReceiveMessage", Dict{String,Any}("QueueUrl" => QueueUrl); aws_config=aws_config
+        "ReceiveMessage",
+        Dict{String,Any}("QueueUrl" => QueueUrl);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function receive_message(
@@ -949,6 +986,7 @@ function receive_message(
             mergewith(_merge, Dict{String,Any}("QueueUrl" => QueueUrl), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -977,6 +1015,7 @@ function remove_permission(
         "RemovePermission",
         Dict{String,Any}("Label" => Label, "QueueUrl" => QueueUrl);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function remove_permission(
@@ -993,6 +1032,7 @@ function remove_permission(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1077,6 +1117,7 @@ function send_message(
         "SendMessage",
         Dict{String,Any}("MessageBody" => MessageBody, "QueueUrl" => QueueUrl);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function send_message(
@@ -1095,6 +1136,7 @@ function send_message(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1139,6 +1181,7 @@ function send_message_batch(
             "SendMessageBatchRequestEntry" => SendMessageBatchRequestEntry,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function send_message_batch(
@@ -1160,6 +1203,7 @@ function send_message_batch(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1265,6 +1309,7 @@ function set_queue_attributes(
         "SetQueueAttributes",
         Dict{String,Any}("Attribute" => Attribute, "QueueUrl" => QueueUrl);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function set_queue_attributes(
@@ -1283,6 +1328,7 @@ function set_queue_attributes(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1310,6 +1356,7 @@ function tag_queue(QueueUrl, Tags; aws_config::AbstractAWSConfig=global_aws_conf
         "TagQueue",
         Dict{String,Any}("QueueUrl" => QueueUrl, "Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_queue(
@@ -1326,6 +1373,7 @@ function tag_queue(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1351,6 +1399,7 @@ function untag_queue(QueueUrl, TagKey; aws_config::AbstractAWSConfig=global_aws_
         "UntagQueue",
         Dict{String,Any}("QueueUrl" => QueueUrl, "TagKey" => TagKey);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_queue(
@@ -1367,5 +1416,6 @@ function untag_queue(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/ssm.jl
+++ b/src/services/ssm.jl
@@ -53,6 +53,7 @@ function add_tags_to_resource(
             "ResourceId" => ResourceId, "ResourceType" => ResourceType, "Tags" => Tags
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function add_tags_to_resource(
@@ -76,6 +77,7 @@ function add_tags_to_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -115,6 +117,7 @@ function associate_ops_item_related_item(
             "ResourceUri" => ResourceUri,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_ops_item_related_item(
@@ -140,6 +143,7 @@ function associate_ops_item_related_item(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -161,7 +165,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function cancel_command(CommandId; aws_config::AbstractAWSConfig=global_aws_config())
     return ssm(
-        "CancelCommand", Dict{String,Any}("CommandId" => CommandId); aws_config=aws_config
+        "CancelCommand",
+        Dict{String,Any}("CommandId" => CommandId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function cancel_command(
@@ -175,6 +182,7 @@ function cancel_command(
             mergewith(_merge, Dict{String,Any}("CommandId" => CommandId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -197,6 +205,7 @@ function cancel_maintenance_window_execution(
         "CancelMaintenanceWindowExecution",
         Dict{String,Any}("WindowExecutionId" => WindowExecutionId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function cancel_maintenance_window_execution(
@@ -212,6 +221,7 @@ function cancel_maintenance_window_execution(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -267,7 +277,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function create_activation(IamRole; aws_config::AbstractAWSConfig=global_aws_config())
     return ssm(
-        "CreateActivation", Dict{String,Any}("IamRole" => IamRole); aws_config=aws_config
+        "CreateActivation",
+        Dict{String,Any}("IamRole" => IamRole);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_activation(
@@ -277,6 +290,7 @@ function create_activation(
         "CreateActivation",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("IamRole" => IamRole), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -371,7 +385,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Services Systems Manager User Guide.
 """
 function create_association(Name; aws_config::AbstractAWSConfig=global_aws_config())
-    return ssm("CreateAssociation", Dict{String,Any}("Name" => Name); aws_config=aws_config)
+    return ssm(
+        "CreateAssociation",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function create_association(
     Name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -380,6 +399,7 @@ function create_association(
         "CreateAssociation",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -405,6 +425,7 @@ function create_association_batch(
         "CreateAssociationBatch",
         Dict{String,Any}("Entries" => Entries);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_association_batch(
@@ -414,6 +435,7 @@ function create_association_batch(
         "CreateAssociationBatch",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Entries" => Entries), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -474,6 +496,7 @@ function create_document(Content, Name; aws_config::AbstractAWSConfig=global_aws
         "CreateDocument",
         Dict{String,Any}("Content" => Content, "Name" => Name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_document(
@@ -490,6 +513,7 @@ function create_document(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -564,6 +588,7 @@ function create_maintenance_window(
             "ClientToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_maintenance_window(
@@ -592,6 +617,7 @@ function create_maintenance_window(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -665,6 +691,7 @@ function create_ops_item(
             "Description" => Description, "Source" => Source, "Title" => Title
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_ops_item(
@@ -686,6 +713,7 @@ function create_ops_item(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -715,6 +743,7 @@ function create_ops_metadata(ResourceId; aws_config::AbstractAWSConfig=global_aw
         "CreateOpsMetadata",
         Dict{String,Any}("ResourceId" => ResourceId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_ops_metadata(
@@ -728,6 +757,7 @@ function create_ops_metadata(
             mergewith(_merge, Dict{String,Any}("ResourceId" => ResourceId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -785,6 +815,7 @@ function create_patch_baseline(Name; aws_config::AbstractAWSConfig=global_aws_co
         "CreatePatchBaseline",
         Dict{String,Any}("Name" => Name, "ClientToken" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_patch_baseline(
@@ -800,6 +831,7 @@ function create_patch_baseline(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -849,6 +881,7 @@ function create_resource_data_sync(
         "CreateResourceDataSync",
         Dict{String,Any}("SyncName" => SyncName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_resource_data_sync(
@@ -862,6 +895,7 @@ function create_resource_data_sync(
             mergewith(_merge, Dict{String,Any}("SyncName" => SyncName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -883,6 +917,7 @@ function delete_activation(ActivationId; aws_config::AbstractAWSConfig=global_aw
         "DeleteActivation",
         Dict{String,Any}("ActivationId" => ActivationId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_activation(
@@ -896,6 +931,7 @@ function delete_activation(
             mergewith(_merge, Dict{String,Any}("ActivationId" => ActivationId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -922,12 +958,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"Name"`: The name of the SSM document.
 """
 function delete_association(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ssm("DeleteAssociation"; aws_config=aws_config)
+    return ssm("DeleteAssociation"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function delete_association(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ssm("DeleteAssociation", params; aws_config=aws_config)
+    return ssm(
+        "DeleteAssociation", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -953,7 +991,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   provided, all versions of the document are deleted.
 """
 function delete_document(Name; aws_config::AbstractAWSConfig=global_aws_config())
-    return ssm("DeleteDocument", Dict{String,Any}("Name" => Name); aws_config=aws_config)
+    return ssm(
+        "DeleteDocument",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_document(
     Name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -962,6 +1005,7 @@ function delete_document(
         "DeleteDocument",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -997,6 +1041,7 @@ function delete_inventory(TypeName; aws_config::AbstractAWSConfig=global_aws_con
         "DeleteInventory",
         Dict{String,Any}("TypeName" => TypeName, "ClientToken" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_inventory(
@@ -1014,6 +1059,7 @@ function delete_inventory(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1034,6 +1080,7 @@ function delete_maintenance_window(
         "DeleteMaintenanceWindow",
         Dict{String,Any}("WindowId" => WindowId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_maintenance_window(
@@ -1047,6 +1094,7 @@ function delete_maintenance_window(
             mergewith(_merge, Dict{String,Any}("WindowId" => WindowId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1067,6 +1115,7 @@ function delete_ops_metadata(
         "DeleteOpsMetadata",
         Dict{String,Any}("OpsMetadataArn" => OpsMetadataArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_ops_metadata(
@@ -1080,6 +1129,7 @@ function delete_ops_metadata(
             mergewith(_merge, Dict{String,Any}("OpsMetadataArn" => OpsMetadataArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1095,7 +1145,12 @@ seconds to create a parameter with the same name.
 
 """
 function delete_parameter(Name; aws_config::AbstractAWSConfig=global_aws_config())
-    return ssm("DeleteParameter", Dict{String,Any}("Name" => Name); aws_config=aws_config)
+    return ssm(
+        "DeleteParameter",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_parameter(
     Name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -1104,6 +1159,7 @@ function delete_parameter(
         "DeleteParameter",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1121,7 +1177,10 @@ create a parameter with the same name.
 """
 function delete_parameters(Names; aws_config::AbstractAWSConfig=global_aws_config())
     return ssm(
-        "DeleteParameters", Dict{String,Any}("Names" => Names); aws_config=aws_config
+        "DeleteParameters",
+        Dict{String,Any}("Names" => Names);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_parameters(
@@ -1131,6 +1190,7 @@ function delete_parameters(
         "DeleteParameters",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Names" => Names), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1151,6 +1211,7 @@ function delete_patch_baseline(
         "DeletePatchBaseline",
         Dict{String,Any}("BaselineId" => BaselineId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_patch_baseline(
@@ -1164,6 +1225,7 @@ function delete_patch_baseline(
             mergewith(_merge, Dict{String,Any}("BaselineId" => BaselineId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1189,6 +1251,7 @@ function delete_resource_data_sync(
         "DeleteResourceDataSync",
         Dict{String,Any}("SyncName" => SyncName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_resource_data_sync(
@@ -1202,6 +1265,7 @@ function delete_resource_data_sync(
             mergewith(_merge, Dict{String,Any}("SyncName" => SyncName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1225,6 +1289,7 @@ function deregister_managed_instance(
         "DeregisterManagedInstance",
         Dict{String,Any}("InstanceId" => InstanceId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function deregister_managed_instance(
@@ -1238,6 +1303,7 @@ function deregister_managed_instance(
             mergewith(_merge, Dict{String,Any}("InstanceId" => InstanceId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1260,6 +1326,7 @@ function deregister_patch_baseline_for_patch_group(
         "DeregisterPatchBaselineForPatchGroup",
         Dict{String,Any}("BaselineId" => BaselineId, "PatchGroup" => PatchGroup);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function deregister_patch_baseline_for_patch_group(
@@ -1278,6 +1345,7 @@ function deregister_patch_baseline_for_patch_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1304,6 +1372,7 @@ function deregister_target_from_maintenance_window(
         "DeregisterTargetFromMaintenanceWindow",
         Dict{String,Any}("WindowId" => WindowId, "WindowTargetId" => WindowTargetId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function deregister_target_from_maintenance_window(
@@ -1324,6 +1393,7 @@ function deregister_target_from_maintenance_window(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1345,6 +1415,7 @@ function deregister_task_from_maintenance_window(
         "DeregisterTaskFromMaintenanceWindow",
         Dict{String,Any}("WindowId" => WindowId, "WindowTaskId" => WindowTaskId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function deregister_task_from_maintenance_window(
@@ -1363,6 +1434,7 @@ function deregister_task_from_maintenance_window(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1383,12 +1455,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`: A token to start the list. Use this token to get the next set of results.
 """
 function describe_activations(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ssm("DescribeActivations"; aws_config=aws_config)
+    return ssm(
+        "DescribeActivations"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_activations(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ssm("DescribeActivations", params; aws_config=aws_config)
+    return ssm(
+        "DescribeActivations",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1410,12 +1489,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"Name"`: The name of the SSM document.
 """
 function describe_association(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ssm("DescribeAssociation"; aws_config=aws_config)
+    return ssm(
+        "DescribeAssociation"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_association(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ssm("DescribeAssociation", params; aws_config=aws_config)
+    return ssm(
+        "DescribeAssociation",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1444,6 +1530,7 @@ function describe_association_execution_targets(
         "DescribeAssociationExecutionTargets",
         Dict{String,Any}("AssociationId" => AssociationId, "ExecutionId" => ExecutionId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_association_execution_targets(
@@ -1464,6 +1551,7 @@ function describe_association_execution_targets(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1491,6 +1579,7 @@ function describe_association_executions(
         "DescribeAssociationExecutions",
         Dict{String,Any}("AssociationId" => AssociationId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_association_executions(
@@ -1504,6 +1593,7 @@ function describe_association_executions(
             mergewith(_merge, Dict{String,Any}("AssociationId" => AssociationId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1522,12 +1612,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   from a previous call.)
 """
 function describe_automation_executions(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ssm("DescribeAutomationExecutions"; aws_config=aws_config)
+    return ssm(
+        "DescribeAutomationExecutions";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_automation_executions(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ssm("DescribeAutomationExecutions", params; aws_config=aws_config)
+    return ssm(
+        "DescribeAutomationExecutions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1558,6 +1657,7 @@ function describe_automation_step_executions(
         "DescribeAutomationStepExecutions",
         Dict{String,Any}("AutomationExecutionId" => AutomationExecutionId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_automation_step_executions(
@@ -1575,6 +1675,7 @@ function describe_automation_step_executions(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1611,12 +1712,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   from a previous call.)
 """
 function describe_available_patches(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ssm("DescribeAvailablePatches"; aws_config=aws_config)
+    return ssm(
+        "DescribeAvailablePatches"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_available_patches(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ssm("DescribeAvailablePatches", params; aws_config=aws_config)
+    return ssm(
+        "DescribeAvailablePatches",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1637,7 +1745,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   versions of a document, and can't be changed.
 """
 function describe_document(Name; aws_config::AbstractAWSConfig=global_aws_config())
-    return ssm("DescribeDocument", Dict{String,Any}("Name" => Name); aws_config=aws_config)
+    return ssm(
+        "DescribeDocument",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_document(
     Name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -1646,6 +1759,7 @@ function describe_document(
         "DescribeDocument",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1676,6 +1790,7 @@ function describe_document_permission(
         "DescribeDocumentPermission",
         Dict{String,Any}("Name" => Name, "PermissionType" => PermissionType);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_document_permission(
@@ -1694,6 +1809,7 @@ function describe_document_permission(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1720,6 +1836,7 @@ function describe_effective_instance_associations(
         "DescribeEffectiveInstanceAssociations",
         Dict{String,Any}("InstanceId" => InstanceId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_effective_instance_associations(
@@ -1733,6 +1850,7 @@ function describe_effective_instance_associations(
             mergewith(_merge, Dict{String,Any}("InstanceId" => InstanceId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1759,6 +1877,7 @@ function describe_effective_patches_for_patch_baseline(
         "DescribeEffectivePatchesForPatchBaseline",
         Dict{String,Any}("BaselineId" => BaselineId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_effective_patches_for_patch_baseline(
@@ -1772,6 +1891,7 @@ function describe_effective_patches_for_patch_baseline(
             mergewith(_merge, Dict{String,Any}("BaselineId" => BaselineId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1798,6 +1918,7 @@ function describe_instance_associations_status(
         "DescribeInstanceAssociationsStatus",
         Dict{String,Any}("InstanceId" => InstanceId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_instance_associations_status(
@@ -1811,6 +1932,7 @@ function describe_instance_associations_status(
             mergewith(_merge, Dict{String,Any}("InstanceId" => InstanceId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1841,12 +1963,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   from a previous call.)
 """
 function describe_instance_information(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ssm("DescribeInstanceInformation"; aws_config=aws_config)
+    return ssm(
+        "DescribeInstanceInformation";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_instance_information(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ssm("DescribeInstanceInformation", params; aws_config=aws_config)
+    return ssm(
+        "DescribeInstanceInformation",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1872,6 +2003,7 @@ function describe_instance_patch_states(
         "DescribeInstancePatchStates",
         Dict{String,Any}("InstanceIds" => InstanceIds);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_instance_patch_states(
@@ -1885,6 +2017,7 @@ function describe_instance_patch_states(
             mergewith(_merge, Dict{String,Any}("InstanceIds" => InstanceIds), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1914,6 +2047,7 @@ function describe_instance_patch_states_for_patch_group(
         "DescribeInstancePatchStatesForPatchGroup",
         Dict{String,Any}("PatchGroup" => PatchGroup);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_instance_patch_states_for_patch_group(
@@ -1927,6 +2061,7 @@ function describe_instance_patch_states_for_patch_group(
             mergewith(_merge, Dict{String,Any}("PatchGroup" => PatchGroup), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1958,6 +2093,7 @@ function describe_instance_patches(
         "DescribeInstancePatches",
         Dict{String,Any}("InstanceId" => InstanceId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_instance_patches(
@@ -1971,6 +2107,7 @@ function describe_instance_patches(
             mergewith(_merge, Dict{String,Any}("InstanceId" => InstanceId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1989,12 +2126,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`: A token to start the list. Use this token to get the next set of results.
 """
 function describe_inventory_deletions(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ssm("DescribeInventoryDeletions"; aws_config=aws_config)
+    return ssm(
+        "DescribeInventoryDeletions"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_inventory_deletions(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ssm("DescribeInventoryDeletions", params; aws_config=aws_config)
+    return ssm(
+        "DescribeInventoryDeletions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2026,6 +2170,7 @@ function describe_maintenance_window_execution_task_invocations(
         "DescribeMaintenanceWindowExecutionTaskInvocations",
         Dict{String,Any}("TaskId" => TaskId, "WindowExecutionId" => WindowExecutionId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_maintenance_window_execution_task_invocations(
@@ -2046,6 +2191,7 @@ function describe_maintenance_window_execution_task_invocations(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2076,6 +2222,7 @@ function describe_maintenance_window_execution_tasks(
         "DescribeMaintenanceWindowExecutionTasks",
         Dict{String,Any}("WindowExecutionId" => WindowExecutionId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_maintenance_window_execution_tasks(
@@ -2091,6 +2238,7 @@ function describe_maintenance_window_execution_tasks(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2123,6 +2271,7 @@ function describe_maintenance_window_executions(
         "DescribeMaintenanceWindowExecutions",
         Dict{String,Any}("WindowId" => WindowId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_maintenance_window_executions(
@@ -2136,6 +2285,7 @@ function describe_maintenance_window_executions(
             mergewith(_merge, Dict{String,Any}("WindowId" => WindowId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2162,12 +2312,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_maintenance_window_schedule(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ssm("DescribeMaintenanceWindowSchedule"; aws_config=aws_config)
+    return ssm(
+        "DescribeMaintenanceWindowSchedule";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_maintenance_window_schedule(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ssm("DescribeMaintenanceWindowSchedule", params; aws_config=aws_config)
+    return ssm(
+        "DescribeMaintenanceWindowSchedule",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2195,6 +2354,7 @@ function describe_maintenance_window_targets(
         "DescribeMaintenanceWindowTargets",
         Dict{String,Any}("WindowId" => WindowId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_maintenance_window_targets(
@@ -2208,6 +2368,7 @@ function describe_maintenance_window_targets(
             mergewith(_merge, Dict{String,Any}("WindowId" => WindowId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2239,6 +2400,7 @@ function describe_maintenance_window_tasks(
         "DescribeMaintenanceWindowTasks",
         Dict{String,Any}("WindowId" => WindowId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_maintenance_window_tasks(
@@ -2252,6 +2414,7 @@ function describe_maintenance_window_tasks(
             mergewith(_merge, Dict{String,Any}("WindowId" => WindowId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2272,12 +2435,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   from a previous call.)
 """
 function describe_maintenance_windows(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ssm("DescribeMaintenanceWindows"; aws_config=aws_config)
+    return ssm(
+        "DescribeMaintenanceWindows"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_maintenance_windows(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ssm("DescribeMaintenanceWindows", params; aws_config=aws_config)
+    return ssm(
+        "DescribeMaintenanceWindows",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2306,6 +2476,7 @@ function describe_maintenance_windows_for_target(
         "DescribeMaintenanceWindowsForTarget",
         Dict{String,Any}("ResourceType" => ResourceType, "Targets" => Targets);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_maintenance_windows_for_target(
@@ -2324,6 +2495,7 @@ function describe_maintenance_windows_for_target(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2358,12 +2530,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   {\"key\":\"key_name\",\"value\":\"a_value\"}
 """
 function describe_ops_items(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ssm("DescribeOpsItems"; aws_config=aws_config)
+    return ssm("DescribeOpsItems"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function describe_ops_items(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ssm("DescribeOpsItems", params; aws_config=aws_config)
+    return ssm(
+        "DescribeOpsItems", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -2390,12 +2564,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"ParameterFilters"`: Filters to limit the request results.
 """
 function describe_parameters(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ssm("DescribeParameters"; aws_config=aws_config)
+    return ssm("DescribeParameters"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function describe_parameters(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ssm("DescribeParameters", params; aws_config=aws_config)
+    return ssm(
+        "DescribeParameters", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -2415,12 +2591,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   from a previous call.)
 """
 function describe_patch_baselines(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ssm("DescribePatchBaselines"; aws_config=aws_config)
+    return ssm(
+        "DescribePatchBaselines"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_patch_baselines(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ssm("DescribePatchBaselines", params; aws_config=aws_config)
+    return ssm(
+        "DescribePatchBaselines",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2440,6 +2623,7 @@ function describe_patch_group_state(
         "DescribePatchGroupState",
         Dict{String,Any}("PatchGroup" => PatchGroup);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_patch_group_state(
@@ -2453,6 +2637,7 @@ function describe_patch_group_state(
             mergewith(_merge, Dict{String,Any}("PatchGroup" => PatchGroup), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2472,12 +2657,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   from a previous call.)
 """
 function describe_patch_groups(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ssm("DescribePatchGroups"; aws_config=aws_config)
+    return ssm(
+        "DescribePatchGroups"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_patch_groups(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ssm("DescribePatchGroups", params; aws_config=aws_config)
+    return ssm(
+        "DescribePatchGroups",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2519,6 +2711,7 @@ function describe_patch_properties(
         "DescribePatchProperties",
         Dict{String,Any}("OperatingSystem" => OperatingSystem, "Property" => Property);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_patch_properties(
@@ -2539,6 +2732,7 @@ function describe_patch_properties(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2562,7 +2756,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function describe_sessions(State; aws_config::AbstractAWSConfig=global_aws_config())
     return ssm(
-        "DescribeSessions", Dict{String,Any}("State" => State); aws_config=aws_config
+        "DescribeSessions",
+        Dict{String,Any}("State" => State);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_sessions(
@@ -2572,6 +2769,7 @@ function describe_sessions(
         "DescribeSessions",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("State" => State), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2597,6 +2795,7 @@ function disassociate_ops_item_related_item(
         "DisassociateOpsItemRelatedItem",
         Dict{String,Any}("AssociationId" => AssociationId, "OpsItemId" => OpsItemId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disassociate_ops_item_related_item(
@@ -2617,6 +2816,7 @@ function disassociate_ops_item_related_item(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2639,6 +2839,7 @@ function get_automation_execution(
         "GetAutomationExecution",
         Dict{String,Any}("AutomationExecutionId" => AutomationExecutionId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_automation_execution(
@@ -2656,6 +2857,7 @@ function get_automation_execution(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2692,6 +2894,7 @@ function get_calendar_state(
         "GetCalendarState",
         Dict{String,Any}("CalendarNames" => CalendarNames);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_calendar_state(
@@ -2705,6 +2908,7 @@ function get_calendar_state(
             mergewith(_merge, Dict{String,Any}("CalendarNames" => CalendarNames), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2742,6 +2946,7 @@ function get_command_invocation(
         "GetCommandInvocation",
         Dict{String,Any}("CommandId" => CommandId, "InstanceId" => InstanceId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_command_invocation(
@@ -2760,6 +2965,7 @@ function get_command_invocation(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2776,7 +2982,10 @@ running and ready to receive Session Manager connections.
 """
 function get_connection_status(Target; aws_config::AbstractAWSConfig=global_aws_config())
     return ssm(
-        "GetConnectionStatus", Dict{String,Any}("Target" => Target); aws_config=aws_config
+        "GetConnectionStatus",
+        Dict{String,Any}("Target" => Target);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_connection_status(
@@ -2786,6 +2995,7 @@ function get_connection_status(
         "GetConnectionStatus",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Target" => Target), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2804,12 +3014,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   system.
 """
 function get_default_patch_baseline(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ssm("GetDefaultPatchBaseline"; aws_config=aws_config)
+    return ssm(
+        "GetDefaultPatchBaseline"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_default_patch_baseline(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ssm("GetDefaultPatchBaseline", params; aws_config=aws_config)
+    return ssm(
+        "GetDefaultPatchBaseline",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2841,6 +3058,7 @@ function get_deployable_patch_snapshot_for_instance(
         "GetDeployablePatchSnapshotForInstance",
         Dict{String,Any}("InstanceId" => InstanceId, "SnapshotId" => SnapshotId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_deployable_patch_snapshot_for_instance(
@@ -2859,6 +3077,7 @@ function get_deployable_patch_snapshot_for_instance(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2882,7 +3101,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   versions of a document and can't be changed.
 """
 function get_document(Name; aws_config::AbstractAWSConfig=global_aws_config())
-    return ssm("GetDocument", Dict{String,Any}("Name" => Name); aws_config=aws_config)
+    return ssm(
+        "GetDocument",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_document(
     Name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -2891,6 +3115,7 @@ function get_document(
         "GetDocument",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2914,12 +3139,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"ResultAttributes"`: The list of inventory item types to return.
 """
 function get_inventory(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ssm("GetInventory"; aws_config=aws_config)
+    return ssm("GetInventory"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function get_inventory(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ssm("GetInventory", params; aws_config=aws_config)
+    return ssm(
+        "GetInventory", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -2942,12 +3169,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"TypeName"`: The type of inventory item to return.
 """
 function get_inventory_schema(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ssm("GetInventorySchema"; aws_config=aws_config)
+    return ssm("GetInventorySchema"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function get_inventory_schema(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ssm("GetInventorySchema", params; aws_config=aws_config)
+    return ssm(
+        "GetInventorySchema", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -2965,6 +3194,7 @@ function get_maintenance_window(WindowId; aws_config::AbstractAWSConfig=global_a
         "GetMaintenanceWindow",
         Dict{String,Any}("WindowId" => WindowId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_maintenance_window(
@@ -2978,6 +3208,7 @@ function get_maintenance_window(
             mergewith(_merge, Dict{String,Any}("WindowId" => WindowId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2998,6 +3229,7 @@ function get_maintenance_window_execution(
         "GetMaintenanceWindowExecution",
         Dict{String,Any}("WindowExecutionId" => WindowExecutionId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_maintenance_window_execution(
@@ -3013,6 +3245,7 @@ function get_maintenance_window_execution(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3035,6 +3268,7 @@ function get_maintenance_window_execution_task(
         "GetMaintenanceWindowExecutionTask",
         Dict{String,Any}("TaskId" => TaskId, "WindowExecutionId" => WindowExecutionId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_maintenance_window_execution_task(
@@ -3055,6 +3289,7 @@ function get_maintenance_window_execution_task(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3086,6 +3321,7 @@ function get_maintenance_window_execution_task_invocation(
             "WindowExecutionId" => WindowExecutionId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_maintenance_window_execution_task_invocation(
@@ -3109,6 +3345,7 @@ function get_maintenance_window_execution_task_invocation(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3133,6 +3370,7 @@ function get_maintenance_window_task(
         "GetMaintenanceWindowTask",
         Dict{String,Any}("WindowId" => WindowId, "WindowTaskId" => WindowTaskId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_maintenance_window_task(
@@ -3151,6 +3389,7 @@ function get_maintenance_window_task(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3172,7 +3411,10 @@ Web Services Systems Manager User Guide.
 """
 function get_ops_item(OpsItemId; aws_config::AbstractAWSConfig=global_aws_config())
     return ssm(
-        "GetOpsItem", Dict{String,Any}("OpsItemId" => OpsItemId); aws_config=aws_config
+        "GetOpsItem",
+        Dict{String,Any}("OpsItemId" => OpsItemId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_ops_item(
@@ -3186,6 +3428,7 @@ function get_ops_item(
             mergewith(_merge, Dict{String,Any}("OpsItemId" => OpsItemId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3209,6 +3452,7 @@ function get_ops_metadata(OpsMetadataArn; aws_config::AbstractAWSConfig=global_a
         "GetOpsMetadata",
         Dict{String,Any}("OpsMetadataArn" => OpsMetadataArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_ops_metadata(
@@ -3222,6 +3466,7 @@ function get_ops_metadata(
             mergewith(_merge, Dict{String,Any}("OpsMetadataArn" => OpsMetadataArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3247,12 +3492,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"SyncName"`: Specify the name of a resource data sync to get.
 """
 function get_ops_summary(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ssm("GetOpsSummary"; aws_config=aws_config)
+    return ssm("GetOpsSummary"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function get_ops_summary(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ssm("GetOpsSummary", params; aws_config=aws_config)
+    return ssm(
+        "GetOpsSummary", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -3272,7 +3519,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   ignored for String and StringList parameter types.
 """
 function get_parameter(Name; aws_config::AbstractAWSConfig=global_aws_config())
-    return ssm("GetParameter", Dict{String,Any}("Name" => Name); aws_config=aws_config)
+    return ssm(
+        "GetParameter",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_parameter(
     Name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -3281,6 +3533,7 @@ function get_parameter(
         "GetParameter",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3307,7 +3560,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function get_parameter_history(Name; aws_config::AbstractAWSConfig=global_aws_config())
     return ssm(
-        "GetParameterHistory", Dict{String,Any}("Name" => Name); aws_config=aws_config
+        "GetParameterHistory",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_parameter_history(
@@ -3317,6 +3573,7 @@ function get_parameter_history(
         "GetParameterHistory",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3338,7 +3595,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   secure string parameters. This flag is ignored for String and StringList parameter types.
 """
 function get_parameters(Names; aws_config::AbstractAWSConfig=global_aws_config())
-    return ssm("GetParameters", Dict{String,Any}("Names" => Names); aws_config=aws_config)
+    return ssm(
+        "GetParameters",
+        Dict{String,Any}("Names" => Names);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_parameters(
     Names, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -3347,6 +3609,7 @@ function get_parameters(
         "GetParameters",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Names" => Names), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3386,7 +3649,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function get_parameters_by_path(Path; aws_config::AbstractAWSConfig=global_aws_config())
     return ssm(
-        "GetParametersByPath", Dict{String,Any}("Path" => Path); aws_config=aws_config
+        "GetParametersByPath",
+        Dict{String,Any}("Path" => Path);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_parameters_by_path(
@@ -3396,6 +3662,7 @@ function get_parameters_by_path(
         "GetParametersByPath",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Path" => Path), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3418,6 +3685,7 @@ function get_patch_baseline(BaselineId; aws_config::AbstractAWSConfig=global_aws
         "GetPatchBaseline",
         Dict{String,Any}("BaselineId" => BaselineId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_patch_baseline(
@@ -3431,6 +3699,7 @@ function get_patch_baseline(
             mergewith(_merge, Dict{String,Any}("BaselineId" => BaselineId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3455,6 +3724,7 @@ function get_patch_baseline_for_patch_group(
         "GetPatchBaselineForPatchGroup",
         Dict{String,Any}("PatchGroup" => PatchGroup);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_patch_baseline_for_patch_group(
@@ -3468,6 +3738,7 @@ function get_patch_baseline_for_patch_group(
             mergewith(_merge, Dict{String,Any}("PatchGroup" => PatchGroup), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3502,6 +3773,7 @@ function get_service_setting(SettingId; aws_config::AbstractAWSConfig=global_aws
         "GetServiceSetting",
         Dict{String,Any}("SettingId" => SettingId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_service_setting(
@@ -3515,6 +3787,7 @@ function get_service_setting(
             mergewith(_merge, Dict{String,Any}("SettingId" => SettingId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3555,6 +3828,7 @@ function label_parameter_version(
         "LabelParameterVersion",
         Dict{String,Any}("Labels" => Labels, "Name" => Name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function label_parameter_version(
@@ -3569,6 +3843,7 @@ function label_parameter_version(
             mergewith(_merge, Dict{String,Any}("Labels" => Labels, "Name" => Name), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3594,6 +3869,7 @@ function list_association_versions(
         "ListAssociationVersions",
         Dict{String,Any}("AssociationId" => AssociationId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_association_versions(
@@ -3607,6 +3883,7 @@ function list_association_versions(
             mergewith(_merge, Dict{String,Any}("AssociationId" => AssociationId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3631,12 +3908,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   from a previous call.)
 """
 function list_associations(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ssm("ListAssociations"; aws_config=aws_config)
+    return ssm("ListAssociations"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_associations(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ssm("ListAssociations", params; aws_config=aws_config)
+    return ssm(
+        "ListAssociations", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -3663,12 +3942,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   this token from a previous call.)
 """
 function list_command_invocations(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ssm("ListCommandInvocations"; aws_config=aws_config)
+    return ssm(
+        "ListCommandInvocations"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_command_invocations(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ssm("ListCommandInvocations", params; aws_config=aws_config)
+    return ssm(
+        "ListCommandInvocations",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -3692,12 +3978,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   this token from a previous call.)
 """
 function list_commands(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ssm("ListCommands"; aws_config=aws_config)
+    return ssm("ListCommands"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_commands(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ssm("ListCommands", params; aws_config=aws_config)
+    return ssm(
+        "ListCommands", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -3721,12 +4009,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Currently, the only supported resource type is ManagedInstance.
 """
 function list_compliance_items(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ssm("ListComplianceItems"; aws_config=aws_config)
+    return ssm(
+        "ListComplianceItems"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_compliance_items(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ssm("ListComplianceItems", params; aws_config=aws_config)
+    return ssm(
+        "ListComplianceItems",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -3747,12 +4042,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`: A token to start the list. Use this token to get the next set of results.
 """
 function list_compliance_summaries(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ssm("ListComplianceSummaries"; aws_config=aws_config)
+    return ssm(
+        "ListComplianceSummaries"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_compliance_summaries(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ssm("ListComplianceSummaries", params; aws_config=aws_config)
+    return ssm(
+        "ListComplianceSummaries",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -3781,6 +4083,7 @@ function list_document_metadata_history(
         "ListDocumentMetadataHistory",
         Dict{String,Any}("Metadata" => Metadata, "Name" => Name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_document_metadata_history(
@@ -3797,6 +4100,7 @@ function list_document_metadata_history(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3818,7 +4122,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function list_document_versions(Name; aws_config::AbstractAWSConfig=global_aws_config())
     return ssm(
-        "ListDocumentVersions", Dict{String,Any}("Name" => Name); aws_config=aws_config
+        "ListDocumentVersions",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_document_versions(
@@ -3828,6 +4135,7 @@ function list_document_versions(
         "ListDocumentVersions",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3855,12 +4163,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   from a previous call.)
 """
 function list_documents(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ssm("ListDocuments"; aws_config=aws_config)
+    return ssm("ListDocuments"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_documents(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ssm("ListDocuments", params; aws_config=aws_config)
+    return ssm(
+        "ListDocuments", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -3888,6 +4198,7 @@ function list_inventory_entries(
         "ListInventoryEntries",
         Dict{String,Any}("InstanceId" => InstanceId, "TypeName" => TypeName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_inventory_entries(
@@ -3906,6 +4217,7 @@ function list_inventory_entries(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3926,12 +4238,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`: A token to start the list. Use this token to get the next set of results.
 """
 function list_ops_item_events(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ssm("ListOpsItemEvents"; aws_config=aws_config)
+    return ssm("ListOpsItemEvents"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_ops_item_events(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ssm("ListOpsItemEvents", params; aws_config=aws_config)
+    return ssm(
+        "ListOpsItemEvents", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -3953,12 +4267,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   resources.
 """
 function list_ops_item_related_items(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ssm("ListOpsItemRelatedItems"; aws_config=aws_config)
+    return ssm(
+        "ListOpsItemRelatedItems"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_ops_item_related_items(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ssm("ListOpsItemRelatedItems", params; aws_config=aws_config)
+    return ssm(
+        "ListOpsItemRelatedItems",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -3977,12 +4298,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`: A token to start the list. Use this token to get the next set of results.
 """
 function list_ops_metadata(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ssm("ListOpsMetadata"; aws_config=aws_config)
+    return ssm("ListOpsMetadata"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_ops_metadata(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ssm("ListOpsMetadata", params; aws_config=aws_config)
+    return ssm(
+        "ListOpsMetadata", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -4003,12 +4326,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function list_resource_compliance_summaries(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ssm("ListResourceComplianceSummaries"; aws_config=aws_config)
+    return ssm(
+        "ListResourceComplianceSummaries";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_resource_compliance_summaries(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ssm("ListResourceComplianceSummaries", params; aws_config=aws_config)
+    return ssm(
+        "ListResourceComplianceSummaries",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -4035,12 +4367,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   Amazon Web Services Regions.
 """
 function list_resource_data_sync(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ssm("ListResourceDataSync"; aws_config=aws_config)
+    return ssm(
+        "ListResourceDataSync"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_resource_data_sync(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ssm("ListResourceDataSync", params; aws_config=aws_config)
+    return ssm(
+        "ListResourceDataSync",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -4062,6 +4401,7 @@ function list_tags_for_resource(
         "ListTagsForResource",
         Dict{String,Any}("ResourceId" => ResourceId, "ResourceType" => ResourceType);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags_for_resource(
@@ -4082,6 +4422,7 @@ function list_tags_for_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4116,6 +4457,7 @@ function modify_document_permission(
         "ModifyDocumentPermission",
         Dict{String,Any}("Name" => Name, "PermissionType" => PermissionType);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_document_permission(
@@ -4134,6 +4476,7 @@ function modify_document_permission(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4204,6 +4547,7 @@ function put_compliance_items(
             "ResourceType" => ResourceType,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_compliance_items(
@@ -4231,6 +4575,7 @@ function put_compliance_items(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4251,6 +4596,7 @@ function put_inventory(InstanceId, Items; aws_config::AbstractAWSConfig=global_a
         "PutInventory",
         Dict{String,Any}("InstanceId" => InstanceId, "Items" => Items);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_inventory(
@@ -4269,6 +4615,7 @@ function put_inventory(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4392,6 +4739,7 @@ function put_parameter(Name, Value; aws_config::AbstractAWSConfig=global_aws_con
         "PutParameter",
         Dict{String,Any}("Name" => Name, "Value" => Value);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_parameter(
@@ -4406,6 +4754,7 @@ function put_parameter(
             mergewith(_merge, Dict{String,Any}("Name" => Name, "Value" => Value), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4430,6 +4779,7 @@ function register_default_patch_baseline(
         "RegisterDefaultPatchBaseline",
         Dict{String,Any}("BaselineId" => BaselineId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function register_default_patch_baseline(
@@ -4443,6 +4793,7 @@ function register_default_patch_baseline(
             mergewith(_merge, Dict{String,Any}("BaselineId" => BaselineId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4464,6 +4815,7 @@ function register_patch_baseline_for_patch_group(
         "RegisterPatchBaselineForPatchGroup",
         Dict{String,Any}("BaselineId" => BaselineId, "PatchGroup" => PatchGroup);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function register_patch_baseline_for_patch_group(
@@ -4482,6 +4834,7 @@ function register_patch_baseline_for_patch_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4533,6 +4886,7 @@ function register_target_with_maintenance_window(
             "ClientToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function register_target_with_maintenance_window(
@@ -4557,6 +4911,7 @@ function register_target_with_maintenance_window(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4640,6 +4995,7 @@ function register_task_with_maintenance_window(
             "ClientToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function register_task_with_maintenance_window(
@@ -4664,6 +5020,7 @@ function register_task_with_maintenance_window(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4700,6 +5057,7 @@ function remove_tags_from_resource(
             "ResourceId" => ResourceId, "ResourceType" => ResourceType, "TagKeys" => TagKeys
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function remove_tags_from_resource(
@@ -4723,6 +5081,7 @@ function remove_tags_from_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4757,6 +5116,7 @@ function reset_service_setting(SettingId; aws_config::AbstractAWSConfig=global_a
         "ResetServiceSetting",
         Dict{String,Any}("SettingId" => SettingId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function reset_service_setting(
@@ -4770,6 +5130,7 @@ function reset_service_setting(
             mergewith(_merge, Dict{String,Any}("SettingId" => SettingId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4788,7 +5149,10 @@ It isn't intended for any other use.
 """
 function resume_session(SessionId; aws_config::AbstractAWSConfig=global_aws_config())
     return ssm(
-        "ResumeSession", Dict{String,Any}("SessionId" => SessionId); aws_config=aws_config
+        "ResumeSession",
+        Dict{String,Any}("SessionId" => SessionId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function resume_session(
@@ -4802,6 +5166,7 @@ function resume_session(
             mergewith(_merge, Dict{String,Any}("SessionId" => SessionId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4836,6 +5201,7 @@ function send_automation_signal(
             "AutomationExecutionId" => AutomationExecutionId, "SignalType" => SignalType
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function send_automation_signal(
@@ -4857,6 +5223,7 @@ function send_automation_signal(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4934,6 +5301,7 @@ function send_command(DocumentName; aws_config::AbstractAWSConfig=global_aws_con
         "SendCommand",
         Dict{String,Any}("DocumentName" => DocumentName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function send_command(
@@ -4947,6 +5315,7 @@ function send_command(
             mergewith(_merge, Dict{String,Any}("DocumentName" => DocumentName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4968,6 +5337,7 @@ function start_associations_once(
         "StartAssociationsOnce",
         Dict{String,Any}("AssociationIds" => AssociationIds);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_associations_once(
@@ -4981,6 +5351,7 @@ function start_associations_once(
             mergewith(_merge, Dict{String,Any}("AssociationIds" => AssociationIds), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5044,6 +5415,7 @@ function start_automation_execution(
         "StartAutomationExecution",
         Dict{String,Any}("DocumentName" => DocumentName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_automation_execution(
@@ -5057,6 +5429,7 @@ function start_automation_execution(
             mergewith(_merge, Dict{String,Any}("DocumentName" => DocumentName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5108,6 +5481,7 @@ function start_change_request_execution(
         "StartChangeRequestExecution",
         Dict{String,Any}("DocumentName" => DocumentName, "Runbooks" => Runbooks);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_change_request_execution(
@@ -5126,6 +5500,7 @@ function start_change_request_execution(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5154,7 +5529,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"Parameters"`: Reserved for future use.
 """
 function start_session(Target; aws_config::AbstractAWSConfig=global_aws_config())
-    return ssm("StartSession", Dict{String,Any}("Target" => Target); aws_config=aws_config)
+    return ssm(
+        "StartSession",
+        Dict{String,Any}("Target" => Target);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function start_session(
     Target, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -5163,6 +5543,7 @@ function start_session(
         "StartSession",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Target" => Target), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5187,6 +5568,7 @@ function stop_automation_execution(
         "StopAutomationExecution",
         Dict{String,Any}("AutomationExecutionId" => AutomationExecutionId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function stop_automation_execution(
@@ -5204,6 +5586,7 @@ function stop_automation_execution(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5223,6 +5606,7 @@ function terminate_session(SessionId; aws_config::AbstractAWSConfig=global_aws_c
         "TerminateSession",
         Dict{String,Any}("SessionId" => SessionId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function terminate_session(
@@ -5236,6 +5620,7 @@ function terminate_session(
             mergewith(_merge, Dict{String,Any}("SessionId" => SessionId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5261,6 +5646,7 @@ function unlabel_parameter_version(
             "Labels" => Labels, "Name" => Name, "ParameterVersion" => ParameterVersion
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function unlabel_parameter_version(
@@ -5284,6 +5670,7 @@ function unlabel_parameter_version(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5381,6 +5768,7 @@ function update_association(
         "UpdateAssociation",
         Dict{String,Any}("AssociationId" => AssociationId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_association(
@@ -5394,6 +5782,7 @@ function update_association(
             mergewith(_merge, Dict{String,Any}("AssociationId" => AssociationId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5423,6 +5812,7 @@ function update_association_status(
             "Name" => Name,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_association_status(
@@ -5446,6 +5836,7 @@ function update_association_status(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5481,6 +5872,7 @@ function update_document(Content, Name; aws_config::AbstractAWSConfig=global_aws
         "UpdateDocument",
         Dict{String,Any}("Content" => Content, "Name" => Name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_document(
@@ -5497,6 +5889,7 @@ function update_document(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5519,6 +5912,7 @@ function update_document_default_version(
         "UpdateDocumentDefaultVersion",
         Dict{String,Any}("DocumentVersion" => DocumentVersion, "Name" => Name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_document_default_version(
@@ -5537,6 +5931,7 @@ function update_document_default_version(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5563,6 +5958,7 @@ function update_document_metadata(
         "UpdateDocumentMetadata",
         Dict{String,Any}("DocumentReviews" => DocumentReviews, "Name" => Name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_document_metadata(
@@ -5581,6 +5977,7 @@ function update_document_metadata(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5637,6 +6034,7 @@ function update_maintenance_window(
         "UpdateMaintenanceWindow",
         Dict{String,Any}("WindowId" => WindowId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_maintenance_window(
@@ -5650,6 +6048,7 @@ function update_maintenance_window(
             mergewith(_merge, Dict{String,Any}("WindowId" => WindowId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5685,6 +6084,7 @@ function update_maintenance_window_target(
         "UpdateMaintenanceWindowTarget",
         Dict{String,Any}("WindowId" => WindowId, "WindowTargetId" => WindowTargetId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_maintenance_window_target(
@@ -5705,6 +6105,7 @@ function update_maintenance_window_target(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5809,6 +6210,7 @@ function update_maintenance_window_task(
         "UpdateMaintenanceWindowTask",
         Dict{String,Any}("WindowId" => WindowId, "WindowTaskId" => WindowTaskId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_maintenance_window_task(
@@ -5827,6 +6229,7 @@ function update_maintenance_window_task(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5850,6 +6253,7 @@ function update_managed_instance_role(
         "UpdateManagedInstanceRole",
         Dict{String,Any}("IamRole" => IamRole, "InstanceId" => InstanceId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_managed_instance_role(
@@ -5868,6 +6272,7 @@ function update_managed_instance_role(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5930,7 +6335,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function update_ops_item(OpsItemId; aws_config::AbstractAWSConfig=global_aws_config())
     return ssm(
-        "UpdateOpsItem", Dict{String,Any}("OpsItemId" => OpsItemId); aws_config=aws_config
+        "UpdateOpsItem",
+        Dict{String,Any}("OpsItemId" => OpsItemId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_ops_item(
@@ -5944,6 +6352,7 @@ function update_ops_item(
             mergewith(_merge, Dict{String,Any}("OpsItemId" => OpsItemId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -5969,6 +6378,7 @@ function update_ops_metadata(
         "UpdateOpsMetadata",
         Dict{String,Any}("OpsMetadataArn" => OpsMetadataArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_ops_metadata(
@@ -5982,6 +6392,7 @@ function update_ops_metadata(
             mergewith(_merge, Dict{String,Any}("OpsMetadataArn" => OpsMetadataArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6036,6 +6447,7 @@ function update_patch_baseline(
         "UpdatePatchBaseline",
         Dict{String,Any}("BaselineId" => BaselineId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_patch_baseline(
@@ -6049,6 +6461,7 @@ function update_patch_baseline(
             mergewith(_merge, Dict{String,Any}("BaselineId" => BaselineId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6079,6 +6492,7 @@ function update_resource_data_sync(
             "SyncName" => SyncName, "SyncSource" => SyncSource, "SyncType" => SyncType
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_resource_data_sync(
@@ -6102,6 +6516,7 @@ function update_resource_data_sync(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -6150,6 +6565,7 @@ function update_service_setting(
         "UpdateServiceSetting",
         Dict{String,Any}("SettingId" => SettingId, "SettingValue" => SettingValue);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_service_setting(
@@ -6168,5 +6584,6 @@ function update_service_setting(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/ssm_contacts.jl
+++ b/src/services/ssm_contacts.jl
@@ -36,6 +36,7 @@ function accept_page(
             "AcceptCode" => AcceptCode, "AcceptType" => AcceptType, "PageId" => PageId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function accept_page(
@@ -59,6 +60,7 @@ function accept_page(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -84,6 +86,7 @@ function activate_contact_channel(
             "ActivationCode" => ActivationCode, "ContactChannelId" => ContactChannelId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function activate_contact_channel(
@@ -105,6 +108,7 @@ function activate_contact_channel(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -143,6 +147,7 @@ function create_contact(
             "IdempotencyToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_contact(
@@ -167,6 +172,7 @@ function create_contact(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -212,6 +218,7 @@ function create_contact_channel(
             "IdempotencyToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_contact_channel(
@@ -238,6 +245,7 @@ function create_contact_channel(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -260,6 +268,7 @@ function deactivate_contact_channel(
         "DeactivateContactChannel",
         Dict{String,Any}("ContactChannelId" => ContactChannelId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function deactivate_contact_channel(
@@ -275,6 +284,7 @@ function deactivate_contact_channel(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -293,7 +303,10 @@ its contact channels before you can use it again.
 """
 function delete_contact(ContactId; aws_config::AbstractAWSConfig=global_aws_config())
     return ssm_contacts(
-        "DeleteContact", Dict{String,Any}("ContactId" => ContactId); aws_config=aws_config
+        "DeleteContact",
+        Dict{String,Any}("ContactId" => ContactId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_contact(
@@ -307,6 +320,7 @@ function delete_contact(
             mergewith(_merge, Dict{String,Any}("ContactId" => ContactId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -330,6 +344,7 @@ function delete_contact_channel(
         "DeleteContactChannel",
         Dict{String,Any}("ContactChannelId" => ContactChannelId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_contact_channel(
@@ -345,6 +360,7 @@ function delete_contact_channel(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -366,6 +382,7 @@ function describe_engagement(
         "DescribeEngagement",
         Dict{String,Any}("EngagementId" => EngagementId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_engagement(
@@ -379,6 +396,7 @@ function describe_engagement(
             mergewith(_merge, Dict{String,Any}("EngagementId" => EngagementId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -394,7 +412,10 @@ Lists details of the engagement to a contact channel.
 """
 function describe_page(PageId; aws_config::AbstractAWSConfig=global_aws_config())
     return ssm_contacts(
-        "DescribePage", Dict{String,Any}("PageId" => PageId); aws_config=aws_config
+        "DescribePage",
+        Dict{String,Any}("PageId" => PageId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_page(
@@ -404,6 +425,7 @@ function describe_page(
         "DescribePage",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("PageId" => PageId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -419,7 +441,10 @@ Retrieves information about the specified contact or escalation plan.
 """
 function get_contact(ContactId; aws_config::AbstractAWSConfig=global_aws_config())
     return ssm_contacts(
-        "GetContact", Dict{String,Any}("ContactId" => ContactId); aws_config=aws_config
+        "GetContact",
+        Dict{String,Any}("ContactId" => ContactId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_contact(
@@ -433,6 +458,7 @@ function get_contact(
             mergewith(_merge, Dict{String,Any}("ContactId" => ContactId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -454,6 +480,7 @@ function get_contact_channel(
         "GetContactChannel",
         Dict{String,Any}("ContactChannelId" => ContactChannelId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_contact_channel(
@@ -469,6 +496,7 @@ function get_contact_channel(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -487,6 +515,7 @@ function get_contact_policy(ContactArn; aws_config::AbstractAWSConfig=global_aws
         "GetContactPolicy",
         Dict{String,Any}("ContactArn" => ContactArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_contact_policy(
@@ -500,6 +529,7 @@ function get_contact_policy(
             mergewith(_merge, Dict{String,Any}("ContactArn" => ContactArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -522,6 +552,7 @@ function list_contact_channels(ContactId; aws_config::AbstractAWSConfig=global_a
         "ListContactChannels",
         Dict{String,Any}("ContactId" => ContactId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_contact_channels(
@@ -535,6 +566,7 @@ function list_contact_channels(
             mergewith(_merge, Dict{String,Any}("ContactId" => ContactId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -553,12 +585,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   ESCALATION.
 """
 function list_contacts(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ssm_contacts("ListContacts"; aws_config=aws_config)
+    return ssm_contacts(
+        "ListContacts"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_contacts(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ssm_contacts("ListContacts", params; aws_config=aws_config)
+    return ssm_contacts(
+        "ListContacts", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -576,12 +612,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"TimeRangeValue"`: The time range to lists engagements for an incident.
 """
 function list_engagements(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ssm_contacts("ListEngagements"; aws_config=aws_config)
+    return ssm_contacts(
+        "ListEngagements"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_engagements(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ssm_contacts("ListEngagements", params; aws_config=aws_config)
+    return ssm_contacts(
+        "ListEngagements", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -600,7 +640,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function list_page_receipts(PageId; aws_config::AbstractAWSConfig=global_aws_config())
     return ssm_contacts(
-        "ListPageReceipts", Dict{String,Any}("PageId" => PageId); aws_config=aws_config
+        "ListPageReceipts",
+        Dict{String,Any}("PageId" => PageId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_page_receipts(
@@ -610,6 +653,7 @@ function list_page_receipts(
         "ListPageReceipts",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("PageId" => PageId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -634,6 +678,7 @@ function list_pages_by_contact(ContactId; aws_config::AbstractAWSConfig=global_a
         "ListPagesByContact",
         Dict{String,Any}("ContactId" => ContactId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_pages_by_contact(
@@ -647,6 +692,7 @@ function list_pages_by_contact(
             mergewith(_merge, Dict{String,Any}("ContactId" => ContactId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -672,6 +718,7 @@ function list_pages_by_engagement(
         "ListPagesByEngagement",
         Dict{String,Any}("EngagementId" => EngagementId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_pages_by_engagement(
@@ -685,6 +732,7 @@ function list_pages_by_engagement(
             mergewith(_merge, Dict{String,Any}("EngagementId" => EngagementId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -705,6 +753,7 @@ function list_tags_for_resource(
         "ListTagsForResource",
         Dict{String,Any}("ResourceARN" => ResourceARN);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags_for_resource(
@@ -718,6 +767,7 @@ function list_tags_for_resource(
             mergewith(_merge, Dict{String,Any}("ResourceARN" => ResourceARN), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -739,6 +789,7 @@ function put_contact_policy(
         "PutContactPolicy",
         Dict{String,Any}("ContactArn" => ContactArn, "Policy" => Policy);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_contact_policy(
@@ -757,6 +808,7 @@ function put_contact_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -779,6 +831,7 @@ function send_activation_code(
         "SendActivationCode",
         Dict{String,Any}("ContactChannelId" => ContactChannelId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function send_activation_code(
@@ -794,6 +847,7 @@ function send_activation_code(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -835,6 +889,7 @@ function start_engagement(
             "IdempotencyToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_engagement(
@@ -861,6 +916,7 @@ function start_engagement(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -883,6 +939,7 @@ function stop_engagement(EngagementId; aws_config::AbstractAWSConfig=global_aws_
         "StopEngagement",
         Dict{String,Any}("EngagementId" => EngagementId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function stop_engagement(
@@ -896,6 +953,7 @@ function stop_engagement(
             mergewith(_merge, Dict{String,Any}("EngagementId" => EngagementId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -916,6 +974,7 @@ function tag_resource(ResourceARN, Tags; aws_config::AbstractAWSConfig=global_aw
         "TagResource",
         Dict{String,Any}("ResourceARN" => ResourceARN, "Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -934,6 +993,7 @@ function tag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -955,6 +1015,7 @@ function untag_resource(
         "UntagResource",
         Dict{String,Any}("ResourceARN" => ResourceARN, "TagKeys" => TagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -973,6 +1034,7 @@ function untag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -994,7 +1056,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function update_contact(ContactId; aws_config::AbstractAWSConfig=global_aws_config())
     return ssm_contacts(
-        "UpdateContact", Dict{String,Any}("ContactId" => ContactId); aws_config=aws_config
+        "UpdateContact",
+        Dict{String,Any}("ContactId" => ContactId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_contact(
@@ -1008,6 +1073,7 @@ function update_contact(
             mergewith(_merge, Dict{String,Any}("ContactId" => ContactId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1034,6 +1100,7 @@ function update_contact_channel(
         "UpdateContactChannel",
         Dict{String,Any}("ContactChannelId" => ContactChannelId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_contact_channel(
@@ -1049,5 +1116,6 @@ function update_contact_channel(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/ssm_incidents.jl
+++ b/src/services/ssm_incidents.jl
@@ -26,6 +26,7 @@ function create_replication_set(regions; aws_config::AbstractAWSConfig=global_aw
         "/createReplicationSet",
         Dict{String,Any}("regions" => regions, "clientToken" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_replication_set(
@@ -42,6 +43,7 @@ function create_replication_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -80,6 +82,7 @@ function create_response_plan(
             "clientToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_response_plan(
@@ -103,6 +106,7 @@ function create_response_plan(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -146,6 +150,7 @@ function create_timeline_event(
             "clientToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_timeline_event(
@@ -173,6 +178,7 @@ function create_timeline_event(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -192,6 +198,7 @@ function delete_incident_record(arn; aws_config::AbstractAWSConfig=global_aws_co
         "/deleteIncidentRecord",
         Dict{String,Any}("arn" => arn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_incident_record(
@@ -202,6 +209,7 @@ function delete_incident_record(
         "/deleteIncidentRecord",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("arn" => arn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -222,6 +230,7 @@ function delete_replication_set(arn; aws_config::AbstractAWSConfig=global_aws_co
         "/deleteReplicationSet",
         Dict{String,Any}("arn" => arn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_replication_set(
@@ -232,6 +241,7 @@ function delete_replication_set(
         "/deleteReplicationSet",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("arn" => arn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -256,6 +266,7 @@ function delete_resource_policy(
         "/deleteResourcePolicy",
         Dict{String,Any}("policyId" => policyId, "resourceArn" => resourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_resource_policy(
@@ -275,6 +286,7 @@ function delete_resource_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -291,7 +303,11 @@ alarms and EventBridge events from creating an incident with this response plan.
 """
 function delete_response_plan(arn; aws_config::AbstractAWSConfig=global_aws_config())
     return ssm_incidents(
-        "POST", "/deleteResponsePlan", Dict{String,Any}("arn" => arn); aws_config=aws_config
+        "POST",
+        "/deleteResponsePlan",
+        Dict{String,Any}("arn" => arn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_response_plan(
@@ -302,6 +318,7 @@ function delete_response_plan(
         "/deleteResponsePlan",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("arn" => arn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -326,6 +343,7 @@ function delete_timeline_event(
         "/deleteTimelineEvent",
         Dict{String,Any}("eventId" => eventId, "incidentRecordArn" => incidentRecordArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_timeline_event(
@@ -347,6 +365,7 @@ function delete_timeline_event(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -362,7 +381,11 @@ Returns the details of the specified incident record.
 """
 function get_incident_record(arn; aws_config::AbstractAWSConfig=global_aws_config())
     return ssm_incidents(
-        "GET", "/getIncidentRecord", Dict{String,Any}("arn" => arn); aws_config=aws_config
+        "GET",
+        "/getIncidentRecord",
+        Dict{String,Any}("arn" => arn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_incident_record(
@@ -373,6 +396,7 @@ function get_incident_record(
         "/getIncidentRecord",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("arn" => arn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -388,7 +412,11 @@ Retrieve your Incident Manager replication set.
 """
 function get_replication_set(arn; aws_config::AbstractAWSConfig=global_aws_config())
     return ssm_incidents(
-        "GET", "/getReplicationSet", Dict{String,Any}("arn" => arn); aws_config=aws_config
+        "GET",
+        "/getReplicationSet",
+        Dict{String,Any}("arn" => arn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_replication_set(
@@ -399,6 +427,7 @@ function get_replication_set(
         "/getReplicationSet",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("arn" => arn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -425,6 +454,7 @@ function get_resource_policies(
         "/getResourcePolicies",
         Dict{String,Any}("resourceArn" => resourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_resource_policies(
@@ -439,6 +469,7 @@ function get_resource_policies(
             mergewith(_merge, Dict{String,Any}("resourceArn" => resourceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -454,7 +485,11 @@ Retrieves the details of the specified response plan.
 """
 function get_response_plan(arn; aws_config::AbstractAWSConfig=global_aws_config())
     return ssm_incidents(
-        "GET", "/getResponsePlan", Dict{String,Any}("arn" => arn); aws_config=aws_config
+        "GET",
+        "/getResponsePlan",
+        Dict{String,Any}("arn" => arn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_response_plan(
@@ -465,6 +500,7 @@ function get_response_plan(
         "/getResponsePlan",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("arn" => arn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -489,6 +525,7 @@ function get_timeline_event(
         "/getTimelineEvent",
         Dict{String,Any}("eventId" => eventId, "incidentRecordArn" => incidentRecordArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_timeline_event(
@@ -510,6 +547,7 @@ function get_timeline_event(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -528,12 +566,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: The pagination token to continue to the next page of results.
 """
 function list_incident_records(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ssm_incidents("POST", "/listIncidentRecords"; aws_config=aws_config)
+    return ssm_incidents(
+        "POST",
+        "/listIncidentRecords";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_incident_records(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ssm_incidents("POST", "/listIncidentRecords", params; aws_config=aws_config)
+    return ssm_incidents(
+        "POST",
+        "/listIncidentRecords",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -559,6 +608,7 @@ function list_related_items(
         "/listRelatedItems",
         Dict{String,Any}("incidentRecordArn" => incidentRecordArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_related_items(
@@ -575,6 +625,7 @@ function list_related_items(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -590,12 +641,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: The pagination token to continue to the next page of results.
 """
 function list_replication_sets(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ssm_incidents("POST", "/listReplicationSets"; aws_config=aws_config)
+    return ssm_incidents(
+        "POST",
+        "/listReplicationSets";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_replication_sets(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ssm_incidents("POST", "/listReplicationSets", params; aws_config=aws_config)
+    return ssm_incidents(
+        "POST",
+        "/listReplicationSets",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -610,12 +672,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: The pagination token to continue to the next page of results.
 """
 function list_response_plans(; aws_config::AbstractAWSConfig=global_aws_config())
-    return ssm_incidents("POST", "/listResponsePlans"; aws_config=aws_config)
+    return ssm_incidents(
+        "POST", "/listResponsePlans"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_response_plans(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ssm_incidents("POST", "/listResponsePlans", params; aws_config=aws_config)
+    return ssm_incidents(
+        "POST",
+        "/listResponsePlans",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -631,14 +701,25 @@ Lists the tags that are attached to the specified response plan.
 function list_tags_for_resource(
     resourceArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return ssm_incidents("GET", "/tags/$(resourceArn)"; aws_config=aws_config)
+    return ssm_incidents(
+        "GET",
+        "/tags/$(resourceArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_tags_for_resource(
     resourceArn,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return ssm_incidents("GET", "/tags/$(resourceArn)", params; aws_config=aws_config)
+    return ssm_incidents(
+        "GET",
+        "/tags/$(resourceArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -669,6 +750,7 @@ function list_timeline_events(
         "/listTimelineEvents",
         Dict{String,Any}("incidentRecordArn" => incidentRecordArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_timeline_events(
@@ -685,6 +767,7 @@ function list_timeline_events(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -708,6 +791,7 @@ function put_resource_policy(
         "/putResourcePolicy",
         Dict{String,Any}("policy" => policy, "resourceArn" => resourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_resource_policy(
@@ -727,6 +811,7 @@ function put_resource_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -765,6 +850,7 @@ function start_incident(responsePlanArn; aws_config::AbstractAWSConfig=global_aw
             "responsePlanArn" => responsePlanArn, "clientToken" => string(uuid4())
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_incident(
@@ -785,6 +871,7 @@ function start_incident(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -806,6 +893,7 @@ function tag_resource(resourceArn, tags; aws_config::AbstractAWSConfig=global_aw
         "/tags/$(resourceArn)",
         Dict{String,Any}("tags" => tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -819,6 +907,7 @@ function tag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tags" => tags), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -842,6 +931,7 @@ function untag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}("tagKeys" => tagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -855,6 +945,7 @@ function untag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tagKeys" => tagKeys), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -887,6 +978,7 @@ function update_deletion_protection(
             "clientToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_deletion_protection(
@@ -910,6 +1002,7 @@ function update_deletion_protection(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -949,6 +1042,7 @@ function update_incident_record(arn; aws_config::AbstractAWSConfig=global_aws_co
         "/updateIncidentRecord",
         Dict{String,Any}("arn" => arn, "clientToken" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_incident_record(
@@ -965,6 +1059,7 @@ function update_incident_record(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -996,6 +1091,7 @@ function update_related_items(
             "clientToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_related_items(
@@ -1019,6 +1115,7 @@ function update_related_items(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1047,6 +1144,7 @@ function update_replication_set(
             "actions" => actions, "arn" => arn, "clientToken" => string(uuid4())
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_replication_set(
@@ -1068,6 +1166,7 @@ function update_replication_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1106,6 +1205,7 @@ function update_response_plan(arn; aws_config::AbstractAWSConfig=global_aws_conf
         "/updateResponsePlan",
         Dict{String,Any}("arn" => arn, "clientToken" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_response_plan(
@@ -1122,6 +1222,7 @@ function update_response_plan(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1157,6 +1258,7 @@ function update_timeline_event(
             "clientToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_timeline_event(
@@ -1180,5 +1282,6 @@ function update_timeline_event(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/sso.jl
+++ b/src/services/sso.jl
@@ -33,6 +33,7 @@ function get_role_credentials(
                 Dict{String,Any}("x-amz-sso_bearer_token" => x_amz_sso_bearer_token),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_role_credentials(
@@ -59,6 +60,7 @@ function get_role_credentials(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -91,6 +93,7 @@ function list_account_roles(
                 Dict{String,Any}("x-amz-sso_bearer_token" => x_amz_sso_bearer_token),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_account_roles(
@@ -115,6 +118,7 @@ function list_account_roles(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -147,6 +151,7 @@ function list_accounts(
                 Dict{String,Any}("x-amz-sso_bearer_token" => x_amz_sso_bearer_token),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_accounts(
@@ -169,6 +174,7 @@ function list_accounts(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -192,6 +198,7 @@ function logout(x_amz_sso_bearer_token; aws_config::AbstractAWSConfig=global_aws
                 Dict{String,Any}("x-amz-sso_bearer_token" => x_amz_sso_bearer_token),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function logout(
@@ -214,5 +221,6 @@ function logout(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/sso_admin.jl
+++ b/src/services/sso_admin.jl
@@ -36,6 +36,7 @@ function attach_managed_policy_to_permission_set(
             "PermissionSetArn" => PermissionSetArn,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function attach_managed_policy_to_permission_set(
@@ -59,6 +60,7 @@ function attach_managed_policy_to_permission_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -111,6 +113,7 @@ function create_account_assignment(
             "TargetType" => TargetType,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_account_assignment(
@@ -140,6 +143,7 @@ function create_account_assignment(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -176,6 +180,7 @@ function create_instance_access_control_attribute_configuration(
             "InstanceArn" => InstanceArn,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_instance_access_control_attribute_configuration(
@@ -198,6 +203,7 @@ function create_instance_access_control_attribute_configuration(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -230,6 +236,7 @@ function create_permission_set(
         "CreatePermissionSet",
         Dict{String,Any}("InstanceArn" => InstanceArn, "Name" => Name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_permission_set(
@@ -248,6 +255,7 @@ function create_permission_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -293,6 +301,7 @@ function delete_account_assignment(
             "TargetType" => TargetType,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_account_assignment(
@@ -322,6 +331,7 @@ function delete_account_assignment(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -347,6 +357,7 @@ function delete_inline_policy_from_permission_set(
             "InstanceArn" => InstanceArn, "PermissionSetArn" => PermissionSetArn
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_inline_policy_from_permission_set(
@@ -367,6 +378,7 @@ function delete_inline_policy_from_permission_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -391,6 +403,7 @@ function delete_instance_access_control_attribute_configuration(
         "DeleteInstanceAccessControlAttributeConfiguration",
         Dict{String,Any}("InstanceArn" => InstanceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_instance_access_control_attribute_configuration(
@@ -404,6 +417,7 @@ function delete_instance_access_control_attribute_configuration(
             mergewith(_merge, Dict{String,Any}("InstanceArn" => InstanceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -429,6 +443,7 @@ function delete_permission_set(
             "InstanceArn" => InstanceArn, "PermissionSetArn" => PermissionSetArn
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_permission_set(
@@ -449,6 +464,7 @@ function delete_permission_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -478,6 +494,7 @@ function describe_account_assignment_creation_status(
             "InstanceArn" => InstanceArn,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_account_assignment_creation_status(
@@ -500,6 +517,7 @@ function describe_account_assignment_creation_status(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -529,6 +547,7 @@ function describe_account_assignment_deletion_status(
             "InstanceArn" => InstanceArn,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_account_assignment_deletion_status(
@@ -551,6 +570,7 @@ function describe_account_assignment_deletion_status(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -575,6 +595,7 @@ function describe_instance_access_control_attribute_configuration(
         "DescribeInstanceAccessControlAttributeConfiguration",
         Dict{String,Any}("InstanceArn" => InstanceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_instance_access_control_attribute_configuration(
@@ -588,6 +609,7 @@ function describe_instance_access_control_attribute_configuration(
             mergewith(_merge, Dict{String,Any}("InstanceArn" => InstanceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -613,6 +635,7 @@ function describe_permission_set(
             "InstanceArn" => InstanceArn, "PermissionSetArn" => PermissionSetArn
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_permission_set(
@@ -633,6 +656,7 @@ function describe_permission_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -662,6 +686,7 @@ function describe_permission_set_provisioning_status(
             "ProvisionPermissionSetRequestId" => ProvisionPermissionSetRequestId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_permission_set_provisioning_status(
@@ -683,6 +708,7 @@ function describe_permission_set_provisioning_status(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -715,6 +741,7 @@ function detach_managed_policy_from_permission_set(
             "PermissionSetArn" => PermissionSetArn,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function detach_managed_policy_from_permission_set(
@@ -738,6 +765,7 @@ function detach_managed_policy_from_permission_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -763,6 +791,7 @@ function get_inline_policy_for_permission_set(
             "InstanceArn" => InstanceArn, "PermissionSetArn" => PermissionSetArn
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_inline_policy_for_permission_set(
@@ -783,6 +812,7 @@ function get_inline_policy_for_permission_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -812,6 +842,7 @@ function list_account_assignment_creation_status(
         "ListAccountAssignmentCreationStatus",
         Dict{String,Any}("InstanceArn" => InstanceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_account_assignment_creation_status(
@@ -825,6 +856,7 @@ function list_account_assignment_creation_status(
             mergewith(_merge, Dict{String,Any}("InstanceArn" => InstanceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -854,6 +886,7 @@ function list_account_assignment_deletion_status(
         "ListAccountAssignmentDeletionStatus",
         Dict{String,Any}("InstanceArn" => InstanceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_account_assignment_deletion_status(
@@ -867,6 +900,7 @@ function list_account_assignment_deletion_status(
             mergewith(_merge, Dict{String,Any}("InstanceArn" => InstanceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -905,6 +939,7 @@ function list_account_assignments(
             "PermissionSetArn" => PermissionSetArn,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_account_assignments(
@@ -928,6 +963,7 @@ function list_account_assignments(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -962,6 +998,7 @@ function list_accounts_for_provisioned_permission_set(
             "InstanceArn" => InstanceArn, "PermissionSetArn" => PermissionSetArn
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_accounts_for_provisioned_permission_set(
@@ -982,6 +1019,7 @@ function list_accounts_for_provisioned_permission_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -998,12 +1036,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   the output of previous API calls to make subsequent calls.
 """
 function list_instances(; aws_config::AbstractAWSConfig=global_aws_config())
-    return sso_admin("ListInstances"; aws_config=aws_config)
+    return sso_admin(
+        "ListInstances"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_instances(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sso_admin("ListInstances", params; aws_config=aws_config)
+    return sso_admin(
+        "ListInstances", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1033,6 +1075,7 @@ function list_managed_policies_in_permission_set(
             "InstanceArn" => InstanceArn, "PermissionSetArn" => PermissionSetArn
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_managed_policies_in_permission_set(
@@ -1053,6 +1096,7 @@ function list_managed_policies_in_permission_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1081,6 +1125,7 @@ function list_permission_set_provisioning_status(
         "ListPermissionSetProvisioningStatus",
         Dict{String,Any}("InstanceArn" => InstanceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_permission_set_provisioning_status(
@@ -1094,6 +1139,7 @@ function list_permission_set_provisioning_status(
             mergewith(_merge, Dict{String,Any}("InstanceArn" => InstanceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1121,6 +1167,7 @@ function list_permission_sets(
         "ListPermissionSets",
         Dict{String,Any}("InstanceArn" => InstanceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_permission_sets(
@@ -1134,6 +1181,7 @@ function list_permission_sets(
             mergewith(_merge, Dict{String,Any}("InstanceArn" => InstanceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1165,6 +1213,7 @@ function list_permission_sets_provisioned_to_account(
         "ListPermissionSetsProvisionedToAccount",
         Dict{String,Any}("AccountId" => AccountId, "InstanceArn" => InstanceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_permission_sets_provisioned_to_account(
@@ -1183,6 +1232,7 @@ function list_permission_sets_provisioned_to_account(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1210,6 +1260,7 @@ function list_tags_for_resource(
         "ListTagsForResource",
         Dict{String,Any}("InstanceArn" => InstanceArn, "ResourceArn" => ResourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags_for_resource(
@@ -1230,6 +1281,7 @@ function list_tags_for_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1265,6 +1317,7 @@ function provision_permission_set(
             "TargetType" => TargetType,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function provision_permission_set(
@@ -1288,6 +1341,7 @@ function provision_permission_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1322,6 +1376,7 @@ function put_inline_policy_to_permission_set(
             "PermissionSetArn" => PermissionSetArn,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_inline_policy_to_permission_set(
@@ -1345,6 +1400,7 @@ function put_inline_policy_to_permission_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1371,6 +1427,7 @@ function tag_resource(
             "InstanceArn" => InstanceArn, "ResourceArn" => ResourceArn, "Tags" => Tags
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -1394,6 +1451,7 @@ function tag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1420,6 +1478,7 @@ function untag_resource(
             "InstanceArn" => InstanceArn, "ResourceArn" => ResourceArn, "TagKeys" => TagKeys
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -1443,6 +1502,7 @@ function untag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1478,6 +1538,7 @@ function update_instance_access_control_attribute_configuration(
             "InstanceArn" => InstanceArn,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_instance_access_control_attribute_configuration(
@@ -1500,6 +1561,7 @@ function update_instance_access_control_attribute_configuration(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1532,6 +1594,7 @@ function update_permission_set(
             "InstanceArn" => InstanceArn, "PermissionSetArn" => PermissionSetArn
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_permission_set(
@@ -1552,5 +1615,6 @@ function update_permission_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/sso_oidc.jl
+++ b/src/services/sso_oidc.jl
@@ -50,6 +50,7 @@ function create_token(
             "grantType" => grantType,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_token(
@@ -76,6 +77,7 @@ function create_token(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -104,6 +106,7 @@ function register_client(
         "/client/register",
         Dict{String,Any}("clientName" => clientName, "clientType" => clientType);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function register_client(
@@ -123,6 +126,7 @@ function register_client(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -152,6 +156,7 @@ function start_device_authorization(
             "clientId" => clientId, "clientSecret" => clientSecret, "startUrl" => startUrl
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_device_authorization(
@@ -176,5 +181,6 @@ function start_device_authorization(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/storage_gateway.jl
+++ b/src/services/storage_gateway.jl
@@ -68,6 +68,7 @@ function activate_gateway(
             "GatewayTimezone" => GatewayTimezone,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function activate_gateway(
@@ -93,6 +94,7 @@ function activate_gateway(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -117,6 +119,7 @@ function add_cache(DiskIds, GatewayARN; aws_config::AbstractAWSConfig=global_aws
         "AddCache",
         Dict{String,Any}("DiskIds" => DiskIds, "GatewayARN" => GatewayARN);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function add_cache(
@@ -135,6 +138,7 @@ function add_cache(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -166,6 +170,7 @@ function add_tags_to_resource(
         "AddTagsToResource",
         Dict{String,Any}("ResourceARN" => ResourceARN, "Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function add_tags_to_resource(
@@ -184,6 +189,7 @@ function add_tags_to_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -210,6 +216,7 @@ function add_upload_buffer(
         "AddUploadBuffer",
         Dict{String,Any}("DiskIds" => DiskIds, "GatewayARN" => GatewayARN);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function add_upload_buffer(
@@ -228,6 +235,7 @@ function add_upload_buffer(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -257,6 +265,7 @@ function add_working_storage(
         "AddWorkingStorage",
         Dict{String,Any}("DiskIds" => DiskIds, "GatewayARN" => GatewayARN);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function add_working_storage(
@@ -275,6 +284,7 @@ function add_working_storage(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -311,6 +321,7 @@ function assign_tape_pool(
         "AssignTapePool",
         Dict{String,Any}("PoolId" => PoolId, "TapeARN" => TapeARN);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function assign_tape_pool(
@@ -327,6 +338,7 @@ function assign_tape_pool(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -378,6 +390,7 @@ function associate_file_system(
             "UserName" => UserName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_file_system(
@@ -405,6 +418,7 @@ function associate_file_system(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -453,6 +467,7 @@ function attach_volume(
             "VolumeARN" => VolumeARN,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function attach_volume(
@@ -476,6 +491,7 @@ function attach_volume(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -499,6 +515,7 @@ function cancel_archival(
         "CancelArchival",
         Dict{String,Any}("GatewayARN" => GatewayARN, "TapeARN" => TapeARN);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function cancel_archival(
@@ -517,6 +534,7 @@ function cancel_archival(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -541,6 +559,7 @@ function cancel_retrieval(
         "CancelRetrieval",
         Dict{String,Any}("GatewayARN" => GatewayARN, "TapeARN" => TapeARN);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function cancel_retrieval(
@@ -559,6 +578,7 @@ function cancel_retrieval(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -634,6 +654,7 @@ function create_cachedi_scsivolume(
             "VolumeSizeInBytes" => VolumeSizeInBytes,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_cachedi_scsivolume(
@@ -661,6 +682,7 @@ function create_cachedi_scsivolume(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -764,6 +786,7 @@ function create_nfsfile_share(
             "Role" => Role,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_nfsfile_share(
@@ -789,6 +812,7 @@ function create_nfsfile_share(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -915,6 +939,7 @@ function create_smbfile_share(
             "Role" => Role,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_smbfile_share(
@@ -940,6 +965,7 @@ function create_smbfile_share(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -987,6 +1013,7 @@ function create_snapshot(
             "SnapshotDescription" => SnapshotDescription, "VolumeARN" => VolumeARN
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_snapshot(
@@ -1007,6 +1034,7 @@ function create_snapshot(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1052,6 +1080,7 @@ function create_snapshot_from_volume_recovery_point(
             "SnapshotDescription" => SnapshotDescription, "VolumeARN" => VolumeARN
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_snapshot_from_volume_recovery_point(
@@ -1072,6 +1101,7 @@ function create_snapshot_from_volume_recovery_point(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1140,6 +1170,7 @@ function create_storedi_scsivolume(
             "TargetName" => TargetName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_storedi_scsivolume(
@@ -1167,6 +1198,7 @@ function create_storedi_scsivolume(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1204,6 +1236,7 @@ function create_tape_pool(
         "CreateTapePool",
         Dict{String,Any}("PoolName" => PoolName, "StorageClass" => StorageClass);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_tape_pool(
@@ -1222,6 +1255,7 @@ function create_tape_pool(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1278,6 +1312,7 @@ function create_tape_with_barcode(
             "TapeSizeInBytes" => TapeSizeInBytes,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_tape_with_barcode(
@@ -1301,6 +1336,7 @@ function create_tape_with_barcode(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1365,6 +1401,7 @@ function create_tapes(
             "TapeSizeInBytes" => TapeSizeInBytes,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_tapes(
@@ -1392,6 +1429,7 @@ function create_tapes(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1414,6 +1452,7 @@ function delete_automatic_tape_creation_policy(
         "DeleteAutomaticTapeCreationPolicy",
         Dict{String,Any}("GatewayARN" => GatewayARN);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_automatic_tape_creation_policy(
@@ -1427,6 +1466,7 @@ function delete_automatic_tape_creation_policy(
             mergewith(_merge, Dict{String,Any}("GatewayARN" => GatewayARN), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1453,6 +1493,7 @@ function delete_bandwidth_rate_limit(
         "DeleteBandwidthRateLimit",
         Dict{String,Any}("BandwidthType" => BandwidthType, "GatewayARN" => GatewayARN);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_bandwidth_rate_limit(
@@ -1473,6 +1514,7 @@ function delete_bandwidth_rate_limit(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1498,6 +1540,7 @@ function delete_chap_credentials(
         "DeleteChapCredentials",
         Dict{String,Any}("InitiatorName" => InitiatorName, "TargetARN" => TargetARN);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_chap_credentials(
@@ -1518,6 +1561,7 @@ function delete_chap_credentials(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1544,6 +1588,7 @@ function delete_file_share(FileShareARN; aws_config::AbstractAWSConfig=global_aw
         "DeleteFileShare",
         Dict{String,Any}("FileShareARN" => FileShareARN);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_file_share(
@@ -1557,6 +1602,7 @@ function delete_file_share(
             mergewith(_merge, Dict{String,Any}("FileShareARN" => FileShareARN), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1582,7 +1628,10 @@ Amazon EC2 console. For more information, see the Storage Gateway detail page.
 """
 function delete_gateway(GatewayARN; aws_config::AbstractAWSConfig=global_aws_config())
     return storage_gateway(
-        "DeleteGateway", Dict{String,Any}("GatewayARN" => GatewayARN); aws_config=aws_config
+        "DeleteGateway",
+        Dict{String,Any}("GatewayARN" => GatewayARN);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_gateway(
@@ -1596,6 +1645,7 @@ function delete_gateway(
             mergewith(_merge, Dict{String,Any}("GatewayARN" => GatewayARN), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1622,6 +1672,7 @@ function delete_snapshot_schedule(
         "DeleteSnapshotSchedule",
         Dict{String,Any}("VolumeARN" => VolumeARN);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_snapshot_schedule(
@@ -1635,6 +1686,7 @@ function delete_snapshot_schedule(
             mergewith(_merge, Dict{String,Any}("VolumeARN" => VolumeARN), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1663,6 +1715,7 @@ function delete_tape(GatewayARN, TapeARN; aws_config::AbstractAWSConfig=global_a
         "DeleteTape",
         Dict{String,Any}("GatewayARN" => GatewayARN, "TapeARN" => TapeARN);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_tape(
@@ -1681,6 +1734,7 @@ function delete_tape(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1704,7 +1758,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function delete_tape_archive(TapeARN; aws_config::AbstractAWSConfig=global_aws_config())
     return storage_gateway(
-        "DeleteTapeArchive", Dict{String,Any}("TapeARN" => TapeARN); aws_config=aws_config
+        "DeleteTapeArchive",
+        Dict{String,Any}("TapeARN" => TapeARN);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_tape_archive(
@@ -1714,6 +1771,7 @@ function delete_tape_archive(
         "DeleteTapeArchive",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("TapeARN" => TapeARN), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1731,7 +1789,10 @@ tape pool.
 """
 function delete_tape_pool(PoolARN; aws_config::AbstractAWSConfig=global_aws_config())
     return storage_gateway(
-        "DeleteTapePool", Dict{String,Any}("PoolARN" => PoolARN); aws_config=aws_config
+        "DeleteTapePool",
+        Dict{String,Any}("PoolARN" => PoolARN);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_tape_pool(
@@ -1741,6 +1802,7 @@ function delete_tape_pool(
         "DeleteTapePool",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("PoolARN" => PoolARN), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1767,7 +1829,10 @@ to delete.
 """
 function delete_volume(VolumeARN; aws_config::AbstractAWSConfig=global_aws_config())
     return storage_gateway(
-        "DeleteVolume", Dict{String,Any}("VolumeARN" => VolumeARN); aws_config=aws_config
+        "DeleteVolume",
+        Dict{String,Any}("VolumeARN" => VolumeARN);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_volume(
@@ -1781,6 +1846,7 @@ function delete_volume(
             mergewith(_merge, Dict{String,Any}("VolumeARN" => VolumeARN), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1803,6 +1869,7 @@ function describe_availability_monitor_test(
         "DescribeAvailabilityMonitorTest",
         Dict{String,Any}("GatewayARN" => GatewayARN);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_availability_monitor_test(
@@ -1816,6 +1883,7 @@ function describe_availability_monitor_test(
             mergewith(_merge, Dict{String,Any}("GatewayARN" => GatewayARN), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1841,6 +1909,7 @@ function describe_bandwidth_rate_limit(
         "DescribeBandwidthRateLimit",
         Dict{String,Any}("GatewayARN" => GatewayARN);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_bandwidth_rate_limit(
@@ -1854,6 +1923,7 @@ function describe_bandwidth_rate_limit(
             mergewith(_merge, Dict{String,Any}("GatewayARN" => GatewayARN), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1885,6 +1955,7 @@ function describe_bandwidth_rate_limit_schedule(
         "DescribeBandwidthRateLimitSchedule",
         Dict{String,Any}("GatewayARN" => GatewayARN);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_bandwidth_rate_limit_schedule(
@@ -1898,6 +1969,7 @@ function describe_bandwidth_rate_limit_schedule(
             mergewith(_merge, Dict{String,Any}("GatewayARN" => GatewayARN), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1915,7 +1987,10 @@ configured as cache, and it includes the amount of cache allocated and used.
 """
 function describe_cache(GatewayARN; aws_config::AbstractAWSConfig=global_aws_config())
     return storage_gateway(
-        "DescribeCache", Dict{String,Any}("GatewayARN" => GatewayARN); aws_config=aws_config
+        "DescribeCache",
+        Dict{String,Any}("GatewayARN" => GatewayARN);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_cache(
@@ -1929,6 +2004,7 @@ function describe_cache(
             mergewith(_merge, Dict{String,Any}("GatewayARN" => GatewayARN), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1954,6 +2030,7 @@ function describe_cachedi_scsivolumes(
         "DescribeCachediSCSIVolumes",
         Dict{String,Any}("VolumeARNs" => VolumeARNs);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_cachedi_scsivolumes(
@@ -1967,6 +2044,7 @@ function describe_cachedi_scsivolumes(
             mergewith(_merge, Dict{String,Any}("VolumeARNs" => VolumeARNs), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1991,6 +2069,7 @@ function describe_chap_credentials(
         "DescribeChapCredentials",
         Dict{String,Any}("TargetARN" => TargetARN);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_chap_credentials(
@@ -2004,6 +2083,7 @@ function describe_chap_credentials(
             mergewith(_merge, Dict{String,Any}("TargetARN" => TargetARN), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2026,6 +2106,7 @@ function describe_file_system_associations(
         "DescribeFileSystemAssociations",
         Dict{String,Any}("FileSystemAssociationARNList" => FileSystemAssociationARNList);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_file_system_associations(
@@ -2045,6 +2126,7 @@ function describe_file_system_associations(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2067,6 +2149,7 @@ function describe_gateway_information(
         "DescribeGatewayInformation",
         Dict{String,Any}("GatewayARN" => GatewayARN);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_gateway_information(
@@ -2080,6 +2163,7 @@ function describe_gateway_information(
             mergewith(_merge, Dict{String,Any}("GatewayARN" => GatewayARN), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2101,6 +2185,7 @@ function describe_maintenance_start_time(
         "DescribeMaintenanceStartTime",
         Dict{String,Any}("GatewayARN" => GatewayARN);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_maintenance_start_time(
@@ -2114,6 +2199,7 @@ function describe_maintenance_start_time(
             mergewith(_merge, Dict{String,Any}("GatewayARN" => GatewayARN), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2136,6 +2222,7 @@ function describe_nfsfile_shares(
         "DescribeNFSFileShares",
         Dict{String,Any}("FileShareARNList" => FileShareARNList);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_nfsfile_shares(
@@ -2151,6 +2238,7 @@ function describe_nfsfile_shares(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2173,6 +2261,7 @@ function describe_smbfile_shares(
         "DescribeSMBFileShares",
         Dict{String,Any}("FileShareARNList" => FileShareARNList);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_smbfile_shares(
@@ -2188,6 +2277,7 @@ function describe_smbfile_shares(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2207,6 +2297,7 @@ function describe_smbsettings(GatewayARN; aws_config::AbstractAWSConfig=global_a
         "DescribeSMBSettings",
         Dict{String,Any}("GatewayARN" => GatewayARN);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_smbsettings(
@@ -2220,6 +2311,7 @@ function describe_smbsettings(
             mergewith(_merge, Dict{String,Any}("GatewayARN" => GatewayARN), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2243,6 +2335,7 @@ function describe_snapshot_schedule(
         "DescribeSnapshotSchedule",
         Dict{String,Any}("VolumeARN" => VolumeARN);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_snapshot_schedule(
@@ -2256,6 +2349,7 @@ function describe_snapshot_schedule(
             mergewith(_merge, Dict{String,Any}("VolumeARN" => VolumeARN), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2281,6 +2375,7 @@ function describe_storedi_scsivolumes(
         "DescribeStorediSCSIVolumes",
         Dict{String,Any}("VolumeARNs" => VolumeARNs);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_storedi_scsivolumes(
@@ -2294,6 +2389,7 @@ function describe_storedi_scsivolumes(
             mergewith(_merge, Dict{String,Any}("VolumeARNs" => VolumeARNs), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2316,12 +2412,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   the virtual tapes you want to describe.
 """
 function describe_tape_archives(; aws_config::AbstractAWSConfig=global_aws_config())
-    return storage_gateway("DescribeTapeArchives"; aws_config=aws_config)
+    return storage_gateway(
+        "DescribeTapeArchives"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_tape_archives(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return storage_gateway("DescribeTapeArchives", params; aws_config=aws_config)
+    return storage_gateway(
+        "DescribeTapeArchives",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2351,6 +2454,7 @@ function describe_tape_recovery_points(
         "DescribeTapeRecoveryPoints",
         Dict{String,Any}("GatewayARN" => GatewayARN);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_tape_recovery_points(
@@ -2364,6 +2468,7 @@ function describe_tape_recovery_points(
             mergewith(_merge, Dict{String,Any}("GatewayARN" => GatewayARN), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2391,7 +2496,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function describe_tapes(GatewayARN; aws_config::AbstractAWSConfig=global_aws_config())
     return storage_gateway(
-        "DescribeTapes", Dict{String,Any}("GatewayARN" => GatewayARN); aws_config=aws_config
+        "DescribeTapes",
+        Dict{String,Any}("GatewayARN" => GatewayARN);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_tapes(
@@ -2405,6 +2513,7 @@ function describe_tapes(
             mergewith(_merge, Dict{String,Any}("GatewayARN" => GatewayARN), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2428,6 +2537,7 @@ function describe_upload_buffer(
         "DescribeUploadBuffer",
         Dict{String,Any}("GatewayARN" => GatewayARN);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_upload_buffer(
@@ -2441,6 +2551,7 @@ function describe_upload_buffer(
             mergewith(_merge, Dict{String,Any}("GatewayARN" => GatewayARN), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2471,6 +2582,7 @@ function describe_vtldevices(GatewayARN; aws_config::AbstractAWSConfig=global_aw
         "DescribeVTLDevices",
         Dict{String,Any}("GatewayARN" => GatewayARN);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_vtldevices(
@@ -2484,6 +2596,7 @@ function describe_vtldevices(
             mergewith(_merge, Dict{String,Any}("GatewayARN" => GatewayARN), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2510,6 +2623,7 @@ function describe_working_storage(
         "DescribeWorkingStorage",
         Dict{String,Any}("GatewayARN" => GatewayARN);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_working_storage(
@@ -2523,6 +2637,7 @@ function describe_working_storage(
             mergewith(_merge, Dict{String,Any}("GatewayARN" => GatewayARN), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2547,7 +2662,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function detach_volume(VolumeARN; aws_config::AbstractAWSConfig=global_aws_config())
     return storage_gateway(
-        "DetachVolume", Dict{String,Any}("VolumeARN" => VolumeARN); aws_config=aws_config
+        "DetachVolume",
+        Dict{String,Any}("VolumeARN" => VolumeARN);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function detach_volume(
@@ -2561,6 +2679,7 @@ function detach_volume(
             mergewith(_merge, Dict{String,Any}("VolumeARN" => VolumeARN), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2583,6 +2702,7 @@ function disable_gateway(GatewayARN; aws_config::AbstractAWSConfig=global_aws_co
         "DisableGateway",
         Dict{String,Any}("GatewayARN" => GatewayARN);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disable_gateway(
@@ -2596,6 +2716,7 @@ function disable_gateway(
             mergewith(_merge, Dict{String,Any}("GatewayARN" => GatewayARN), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2625,6 +2746,7 @@ function disassociate_file_system(
         "DisassociateFileSystem",
         Dict{String,Any}("FileSystemAssociationARN" => FileSystemAssociationARN);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disassociate_file_system(
@@ -2642,6 +2764,7 @@ function disassociate_file_system(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2690,6 +2813,7 @@ function join_domain(
             "UserName" => UserName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function join_domain(
@@ -2715,6 +2839,7 @@ function join_domain(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2733,13 +2858,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function list_automatic_tape_creation_policies(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return storage_gateway("ListAutomaticTapeCreationPolicies"; aws_config=aws_config)
+    return storage_gateway(
+        "ListAutomaticTapeCreationPolicies";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_automatic_tape_creation_policies(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return storage_gateway(
-        "ListAutomaticTapeCreationPolicies", params; aws_config=aws_config
+        "ListAutomaticTapeCreationPolicies",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2762,12 +2894,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   ListFileShares. Optional.
 """
 function list_file_shares(; aws_config::AbstractAWSConfig=global_aws_config())
-    return storage_gateway("ListFileShares"; aws_config=aws_config)
+    return storage_gateway(
+        "ListFileShares"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_file_shares(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return storage_gateway("ListFileShares", params; aws_config=aws_config)
+    return storage_gateway(
+        "ListFileShares", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -2787,12 +2923,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   call to ListFileSystemAssociations. Optional.
 """
 function list_file_system_associations(; aws_config::AbstractAWSConfig=global_aws_config())
-    return storage_gateway("ListFileSystemAssociations"; aws_config=aws_config)
+    return storage_gateway(
+        "ListFileSystemAssociations"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_file_system_associations(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return storage_gateway("ListFileSystemAssociations", params; aws_config=aws_config)
+    return storage_gateway(
+        "ListFileSystemAssociations",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2815,12 +2958,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   list of gateways.
 """
 function list_gateways(; aws_config::AbstractAWSConfig=global_aws_config())
-    return storage_gateway("ListGateways"; aws_config=aws_config)
+    return storage_gateway(
+        "ListGateways"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_gateways(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return storage_gateway("ListGateways", params; aws_config=aws_config)
+    return storage_gateway(
+        "ListGateways", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -2844,6 +2991,7 @@ function list_local_disks(GatewayARN; aws_config::AbstractAWSConfig=global_aws_c
         "ListLocalDisks",
         Dict{String,Any}("GatewayARN" => GatewayARN);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_local_disks(
@@ -2857,6 +3005,7 @@ function list_local_disks(
             mergewith(_merge, Dict{String,Any}("GatewayARN" => GatewayARN), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2885,6 +3034,7 @@ function list_tags_for_resource(
         "ListTagsForResource",
         Dict{String,Any}("ResourceARN" => ResourceARN);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags_for_resource(
@@ -2898,6 +3048,7 @@ function list_tags_for_resource(
             mergewith(_merge, Dict{String,Any}("ResourceARN" => ResourceARN), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2923,12 +3074,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   pools.
 """
 function list_tape_pools(; aws_config::AbstractAWSConfig=global_aws_config())
-    return storage_gateway("ListTapePools"; aws_config=aws_config)
+    return storage_gateway(
+        "ListTapePools"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_tape_pools(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return storage_gateway("ListTapePools", params; aws_config=aws_config)
+    return storage_gateway(
+        "ListTapePools", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -2953,12 +3108,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"TapeARNs"`:
 """
 function list_tapes(; aws_config::AbstractAWSConfig=global_aws_config())
-    return storage_gateway("ListTapes"; aws_config=aws_config)
+    return storage_gateway(
+        "ListTapes"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_tapes(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return storage_gateway("ListTapes", params; aws_config=aws_config)
+    return storage_gateway(
+        "ListTapes", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -2981,6 +3140,7 @@ function list_volume_initiators(
         "ListVolumeInitiators",
         Dict{String,Any}("VolumeARN" => VolumeARN);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_volume_initiators(
@@ -2994,6 +3154,7 @@ function list_volume_initiators(
             mergewith(_merge, Dict{String,Any}("VolumeARN" => VolumeARN), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3019,6 +3180,7 @@ function list_volume_recovery_points(
         "ListVolumeRecoveryPoints",
         Dict{String,Any}("GatewayARN" => GatewayARN);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_volume_recovery_points(
@@ -3032,6 +3194,7 @@ function list_volume_recovery_points(
             mergewith(_merge, Dict{String,Any}("GatewayARN" => GatewayARN), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3058,12 +3221,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   volumes. Obtain the marker from the response of a previous List iSCSI Volumes request.
 """
 function list_volumes(; aws_config::AbstractAWSConfig=global_aws_config())
-    return storage_gateway("ListVolumes"; aws_config=aws_config)
+    return storage_gateway(
+        "ListVolumes"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_volumes(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return storage_gateway("ListVolumes", params; aws_config=aws_config)
+    return storage_gateway(
+        "ListVolumes", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -3091,6 +3258,7 @@ function notify_when_uploaded(
         "NotifyWhenUploaded",
         Dict{String,Any}("FileShareARN" => FileShareARN);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function notify_when_uploaded(
@@ -3104,6 +3272,7 @@ function notify_when_uploaded(
             mergewith(_merge, Dict{String,Any}("FileShareARN" => FileShareARN), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3154,6 +3323,7 @@ function refresh_cache(FileShareARN; aws_config::AbstractAWSConfig=global_aws_co
         "RefreshCache",
         Dict{String,Any}("FileShareARN" => FileShareARN);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function refresh_cache(
@@ -3167,6 +3337,7 @@ function refresh_cache(
             mergewith(_merge, Dict{String,Any}("FileShareARN" => FileShareARN), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3191,6 +3362,7 @@ function remove_tags_from_resource(
         "RemoveTagsFromResource",
         Dict{String,Any}("ResourceARN" => ResourceARN, "TagKeys" => TagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function remove_tags_from_resource(
@@ -3209,6 +3381,7 @@ function remove_tags_from_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3233,7 +3406,10 @@ properly.
 """
 function reset_cache(GatewayARN; aws_config::AbstractAWSConfig=global_aws_config())
     return storage_gateway(
-        "ResetCache", Dict{String,Any}("GatewayARN" => GatewayARN); aws_config=aws_config
+        "ResetCache",
+        Dict{String,Any}("GatewayARN" => GatewayARN);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function reset_cache(
@@ -3247,6 +3423,7 @@ function reset_cache(
             mergewith(_merge, Dict{String,Any}("GatewayARN" => GatewayARN), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3278,6 +3455,7 @@ function retrieve_tape_archive(
         "RetrieveTapeArchive",
         Dict{String,Any}("GatewayARN" => GatewayARN, "TapeARN" => TapeARN);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function retrieve_tape_archive(
@@ -3296,6 +3474,7 @@ function retrieve_tape_archive(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3323,6 +3502,7 @@ function retrieve_tape_recovery_point(
         "RetrieveTapeRecoveryPoint",
         Dict{String,Any}("GatewayARN" => GatewayARN, "TapeARN" => TapeARN);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function retrieve_tape_recovery_point(
@@ -3341,6 +3521,7 @@ function retrieve_tape_recovery_point(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3366,6 +3547,7 @@ function set_local_console_password(
             "GatewayARN" => GatewayARN, "LocalConsolePassword" => LocalConsolePassword
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function set_local_console_password(
@@ -3387,6 +3569,7 @@ function set_local_console_password(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3411,6 +3594,7 @@ function set_smbguest_password(
         "SetSMBGuestPassword",
         Dict{String,Any}("GatewayARN" => GatewayARN, "Password" => Password);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function set_smbguest_password(
@@ -3429,6 +3613,7 @@ function set_smbguest_password(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3459,6 +3644,7 @@ function shutdown_gateway(GatewayARN; aws_config::AbstractAWSConfig=global_aws_c
         "ShutdownGateway",
         Dict{String,Any}("GatewayARN" => GatewayARN);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function shutdown_gateway(
@@ -3472,6 +3658,7 @@ function shutdown_gateway(
             mergewith(_merge, Dict{String,Any}("GatewayARN" => GatewayARN), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3496,6 +3683,7 @@ function start_availability_monitor_test(
         "StartAvailabilityMonitorTest",
         Dict{String,Any}("GatewayARN" => GatewayARN);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_availability_monitor_test(
@@ -3509,6 +3697,7 @@ function start_availability_monitor_test(
             mergewith(_merge, Dict{String,Any}("GatewayARN" => GatewayARN), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3531,7 +3720,10 @@ your request.
 """
 function start_gateway(GatewayARN; aws_config::AbstractAWSConfig=global_aws_config())
     return storage_gateway(
-        "StartGateway", Dict{String,Any}("GatewayARN" => GatewayARN); aws_config=aws_config
+        "StartGateway",
+        Dict{String,Any}("GatewayARN" => GatewayARN);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_gateway(
@@ -3545,6 +3737,7 @@ function start_gateway(
             mergewith(_merge, Dict{String,Any}("GatewayARN" => GatewayARN), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3576,6 +3769,7 @@ function update_automatic_tape_creation_policy(
             "GatewayARN" => GatewayARN,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_automatic_tape_creation_policy(
@@ -3597,6 +3791,7 @@ function update_automatic_tape_creation_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3629,6 +3824,7 @@ function update_bandwidth_rate_limit(
         "UpdateBandwidthRateLimit",
         Dict{String,Any}("GatewayARN" => GatewayARN);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_bandwidth_rate_limit(
@@ -3642,6 +3838,7 @@ function update_bandwidth_rate_limit(
             mergewith(_merge, Dict{String,Any}("GatewayARN" => GatewayARN), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3673,6 +3870,7 @@ function update_bandwidth_rate_limit_schedule(
             "GatewayARN" => GatewayARN,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_bandwidth_rate_limit_schedule(
@@ -3694,6 +3892,7 @@ function update_bandwidth_rate_limit_schedule(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3736,6 +3935,7 @@ function update_chap_credentials(
             "TargetARN" => TargetARN,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_chap_credentials(
@@ -3759,6 +3959,7 @@ function update_chap_credentials(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3790,6 +3991,7 @@ function update_file_system_association(
         "UpdateFileSystemAssociation",
         Dict{String,Any}("FileSystemAssociationARN" => FileSystemAssociationARN);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_file_system_association(
@@ -3807,6 +4009,7 @@ function update_file_system_association(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3839,6 +4042,7 @@ function update_gateway_information(
         "UpdateGatewayInformation",
         Dict{String,Any}("GatewayARN" => GatewayARN);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_gateway_information(
@@ -3852,6 +4056,7 @@ function update_gateway_information(
             mergewith(_merge, Dict{String,Any}("GatewayARN" => GatewayARN), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3880,6 +4085,7 @@ function update_gateway_software_now(
         "UpdateGatewaySoftwareNow",
         Dict{String,Any}("GatewayARN" => GatewayARN);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_gateway_software_now(
@@ -3893,6 +4099,7 @@ function update_gateway_software_now(
             mergewith(_merge, Dict{String,Any}("GatewayARN" => GatewayARN), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3930,6 +4137,7 @@ function update_maintenance_start_time(
             "MinuteOfHour" => MinuteOfHour,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_maintenance_start_time(
@@ -3953,6 +4161,7 @@ function update_maintenance_start_time(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4018,6 +4227,7 @@ function update_nfsfile_share(
         "UpdateNFSFileShare",
         Dict{String,Any}("FileShareARN" => FileShareARN);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_nfsfile_share(
@@ -4031,6 +4241,7 @@ function update_nfsfile_share(
             mergewith(_merge, Dict{String,Any}("FileShareARN" => FileShareARN), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4121,6 +4332,7 @@ function update_smbfile_share(
         "UpdateSMBFileShare",
         Dict{String,Any}("FileShareARN" => FileShareARN);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_smbfile_share(
@@ -4134,6 +4346,7 @@ function update_smbfile_share(
             mergewith(_merge, Dict{String,Any}("FileShareARN" => FileShareARN), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4158,6 +4371,7 @@ function update_smbfile_share_visibility(
             "FileSharesVisible" => FileSharesVisible, "GatewayARN" => GatewayARN
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_smbfile_share_visibility(
@@ -4178,6 +4392,7 @@ function update_smbfile_share_visibility(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4212,6 +4427,7 @@ function update_smbsecurity_strategy(
             "GatewayARN" => GatewayARN, "SMBSecurityStrategy" => SMBSecurityStrategy
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_smbsecurity_strategy(
@@ -4232,6 +4448,7 @@ function update_smbsecurity_strategy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4276,6 +4493,7 @@ function update_snapshot_schedule(
             "VolumeARN" => VolumeARN,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_snapshot_schedule(
@@ -4299,6 +4517,7 @@ function update_snapshot_schedule(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -4324,6 +4543,7 @@ function update_vtldevice_type(
         "UpdateVTLDeviceType",
         Dict{String,Any}("DeviceType" => DeviceType, "VTLDeviceARN" => VTLDeviceARN);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_vtldevice_type(
@@ -4344,5 +4564,6 @@ function update_vtldevice_type(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/sts.jl
+++ b/src/services/sts.jl
@@ -191,6 +191,7 @@ function assume_role(
         "AssumeRole",
         Dict{String,Any}("RoleArn" => RoleArn, "RoleSessionName" => RoleSessionName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function assume_role(
@@ -211,6 +212,7 @@ function assume_role(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -359,6 +361,7 @@ function assume_role_with_saml(
             "SAMLAssertion" => SAMLAssertion,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function assume_role_with_saml(
@@ -382,6 +385,7 @@ function assume_role_with_saml(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -550,6 +554,7 @@ function assume_role_with_web_identity(
             "WebIdentityToken" => WebIdentityToken,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function assume_role_with_web_identity(
@@ -573,6 +578,7 @@ function assume_role_with_web_identity(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -609,6 +615,7 @@ function decode_authorization_message(
         "DecodeAuthorizationMessage",
         Dict{String,Any}("EncodedMessage" => EncodedMessage);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function decode_authorization_message(
@@ -622,6 +629,7 @@ function decode_authorization_message(
             mergewith(_merge, Dict{String,Any}("EncodedMessage" => EncodedMessage), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -656,6 +664,7 @@ function get_access_key_info(AccessKeyId; aws_config::AbstractAWSConfig=global_a
         "GetAccessKeyInfo",
         Dict{String,Any}("AccessKeyId" => AccessKeyId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_access_key_info(
@@ -669,6 +678,7 @@ function get_access_key_info(
             mergewith(_merge, Dict{String,Any}("AccessKeyId" => AccessKeyId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -686,12 +696,14 @@ iam:DeleteVirtualMFADevice in the IAM User Guide.
 
 """
 function get_caller_identity(; aws_config::AbstractAWSConfig=global_aws_config())
-    return sts("GetCallerIdentity"; aws_config=aws_config)
+    return sts("GetCallerIdentity"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function get_caller_identity(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sts("GetCallerIdentity", params; aws_config=aws_config)
+    return sts(
+        "GetCallerIdentity", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -866,7 +878,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function get_federation_token(Name; aws_config::AbstractAWSConfig=global_aws_config())
     return sts(
-        "GetFederationToken", Dict{String,Any}("Name" => Name); aws_config=aws_config
+        "GetFederationToken",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_federation_token(
@@ -876,6 +891,7 @@ function get_federation_token(
         "GetFederationToken",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -940,10 +956,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   as described by its regex pattern, is a sequence of six numeric digits.
 """
 function get_session_token(; aws_config::AbstractAWSConfig=global_aws_config())
-    return sts("GetSessionToken"; aws_config=aws_config)
+    return sts("GetSessionToken"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function get_session_token(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return sts("GetSessionToken", params; aws_config=aws_config)
+    return sts(
+        "GetSessionToken", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end

--- a/src/services/support.jl
+++ b/src/services/support.jl
@@ -37,6 +37,7 @@ function add_attachments_to_set(
         "AddAttachmentsToSet",
         Dict{String,Any}("attachments" => attachments);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function add_attachments_to_set(
@@ -50,6 +51,7 @@ function add_attachments_to_set(
             mergewith(_merge, Dict{String,Any}("attachments" => attachments), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -85,6 +87,7 @@ function add_communication_to_case(
         "AddCommunicationToCase",
         Dict{String,Any}("communicationBody" => communicationBody);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function add_communication_to_case(
@@ -100,6 +103,7 @@ function add_communication_to_case(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -158,6 +162,7 @@ function create_case(
         "CreateCase",
         Dict{String,Any}("communicationBody" => communicationBody, "subject" => subject);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_case(
@@ -178,6 +183,7 @@ function create_case(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -206,6 +212,7 @@ function describe_attachment(
         "DescribeAttachment",
         Dict{String,Any}("attachmentId" => attachmentId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_attachment(
@@ -219,6 +226,7 @@ function describe_attachment(
             mergewith(_merge, Dict{String,Any}("attachmentId" => attachmentId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -258,12 +266,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"nextToken"`: A resumption point for pagination.
 """
 function describe_cases(; aws_config::AbstractAWSConfig=global_aws_config())
-    return support("DescribeCases"; aws_config=aws_config)
+    return support("DescribeCases"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function describe_cases(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return support("DescribeCases", params; aws_config=aws_config)
+    return support(
+        "DescribeCases", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -300,6 +310,7 @@ function describe_communications(caseId; aws_config::AbstractAWSConfig=global_aw
         "DescribeCommunications",
         Dict{String,Any}("caseId" => caseId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_communications(
@@ -309,6 +320,7 @@ function describe_communications(
         "DescribeCommunications",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("caseId" => caseId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -336,12 +348,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"serviceCodeList"`: A JSON-formatted list of service codes available for AWS services.
 """
 function describe_services(; aws_config::AbstractAWSConfig=global_aws_config())
-    return support("DescribeServices"; aws_config=aws_config)
+    return support(
+        "DescribeServices"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_services(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return support("DescribeServices", params; aws_config=aws_config)
+    return support(
+        "DescribeServices", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -362,12 +378,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   be passed explicitly for operations that take them.
 """
 function describe_severity_levels(; aws_config::AbstractAWSConfig=global_aws_config())
-    return support("DescribeSeverityLevels"; aws_config=aws_config)
+    return support(
+        "DescribeSeverityLevels"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_severity_levels(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return support("DescribeSeverityLevels", params; aws_config=aws_config)
+    return support(
+        "DescribeSeverityLevels",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -397,6 +420,7 @@ function describe_trusted_advisor_check_refresh_statuses(
         "DescribeTrustedAdvisorCheckRefreshStatuses",
         Dict{String,Any}("checkIds" => checkIds);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_trusted_advisor_check_refresh_statuses(
@@ -410,6 +434,7 @@ function describe_trusted_advisor_check_refresh_statuses(
             mergewith(_merge, Dict{String,Any}("checkIds" => checkIds), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -445,6 +470,7 @@ function describe_trusted_advisor_check_result(
         "DescribeTrustedAdvisorCheckResult",
         Dict{String,Any}("checkId" => checkId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_trusted_advisor_check_result(
@@ -454,6 +480,7 @@ function describe_trusted_advisor_check_result(
         "DescribeTrustedAdvisorCheckResult",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("checkId" => checkId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -480,6 +507,7 @@ function describe_trusted_advisor_check_summaries(
         "DescribeTrustedAdvisorCheckSummaries",
         Dict{String,Any}("checkIds" => checkIds);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_trusted_advisor_check_summaries(
@@ -493,6 +521,7 @@ function describe_trusted_advisor_check_summaries(
             mergewith(_merge, Dict{String,Any}("checkIds" => checkIds), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -524,6 +553,7 @@ function describe_trusted_advisor_checks(
         "DescribeTrustedAdvisorChecks",
         Dict{String,Any}("language" => language);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_trusted_advisor_checks(
@@ -537,6 +567,7 @@ function describe_trusted_advisor_checks(
             mergewith(_merge, Dict{String,Any}("language" => language), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -566,6 +597,7 @@ function refresh_trusted_advisor_check(
         "RefreshTrustedAdvisorCheck",
         Dict{String,Any}("checkId" => checkId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function refresh_trusted_advisor_check(
@@ -575,6 +607,7 @@ function refresh_trusted_advisor_check(
         "RefreshTrustedAdvisorCheck",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("checkId" => checkId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -595,10 +628,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   case-12345678910-2013-c4c1d2bf33c5cf47
 """
 function resolve_case(; aws_config::AbstractAWSConfig=global_aws_config())
-    return support("ResolveCase"; aws_config=aws_config)
+    return support("ResolveCase"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function resolve_case(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return support("ResolveCase", params; aws_config=aws_config)
+    return support(
+        "ResolveCase", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end

--- a/src/services/swf.jl
+++ b/src/services/swf.jl
@@ -55,6 +55,7 @@ function count_closed_workflow_executions(
         "CountClosedWorkflowExecutions",
         Dict{String,Any}("domain" => domain);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function count_closed_workflow_executions(
@@ -64,6 +65,7 @@ function count_closed_workflow_executions(
         "CountClosedWorkflowExecutions",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("domain" => domain), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -110,6 +112,7 @@ function count_open_workflow_executions(
         "CountOpenWorkflowExecutions",
         Dict{String,Any}("domain" => domain, "startTimeFilter" => startTimeFilter);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function count_open_workflow_executions(
@@ -128,6 +131,7 @@ function count_open_workflow_executions(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -160,6 +164,7 @@ function count_pending_activity_tasks(
         "CountPendingActivityTasks",
         Dict{String,Any}("domain" => domain, "taskList" => taskList);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function count_pending_activity_tasks(
@@ -176,6 +181,7 @@ function count_pending_activity_tasks(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -208,6 +214,7 @@ function count_pending_decision_tasks(
         "CountPendingDecisionTasks",
         Dict{String,Any}("domain" => domain, "taskList" => taskList);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function count_pending_decision_tasks(
@@ -224,6 +231,7 @@ function count_pending_decision_tasks(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -259,6 +267,7 @@ function deprecate_activity_type(
         "DeprecateActivityType",
         Dict{String,Any}("activityType" => activityType, "domain" => domain);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function deprecate_activity_type(
@@ -277,6 +286,7 @@ function deprecate_activity_type(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -304,7 +314,12 @@ Access to Amazon SWF Workflows in the Amazon SWF Developer Guide.
 
 """
 function deprecate_domain(name; aws_config::AbstractAWSConfig=global_aws_config())
-    return swf("DeprecateDomain", Dict{String,Any}("name" => name); aws_config=aws_config)
+    return swf(
+        "DeprecateDomain",
+        Dict{String,Any}("name" => name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function deprecate_domain(
     name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -313,6 +328,7 @@ function deprecate_domain(
         "DeprecateDomain",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("name" => name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -348,6 +364,7 @@ function deprecate_workflow_type(
         "DeprecateWorkflowType",
         Dict{String,Any}("domain" => domain, "workflowType" => workflowType);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function deprecate_workflow_type(
@@ -366,6 +383,7 @@ function deprecate_workflow_type(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -399,6 +417,7 @@ function describe_activity_type(
         "DescribeActivityType",
         Dict{String,Any}("activityType" => activityType, "domain" => domain);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_activity_type(
@@ -417,6 +436,7 @@ function describe_activity_type(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -439,7 +459,12 @@ Using IAM to Manage Access to Amazon SWF Workflows in the Amazon SWF Developer G
 
 """
 function describe_domain(name; aws_config::AbstractAWSConfig=global_aws_config())
-    return swf("DescribeDomain", Dict{String,Any}("name" => name); aws_config=aws_config)
+    return swf(
+        "DescribeDomain",
+        Dict{String,Any}("name" => name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_domain(
     name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -448,6 +473,7 @@ function describe_domain(
         "DescribeDomain",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("name" => name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -479,6 +505,7 @@ function describe_workflow_execution(
         "DescribeWorkflowExecution",
         Dict{String,Any}("domain" => domain, "execution" => execution);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_workflow_execution(
@@ -497,6 +524,7 @@ function describe_workflow_execution(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -530,6 +558,7 @@ function describe_workflow_type(
         "DescribeWorkflowType",
         Dict{String,Any}("domain" => domain, "workflowType" => workflowType);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_workflow_type(
@@ -548,6 +577,7 @@ function describe_workflow_type(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -592,6 +622,7 @@ function get_workflow_execution_history(
         "GetWorkflowExecutionHistory",
         Dict{String,Any}("domain" => domain, "execution" => execution);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_workflow_execution_history(
@@ -610,6 +641,7 @@ function get_workflow_execution_history(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -656,6 +688,7 @@ function list_activity_types(
         "ListActivityTypes",
         Dict{String,Any}("domain" => domain, "registrationStatus" => registrationStatus);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_activity_types(
@@ -676,6 +709,7 @@ function list_activity_types(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -746,6 +780,7 @@ function list_closed_workflow_executions(
         "ListClosedWorkflowExecutions",
         Dict{String,Any}("domain" => domain);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_closed_workflow_executions(
@@ -755,6 +790,7 @@ function list_closed_workflow_executions(
         "ListClosedWorkflowExecutions",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("domain" => domain), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -797,6 +833,7 @@ function list_domains(registrationStatus; aws_config::AbstractAWSConfig=global_a
         "ListDomains",
         Dict{String,Any}("registrationStatus" => registrationStatus);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_domains(
@@ -812,6 +849,7 @@ function list_domains(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -869,6 +907,7 @@ function list_open_workflow_executions(
         "ListOpenWorkflowExecutions",
         Dict{String,Any}("domain" => domain, "startTimeFilter" => startTimeFilter);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_open_workflow_executions(
@@ -887,6 +926,7 @@ function list_open_workflow_executions(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -907,6 +947,7 @@ function list_tags_for_resource(
         "ListTagsForResource",
         Dict{String,Any}("resourceArn" => resourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags_for_resource(
@@ -920,6 +961,7 @@ function list_tags_for_resource(
             mergewith(_merge, Dict{String,Any}("resourceArn" => resourceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -963,6 +1005,7 @@ function list_workflow_types(
         "ListWorkflowTypes",
         Dict{String,Any}("domain" => domain, "registrationStatus" => registrationStatus);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_workflow_types(
@@ -983,6 +1026,7 @@ function list_workflow_types(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1029,6 +1073,7 @@ function poll_for_activity_task(
         "PollForActivityTask",
         Dict{String,Any}("domain" => domain, "taskList" => taskList);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function poll_for_activity_task(
@@ -1045,6 +1090,7 @@ function poll_for_activity_task(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1112,6 +1158,7 @@ function poll_for_decision_task(
         "PollForDecisionTask",
         Dict{String,Any}("domain" => domain, "taskList" => taskList);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function poll_for_decision_task(
@@ -1128,6 +1175,7 @@ function poll_for_decision_task(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1178,6 +1226,7 @@ function record_activity_task_heartbeat(
         "RecordActivityTaskHeartbeat",
         Dict{String,Any}("taskToken" => taskToken);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function record_activity_task_heartbeat(
@@ -1191,6 +1240,7 @@ function record_activity_task_heartbeat(
             mergewith(_merge, Dict{String,Any}("taskToken" => taskToken), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1267,6 +1317,7 @@ function register_activity_type(
         "RegisterActivityType",
         Dict{String,Any}("domain" => domain, "name" => name, "version" => version);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function register_activity_type(
@@ -1286,6 +1337,7 @@ function register_activity_type(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1336,6 +1388,7 @@ function register_domain(
                 workflowExecutionRetentionPeriodInDays,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function register_domain(
@@ -1358,6 +1411,7 @@ function register_domain(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1442,6 +1496,7 @@ function register_workflow_type(
         "RegisterWorkflowType",
         Dict{String,Any}("domain" => domain, "name" => name, "version" => version);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function register_workflow_type(
@@ -1461,6 +1516,7 @@ function register_workflow_type(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1500,6 +1556,7 @@ function request_cancel_workflow_execution(
         "RequestCancelWorkflowExecution",
         Dict{String,Any}("domain" => domain, "workflowId" => workflowId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function request_cancel_workflow_execution(
@@ -1518,6 +1575,7 @@ function request_cancel_workflow_execution(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1560,6 +1618,7 @@ function respond_activity_task_canceled(
         "RespondActivityTaskCanceled",
         Dict{String,Any}("taskToken" => taskToken);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function respond_activity_task_canceled(
@@ -1573,6 +1632,7 @@ function respond_activity_task_canceled(
             mergewith(_merge, Dict{String,Any}("taskToken" => taskToken), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1617,6 +1677,7 @@ function respond_activity_task_completed(
         "RespondActivityTaskCompleted",
         Dict{String,Any}("taskToken" => taskToken);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function respond_activity_task_completed(
@@ -1630,6 +1691,7 @@ function respond_activity_task_completed(
             mergewith(_merge, Dict{String,Any}("taskToken" => taskToken), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1671,6 +1733,7 @@ function respond_activity_task_failed(
         "RespondActivityTaskFailed",
         Dict{String,Any}("taskToken" => taskToken);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function respond_activity_task_failed(
@@ -1684,6 +1747,7 @@ function respond_activity_task_failed(
             mergewith(_merge, Dict{String,Any}("taskToken" => taskToken), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1721,6 +1785,7 @@ function respond_decision_task_completed(
         "RespondDecisionTaskCompleted",
         Dict{String,Any}("taskToken" => taskToken);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function respond_decision_task_completed(
@@ -1734,6 +1799,7 @@ function respond_decision_task_completed(
             mergewith(_merge, Dict{String,Any}("taskToken" => taskToken), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1778,6 +1844,7 @@ function signal_workflow_execution(
             "domain" => domain, "signalName" => signalName, "workflowId" => workflowId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function signal_workflow_execution(
@@ -1801,6 +1868,7 @@ function signal_workflow_execution(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1904,6 +1972,7 @@ function start_workflow_execution(
             "domain" => domain, "workflowId" => workflowId, "workflowType" => workflowType
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_workflow_execution(
@@ -1927,6 +1996,7 @@ function start_workflow_execution(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1947,6 +2017,7 @@ function tag_resource(resourceArn, tags; aws_config::AbstractAWSConfig=global_aw
         "TagResource",
         Dict{String,Any}("resourceArn" => resourceArn, "tags" => tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -1965,6 +2036,7 @@ function tag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2018,6 +2090,7 @@ function terminate_workflow_execution(
         "TerminateWorkflowExecution",
         Dict{String,Any}("domain" => domain, "workflowId" => workflowId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function terminate_workflow_execution(
@@ -2036,6 +2109,7 @@ function terminate_workflow_execution(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2070,6 +2144,7 @@ function undeprecate_activity_type(
         "UndeprecateActivityType",
         Dict{String,Any}("activityType" => activityType, "domain" => domain);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function undeprecate_activity_type(
@@ -2088,6 +2163,7 @@ function undeprecate_activity_type(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2113,7 +2189,12 @@ Developer Guide.
 
 """
 function undeprecate_domain(name; aws_config::AbstractAWSConfig=global_aws_config())
-    return swf("UndeprecateDomain", Dict{String,Any}("name" => name); aws_config=aws_config)
+    return swf(
+        "UndeprecateDomain",
+        Dict{String,Any}("name" => name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function undeprecate_domain(
     name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -2122,6 +2203,7 @@ function undeprecate_domain(
         "UndeprecateDomain",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("name" => name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2156,6 +2238,7 @@ function undeprecate_workflow_type(
         "UndeprecateWorkflowType",
         Dict{String,Any}("domain" => domain, "workflowType" => workflowType);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function undeprecate_workflow_type(
@@ -2174,6 +2257,7 @@ function undeprecate_workflow_type(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2195,6 +2279,7 @@ function untag_resource(
         "UntagResource",
         Dict{String,Any}("resourceArn" => resourceArn, "tagKeys" => tagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -2213,5 +2298,6 @@ function untag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/synthetics.jl
+++ b/src/services/synthetics.jl
@@ -83,6 +83,7 @@ function create_canary(
             "Schedule" => Schedule,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_canary(
@@ -113,6 +114,7 @@ function create_canary(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -140,12 +142,20 @@ canary.
 
 """
 function delete_canary(name; aws_config::AbstractAWSConfig=global_aws_config())
-    return synthetics("DELETE", "/canary/$(name)"; aws_config=aws_config)
+    return synthetics(
+        "DELETE", "/canary/$(name)"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function delete_canary(
     name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return synthetics("DELETE", "/canary/$(name)", params; aws_config=aws_config)
+    return synthetics(
+        "DELETE",
+        "/canary/$(name)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -167,12 +177,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   token in a subsequent operation to retrieve the next set of results.
 """
 function describe_canaries(; aws_config::AbstractAWSConfig=global_aws_config())
-    return synthetics("POST", "/canaries"; aws_config=aws_config)
+    return synthetics(
+        "POST", "/canaries"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_canaries(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return synthetics("POST", "/canaries", params; aws_config=aws_config)
+    return synthetics(
+        "POST", "/canaries", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -190,12 +204,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   token in a subsequent DescribeCanaries operation to retrieve the next set of results.
 """
 function describe_canaries_last_run(; aws_config::AbstractAWSConfig=global_aws_config())
-    return synthetics("POST", "/canaries/last-run"; aws_config=aws_config)
+    return synthetics(
+        "POST", "/canaries/last-run"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_canaries_last_run(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return synthetics("POST", "/canaries/last-run", params; aws_config=aws_config)
+    return synthetics(
+        "POST",
+        "/canaries/last-run",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -214,12 +236,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   token in a subsequent DescribeRuntimeVersions operation to retrieve the next set of results.
 """
 function describe_runtime_versions(; aws_config::AbstractAWSConfig=global_aws_config())
-    return synthetics("POST", "/runtime-versions"; aws_config=aws_config)
+    return synthetics(
+        "POST", "/runtime-versions"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_runtime_versions(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return synthetics("POST", "/runtime-versions", params; aws_config=aws_config)
+    return synthetics(
+        "POST",
+        "/runtime-versions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -234,12 +264,20 @@ that you want. To get a list of canaries and their names, use DescribeCanaries.
 
 """
 function get_canary(name; aws_config::AbstractAWSConfig=global_aws_config())
-    return synthetics("GET", "/canary/$(name)"; aws_config=aws_config)
+    return synthetics(
+        "GET", "/canary/$(name)"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_canary(
     name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return synthetics("GET", "/canary/$(name)", params; aws_config=aws_config)
+    return synthetics(
+        "GET",
+        "/canary/$(name)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -259,12 +297,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   token in a subsequent GetCanaryRuns operation to retrieve the next set of results.
 """
 function get_canary_runs(name; aws_config::AbstractAWSConfig=global_aws_config())
-    return synthetics("POST", "/canary/$(name)/runs"; aws_config=aws_config)
+    return synthetics(
+        "POST",
+        "/canary/$(name)/runs";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_canary_runs(
     name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return synthetics("POST", "/canary/$(name)/runs", params; aws_config=aws_config)
+    return synthetics(
+        "POST",
+        "/canary/$(name)/runs",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -281,14 +330,25 @@ Displays the tags associated with a canary.
 function list_tags_for_resource(
     resourceArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return synthetics("GET", "/tags/$(resourceArn)"; aws_config=aws_config)
+    return synthetics(
+        "GET",
+        "/tags/$(resourceArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_tags_for_resource(
     resourceArn,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return synthetics("GET", "/tags/$(resourceArn)", params; aws_config=aws_config)
+    return synthetics(
+        "GET",
+        "/tags/$(resourceArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -305,12 +365,23 @@ schedule, use GetCanary.
 
 """
 function start_canary(name; aws_config::AbstractAWSConfig=global_aws_config())
-    return synthetics("POST", "/canary/$(name)/start"; aws_config=aws_config)
+    return synthetics(
+        "POST",
+        "/canary/$(name)/start";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function start_canary(
     name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return synthetics("POST", "/canary/$(name)/start", params; aws_config=aws_config)
+    return synthetics(
+        "POST",
+        "/canary/$(name)/start",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -329,12 +400,23 @@ again with the canary’s current schedule at any point in the future.
 
 """
 function stop_canary(name; aws_config::AbstractAWSConfig=global_aws_config())
-    return synthetics("POST", "/canary/$(name)/stop"; aws_config=aws_config)
+    return synthetics(
+        "POST",
+        "/canary/$(name)/stop";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function stop_canary(
     name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return synthetics("POST", "/canary/$(name)/stop", params; aws_config=aws_config)
+    return synthetics(
+        "POST",
+        "/canary/$(name)/stop",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -363,6 +445,7 @@ function tag_resource(Tags, resourceArn; aws_config::AbstractAWSConfig=global_aw
         "/tags/$(resourceArn)",
         Dict{String,Any}("Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -376,6 +459,7 @@ function tag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Tags" => Tags), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -399,6 +483,7 @@ function untag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}("tagKeys" => tagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -412,6 +497,7 @@ function untag_resource(
         "/tags/$(resourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tagKeys" => tagKeys), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -460,10 +546,18 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   see  Running a Canary in a VPC.
 """
 function update_canary(name; aws_config::AbstractAWSConfig=global_aws_config())
-    return synthetics("PATCH", "/canary/$(name)"; aws_config=aws_config)
+    return synthetics(
+        "PATCH", "/canary/$(name)"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function update_canary(
     name, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return synthetics("PATCH", "/canary/$(name)", params; aws_config=aws_config)
+    return synthetics(
+        "PATCH",
+        "/canary/$(name)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end

--- a/src/services/textract.jl
+++ b/src/services/textract.jl
@@ -47,6 +47,7 @@ function analyze_document(
         "AnalyzeDocument",
         Dict{String,Any}("Document" => Document, "FeatureTypes" => FeatureTypes);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function analyze_document(
@@ -65,6 +66,7 @@ function analyze_document(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -84,7 +86,10 @@ receipt, such as header information or the vendors name.
 """
 function analyze_expense(Document; aws_config::AbstractAWSConfig=global_aws_config())
     return textract(
-        "AnalyzeExpense", Dict{String,Any}("Document" => Document); aws_config=aws_config
+        "AnalyzeExpense",
+        Dict{String,Any}("Document" => Document);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function analyze_expense(
@@ -98,6 +103,7 @@ function analyze_expense(
             mergewith(_merge, Dict{String,Any}("Document" => Document), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -126,6 +132,7 @@ function detect_document_text(Document; aws_config::AbstractAWSConfig=global_aws
         "DetectDocumentText",
         Dict{String,Any}("Document" => Document);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function detect_document_text(
@@ -139,6 +146,7 @@ function detect_document_text(
             mergewith(_merge, Dict{String,Any}("Document" => Document), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -187,7 +195,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function get_document_analysis(JobId; aws_config::AbstractAWSConfig=global_aws_config())
     return textract(
-        "GetDocumentAnalysis", Dict{String,Any}("JobId" => JobId); aws_config=aws_config
+        "GetDocumentAnalysis",
+        Dict{String,Any}("JobId" => JobId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_document_analysis(
@@ -197,6 +208,7 @@ function get_document_analysis(
         "GetDocumentAnalysis",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("JobId" => JobId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -244,6 +256,7 @@ function get_document_text_detection(
         "GetDocumentTextDetection",
         Dict{String,Any}("JobId" => JobId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_document_text_detection(
@@ -253,6 +266,7 @@ function get_document_text_detection(
         "GetDocumentTextDetection",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("JobId" => JobId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -308,6 +322,7 @@ function start_document_analysis(
             "DocumentLocation" => DocumentLocation, "FeatureTypes" => FeatureTypes
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_document_analysis(
@@ -328,6 +343,7 @@ function start_document_analysis(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -376,6 +392,7 @@ function start_document_text_detection(
         "StartDocumentTextDetection",
         Dict{String,Any}("DocumentLocation" => DocumentLocation);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_document_text_detection(
@@ -391,5 +408,6 @@ function start_document_text_detection(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/timestream_query.jl
+++ b/src/services/timestream_query.jl
@@ -20,7 +20,10 @@ indicating that the query has already been canceled.
 """
 function cancel_query(QueryId; aws_config::AbstractAWSConfig=global_aws_config())
     return timestream_query(
-        "CancelQuery", Dict{String,Any}("QueryId" => QueryId); aws_config=aws_config
+        "CancelQuery",
+        Dict{String,Any}("QueryId" => QueryId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function cancel_query(
@@ -30,6 +33,7 @@ function cancel_query(
         "CancelQuery",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("QueryId" => QueryId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -48,12 +52,16 @@ APIs.
 
 """
 function describe_endpoints(; aws_config::AbstractAWSConfig=global_aws_config())
-    return timestream_query("DescribeEndpoints"; aws_config=aws_config)
+    return timestream_query(
+        "DescribeEndpoints"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_endpoints(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return timestream_query("DescribeEndpoints", params; aws_config=aws_config)
+    return timestream_query(
+        "DescribeEndpoints", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -89,6 +97,7 @@ function query(QueryString; aws_config::AbstractAWSConfig=global_aws_config())
         "Query",
         Dict{String,Any}("QueryString" => QueryString, "ClientToken" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function query(
@@ -108,5 +117,6 @@ function query(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/timestream_write.jl
+++ b/src/services/timestream_write.jl
@@ -28,6 +28,7 @@ function create_database(DatabaseName; aws_config::AbstractAWSConfig=global_aws_
         "CreateDatabase",
         Dict{String,Any}("DatabaseName" => DatabaseName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_database(
@@ -41,6 +42,7 @@ function create_database(
             mergewith(_merge, Dict{String,Any}("DatabaseName" => DatabaseName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -72,6 +74,7 @@ function create_table(
         "CreateTable",
         Dict{String,Any}("DatabaseName" => DatabaseName, "TableName" => TableName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_table(
@@ -90,6 +93,7 @@ function create_table(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -112,6 +116,7 @@ function delete_database(DatabaseName; aws_config::AbstractAWSConfig=global_aws_
         "DeleteDatabase",
         Dict{String,Any}("DatabaseName" => DatabaseName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_database(
@@ -125,6 +130,7 @@ function delete_database(
             mergewith(_merge, Dict{String,Any}("DatabaseName" => DatabaseName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -149,6 +155,7 @@ function delete_table(
         "DeleteTable",
         Dict{String,Any}("DatabaseName" => DatabaseName, "TableName" => TableName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_table(
@@ -167,6 +174,7 @@ function delete_table(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -187,6 +195,7 @@ function describe_database(DatabaseName; aws_config::AbstractAWSConfig=global_aw
         "DescribeDatabase",
         Dict{String,Any}("DatabaseName" => DatabaseName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_database(
@@ -200,6 +209,7 @@ function describe_database(
             mergewith(_merge, Dict{String,Any}("DatabaseName" => DatabaseName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -218,12 +228,16 @@ APIs.
 
 """
 function describe_endpoints(; aws_config::AbstractAWSConfig=global_aws_config())
-    return timestream_write("DescribeEndpoints"; aws_config=aws_config)
+    return timestream_write(
+        "DescribeEndpoints"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_endpoints(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return timestream_write("DescribeEndpoints", params; aws_config=aws_config)
+    return timestream_write(
+        "DescribeEndpoints", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -246,6 +260,7 @@ function describe_table(
         "DescribeTable",
         Dict{String,Any}("DatabaseName" => DatabaseName, "TableName" => TableName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_table(
@@ -264,6 +279,7 @@ function describe_table(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -283,12 +299,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   argument of a subsequent API invocation.
 """
 function list_databases(; aws_config::AbstractAWSConfig=global_aws_config())
-    return timestream_write("ListDatabases"; aws_config=aws_config)
+    return timestream_write(
+        "ListDatabases"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_databases(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return timestream_write("ListDatabases", params; aws_config=aws_config)
+    return timestream_write(
+        "ListDatabases", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -307,12 +327,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   argument of a subsequent API invocation.
 """
 function list_tables(; aws_config::AbstractAWSConfig=global_aws_config())
-    return timestream_write("ListTables"; aws_config=aws_config)
+    return timestream_write(
+        "ListTables"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_tables(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return timestream_write("ListTables", params; aws_config=aws_config)
+    return timestream_write(
+        "ListTables", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -333,6 +357,7 @@ function list_tags_for_resource(
         "ListTagsForResource",
         Dict{String,Any}("ResourceARN" => ResourceARN);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags_for_resource(
@@ -346,6 +371,7 @@ function list_tags_for_resource(
             mergewith(_merge, Dict{String,Any}("ResourceARN" => ResourceARN), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -368,6 +394,7 @@ function tag_resource(ResourceARN, Tags; aws_config::AbstractAWSConfig=global_aw
         "TagResource",
         Dict{String,Any}("ResourceARN" => ResourceARN, "Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -386,6 +413,7 @@ function tag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -409,6 +437,7 @@ function untag_resource(
         "UntagResource",
         Dict{String,Any}("ResourceARN" => ResourceARN, "TagKeys" => TagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -427,6 +456,7 @@ function untag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -456,6 +486,7 @@ function update_database(
         "UpdateDatabase",
         Dict{String,Any}("DatabaseName" => DatabaseName, "KmsKeyId" => KmsKeyId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_database(
@@ -474,6 +505,7 @@ function update_database(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -509,6 +541,7 @@ function update_table(
             "TableName" => TableName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_table(
@@ -532,6 +565,7 @@ function update_table(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -573,6 +607,7 @@ function write_records(
             "DatabaseName" => DatabaseName, "Records" => Records, "TableName" => TableName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function write_records(
@@ -596,5 +631,6 @@ function write_records(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/transcribe.jl
+++ b/src/services/transcribe.jl
@@ -28,6 +28,7 @@ function create_call_analytics_category(
         "CreateCallAnalyticsCategory",
         Dict{String,Any}("CategoryName" => CategoryName, "Rules" => Rules);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_call_analytics_category(
@@ -46,6 +47,7 @@ function create_call_analytics_category(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -90,6 +92,7 @@ function create_language_model(
             "ModelName" => ModelName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_language_model(
@@ -115,6 +118,7 @@ function create_language_model(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -162,6 +166,7 @@ function create_medical_vocabulary(
             "VocabularyName" => VocabularyName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_medical_vocabulary(
@@ -185,6 +190,7 @@ function create_medical_vocabulary(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -222,6 +228,7 @@ function create_vocabulary(
             "LanguageCode" => LanguageCode, "VocabularyName" => VocabularyName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_vocabulary(
@@ -242,6 +249,7 @@ function create_vocabulary(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -283,6 +291,7 @@ function create_vocabulary_filter(
             "LanguageCode" => LanguageCode, "VocabularyFilterName" => VocabularyFilterName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_vocabulary_filter(
@@ -304,6 +313,7 @@ function create_vocabulary_filter(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -325,6 +335,7 @@ function delete_call_analytics_category(
         "DeleteCallAnalyticsCategory",
         Dict{String,Any}("CategoryName" => CategoryName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_call_analytics_category(
@@ -338,6 +349,7 @@ function delete_call_analytics_category(
             mergewith(_merge, Dict{String,Any}("CategoryName" => CategoryName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -358,6 +370,7 @@ function delete_call_analytics_job(
         "DeleteCallAnalyticsJob",
         Dict{String,Any}("CallAnalyticsJobName" => CallAnalyticsJobName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_call_analytics_job(
@@ -375,6 +388,7 @@ function delete_call_analytics_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -393,6 +407,7 @@ function delete_language_model(ModelName; aws_config::AbstractAWSConfig=global_a
         "DeleteLanguageModel",
         Dict{String,Any}("ModelName" => ModelName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_language_model(
@@ -406,6 +421,7 @@ function delete_language_model(
             mergewith(_merge, Dict{String,Any}("ModelName" => ModelName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -428,6 +444,7 @@ function delete_medical_transcription_job(
         "DeleteMedicalTranscriptionJob",
         Dict{String,Any}("MedicalTranscriptionJobName" => MedicalTranscriptionJobName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_medical_transcription_job(
@@ -447,6 +464,7 @@ function delete_medical_transcription_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -467,6 +485,7 @@ function delete_medical_vocabulary(
         "DeleteMedicalVocabulary",
         Dict{String,Any}("VocabularyName" => VocabularyName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_medical_vocabulary(
@@ -480,6 +499,7 @@ function delete_medical_vocabulary(
             mergewith(_merge, Dict{String,Any}("VocabularyName" => VocabularyName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -501,6 +521,7 @@ function delete_transcription_job(
         "DeleteTranscriptionJob",
         Dict{String,Any}("TranscriptionJobName" => TranscriptionJobName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_transcription_job(
@@ -518,6 +539,7 @@ function delete_transcription_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -538,6 +560,7 @@ function delete_vocabulary(
         "DeleteVocabulary",
         Dict{String,Any}("VocabularyName" => VocabularyName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_vocabulary(
@@ -551,6 +574,7 @@ function delete_vocabulary(
             mergewith(_merge, Dict{String,Any}("VocabularyName" => VocabularyName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -571,6 +595,7 @@ function delete_vocabulary_filter(
         "DeleteVocabularyFilter",
         Dict{String,Any}("VocabularyFilterName" => VocabularyFilterName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_vocabulary_filter(
@@ -588,6 +613,7 @@ function delete_vocabulary_filter(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -613,6 +639,7 @@ function describe_language_model(
         "DescribeLanguageModel",
         Dict{String,Any}("ModelName" => ModelName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_language_model(
@@ -626,6 +653,7 @@ function describe_language_model(
             mergewith(_merge, Dict{String,Any}("ModelName" => ModelName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -647,6 +675,7 @@ function get_call_analytics_category(
         "GetCallAnalyticsCategory",
         Dict{String,Any}("CategoryName" => CategoryName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_call_analytics_category(
@@ -660,6 +689,7 @@ function get_call_analytics_category(
             mergewith(_merge, Dict{String,Any}("CategoryName" => CategoryName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -685,6 +715,7 @@ function get_call_analytics_job(
         "GetCallAnalyticsJob",
         Dict{String,Any}("CallAnalyticsJobName" => CallAnalyticsJobName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_call_analytics_job(
@@ -702,6 +733,7 @@ function get_call_analytics_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -724,6 +756,7 @@ function get_medical_transcription_job(
         "GetMedicalTranscriptionJob",
         Dict{String,Any}("MedicalTranscriptionJobName" => MedicalTranscriptionJobName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_medical_transcription_job(
@@ -743,6 +776,7 @@ function get_medical_transcription_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -764,6 +798,7 @@ function get_medical_vocabulary(
         "GetMedicalVocabulary",
         Dict{String,Any}("VocabularyName" => VocabularyName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_medical_vocabulary(
@@ -777,6 +812,7 @@ function get_medical_vocabulary(
             mergewith(_merge, Dict{String,Any}("VocabularyName" => VocabularyName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -800,6 +836,7 @@ function get_transcription_job(
         "GetTranscriptionJob",
         Dict{String,Any}("TranscriptionJobName" => TranscriptionJobName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_transcription_job(
@@ -817,6 +854,7 @@ function get_transcription_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -836,6 +874,7 @@ function get_vocabulary(VocabularyName; aws_config::AbstractAWSConfig=global_aws
         "GetVocabulary",
         Dict{String,Any}("VocabularyName" => VocabularyName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_vocabulary(
@@ -849,6 +888,7 @@ function get_vocabulary(
             mergewith(_merge, Dict{String,Any}("VocabularyName" => VocabularyName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -870,6 +910,7 @@ function get_vocabulary_filter(
         "GetVocabularyFilter",
         Dict{String,Any}("VocabularyFilterName" => VocabularyFilterName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_vocabulary_filter(
@@ -887,6 +928,7 @@ function get_vocabulary_filter(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -907,12 +949,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   of the previous request was truncated.
 """
 function list_call_analytics_categories(; aws_config::AbstractAWSConfig=global_aws_config())
-    return transcribe("ListCallAnalyticsCategories"; aws_config=aws_config)
+    return transcribe(
+        "ListCallAnalyticsCategories";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_call_analytics_categories(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return transcribe("ListCallAnalyticsCategories", params; aws_config=aws_config)
+    return transcribe(
+        "ListCallAnalyticsCategories",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -935,12 +986,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   specify a status, Amazon Transcribe returns all analytics jobs ordered by creation date.
 """
 function list_call_analytics_jobs(; aws_config::AbstractAWSConfig=global_aws_config())
-    return transcribe("ListCallAnalyticsJobs"; aws_config=aws_config)
+    return transcribe(
+        "ListCallAnalyticsJobs"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_call_analytics_jobs(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return transcribe("ListCallAnalyticsJobs", params; aws_config=aws_config)
+    return transcribe(
+        "ListCallAnalyticsJobs",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -966,12 +1024,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   date.
 """
 function list_language_models(; aws_config::AbstractAWSConfig=global_aws_config())
-    return transcribe("ListLanguageModels"; aws_config=aws_config)
+    return transcribe(
+        "ListLanguageModels"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_language_models(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return transcribe("ListLanguageModels", params; aws_config=aws_config)
+    return transcribe(
+        "ListLanguageModels", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -998,12 +1060,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function list_medical_transcription_jobs(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return transcribe("ListMedicalTranscriptionJobs"; aws_config=aws_config)
+    return transcribe(
+        "ListMedicalTranscriptionJobs";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_medical_transcription_jobs(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return transcribe("ListMedicalTranscriptionJobs", params; aws_config=aws_config)
+    return transcribe(
+        "ListMedicalTranscriptionJobs",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1028,12 +1099,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   your medical transcription jobs.
 """
 function list_medical_vocabularies(; aws_config::AbstractAWSConfig=global_aws_config())
-    return transcribe("ListMedicalVocabularies"; aws_config=aws_config)
+    return transcribe(
+        "ListMedicalVocabularies"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_medical_vocabularies(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return transcribe("ListMedicalVocabularies", params; aws_config=aws_config)
+    return transcribe(
+        "ListMedicalVocabularies",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1053,6 +1131,7 @@ function list_tags_for_resource(
         "ListTagsForResource",
         Dict{String,Any}("ResourceArn" => ResourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags_for_resource(
@@ -1066,6 +1145,7 @@ function list_tags_for_resource(
             mergewith(_merge, Dict{String,Any}("ResourceArn" => ResourceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1089,12 +1169,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   specify a status, Amazon Transcribe returns all transcription jobs ordered by creation date.
 """
 function list_transcription_jobs(; aws_config::AbstractAWSConfig=global_aws_config())
-    return transcribe("ListTranscriptionJobs"; aws_config=aws_config)
+    return transcribe(
+        "ListTranscriptionJobs"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_transcription_jobs(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return transcribe("ListTranscriptionJobs", params; aws_config=aws_config)
+    return transcribe(
+        "ListTranscriptionJobs",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1119,12 +1206,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   equal to the specified state.
 """
 function list_vocabularies(; aws_config::AbstractAWSConfig=global_aws_config())
-    return transcribe("ListVocabularies"; aws_config=aws_config)
+    return transcribe(
+        "ListVocabularies"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_vocabularies(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return transcribe("ListVocabularies", params; aws_config=aws_config)
+    return transcribe(
+        "ListVocabularies", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1144,12 +1235,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   truncated, include the NextToken to fetch the next set of collections.
 """
 function list_vocabulary_filters(; aws_config::AbstractAWSConfig=global_aws_config())
-    return transcribe("ListVocabularyFilters"; aws_config=aws_config)
+    return transcribe(
+        "ListVocabularyFilters"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_vocabulary_filters(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return transcribe("ListVocabularyFilters", params; aws_config=aws_config)
+    return transcribe(
+        "ListVocabularyFilters",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1222,6 +1320,7 @@ function start_call_analytics_job(
             "Media" => Media,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_call_analytics_job(
@@ -1245,6 +1344,7 @@ function start_call_analytics_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1339,6 +1439,7 @@ function start_medical_transcription_job(
             "Type" => Type,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_medical_transcription_job(
@@ -1368,6 +1469,7 @@ function start_medical_transcription_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1461,6 +1563,7 @@ function start_transcription_job(
         "StartTranscriptionJob",
         Dict{String,Any}("Media" => Media, "TranscriptionJobName" => TranscriptionJobName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_transcription_job(
@@ -1481,6 +1584,7 @@ function start_transcription_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1501,6 +1605,7 @@ function tag_resource(ResourceArn, Tags; aws_config::AbstractAWSConfig=global_aw
         "TagResource",
         Dict{String,Any}("ResourceArn" => ResourceArn, "Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -1519,6 +1624,7 @@ function tag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1542,6 +1648,7 @@ function untag_resource(
         "UntagResource",
         Dict{String,Any}("ResourceArn" => ResourceArn, "TagKeys" => TagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -1560,6 +1667,7 @@ function untag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1586,6 +1694,7 @@ function update_call_analytics_category(
         "UpdateCallAnalyticsCategory",
         Dict{String,Any}("CategoryName" => CategoryName, "Rules" => Rules);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_call_analytics_category(
@@ -1604,6 +1713,7 @@ function update_call_analytics_category(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1642,6 +1752,7 @@ function update_medical_vocabulary(
             "LanguageCode" => LanguageCode, "VocabularyName" => VocabularyName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_medical_vocabulary(
@@ -1662,6 +1773,7 @@ function update_medical_vocabulary(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1697,6 +1809,7 @@ function update_vocabulary(
             "LanguageCode" => LanguageCode, "VocabularyName" => VocabularyName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_vocabulary(
@@ -1717,6 +1830,7 @@ function update_vocabulary(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1750,6 +1864,7 @@ function update_vocabulary_filter(
         "UpdateVocabularyFilter",
         Dict{String,Any}("VocabularyFilterName" => VocabularyFilterName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_vocabulary_filter(
@@ -1767,5 +1882,6 @@ function update_vocabulary_filter(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/transfer.jl
+++ b/src/services/transfer.jl
@@ -82,6 +82,7 @@ function create_access(
             "ExternalId" => ExternalId, "Role" => Role, "ServerId" => ServerId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_access(
@@ -103,6 +104,7 @@ function create_access(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -193,12 +195,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   execution role used for executing the workflow.
 """
 function create_server(; aws_config::AbstractAWSConfig=global_aws_config())
-    return transfer("CreateServer"; aws_config=aws_config)
+    return transfer("CreateServer"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function create_server(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return transfer("CreateServer", params; aws_config=aws_config)
+    return transfer(
+        "CreateServer", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -281,6 +285,7 @@ function create_user(
         "CreateUser",
         Dict{String,Any}("Role" => Role, "ServerId" => ServerId, "UserName" => UserName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_user(
@@ -302,6 +307,7 @@ function create_user(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -331,7 +337,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function create_workflow(Steps; aws_config::AbstractAWSConfig=global_aws_config())
     return transfer(
-        "CreateWorkflow", Dict{String,Any}("Steps" => Steps); aws_config=aws_config
+        "CreateWorkflow",
+        Dict{String,Any}("Steps" => Steps);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_workflow(
@@ -341,6 +350,7 @@ function create_workflow(
         "CreateWorkflow",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Steps" => Steps), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -370,6 +380,7 @@ function delete_access(
         "DeleteAccess",
         Dict{String,Any}("ExternalId" => ExternalId, "ServerId" => ServerId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_access(
@@ -388,6 +399,7 @@ function delete_access(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -404,7 +416,10 @@ from this operation.
 """
 function delete_server(ServerId; aws_config::AbstractAWSConfig=global_aws_config())
     return transfer(
-        "DeleteServer", Dict{String,Any}("ServerId" => ServerId); aws_config=aws_config
+        "DeleteServer",
+        Dict{String,Any}("ServerId" => ServerId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_server(
@@ -418,6 +433,7 @@ function delete_server(
             mergewith(_merge, Dict{String,Any}("ServerId" => ServerId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -445,6 +461,7 @@ function delete_ssh_public_key(
             "UserName" => UserName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_ssh_public_key(
@@ -468,6 +485,7 @@ function delete_ssh_public_key(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -490,6 +508,7 @@ function delete_user(ServerId, UserName; aws_config::AbstractAWSConfig=global_aw
         "DeleteUser",
         Dict{String,Any}("ServerId" => ServerId, "UserName" => UserName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_user(
@@ -508,6 +527,7 @@ function delete_user(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -526,6 +546,7 @@ function delete_workflow(WorkflowId; aws_config::AbstractAWSConfig=global_aws_co
         "DeleteWorkflow",
         Dict{String,Any}("WorkflowId" => WorkflowId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_workflow(
@@ -539,6 +560,7 @@ function delete_workflow(
             mergewith(_merge, Dict{String,Any}("WorkflowId" => WorkflowId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -572,6 +594,7 @@ function describe_access(
         "DescribeAccess",
         Dict{String,Any}("ExternalId" => ExternalId, "ServerId" => ServerId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_access(
@@ -590,6 +613,7 @@ function describe_access(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -612,6 +636,7 @@ function describe_execution(
         "DescribeExecution",
         Dict{String,Any}("ExecutionId" => ExecutionId, "WorkflowId" => WorkflowId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_execution(
@@ -630,6 +655,7 @@ function describe_execution(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -653,6 +679,7 @@ function describe_security_policy(
         "DescribeSecurityPolicy",
         Dict{String,Any}("SecurityPolicyName" => SecurityPolicyName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_security_policy(
@@ -668,6 +695,7 @@ function describe_security_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -685,7 +713,10 @@ EndpointType to VPC, the response will contain the EndpointDetails.
 """
 function describe_server(ServerId; aws_config::AbstractAWSConfig=global_aws_config())
     return transfer(
-        "DescribeServer", Dict{String,Any}("ServerId" => ServerId); aws_config=aws_config
+        "DescribeServer",
+        Dict{String,Any}("ServerId" => ServerId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_server(
@@ -699,6 +730,7 @@ function describe_server(
             mergewith(_merge, Dict{String,Any}("ServerId" => ServerId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -724,6 +756,7 @@ function describe_user(
         "DescribeUser",
         Dict{String,Any}("ServerId" => ServerId, "UserName" => UserName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_user(
@@ -742,6 +775,7 @@ function describe_user(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -760,6 +794,7 @@ function describe_workflow(WorkflowId; aws_config::AbstractAWSConfig=global_aws_
         "DescribeWorkflow",
         Dict{String,Any}("WorkflowId" => WorkflowId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_workflow(
@@ -773,6 +808,7 @@ function describe_workflow(
             mergewith(_merge, Dict{String,Any}("WorkflowId" => WorkflowId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -801,6 +837,7 @@ function import_ssh_public_key(
             "UserName" => UserName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function import_ssh_public_key(
@@ -824,6 +861,7 @@ function import_ssh_public_key(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -846,7 +884,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function list_accesses(ServerId; aws_config::AbstractAWSConfig=global_aws_config())
     return transfer(
-        "ListAccesses", Dict{String,Any}("ServerId" => ServerId); aws_config=aws_config
+        "ListAccesses",
+        Dict{String,Any}("ServerId" => ServerId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_accesses(
@@ -860,6 +901,7 @@ function list_accesses(
             mergewith(_merge, Dict{String,Any}("ServerId" => ServerId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -891,6 +933,7 @@ function list_executions(WorkflowId; aws_config::AbstractAWSConfig=global_aws_co
         "ListExecutions",
         Dict{String,Any}("WorkflowId" => WorkflowId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_executions(
@@ -904,6 +947,7 @@ function list_executions(
             mergewith(_merge, Dict{String,Any}("WorkflowId" => WorkflowId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -923,12 +967,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   parameter in a subsequent command to continue listing additional security policies.
 """
 function list_security_policies(; aws_config::AbstractAWSConfig=global_aws_config())
-    return transfer("ListSecurityPolicies"; aws_config=aws_config)
+    return transfer(
+        "ListSecurityPolicies"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_security_policies(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return transfer("ListSecurityPolicies", params; aws_config=aws_config)
+    return transfer(
+        "ListSecurityPolicies",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -947,12 +998,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   a subsequent command to continue listing additional servers.
 """
 function list_servers(; aws_config::AbstractAWSConfig=global_aws_config())
-    return transfer("ListServers"; aws_config=aws_config)
+    return transfer("ListServers"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_servers(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return transfer("ListServers", params; aws_config=aws_config)
+    return transfer(
+        "ListServers", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -977,7 +1030,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function list_tags_for_resource(Arn; aws_config::AbstractAWSConfig=global_aws_config())
     return transfer(
-        "ListTagsForResource", Dict{String,Any}("Arn" => Arn); aws_config=aws_config
+        "ListTagsForResource",
+        Dict{String,Any}("Arn" => Arn);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags_for_resource(
@@ -987,6 +1043,7 @@ function list_tags_for_resource(
         "ListTagsForResource",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Arn" => Arn), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1011,7 +1068,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function list_users(ServerId; aws_config::AbstractAWSConfig=global_aws_config())
     return transfer(
-        "ListUsers", Dict{String,Any}("ServerId" => ServerId); aws_config=aws_config
+        "ListUsers",
+        Dict{String,Any}("ServerId" => ServerId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_users(
@@ -1025,6 +1085,7 @@ function list_users(
             mergewith(_merge, Dict{String,Any}("ServerId" => ServerId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1042,12 +1103,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   workflows.
 """
 function list_workflows(; aws_config::AbstractAWSConfig=global_aws_config())
-    return transfer("ListWorkflows"; aws_config=aws_config)
+    return transfer("ListWorkflows"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_workflows(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return transfer("ListWorkflows", params; aws_config=aws_config)
+    return transfer(
+        "ListWorkflows", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1082,6 +1145,7 @@ function send_workflow_step_state(
             "WorkflowId" => WorkflowId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function send_workflow_step_state(
@@ -1107,6 +1171,7 @@ function send_workflow_step_state(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1126,7 +1191,10 @@ indicate an error condition. No response is returned from this call.
 """
 function start_server(ServerId; aws_config::AbstractAWSConfig=global_aws_config())
     return transfer(
-        "StartServer", Dict{String,Any}("ServerId" => ServerId); aws_config=aws_config
+        "StartServer",
+        Dict{String,Any}("ServerId" => ServerId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_server(
@@ -1140,6 +1208,7 @@ function start_server(
             mergewith(_merge, Dict{String,Any}("ServerId" => ServerId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1162,7 +1231,10 @@ this call.
 """
 function stop_server(ServerId; aws_config::AbstractAWSConfig=global_aws_config())
     return transfer(
-        "StopServer", Dict{String,Any}("ServerId" => ServerId); aws_config=aws_config
+        "StopServer",
+        Dict{String,Any}("ServerId" => ServerId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function stop_server(
@@ -1176,6 +1248,7 @@ function stop_server(
             mergewith(_merge, Dict{String,Any}("ServerId" => ServerId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1196,7 +1269,10 @@ this call.
 """
 function tag_resource(Arn, Tags; aws_config::AbstractAWSConfig=global_aws_config())
     return transfer(
-        "TagResource", Dict{String,Any}("Arn" => Arn, "Tags" => Tags); aws_config=aws_config
+        "TagResource",
+        Dict{String,Any}("Arn" => Arn, "Tags" => Tags);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -1211,6 +1287,7 @@ function tag_resource(
             mergewith(_merge, Dict{String,Any}("Arn" => Arn, "Tags" => Tags), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1254,6 +1331,7 @@ function test_identity_provider(
         "TestIdentityProvider",
         Dict{String,Any}("ServerId" => ServerId, "UserName" => UserName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function test_identity_provider(
@@ -1272,6 +1350,7 @@ function test_identity_provider(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1296,6 +1375,7 @@ function untag_resource(Arn, TagKeys; aws_config::AbstractAWSConfig=global_aws_c
         "UntagResource",
         Dict{String,Any}("Arn" => Arn, "TagKeys" => TagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -1310,6 +1390,7 @@ function untag_resource(
             mergewith(_merge, Dict{String,Any}("Arn" => Arn, "TagKeys" => TagKeys), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1385,6 +1466,7 @@ function update_access(
         "UpdateAccess",
         Dict{String,Any}("ExternalId" => ExternalId, "ServerId" => ServerId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_access(
@@ -1403,6 +1485,7 @@ function update_access(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1483,7 +1566,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function update_server(ServerId; aws_config::AbstractAWSConfig=global_aws_config())
     return transfer(
-        "UpdateServer", Dict{String,Any}("ServerId" => ServerId); aws_config=aws_config
+        "UpdateServer",
+        Dict{String,Any}("ServerId" => ServerId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_server(
@@ -1497,6 +1583,7 @@ function update_server(
             mergewith(_merge, Dict{String,Any}("ServerId" => ServerId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1572,6 +1659,7 @@ function update_user(ServerId, UserName; aws_config::AbstractAWSConfig=global_aw
         "UpdateUser",
         Dict{String,Any}("ServerId" => ServerId, "UserName" => UserName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_user(
@@ -1590,5 +1678,6 @@ function update_user(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/translate.jl
+++ b/src/services/translate.jl
@@ -37,6 +37,7 @@ function create_parallel_data(
             "ParallelDataConfig" => ParallelDataConfig,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_parallel_data(
@@ -60,6 +61,7 @@ function create_parallel_data(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -75,7 +77,10 @@ Deletes a parallel data resource in Amazon Translate.
 """
 function delete_parallel_data(Name; aws_config::AbstractAWSConfig=global_aws_config())
     return translate(
-        "DeleteParallelData", Dict{String,Any}("Name" => Name); aws_config=aws_config
+        "DeleteParallelData",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_parallel_data(
@@ -85,6 +90,7 @@ function delete_parallel_data(
         "DeleteParallelData",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -100,7 +106,10 @@ A synchronous action that deletes a custom terminology.
 """
 function delete_terminology(Name; aws_config::AbstractAWSConfig=global_aws_config())
     return translate(
-        "DeleteTerminology", Dict{String,Any}("Name" => Name); aws_config=aws_config
+        "DeleteTerminology",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_terminology(
@@ -110,6 +119,7 @@ function delete_terminology(
         "DeleteTerminology",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -132,6 +142,7 @@ function describe_text_translation_job(
         "DescribeTextTranslationJob",
         Dict{String,Any}("JobId" => JobId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_text_translation_job(
@@ -141,6 +152,7 @@ function describe_text_translation_job(
         "DescribeTextTranslationJob",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("JobId" => JobId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -156,7 +168,10 @@ Provides information about a parallel data resource.
 """
 function get_parallel_data(Name; aws_config::AbstractAWSConfig=global_aws_config())
     return translate(
-        "GetParallelData", Dict{String,Any}("Name" => Name); aws_config=aws_config
+        "GetParallelData",
+        Dict{String,Any}("Name" => Name);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_parallel_data(
@@ -166,6 +181,7 @@ function get_parallel_data(
         "GetParallelData",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Name" => Name), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -188,6 +204,7 @@ function get_terminology(
         "GetTerminology",
         Dict{String,Any}("Name" => Name, "TerminologyDataFormat" => TerminologyDataFormat);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_terminology(
@@ -208,6 +225,7 @@ function get_terminology(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -247,6 +265,7 @@ function import_terminology(
             "TerminologyData" => TerminologyData,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function import_terminology(
@@ -270,6 +289,7 @@ function import_terminology(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -286,12 +306,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   response.
 """
 function list_parallel_data(; aws_config::AbstractAWSConfig=global_aws_config())
-    return translate("ListParallelData"; aws_config=aws_config)
+    return translate(
+        "ListParallelData"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_parallel_data(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return translate("ListParallelData", params; aws_config=aws_config)
+    return translate(
+        "ListParallelData", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -307,12 +331,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   the NextToken to fetch the next group of custom terminologies.
 """
 function list_terminologies(; aws_config::AbstractAWSConfig=global_aws_config())
-    return translate("ListTerminologies"; aws_config=aws_config)
+    return translate(
+        "ListTerminologies"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_terminologies(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return translate("ListTerminologies", params; aws_config=aws_config)
+    return translate(
+        "ListTerminologies", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -330,12 +358,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`: The token to request the next page of results.
 """
 function list_text_translation_jobs(; aws_config::AbstractAWSConfig=global_aws_config())
-    return translate("ListTextTranslationJobs"; aws_config=aws_config)
+    return translate(
+        "ListTextTranslationJobs"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_text_translation_jobs(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return translate("ListTextTranslationJobs", params; aws_config=aws_config)
+    return translate(
+        "ListTextTranslationJobs",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -392,6 +427,7 @@ function start_text_translation_job(
             "TargetLanguageCodes" => TargetLanguageCodes,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_text_translation_job(
@@ -421,6 +457,7 @@ function start_text_translation_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -442,7 +479,10 @@ job's JobId.
 """
 function stop_text_translation_job(JobId; aws_config::AbstractAWSConfig=global_aws_config())
     return translate(
-        "StopTextTranslationJob", Dict{String,Any}("JobId" => JobId); aws_config=aws_config
+        "StopTextTranslationJob",
+        Dict{String,Any}("JobId" => JobId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function stop_text_translation_job(
@@ -452,6 +492,7 @@ function stop_text_translation_job(
         "StopTextTranslationJob",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("JobId" => JobId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -493,6 +534,7 @@ function translate_text(
             "Text" => Text,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function translate_text(
@@ -516,6 +558,7 @@ function translate_text(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -548,6 +591,7 @@ function update_parallel_data(
             "ParallelDataConfig" => ParallelDataConfig,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_parallel_data(
@@ -571,5 +615,6 @@ function update_parallel_data(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/waf.jl
+++ b/src/services/waf.jl
@@ -37,6 +37,7 @@ function create_byte_match_set(
         "CreateByteMatchSet",
         Dict{String,Any}("ChangeToken" => ChangeToken, "Name" => Name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_byte_match_set(
@@ -55,6 +56,7 @@ function create_byte_match_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -90,6 +92,7 @@ function create_geo_match_set(
         "CreateGeoMatchSet",
         Dict{String,Any}("ChangeToken" => ChangeToken, "Name" => Name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_geo_match_set(
@@ -108,6 +111,7 @@ function create_geo_match_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -141,6 +145,7 @@ function create_ipset(ChangeToken, Name; aws_config::AbstractAWSConfig=global_aw
         "CreateIPSet",
         Dict{String,Any}("ChangeToken" => ChangeToken, "Name" => Name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_ipset(
@@ -159,6 +164,7 @@ function create_ipset(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -242,6 +248,7 @@ function create_rate_based_rule(
             "RateLimit" => RateLimit,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_rate_based_rule(
@@ -269,6 +276,7 @@ function create_rate_based_rule(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -307,6 +315,7 @@ function create_regex_match_set(
         "CreateRegexMatchSet",
         Dict{String,Any}("ChangeToken" => ChangeToken, "Name" => Name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_regex_match_set(
@@ -325,6 +334,7 @@ function create_regex_match_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -359,6 +369,7 @@ function create_regex_pattern_set(
         "CreateRegexPatternSet",
         Dict{String,Any}("ChangeToken" => ChangeToken, "Name" => Name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_regex_pattern_set(
@@ -377,6 +388,7 @@ function create_regex_pattern_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -429,6 +441,7 @@ function create_rule(
             "ChangeToken" => ChangeToken, "MetricName" => MetricName, "Name" => Name
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_rule(
@@ -450,6 +463,7 @@ function create_rule(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -490,6 +504,7 @@ function create_rule_group(
             "ChangeToken" => ChangeToken, "MetricName" => MetricName, "Name" => Name
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_rule_group(
@@ -511,6 +526,7 @@ function create_rule_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -548,6 +564,7 @@ function create_size_constraint_set(
         "CreateSizeConstraintSet",
         Dict{String,Any}("ChangeToken" => ChangeToken, "Name" => Name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_size_constraint_set(
@@ -566,6 +583,7 @@ function create_size_constraint_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -601,6 +619,7 @@ function create_sql_injection_match_set(
         "CreateSqlInjectionMatchSet",
         Dict{String,Any}("ChangeToken" => ChangeToken, "Name" => Name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_sql_injection_match_set(
@@ -619,6 +638,7 @@ function create_sql_injection_match_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -678,6 +698,7 @@ function create_web_acl(
             "Name" => Name,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_web_acl(
@@ -703,6 +724,7 @@ function create_web_acl(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -748,6 +770,7 @@ function create_web_aclmigration_stack(
             "WebACLId" => WebACLId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_web_aclmigration_stack(
@@ -771,6 +794,7 @@ function create_web_aclmigration_stack(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -805,6 +829,7 @@ function create_xss_match_set(
         "CreateXssMatchSet",
         Dict{String,Any}("ChangeToken" => ChangeToken, "Name" => Name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_xss_match_set(
@@ -823,6 +848,7 @@ function create_xss_match_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -854,6 +880,7 @@ function delete_byte_match_set(
         "DeleteByteMatchSet",
         Dict{String,Any}("ByteMatchSetId" => ByteMatchSetId, "ChangeToken" => ChangeToken);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_byte_match_set(
@@ -874,6 +901,7 @@ function delete_byte_match_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -905,6 +933,7 @@ function delete_geo_match_set(
         "DeleteGeoMatchSet",
         Dict{String,Any}("ChangeToken" => ChangeToken, "GeoMatchSetId" => GeoMatchSetId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_geo_match_set(
@@ -925,6 +954,7 @@ function delete_geo_match_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -956,6 +986,7 @@ function delete_ipset(
         "DeleteIPSet",
         Dict{String,Any}("ChangeToken" => ChangeToken, "IPSetId" => IPSetId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_ipset(
@@ -974,6 +1005,7 @@ function delete_ipset(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -999,6 +1031,7 @@ function delete_logging_configuration(
         "DeleteLoggingConfiguration",
         Dict{String,Any}("ResourceArn" => ResourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_logging_configuration(
@@ -1012,6 +1045,7 @@ function delete_logging_configuration(
             mergewith(_merge, Dict{String,Any}("ResourceArn" => ResourceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1037,6 +1071,7 @@ function delete_permission_policy(
         "DeletePermissionPolicy",
         Dict{String,Any}("ResourceArn" => ResourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_permission_policy(
@@ -1050,6 +1085,7 @@ function delete_permission_policy(
             mergewith(_merge, Dict{String,Any}("ResourceArn" => ResourceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1081,6 +1117,7 @@ function delete_rate_based_rule(
         "DeleteRateBasedRule",
         Dict{String,Any}("ChangeToken" => ChangeToken, "RuleId" => RuleId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_rate_based_rule(
@@ -1099,6 +1136,7 @@ function delete_rate_based_rule(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1132,6 +1170,7 @@ function delete_regex_match_set(
             "ChangeToken" => ChangeToken, "RegexMatchSetId" => RegexMatchSetId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_regex_match_set(
@@ -1152,6 +1191,7 @@ function delete_regex_match_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1181,6 +1221,7 @@ function delete_regex_pattern_set(
             "ChangeToken" => ChangeToken, "RegexPatternSetId" => RegexPatternSetId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_regex_pattern_set(
@@ -1201,6 +1242,7 @@ function delete_regex_pattern_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1230,6 +1272,7 @@ function delete_rule(ChangeToken, RuleId; aws_config::AbstractAWSConfig=global_a
         "DeleteRule",
         Dict{String,Any}("ChangeToken" => ChangeToken, "RuleId" => RuleId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_rule(
@@ -1248,6 +1291,7 @@ function delete_rule(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1279,6 +1323,7 @@ function delete_rule_group(
         "DeleteRuleGroup",
         Dict{String,Any}("ChangeToken" => ChangeToken, "RuleGroupId" => RuleGroupId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_rule_group(
@@ -1299,6 +1344,7 @@ function delete_rule_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1334,6 +1380,7 @@ function delete_size_constraint_set(
             "ChangeToken" => ChangeToken, "SizeConstraintSetId" => SizeConstraintSetId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_size_constraint_set(
@@ -1355,6 +1402,7 @@ function delete_size_constraint_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1390,6 +1438,7 @@ function delete_sql_injection_match_set(
             "ChangeToken" => ChangeToken, "SqlInjectionMatchSetId" => SqlInjectionMatchSetId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_sql_injection_match_set(
@@ -1411,6 +1460,7 @@ function delete_sql_injection_match_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1440,6 +1490,7 @@ function delete_web_acl(
         "DeleteWebACL",
         Dict{String,Any}("ChangeToken" => ChangeToken, "WebACLId" => WebACLId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_web_acl(
@@ -1458,6 +1509,7 @@ function delete_web_acl(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1489,6 +1541,7 @@ function delete_xss_match_set(
         "DeleteXssMatchSet",
         Dict{String,Any}("ChangeToken" => ChangeToken, "XssMatchSetId" => XssMatchSetId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_xss_match_set(
@@ -1509,6 +1562,7 @@ function delete_xss_match_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1533,6 +1587,7 @@ function get_byte_match_set(
         "GetByteMatchSet",
         Dict{String,Any}("ByteMatchSetId" => ByteMatchSetId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_byte_match_set(
@@ -1546,6 +1601,7 @@ function get_byte_match_set(
             mergewith(_merge, Dict{String,Any}("ByteMatchSetId" => ByteMatchSetId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1569,12 +1625,14 @@ GetChangeTokenStatus to determine the status of your change token.
 
 """
 function get_change_token(; aws_config::AbstractAWSConfig=global_aws_config())
-    return waf("GetChangeToken"; aws_config=aws_config)
+    return waf("GetChangeToken"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function get_change_token(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return waf("GetChangeToken", params; aws_config=aws_config)
+    return waf(
+        "GetChangeToken", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1603,6 +1661,7 @@ function get_change_token_status(
         "GetChangeTokenStatus",
         Dict{String,Any}("ChangeToken" => ChangeToken);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_change_token_status(
@@ -1616,6 +1675,7 @@ function get_change_token_status(
             mergewith(_merge, Dict{String,Any}("ChangeToken" => ChangeToken), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1638,6 +1698,7 @@ function get_geo_match_set(GeoMatchSetId; aws_config::AbstractAWSConfig=global_a
         "GetGeoMatchSet",
         Dict{String,Any}("GeoMatchSetId" => GeoMatchSetId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_geo_match_set(
@@ -1651,6 +1712,7 @@ function get_geo_match_set(
             mergewith(_merge, Dict{String,Any}("GeoMatchSetId" => GeoMatchSetId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1669,7 +1731,12 @@ regional and global use.   Returns the IPSet that is specified by IPSetId.
 
 """
 function get_ipset(IPSetId; aws_config::AbstractAWSConfig=global_aws_config())
-    return waf("GetIPSet", Dict{String,Any}("IPSetId" => IPSetId); aws_config=aws_config)
+    return waf(
+        "GetIPSet",
+        Dict{String,Any}("IPSetId" => IPSetId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_ipset(
     IPSetId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -1678,6 +1745,7 @@ function get_ipset(
         "GetIPSet",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("IPSetId" => IPSetId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1702,6 +1770,7 @@ function get_logging_configuration(
         "GetLoggingConfiguration",
         Dict{String,Any}("ResourceArn" => ResourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_logging_configuration(
@@ -1715,6 +1784,7 @@ function get_logging_configuration(
             mergewith(_merge, Dict{String,Any}("ResourceArn" => ResourceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1739,6 +1809,7 @@ function get_permission_policy(
         "GetPermissionPolicy",
         Dict{String,Any}("ResourceArn" => ResourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_permission_policy(
@@ -1752,6 +1823,7 @@ function get_permission_policy(
             mergewith(_merge, Dict{String,Any}("ResourceArn" => ResourceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1772,7 +1844,10 @@ you included in the GetRateBasedRule request.
 """
 function get_rate_based_rule(RuleId; aws_config::AbstractAWSConfig=global_aws_config())
     return waf(
-        "GetRateBasedRule", Dict{String,Any}("RuleId" => RuleId); aws_config=aws_config
+        "GetRateBasedRule",
+        Dict{String,Any}("RuleId" => RuleId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_rate_based_rule(
@@ -1782,6 +1857,7 @@ function get_rate_based_rule(
         "GetRateBasedRule",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("RuleId" => RuleId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1812,6 +1888,7 @@ function get_rate_based_rule_managed_keys(
         "GetRateBasedRuleManagedKeys",
         Dict{String,Any}("RuleId" => RuleId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_rate_based_rule_managed_keys(
@@ -1821,6 +1898,7 @@ function get_rate_based_rule_managed_keys(
         "GetRateBasedRuleManagedKeys",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("RuleId" => RuleId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1845,6 +1923,7 @@ function get_regex_match_set(
         "GetRegexMatchSet",
         Dict{String,Any}("RegexMatchSetId" => RegexMatchSetId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_regex_match_set(
@@ -1860,6 +1939,7 @@ function get_regex_match_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1884,6 +1964,7 @@ function get_regex_pattern_set(
         "GetRegexPatternSet",
         Dict{String,Any}("RegexPatternSetId" => RegexPatternSetId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_regex_pattern_set(
@@ -1899,6 +1980,7 @@ function get_regex_pattern_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1918,7 +2000,12 @@ included in the GetRule request.
 
 """
 function get_rule(RuleId; aws_config::AbstractAWSConfig=global_aws_config())
-    return waf("GetRule", Dict{String,Any}("RuleId" => RuleId); aws_config=aws_config)
+    return waf(
+        "GetRule",
+        Dict{String,Any}("RuleId" => RuleId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_rule(
     RuleId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -1927,6 +2014,7 @@ function get_rule(
         "GetRule",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("RuleId" => RuleId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1951,6 +2039,7 @@ function get_rule_group(RuleGroupId; aws_config::AbstractAWSConfig=global_aws_co
         "GetRuleGroup",
         Dict{String,Any}("RuleGroupId" => RuleGroupId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_rule_group(
@@ -1964,6 +2053,7 @@ function get_rule_group(
             mergewith(_merge, Dict{String,Any}("RuleGroupId" => RuleGroupId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2017,6 +2107,7 @@ function get_sampled_requests(
             "WebAclId" => WebAclId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_sampled_requests(
@@ -2042,6 +2133,7 @@ function get_sampled_requests(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2067,6 +2159,7 @@ function get_size_constraint_set(
         "GetSizeConstraintSet",
         Dict{String,Any}("SizeConstraintSetId" => SizeConstraintSetId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_size_constraint_set(
@@ -2084,6 +2177,7 @@ function get_size_constraint_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2110,6 +2204,7 @@ function get_sql_injection_match_set(
         "GetSqlInjectionMatchSet",
         Dict{String,Any}("SqlInjectionMatchSetId" => SqlInjectionMatchSetId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_sql_injection_match_set(
@@ -2127,6 +2222,7 @@ function get_sql_injection_match_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2145,7 +2241,12 @@ regional and global use.   Returns the WebACL that is specified by WebACLId.
 
 """
 function get_web_acl(WebACLId; aws_config::AbstractAWSConfig=global_aws_config())
-    return waf("GetWebACL", Dict{String,Any}("WebACLId" => WebACLId); aws_config=aws_config)
+    return waf(
+        "GetWebACL",
+        Dict{String,Any}("WebACLId" => WebACLId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_web_acl(
     WebACLId,
@@ -2158,6 +2259,7 @@ function get_web_acl(
             mergewith(_merge, Dict{String,Any}("WebACLId" => WebACLId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2180,6 +2282,7 @@ function get_xss_match_set(XssMatchSetId; aws_config::AbstractAWSConfig=global_a
         "GetXssMatchSet",
         Dict{String,Any}("XssMatchSetId" => XssMatchSetId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_xss_match_set(
@@ -2193,6 +2296,7 @@ function get_xss_match_set(
             mergewith(_merge, Dict{String,Any}("XssMatchSetId" => XssMatchSetId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2222,12 +2326,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function list_activated_rules_in_rule_group(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return waf("ListActivatedRulesInRuleGroup"; aws_config=aws_config)
+    return waf(
+        "ListActivatedRulesInRuleGroup";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_activated_rules_in_rule_group(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return waf("ListActivatedRulesInRuleGroup", params; aws_config=aws_config)
+    return waf(
+        "ListActivatedRulesInRuleGroup",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2252,12 +2365,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   batch of ByteMatchSets.
 """
 function list_byte_match_sets(; aws_config::AbstractAWSConfig=global_aws_config())
-    return waf("ListByteMatchSets"; aws_config=aws_config)
+    return waf("ListByteMatchSets"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_byte_match_sets(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return waf("ListByteMatchSets", params; aws_config=aws_config)
+    return waf(
+        "ListByteMatchSets", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -2282,12 +2397,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   about another batch of GeoMatchSet objects.
 """
 function list_geo_match_sets(; aws_config::AbstractAWSConfig=global_aws_config())
-    return waf("ListGeoMatchSets"; aws_config=aws_config)
+    return waf("ListGeoMatchSets"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_geo_match_sets(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return waf("ListGeoMatchSets", params; aws_config=aws_config)
+    return waf(
+        "ListGeoMatchSets", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -2310,12 +2427,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   of IPSets.
 """
 function list_ipsets(; aws_config::AbstractAWSConfig=global_aws_config())
-    return waf("ListIPSets"; aws_config=aws_config)
+    return waf("ListIPSets"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_ipsets(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return waf("ListIPSets", params; aws_config=aws_config)
+    return waf("ListIPSets", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 
 """
@@ -2340,12 +2457,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   response to get information about another batch of ListLoggingConfigurations.
 """
 function list_logging_configurations(; aws_config::AbstractAWSConfig=global_aws_config())
-    return waf("ListLoggingConfigurations"; aws_config=aws_config)
+    return waf(
+        "ListLoggingConfigurations"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_logging_configurations(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return waf("ListLoggingConfigurations", params; aws_config=aws_config)
+    return waf(
+        "ListLoggingConfigurations",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2369,12 +2493,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   of Rules.
 """
 function list_rate_based_rules(; aws_config::AbstractAWSConfig=global_aws_config())
-    return waf("ListRateBasedRules"; aws_config=aws_config)
+    return waf("ListRateBasedRules"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_rate_based_rules(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return waf("ListRateBasedRules", params; aws_config=aws_config)
+    return waf(
+        "ListRateBasedRules", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -2399,12 +2525,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   about another batch of RegexMatchSet objects.
 """
 function list_regex_match_sets(; aws_config::AbstractAWSConfig=global_aws_config())
-    return waf("ListRegexMatchSets"; aws_config=aws_config)
+    return waf("ListRegexMatchSets"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_regex_match_sets(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return waf("ListRegexMatchSets", params; aws_config=aws_config)
+    return waf(
+        "ListRegexMatchSets", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -2429,12 +2557,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   to get information about another batch of RegexPatternSet objects.
 """
 function list_regex_pattern_sets(; aws_config::AbstractAWSConfig=global_aws_config())
-    return waf("ListRegexPatternSets"; aws_config=aws_config)
+    return waf(
+        "ListRegexPatternSets"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_regex_pattern_sets(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return waf("ListRegexPatternSets", params; aws_config=aws_config)
+    return waf(
+        "ListRegexPatternSets",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2458,12 +2593,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   of RuleGroups.
 """
 function list_rule_groups(; aws_config::AbstractAWSConfig=global_aws_config())
-    return waf("ListRuleGroups"; aws_config=aws_config)
+    return waf("ListRuleGroups"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_rule_groups(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return waf("ListRuleGroups", params; aws_config=aws_config)
+    return waf(
+        "ListRuleGroups", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -2486,12 +2623,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   of NextMarker from the previous response to get information about another batch of Rules.
 """
 function list_rules(; aws_config::AbstractAWSConfig=global_aws_config())
-    return waf("ListRules"; aws_config=aws_config)
+    return waf("ListRules"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_rules(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return waf("ListRules", params; aws_config=aws_config)
+    return waf("ListRules", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 
 """
@@ -2516,12 +2653,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   to get information about another batch of SizeConstraintSets.
 """
 function list_size_constraint_sets(; aws_config::AbstractAWSConfig=global_aws_config())
-    return waf("ListSizeConstraintSets"; aws_config=aws_config)
+    return waf(
+        "ListSizeConstraintSets"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_size_constraint_sets(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return waf("ListSizeConstraintSets", params; aws_config=aws_config)
+    return waf(
+        "ListSizeConstraintSets",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2546,12 +2690,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   response to get information about another batch of SqlInjectionMatchSets.
 """
 function list_sql_injection_match_sets(; aws_config::AbstractAWSConfig=global_aws_config())
-    return waf("ListSqlInjectionMatchSets"; aws_config=aws_config)
+    return waf(
+        "ListSqlInjectionMatchSets"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_sql_injection_match_sets(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return waf("ListSqlInjectionMatchSets", params; aws_config=aws_config)
+    return waf(
+        "ListSqlInjectionMatchSets",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2576,12 +2727,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   rule groups.
 """
 function list_subscribed_rule_groups(; aws_config::AbstractAWSConfig=global_aws_config())
-    return waf("ListSubscribedRuleGroups"; aws_config=aws_config)
+    return waf(
+        "ListSubscribedRuleGroups"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_subscribed_rule_groups(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return waf("ListSubscribedRuleGroups", params; aws_config=aws_config)
+    return waf(
+        "ListSubscribedRuleGroups",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2614,6 +2772,7 @@ function list_tags_for_resource(
         "ListTagsForResource",
         Dict{String,Any}("ResourceARN" => ResourceARN);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags_for_resource(
@@ -2627,6 +2786,7 @@ function list_tags_for_resource(
             mergewith(_merge, Dict{String,Any}("ResourceARN" => ResourceARN), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2652,12 +2812,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   information about another batch of WebACL objects.
 """
 function list_web_acls(; aws_config::AbstractAWSConfig=global_aws_config())
-    return waf("ListWebACLs"; aws_config=aws_config)
+    return waf("ListWebACLs"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_web_acls(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return waf("ListWebACLs", params; aws_config=aws_config)
+    return waf(
+        "ListWebACLs", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -2682,12 +2844,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   about another batch of XssMatchSets.
 """
 function list_xss_match_sets(; aws_config::AbstractAWSConfig=global_aws_config())
-    return waf("ListXssMatchSets"; aws_config=aws_config)
+    return waf("ListXssMatchSets"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_xss_match_sets(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return waf("ListXssMatchSets", params; aws_config=aws_config)
+    return waf(
+        "ListXssMatchSets", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -2722,6 +2886,7 @@ function put_logging_configuration(
         "PutLoggingConfiguration",
         Dict{String,Any}("LoggingConfiguration" => LoggingConfiguration);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_logging_configuration(
@@ -2739,6 +2904,7 @@ function put_logging_configuration(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2775,6 +2941,7 @@ function put_permission_policy(
         "PutPermissionPolicy",
         Dict{String,Any}("Policy" => Policy, "ResourceArn" => ResourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_permission_policy(
@@ -2793,6 +2960,7 @@ function put_permission_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2821,6 +2989,7 @@ function tag_resource(ResourceARN, Tags; aws_config::AbstractAWSConfig=global_aw
         "TagResource",
         Dict{String,Any}("ResourceARN" => ResourceARN, "Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -2839,6 +3008,7 @@ function tag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2863,6 +3033,7 @@ function untag_resource(
         "UntagResource",
         Dict{String,Any}("ResourceARN" => ResourceARN, "TagKeys" => TagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -2881,6 +3052,7 @@ function untag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2933,6 +3105,7 @@ function update_byte_match_set(
             "Updates" => Updates,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_byte_match_set(
@@ -2956,6 +3129,7 @@ function update_byte_match_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3003,6 +3177,7 @@ function update_geo_match_set(
             "Updates" => Updates,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_geo_match_set(
@@ -3026,6 +3201,7 @@ function update_geo_match_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3080,6 +3256,7 @@ function update_ipset(
             "ChangeToken" => ChangeToken, "IPSetId" => IPSetId, "Updates" => Updates
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_ipset(
@@ -3101,6 +3278,7 @@ function update_ipset(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3158,6 +3336,7 @@ function update_rate_based_rule(
             "Updates" => Updates,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_rate_based_rule(
@@ -3183,6 +3362,7 @@ function update_rate_based_rule(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3231,6 +3411,7 @@ function update_regex_match_set(
             "Updates" => Updates,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_regex_match_set(
@@ -3254,6 +3435,7 @@ function update_regex_match_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3299,6 +3481,7 @@ function update_regex_pattern_set(
             "Updates" => Updates,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_regex_pattern_set(
@@ -3322,6 +3505,7 @@ function update_regex_pattern_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3369,6 +3553,7 @@ function update_rule(
             "ChangeToken" => ChangeToken, "RuleId" => RuleId, "Updates" => Updates
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_rule(
@@ -3390,6 +3575,7 @@ function update_rule(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3431,6 +3617,7 @@ function update_rule_group(
             "ChangeToken" => ChangeToken, "RuleGroupId" => RuleGroupId, "Updates" => Updates
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_rule_group(
@@ -3454,6 +3641,7 @@ function update_rule_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3513,6 +3701,7 @@ function update_size_constraint_set(
             "Updates" => Updates,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_size_constraint_set(
@@ -3536,6 +3725,7 @@ function update_size_constraint_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3592,6 +3782,7 @@ function update_sql_injection_match_set(
             "Updates" => Updates,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_sql_injection_match_set(
@@ -3615,6 +3806,7 @@ function update_sql_injection_match_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3684,6 +3876,7 @@ function update_web_acl(
         "UpdateWebACL",
         Dict{String,Any}("ChangeToken" => ChangeToken, "WebACLId" => WebACLId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_web_acl(
@@ -3702,6 +3895,7 @@ function update_web_acl(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3752,6 +3946,7 @@ function update_xss_match_set(
             "XssMatchSetId" => XssMatchSetId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_xss_match_set(
@@ -3775,5 +3970,6 @@ function update_xss_match_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/waf_regional.jl
+++ b/src/services/waf_regional.jl
@@ -31,6 +31,7 @@ function associate_web_acl(
         "AssociateWebACL",
         Dict{String,Any}("ResourceArn" => ResourceArn, "WebACLId" => WebACLId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_web_acl(
@@ -49,6 +50,7 @@ function associate_web_acl(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -85,6 +87,7 @@ function create_byte_match_set(
         "CreateByteMatchSet",
         Dict{String,Any}("ChangeToken" => ChangeToken, "Name" => Name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_byte_match_set(
@@ -103,6 +106,7 @@ function create_byte_match_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -138,6 +142,7 @@ function create_geo_match_set(
         "CreateGeoMatchSet",
         Dict{String,Any}("ChangeToken" => ChangeToken, "Name" => Name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_geo_match_set(
@@ -156,6 +161,7 @@ function create_geo_match_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -189,6 +195,7 @@ function create_ipset(ChangeToken, Name; aws_config::AbstractAWSConfig=global_aw
         "CreateIPSet",
         Dict{String,Any}("ChangeToken" => ChangeToken, "Name" => Name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_ipset(
@@ -207,6 +214,7 @@ function create_ipset(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -290,6 +298,7 @@ function create_rate_based_rule(
             "RateLimit" => RateLimit,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_rate_based_rule(
@@ -317,6 +326,7 @@ function create_rate_based_rule(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -355,6 +365,7 @@ function create_regex_match_set(
         "CreateRegexMatchSet",
         Dict{String,Any}("ChangeToken" => ChangeToken, "Name" => Name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_regex_match_set(
@@ -373,6 +384,7 @@ function create_regex_match_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -407,6 +419,7 @@ function create_regex_pattern_set(
         "CreateRegexPatternSet",
         Dict{String,Any}("ChangeToken" => ChangeToken, "Name" => Name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_regex_pattern_set(
@@ -425,6 +438,7 @@ function create_regex_pattern_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -477,6 +491,7 @@ function create_rule(
             "ChangeToken" => ChangeToken, "MetricName" => MetricName, "Name" => Name
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_rule(
@@ -498,6 +513,7 @@ function create_rule(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -538,6 +554,7 @@ function create_rule_group(
             "ChangeToken" => ChangeToken, "MetricName" => MetricName, "Name" => Name
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_rule_group(
@@ -559,6 +576,7 @@ function create_rule_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -596,6 +614,7 @@ function create_size_constraint_set(
         "CreateSizeConstraintSet",
         Dict{String,Any}("ChangeToken" => ChangeToken, "Name" => Name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_size_constraint_set(
@@ -614,6 +633,7 @@ function create_size_constraint_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -649,6 +669,7 @@ function create_sql_injection_match_set(
         "CreateSqlInjectionMatchSet",
         Dict{String,Any}("ChangeToken" => ChangeToken, "Name" => Name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_sql_injection_match_set(
@@ -667,6 +688,7 @@ function create_sql_injection_match_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -726,6 +748,7 @@ function create_web_acl(
             "Name" => Name,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_web_acl(
@@ -751,6 +774,7 @@ function create_web_acl(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -796,6 +820,7 @@ function create_web_aclmigration_stack(
             "WebACLId" => WebACLId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_web_aclmigration_stack(
@@ -819,6 +844,7 @@ function create_web_aclmigration_stack(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -853,6 +879,7 @@ function create_xss_match_set(
         "CreateXssMatchSet",
         Dict{String,Any}("ChangeToken" => ChangeToken, "Name" => Name);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_xss_match_set(
@@ -871,6 +898,7 @@ function create_xss_match_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -902,6 +930,7 @@ function delete_byte_match_set(
         "DeleteByteMatchSet",
         Dict{String,Any}("ByteMatchSetId" => ByteMatchSetId, "ChangeToken" => ChangeToken);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_byte_match_set(
@@ -922,6 +951,7 @@ function delete_byte_match_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -953,6 +983,7 @@ function delete_geo_match_set(
         "DeleteGeoMatchSet",
         Dict{String,Any}("ChangeToken" => ChangeToken, "GeoMatchSetId" => GeoMatchSetId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_geo_match_set(
@@ -973,6 +1004,7 @@ function delete_geo_match_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1004,6 +1036,7 @@ function delete_ipset(
         "DeleteIPSet",
         Dict{String,Any}("ChangeToken" => ChangeToken, "IPSetId" => IPSetId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_ipset(
@@ -1022,6 +1055,7 @@ function delete_ipset(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1047,6 +1081,7 @@ function delete_logging_configuration(
         "DeleteLoggingConfiguration",
         Dict{String,Any}("ResourceArn" => ResourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_logging_configuration(
@@ -1060,6 +1095,7 @@ function delete_logging_configuration(
             mergewith(_merge, Dict{String,Any}("ResourceArn" => ResourceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1085,6 +1121,7 @@ function delete_permission_policy(
         "DeletePermissionPolicy",
         Dict{String,Any}("ResourceArn" => ResourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_permission_policy(
@@ -1098,6 +1135,7 @@ function delete_permission_policy(
             mergewith(_merge, Dict{String,Any}("ResourceArn" => ResourceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1129,6 +1167,7 @@ function delete_rate_based_rule(
         "DeleteRateBasedRule",
         Dict{String,Any}("ChangeToken" => ChangeToken, "RuleId" => RuleId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_rate_based_rule(
@@ -1147,6 +1186,7 @@ function delete_rate_based_rule(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1180,6 +1220,7 @@ function delete_regex_match_set(
             "ChangeToken" => ChangeToken, "RegexMatchSetId" => RegexMatchSetId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_regex_match_set(
@@ -1200,6 +1241,7 @@ function delete_regex_match_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1229,6 +1271,7 @@ function delete_regex_pattern_set(
             "ChangeToken" => ChangeToken, "RegexPatternSetId" => RegexPatternSetId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_regex_pattern_set(
@@ -1249,6 +1292,7 @@ function delete_regex_pattern_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1278,6 +1322,7 @@ function delete_rule(ChangeToken, RuleId; aws_config::AbstractAWSConfig=global_a
         "DeleteRule",
         Dict{String,Any}("ChangeToken" => ChangeToken, "RuleId" => RuleId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_rule(
@@ -1296,6 +1341,7 @@ function delete_rule(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1327,6 +1373,7 @@ function delete_rule_group(
         "DeleteRuleGroup",
         Dict{String,Any}("ChangeToken" => ChangeToken, "RuleGroupId" => RuleGroupId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_rule_group(
@@ -1347,6 +1394,7 @@ function delete_rule_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1382,6 +1430,7 @@ function delete_size_constraint_set(
             "ChangeToken" => ChangeToken, "SizeConstraintSetId" => SizeConstraintSetId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_size_constraint_set(
@@ -1403,6 +1452,7 @@ function delete_size_constraint_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1438,6 +1488,7 @@ function delete_sql_injection_match_set(
             "ChangeToken" => ChangeToken, "SqlInjectionMatchSetId" => SqlInjectionMatchSetId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_sql_injection_match_set(
@@ -1459,6 +1510,7 @@ function delete_sql_injection_match_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1488,6 +1540,7 @@ function delete_web_acl(
         "DeleteWebACL",
         Dict{String,Any}("ChangeToken" => ChangeToken, "WebACLId" => WebACLId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_web_acl(
@@ -1506,6 +1559,7 @@ function delete_web_acl(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1537,6 +1591,7 @@ function delete_xss_match_set(
         "DeleteXssMatchSet",
         Dict{String,Any}("ChangeToken" => ChangeToken, "XssMatchSetId" => XssMatchSetId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_xss_match_set(
@@ -1557,6 +1612,7 @@ function delete_xss_match_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1586,6 +1642,7 @@ function disassociate_web_acl(
         "DisassociateWebACL",
         Dict{String,Any}("ResourceArn" => ResourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disassociate_web_acl(
@@ -1599,6 +1656,7 @@ function disassociate_web_acl(
             mergewith(_merge, Dict{String,Any}("ResourceArn" => ResourceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1623,6 +1681,7 @@ function get_byte_match_set(
         "GetByteMatchSet",
         Dict{String,Any}("ByteMatchSetId" => ByteMatchSetId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_byte_match_set(
@@ -1636,6 +1695,7 @@ function get_byte_match_set(
             mergewith(_merge, Dict{String,Any}("ByteMatchSetId" => ByteMatchSetId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1659,12 +1719,16 @@ GetChangeTokenStatus to determine the status of your change token.
 
 """
 function get_change_token(; aws_config::AbstractAWSConfig=global_aws_config())
-    return waf_regional("GetChangeToken"; aws_config=aws_config)
+    return waf_regional(
+        "GetChangeToken"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_change_token(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return waf_regional("GetChangeToken", params; aws_config=aws_config)
+    return waf_regional(
+        "GetChangeToken", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1693,6 +1757,7 @@ function get_change_token_status(
         "GetChangeTokenStatus",
         Dict{String,Any}("ChangeToken" => ChangeToken);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_change_token_status(
@@ -1706,6 +1771,7 @@ function get_change_token_status(
             mergewith(_merge, Dict{String,Any}("ChangeToken" => ChangeToken), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1728,6 +1794,7 @@ function get_geo_match_set(GeoMatchSetId; aws_config::AbstractAWSConfig=global_a
         "GetGeoMatchSet",
         Dict{String,Any}("GeoMatchSetId" => GeoMatchSetId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_geo_match_set(
@@ -1741,6 +1808,7 @@ function get_geo_match_set(
             mergewith(_merge, Dict{String,Any}("GeoMatchSetId" => GeoMatchSetId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1760,7 +1828,10 @@ regional and global use.   Returns the IPSet that is specified by IPSetId.
 """
 function get_ipset(IPSetId; aws_config::AbstractAWSConfig=global_aws_config())
     return waf_regional(
-        "GetIPSet", Dict{String,Any}("IPSetId" => IPSetId); aws_config=aws_config
+        "GetIPSet",
+        Dict{String,Any}("IPSetId" => IPSetId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_ipset(
@@ -1770,6 +1841,7 @@ function get_ipset(
         "GetIPSet",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("IPSetId" => IPSetId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1794,6 +1866,7 @@ function get_logging_configuration(
         "GetLoggingConfiguration",
         Dict{String,Any}("ResourceArn" => ResourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_logging_configuration(
@@ -1807,6 +1880,7 @@ function get_logging_configuration(
             mergewith(_merge, Dict{String,Any}("ResourceArn" => ResourceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1831,6 +1905,7 @@ function get_permission_policy(
         "GetPermissionPolicy",
         Dict{String,Any}("ResourceArn" => ResourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_permission_policy(
@@ -1844,6 +1919,7 @@ function get_permission_policy(
             mergewith(_merge, Dict{String,Any}("ResourceArn" => ResourceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1864,7 +1940,10 @@ you included in the GetRateBasedRule request.
 """
 function get_rate_based_rule(RuleId; aws_config::AbstractAWSConfig=global_aws_config())
     return waf_regional(
-        "GetRateBasedRule", Dict{String,Any}("RuleId" => RuleId); aws_config=aws_config
+        "GetRateBasedRule",
+        Dict{String,Any}("RuleId" => RuleId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_rate_based_rule(
@@ -1874,6 +1953,7 @@ function get_rate_based_rule(
         "GetRateBasedRule",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("RuleId" => RuleId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1904,6 +1984,7 @@ function get_rate_based_rule_managed_keys(
         "GetRateBasedRuleManagedKeys",
         Dict{String,Any}("RuleId" => RuleId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_rate_based_rule_managed_keys(
@@ -1913,6 +1994,7 @@ function get_rate_based_rule_managed_keys(
         "GetRateBasedRuleManagedKeys",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("RuleId" => RuleId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1937,6 +2019,7 @@ function get_regex_match_set(
         "GetRegexMatchSet",
         Dict{String,Any}("RegexMatchSetId" => RegexMatchSetId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_regex_match_set(
@@ -1952,6 +2035,7 @@ function get_regex_match_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1976,6 +2060,7 @@ function get_regex_pattern_set(
         "GetRegexPatternSet",
         Dict{String,Any}("RegexPatternSetId" => RegexPatternSetId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_regex_pattern_set(
@@ -1991,6 +2076,7 @@ function get_regex_pattern_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2011,7 +2097,10 @@ included in the GetRule request.
 """
 function get_rule(RuleId; aws_config::AbstractAWSConfig=global_aws_config())
     return waf_regional(
-        "GetRule", Dict{String,Any}("RuleId" => RuleId); aws_config=aws_config
+        "GetRule",
+        Dict{String,Any}("RuleId" => RuleId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_rule(
@@ -2021,6 +2110,7 @@ function get_rule(
         "GetRule",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("RuleId" => RuleId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2045,6 +2135,7 @@ function get_rule_group(RuleGroupId; aws_config::AbstractAWSConfig=global_aws_co
         "GetRuleGroup",
         Dict{String,Any}("RuleGroupId" => RuleGroupId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_rule_group(
@@ -2058,6 +2149,7 @@ function get_rule_group(
             mergewith(_merge, Dict{String,Any}("RuleGroupId" => RuleGroupId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2111,6 +2203,7 @@ function get_sampled_requests(
             "WebAclId" => WebAclId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_sampled_requests(
@@ -2136,6 +2229,7 @@ function get_sampled_requests(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2161,6 +2255,7 @@ function get_size_constraint_set(
         "GetSizeConstraintSet",
         Dict{String,Any}("SizeConstraintSetId" => SizeConstraintSetId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_size_constraint_set(
@@ -2178,6 +2273,7 @@ function get_size_constraint_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2204,6 +2300,7 @@ function get_sql_injection_match_set(
         "GetSqlInjectionMatchSet",
         Dict{String,Any}("SqlInjectionMatchSetId" => SqlInjectionMatchSetId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_sql_injection_match_set(
@@ -2221,6 +2318,7 @@ function get_sql_injection_match_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2240,7 +2338,10 @@ regional and global use.   Returns the WebACL that is specified by WebACLId.
 """
 function get_web_acl(WebACLId; aws_config::AbstractAWSConfig=global_aws_config())
     return waf_regional(
-        "GetWebACL", Dict{String,Any}("WebACLId" => WebACLId); aws_config=aws_config
+        "GetWebACL",
+        Dict{String,Any}("WebACLId" => WebACLId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_web_acl(
@@ -2254,6 +2355,7 @@ function get_web_acl(
             mergewith(_merge, Dict{String,Any}("WebACLId" => WebACLId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2283,6 +2385,7 @@ function get_web_aclfor_resource(
         "GetWebACLForResource",
         Dict{String,Any}("ResourceArn" => ResourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_web_aclfor_resource(
@@ -2296,6 +2399,7 @@ function get_web_aclfor_resource(
             mergewith(_merge, Dict{String,Any}("ResourceArn" => ResourceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2318,6 +2422,7 @@ function get_xss_match_set(XssMatchSetId; aws_config::AbstractAWSConfig=global_a
         "GetXssMatchSet",
         Dict{String,Any}("XssMatchSetId" => XssMatchSetId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_xss_match_set(
@@ -2331,6 +2436,7 @@ function get_xss_match_set(
             mergewith(_merge, Dict{String,Any}("XssMatchSetId" => XssMatchSetId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2360,12 +2466,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function list_activated_rules_in_rule_group(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return waf_regional("ListActivatedRulesInRuleGroup"; aws_config=aws_config)
+    return waf_regional(
+        "ListActivatedRulesInRuleGroup";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_activated_rules_in_rule_group(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return waf_regional("ListActivatedRulesInRuleGroup", params; aws_config=aws_config)
+    return waf_regional(
+        "ListActivatedRulesInRuleGroup",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2390,12 +2505,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   batch of ByteMatchSets.
 """
 function list_byte_match_sets(; aws_config::AbstractAWSConfig=global_aws_config())
-    return waf_regional("ListByteMatchSets"; aws_config=aws_config)
+    return waf_regional(
+        "ListByteMatchSets"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_byte_match_sets(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return waf_regional("ListByteMatchSets", params; aws_config=aws_config)
+    return waf_regional(
+        "ListByteMatchSets", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -2420,12 +2539,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   about another batch of GeoMatchSet objects.
 """
 function list_geo_match_sets(; aws_config::AbstractAWSConfig=global_aws_config())
-    return waf_regional("ListGeoMatchSets"; aws_config=aws_config)
+    return waf_regional(
+        "ListGeoMatchSets"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_geo_match_sets(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return waf_regional("ListGeoMatchSets", params; aws_config=aws_config)
+    return waf_regional(
+        "ListGeoMatchSets", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -2448,12 +2571,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   of IPSets.
 """
 function list_ipsets(; aws_config::AbstractAWSConfig=global_aws_config())
-    return waf_regional("ListIPSets"; aws_config=aws_config)
+    return waf_regional(
+        "ListIPSets"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_ipsets(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return waf_regional("ListIPSets", params; aws_config=aws_config)
+    return waf_regional(
+        "ListIPSets", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -2478,12 +2605,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   response to get information about another batch of ListLoggingConfigurations.
 """
 function list_logging_configurations(; aws_config::AbstractAWSConfig=global_aws_config())
-    return waf_regional("ListLoggingConfigurations"; aws_config=aws_config)
+    return waf_regional(
+        "ListLoggingConfigurations"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_logging_configurations(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return waf_regional("ListLoggingConfigurations", params; aws_config=aws_config)
+    return waf_regional(
+        "ListLoggingConfigurations",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2507,12 +2641,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   of Rules.
 """
 function list_rate_based_rules(; aws_config::AbstractAWSConfig=global_aws_config())
-    return waf_regional("ListRateBasedRules"; aws_config=aws_config)
+    return waf_regional(
+        "ListRateBasedRules"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_rate_based_rules(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return waf_regional("ListRateBasedRules", params; aws_config=aws_config)
+    return waf_regional(
+        "ListRateBasedRules", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -2537,12 +2675,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   about another batch of RegexMatchSet objects.
 """
 function list_regex_match_sets(; aws_config::AbstractAWSConfig=global_aws_config())
-    return waf_regional("ListRegexMatchSets"; aws_config=aws_config)
+    return waf_regional(
+        "ListRegexMatchSets"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_regex_match_sets(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return waf_regional("ListRegexMatchSets", params; aws_config=aws_config)
+    return waf_regional(
+        "ListRegexMatchSets", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -2567,12 +2709,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   to get information about another batch of RegexPatternSet objects.
 """
 function list_regex_pattern_sets(; aws_config::AbstractAWSConfig=global_aws_config())
-    return waf_regional("ListRegexPatternSets"; aws_config=aws_config)
+    return waf_regional(
+        "ListRegexPatternSets"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_regex_pattern_sets(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return waf_regional("ListRegexPatternSets", params; aws_config=aws_config)
+    return waf_regional(
+        "ListRegexPatternSets",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2601,6 +2750,7 @@ function list_resources_for_web_acl(
         "ListResourcesForWebACL",
         Dict{String,Any}("WebACLId" => WebACLId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_resources_for_web_acl(
@@ -2614,6 +2764,7 @@ function list_resources_for_web_acl(
             mergewith(_merge, Dict{String,Any}("WebACLId" => WebACLId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2638,12 +2789,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   of RuleGroups.
 """
 function list_rule_groups(; aws_config::AbstractAWSConfig=global_aws_config())
-    return waf_regional("ListRuleGroups"; aws_config=aws_config)
+    return waf_regional(
+        "ListRuleGroups"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_rule_groups(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return waf_regional("ListRuleGroups", params; aws_config=aws_config)
+    return waf_regional(
+        "ListRuleGroups", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -2666,12 +2821,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   of NextMarker from the previous response to get information about another batch of Rules.
 """
 function list_rules(; aws_config::AbstractAWSConfig=global_aws_config())
-    return waf_regional("ListRules"; aws_config=aws_config)
+    return waf_regional("ListRules"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function list_rules(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return waf_regional("ListRules", params; aws_config=aws_config)
+    return waf_regional(
+        "ListRules", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -2696,12 +2853,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   to get information about another batch of SizeConstraintSets.
 """
 function list_size_constraint_sets(; aws_config::AbstractAWSConfig=global_aws_config())
-    return waf_regional("ListSizeConstraintSets"; aws_config=aws_config)
+    return waf_regional(
+        "ListSizeConstraintSets"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_size_constraint_sets(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return waf_regional("ListSizeConstraintSets", params; aws_config=aws_config)
+    return waf_regional(
+        "ListSizeConstraintSets",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2726,12 +2890,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   response to get information about another batch of SqlInjectionMatchSets.
 """
 function list_sql_injection_match_sets(; aws_config::AbstractAWSConfig=global_aws_config())
-    return waf_regional("ListSqlInjectionMatchSets"; aws_config=aws_config)
+    return waf_regional(
+        "ListSqlInjectionMatchSets"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_sql_injection_match_sets(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return waf_regional("ListSqlInjectionMatchSets", params; aws_config=aws_config)
+    return waf_regional(
+        "ListSqlInjectionMatchSets",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2756,12 +2927,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   rule groups.
 """
 function list_subscribed_rule_groups(; aws_config::AbstractAWSConfig=global_aws_config())
-    return waf_regional("ListSubscribedRuleGroups"; aws_config=aws_config)
+    return waf_regional(
+        "ListSubscribedRuleGroups"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_subscribed_rule_groups(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return waf_regional("ListSubscribedRuleGroups", params; aws_config=aws_config)
+    return waf_regional(
+        "ListSubscribedRuleGroups",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2794,6 +2972,7 @@ function list_tags_for_resource(
         "ListTagsForResource",
         Dict{String,Any}("ResourceARN" => ResourceARN);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags_for_resource(
@@ -2807,6 +2986,7 @@ function list_tags_for_resource(
             mergewith(_merge, Dict{String,Any}("ResourceARN" => ResourceARN), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2832,12 +3012,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   information about another batch of WebACL objects.
 """
 function list_web_acls(; aws_config::AbstractAWSConfig=global_aws_config())
-    return waf_regional("ListWebACLs"; aws_config=aws_config)
+    return waf_regional(
+        "ListWebACLs"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_web_acls(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return waf_regional("ListWebACLs", params; aws_config=aws_config)
+    return waf_regional(
+        "ListWebACLs", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -2862,12 +3046,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   about another batch of XssMatchSets.
 """
 function list_xss_match_sets(; aws_config::AbstractAWSConfig=global_aws_config())
-    return waf_regional("ListXssMatchSets"; aws_config=aws_config)
+    return waf_regional(
+        "ListXssMatchSets"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_xss_match_sets(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return waf_regional("ListXssMatchSets", params; aws_config=aws_config)
+    return waf_regional(
+        "ListXssMatchSets", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -2902,6 +3090,7 @@ function put_logging_configuration(
         "PutLoggingConfiguration",
         Dict{String,Any}("LoggingConfiguration" => LoggingConfiguration);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_logging_configuration(
@@ -2919,6 +3108,7 @@ function put_logging_configuration(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2955,6 +3145,7 @@ function put_permission_policy(
         "PutPermissionPolicy",
         Dict{String,Any}("Policy" => Policy, "ResourceArn" => ResourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_permission_policy(
@@ -2973,6 +3164,7 @@ function put_permission_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3001,6 +3193,7 @@ function tag_resource(ResourceARN, Tags; aws_config::AbstractAWSConfig=global_aw
         "TagResource",
         Dict{String,Any}("ResourceARN" => ResourceARN, "Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -3019,6 +3212,7 @@ function tag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3043,6 +3237,7 @@ function untag_resource(
         "UntagResource",
         Dict{String,Any}("ResourceARN" => ResourceARN, "TagKeys" => TagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -3061,6 +3256,7 @@ function untag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3113,6 +3309,7 @@ function update_byte_match_set(
             "Updates" => Updates,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_byte_match_set(
@@ -3136,6 +3333,7 @@ function update_byte_match_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3183,6 +3381,7 @@ function update_geo_match_set(
             "Updates" => Updates,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_geo_match_set(
@@ -3206,6 +3405,7 @@ function update_geo_match_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3260,6 +3460,7 @@ function update_ipset(
             "ChangeToken" => ChangeToken, "IPSetId" => IPSetId, "Updates" => Updates
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_ipset(
@@ -3281,6 +3482,7 @@ function update_ipset(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3338,6 +3540,7 @@ function update_rate_based_rule(
             "Updates" => Updates,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_rate_based_rule(
@@ -3363,6 +3566,7 @@ function update_rate_based_rule(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3411,6 +3615,7 @@ function update_regex_match_set(
             "Updates" => Updates,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_regex_match_set(
@@ -3434,6 +3639,7 @@ function update_regex_match_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3479,6 +3685,7 @@ function update_regex_pattern_set(
             "Updates" => Updates,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_regex_pattern_set(
@@ -3502,6 +3709,7 @@ function update_regex_pattern_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3549,6 +3757,7 @@ function update_rule(
             "ChangeToken" => ChangeToken, "RuleId" => RuleId, "Updates" => Updates
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_rule(
@@ -3570,6 +3779,7 @@ function update_rule(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3611,6 +3821,7 @@ function update_rule_group(
             "ChangeToken" => ChangeToken, "RuleGroupId" => RuleGroupId, "Updates" => Updates
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_rule_group(
@@ -3634,6 +3845,7 @@ function update_rule_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3693,6 +3905,7 @@ function update_size_constraint_set(
             "Updates" => Updates,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_size_constraint_set(
@@ -3716,6 +3929,7 @@ function update_size_constraint_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3772,6 +3986,7 @@ function update_sql_injection_match_set(
             "Updates" => Updates,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_sql_injection_match_set(
@@ -3795,6 +4010,7 @@ function update_sql_injection_match_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3864,6 +4080,7 @@ function update_web_acl(
         "UpdateWebACL",
         Dict{String,Any}("ChangeToken" => ChangeToken, "WebACLId" => WebACLId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_web_acl(
@@ -3882,6 +4099,7 @@ function update_web_acl(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -3932,6 +4150,7 @@ function update_xss_match_set(
             "XssMatchSetId" => XssMatchSetId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_xss_match_set(
@@ -3955,5 +4174,6 @@ function update_xss_match_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/wafv2.jl
+++ b/src/services/wafv2.jl
@@ -33,6 +33,7 @@ function associate_web_acl(
         "AssociateWebACL",
         Dict{String,Any}("ResourceArn" => ResourceArn, "WebACLArn" => WebACLArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_web_acl(
@@ -51,6 +52,7 @@ function associate_web_acl(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -82,6 +84,7 @@ function check_capacity(Rules, Scope; aws_config::AbstractAWSConfig=global_aws_c
         "CheckCapacity",
         Dict{String,Any}("Rules" => Rules, "Scope" => Scope);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function check_capacity(
@@ -96,6 +99,7 @@ function check_capacity(
             mergewith(_merge, Dict{String,Any}("Rules" => Rules, "Scope" => Scope), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -152,6 +156,7 @@ function create_ipset(
             "Scope" => Scope,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_ipset(
@@ -177,6 +182,7 @@ function create_ipset(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -213,6 +219,7 @@ function create_regex_pattern_set(
             "Scope" => Scope,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_regex_pattern_set(
@@ -236,6 +243,7 @@ function create_regex_pattern_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -301,6 +309,7 @@ function create_rule_group(
             "VisibilityConfig" => VisibilityConfig,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_rule_group(
@@ -326,6 +335,7 @@ function create_rule_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -387,6 +397,7 @@ function create_web_acl(
             "VisibilityConfig" => VisibilityConfig,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_web_acl(
@@ -412,6 +423,7 @@ function create_web_acl(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -440,6 +452,7 @@ function delete_firewall_manager_rule_groups(
         "DeleteFirewallManagerRuleGroups",
         Dict{String,Any}("WebACLArn" => WebACLArn, "WebACLLockToken" => WebACLLockToken);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_firewall_manager_rule_groups(
@@ -460,6 +473,7 @@ function delete_firewall_manager_rule_groups(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -498,6 +512,7 @@ function delete_ipset(
             "Id" => Id, "LockToken" => LockToken, "Name" => Name, "Scope" => Scope
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_ipset(
@@ -520,6 +535,7 @@ function delete_ipset(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -541,6 +557,7 @@ function delete_logging_configuration(
         "DeleteLoggingConfiguration",
         Dict{String,Any}("ResourceArn" => ResourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_logging_configuration(
@@ -554,6 +571,7 @@ function delete_logging_configuration(
             mergewith(_merge, Dict{String,Any}("ResourceArn" => ResourceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -576,6 +594,7 @@ function delete_permission_policy(
         "DeletePermissionPolicy",
         Dict{String,Any}("ResourceArn" => ResourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_permission_policy(
@@ -589,6 +608,7 @@ function delete_permission_policy(
             mergewith(_merge, Dict{String,Any}("ResourceArn" => ResourceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -626,6 +646,7 @@ function delete_regex_pattern_set(
             "Id" => Id, "LockToken" => LockToken, "Name" => Name, "Scope" => Scope
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_regex_pattern_set(
@@ -648,6 +669,7 @@ function delete_regex_pattern_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -686,6 +708,7 @@ function delete_rule_group(
             "Id" => Id, "LockToken" => LockToken, "Name" => Name, "Scope" => Scope
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_rule_group(
@@ -708,6 +731,7 @@ function delete_rule_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -747,6 +771,7 @@ function delete_web_acl(
             "Id" => Id, "LockToken" => LockToken, "Name" => Name, "Scope" => Scope
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_web_acl(
@@ -769,6 +794,7 @@ function delete_web_acl(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -803,6 +829,7 @@ function describe_managed_rule_group(
         "DescribeManagedRuleGroup",
         Dict{String,Any}("Name" => Name, "Scope" => Scope, "VendorName" => VendorName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_managed_rule_group(
@@ -824,6 +851,7 @@ function describe_managed_rule_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -854,6 +882,7 @@ function disassociate_web_acl(
         "DisassociateWebACL",
         Dict{String,Any}("ResourceArn" => ResourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disassociate_web_acl(
@@ -867,6 +896,7 @@ function disassociate_web_acl(
             mergewith(_merge, Dict{String,Any}("ResourceArn" => ResourceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -894,6 +924,7 @@ function get_ipset(Id, Name, Scope; aws_config::AbstractAWSConfig=global_aws_con
         "GetIPSet",
         Dict{String,Any}("Id" => Id, "Name" => Name, "Scope" => Scope);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_ipset(
@@ -913,6 +944,7 @@ function get_ipset(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -934,6 +966,7 @@ function get_logging_configuration(
         "GetLoggingConfiguration",
         Dict{String,Any}("ResourceArn" => ResourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_logging_configuration(
@@ -947,6 +980,7 @@ function get_logging_configuration(
             mergewith(_merge, Dict{String,Any}("ResourceArn" => ResourceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -982,6 +1016,7 @@ function get_managed_rule_set(
         "GetManagedRuleSet",
         Dict{String,Any}("Id" => Id, "Name" => Name, "Scope" => Scope);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_managed_rule_set(
@@ -1001,6 +1036,7 @@ function get_managed_rule_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1023,6 +1059,7 @@ function get_permission_policy(
         "GetPermissionPolicy",
         Dict{String,Any}("ResourceArn" => ResourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_permission_policy(
@@ -1036,6 +1073,7 @@ function get_permission_policy(
             mergewith(_merge, Dict{String,Any}("ResourceArn" => ResourceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1088,6 +1126,7 @@ function get_rate_based_statement_managed_keys(
             "WebACLName" => WebACLName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_rate_based_statement_managed_keys(
@@ -1113,6 +1152,7 @@ function get_rate_based_statement_managed_keys(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1141,6 +1181,7 @@ function get_regex_pattern_set(
         "GetRegexPatternSet",
         Dict{String,Any}("Id" => Id, "Name" => Name, "Scope" => Scope);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_regex_pattern_set(
@@ -1160,6 +1201,7 @@ function get_regex_pattern_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1184,12 +1226,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   all calls, use the Region endpoint us-east-1.
 """
 function get_rule_group(; aws_config::AbstractAWSConfig=global_aws_config())
-    return wafv2("GetRuleGroup"; aws_config=aws_config)
+    return wafv2("GetRuleGroup"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function get_rule_group(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return wafv2("GetRuleGroup", params; aws_config=aws_config)
+    return wafv2(
+        "GetRuleGroup", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1246,6 +1290,7 @@ function get_sampled_requests(
             "WebAclArn" => WebAclArn,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_sampled_requests(
@@ -1273,6 +1318,7 @@ function get_sampled_requests(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1300,6 +1346,7 @@ function get_web_acl(Id, Name, Scope; aws_config::AbstractAWSConfig=global_aws_c
         "GetWebACL",
         Dict{String,Any}("Id" => Id, "Name" => Name, "Scope" => Scope);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_web_acl(
@@ -1319,6 +1366,7 @@ function get_web_acl(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1339,6 +1387,7 @@ function get_web_aclfor_resource(
         "GetWebACLForResource",
         Dict{String,Any}("ResourceArn" => ResourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_web_aclfor_resource(
@@ -1352,6 +1401,7 @@ function get_web_aclfor_resource(
             mergewith(_merge, Dict{String,Any}("ResourceArn" => ResourceArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1390,6 +1440,7 @@ function list_available_managed_rule_group_versions(
         "ListAvailableManagedRuleGroupVersions",
         Dict{String,Any}("Name" => Name, "Scope" => Scope, "VendorName" => VendorName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_available_managed_rule_group_versions(
@@ -1411,6 +1462,7 @@ function list_available_managed_rule_group_versions(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1447,6 +1499,7 @@ function list_available_managed_rule_groups(
         "ListAvailableManagedRuleGroups",
         Dict{String,Any}("Scope" => Scope);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_available_managed_rule_groups(
@@ -1456,6 +1509,7 @@ function list_available_managed_rule_groups(
         "ListAvailableManagedRuleGroups",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Scope" => Scope), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1484,7 +1538,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   prior call in your next request.
 """
 function list_ipsets(Scope; aws_config::AbstractAWSConfig=global_aws_config())
-    return wafv2("ListIPSets", Dict{String,Any}("Scope" => Scope); aws_config=aws_config)
+    return wafv2(
+        "ListIPSets",
+        Dict{String,Any}("Scope" => Scope);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_ipsets(
     Scope, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -1493,6 +1552,7 @@ function list_ipsets(
         "ListIPSets",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Scope" => Scope), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1519,12 +1579,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   all calls, use the Region endpoint us-east-1.
 """
 function list_logging_configurations(; aws_config::AbstractAWSConfig=global_aws_config())
-    return wafv2("ListLoggingConfigurations"; aws_config=aws_config)
+    return wafv2(
+        "ListLoggingConfigurations"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_logging_configurations(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return wafv2("ListLoggingConfigurations", params; aws_config=aws_config)
+    return wafv2(
+        "ListLoggingConfigurations",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1558,7 +1625,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function list_managed_rule_sets(Scope; aws_config::AbstractAWSConfig=global_aws_config())
     return wafv2(
-        "ListManagedRuleSets", Dict{String,Any}("Scope" => Scope); aws_config=aws_config
+        "ListManagedRuleSets",
+        Dict{String,Any}("Scope" => Scope);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_managed_rule_sets(
@@ -1568,6 +1638,7 @@ function list_managed_rule_sets(
         "ListManagedRuleSets",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Scope" => Scope), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1598,7 +1669,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function list_regex_pattern_sets(Scope; aws_config::AbstractAWSConfig=global_aws_config())
     return wafv2(
-        "ListRegexPatternSets", Dict{String,Any}("Scope" => Scope); aws_config=aws_config
+        "ListRegexPatternSets",
+        Dict{String,Any}("Scope" => Scope);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_regex_pattern_sets(
@@ -1608,6 +1682,7 @@ function list_regex_pattern_sets(
         "ListRegexPatternSets",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Scope" => Scope), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1635,6 +1710,7 @@ function list_resources_for_web_acl(
         "ListResourcesForWebACL",
         Dict{String,Any}("WebACLArn" => WebACLArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_resources_for_web_acl(
@@ -1648,6 +1724,7 @@ function list_resources_for_web_acl(
             mergewith(_merge, Dict{String,Any}("WebACLArn" => WebACLArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1677,7 +1754,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function list_rule_groups(Scope; aws_config::AbstractAWSConfig=global_aws_config())
     return wafv2(
-        "ListRuleGroups", Dict{String,Any}("Scope" => Scope); aws_config=aws_config
+        "ListRuleGroups",
+        Dict{String,Any}("Scope" => Scope);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_rule_groups(
@@ -1687,6 +1767,7 @@ function list_rule_groups(
         "ListRuleGroups",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Scope" => Scope), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1722,6 +1803,7 @@ function list_tags_for_resource(
         "ListTagsForResource",
         Dict{String,Any}("ResourceARN" => ResourceARN);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags_for_resource(
@@ -1735,6 +1817,7 @@ function list_tags_for_resource(
             mergewith(_merge, Dict{String,Any}("ResourceARN" => ResourceARN), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1763,7 +1846,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   prior call in your next request.
 """
 function list_web_acls(Scope; aws_config::AbstractAWSConfig=global_aws_config())
-    return wafv2("ListWebACLs", Dict{String,Any}("Scope" => Scope); aws_config=aws_config)
+    return wafv2(
+        "ListWebACLs",
+        Dict{String,Any}("Scope" => Scope);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_web_acls(
     Scope, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
@@ -1772,6 +1860,7 @@ function list_web_acls(
         "ListWebACLs",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Scope" => Scope), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1807,6 +1896,7 @@ function put_logging_configuration(
         "PutLoggingConfiguration",
         Dict{String,Any}("LoggingConfiguration" => LoggingConfiguration);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_logging_configuration(
@@ -1824,6 +1914,7 @@ function put_logging_configuration(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1882,6 +1973,7 @@ function put_managed_rule_set_versions(
             "Id" => Id, "LockToken" => LockToken, "Name" => Name, "Scope" => Scope
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_managed_rule_set_versions(
@@ -1904,6 +1996,7 @@ function put_managed_rule_set_versions(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1937,6 +2030,7 @@ function put_permission_policy(
         "PutPermissionPolicy",
         Dict{String,Any}("Policy" => Policy, "ResourceArn" => ResourceArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_permission_policy(
@@ -1955,6 +2049,7 @@ function put_permission_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1980,6 +2075,7 @@ function tag_resource(ResourceARN, Tags; aws_config::AbstractAWSConfig=global_aw
         "TagResource",
         Dict{String,Any}("ResourceARN" => ResourceARN, "Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -1998,6 +2094,7 @@ function tag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2022,6 +2119,7 @@ function untag_resource(
         "UntagResource",
         Dict{String,Any}("ResourceARN" => ResourceARN, "TagKeys" => TagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -2040,6 +2138,7 @@ function untag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2100,6 +2199,7 @@ function update_ipset(
             "Scope" => Scope,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_ipset(
@@ -2127,6 +2227,7 @@ function update_ipset(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2189,6 +2290,7 @@ function update_managed_rule_set_version_expiry_date(
             "VersionToExpire" => VersionToExpire,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_managed_rule_set_version_expiry_date(
@@ -2218,6 +2320,7 @@ function update_managed_rule_set_version_expiry_date(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2272,6 +2375,7 @@ function update_regex_pattern_set(
             "Scope" => Scope,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_regex_pattern_set(
@@ -2299,6 +2403,7 @@ function update_regex_pattern_set(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2368,6 +2473,7 @@ function update_rule_group(
             "VisibilityConfig" => VisibilityConfig,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_rule_group(
@@ -2395,6 +2501,7 @@ function update_rule_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2472,6 +2579,7 @@ function update_web_acl(
             "VisibilityConfig" => VisibilityConfig,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_web_acl(
@@ -2501,5 +2609,6 @@ function update_web_acl(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/wellarchitected.jl
+++ b/src/services/wellarchitected.jl
@@ -23,6 +23,7 @@ function associate_lenses(
         "/workloads/$(WorkloadId)/associateLenses",
         Dict{String,Any}("LensAliases" => LensAliases);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_lenses(
@@ -38,6 +39,7 @@ function associate_lenses(
             mergewith(_merge, Dict{String,Any}("LensAliases" => LensAliases), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -66,6 +68,7 @@ function create_milestone(
             "ClientRequestToken" => ClientRequestToken, "MilestoneName" => MilestoneName
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_milestone(
@@ -89,6 +92,7 @@ function create_milestone(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -141,6 +145,7 @@ function create_workload(
             "WorkloadName" => WorkloadName,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_workload(
@@ -171,6 +176,7 @@ function create_workload(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -206,6 +212,7 @@ function create_workload_share(
             "SharedWith" => SharedWith,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_workload_share(
@@ -231,6 +238,7 @@ function create_workload_share(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -253,6 +261,7 @@ function delete_workload(
         "/workloads/$(WorkloadId)",
         Dict{String,Any}("ClientRequestToken" => ClientRequestToken);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_workload(
@@ -270,6 +279,7 @@ function delete_workload(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -296,6 +306,7 @@ function delete_workload_share(
         "/workloads/$(WorkloadId)/shares/$(ShareId)",
         Dict{String,Any}("ClientRequestToken" => ClientRequestToken);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_workload_share(
@@ -314,6 +325,7 @@ function delete_workload_share(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -337,6 +349,7 @@ function disassociate_lenses(
         "/workloads/$(WorkloadId)/disassociateLenses",
         Dict{String,Any}("LensAliases" => LensAliases);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disassociate_lenses(
@@ -352,6 +365,7 @@ function disassociate_lenses(
             mergewith(_merge, Dict{String,Any}("LensAliases" => LensAliases), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -377,6 +391,7 @@ function get_answer(
         "GET",
         "/workloads/$(WorkloadId)/lensReviews/$(LensAlias)/answers/$(QuestionId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_answer(
@@ -391,6 +406,7 @@ function get_answer(
         "/workloads/$(WorkloadId)/lensReviews/$(LensAlias)/answers/$(QuestionId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -412,7 +428,10 @@ function get_lens_review(
     LensAlias, WorkloadId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return wellarchitected(
-        "GET", "/workloads/$(WorkloadId)/lensReviews/$(LensAlias)"; aws_config=aws_config
+        "GET",
+        "/workloads/$(WorkloadId)/lensReviews/$(LensAlias)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_lens_review(
@@ -426,6 +445,7 @@ function get_lens_review(
         "/workloads/$(WorkloadId)/lensReviews/$(LensAlias)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -450,6 +470,7 @@ function get_lens_review_report(
         "GET",
         "/workloads/$(WorkloadId)/lensReviews/$(LensAlias)/report";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_lens_review_report(
@@ -463,6 +484,7 @@ function get_lens_review_report(
         "/workloads/$(WorkloadId)/lensReviews/$(LensAlias)/report",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -485,6 +507,7 @@ function get_lens_version_difference(
         "/lenses/$(LensAlias)/versionDifference",
         Dict{String,Any}("BaseLensVersion" => BaseLensVersion);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_lens_version_difference(
@@ -502,6 +525,7 @@ function get_lens_version_difference(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -523,6 +547,7 @@ function get_milestone(
         "GET",
         "/workloads/$(WorkloadId)/milestones/$(MilestoneNumber)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_milestone(
@@ -536,6 +561,7 @@ function get_milestone(
         "/workloads/$(WorkloadId)/milestones/$(MilestoneNumber)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -550,14 +576,25 @@ Get an existing workload.
 
 """
 function get_workload(WorkloadId; aws_config::AbstractAWSConfig=global_aws_config())
-    return wellarchitected("GET", "/workloads/$(WorkloadId)"; aws_config=aws_config)
+    return wellarchitected(
+        "GET",
+        "/workloads/$(WorkloadId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_workload(
     WorkloadId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return wellarchitected("GET", "/workloads/$(WorkloadId)", params; aws_config=aws_config)
+    return wellarchitected(
+        "GET",
+        "/workloads/$(WorkloadId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -584,6 +621,7 @@ function list_answers(
         "GET",
         "/workloads/$(WorkloadId)/lensReviews/$(LensAlias)/answers";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_answers(
@@ -597,6 +635,7 @@ function list_answers(
         "/workloads/$(WorkloadId)/lensReviews/$(LensAlias)/answers",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -624,6 +663,7 @@ function list_lens_review_improvements(
         "GET",
         "/workloads/$(WorkloadId)/lensReviews/$(LensAlias)/improvements";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_lens_review_improvements(
@@ -637,6 +677,7 @@ function list_lens_review_improvements(
         "/workloads/$(WorkloadId)/lensReviews/$(LensAlias)/improvements",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -657,7 +698,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function list_lens_reviews(WorkloadId; aws_config::AbstractAWSConfig=global_aws_config())
     return wellarchitected(
-        "GET", "/workloads/$(WorkloadId)/lensReviews"; aws_config=aws_config
+        "GET",
+        "/workloads/$(WorkloadId)/lensReviews";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_lens_reviews(
@@ -666,7 +710,11 @@ function list_lens_reviews(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return wellarchitected(
-        "GET", "/workloads/$(WorkloadId)/lensReviews", params; aws_config=aws_config
+        "GET",
+        "/workloads/$(WorkloadId)/lensReviews",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -682,12 +730,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`:
 """
 function list_lenses(; aws_config::AbstractAWSConfig=global_aws_config())
-    return wellarchitected("GET", "/lenses"; aws_config=aws_config)
+    return wellarchitected(
+        "GET", "/lenses"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_lenses(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return wellarchitected("GET", "/lenses", params; aws_config=aws_config)
+    return wellarchitected(
+        "GET", "/lenses", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -706,7 +758,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function list_milestones(WorkloadId; aws_config::AbstractAWSConfig=global_aws_config())
     return wellarchitected(
-        "POST", "/workloads/$(WorkloadId)/milestonesSummaries"; aws_config=aws_config
+        "POST",
+        "/workloads/$(WorkloadId)/milestonesSummaries";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_milestones(
@@ -719,6 +774,7 @@ function list_milestones(
         "/workloads/$(WorkloadId)/milestonesSummaries",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -735,12 +791,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"WorkloadId"`:
 """
 function list_notifications(; aws_config::AbstractAWSConfig=global_aws_config())
-    return wellarchitected("POST", "/notifications"; aws_config=aws_config)
+    return wellarchitected(
+        "POST", "/notifications"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_notifications(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return wellarchitected("POST", "/notifications", params; aws_config=aws_config)
+    return wellarchitected(
+        "POST",
+        "/notifications",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -756,12 +820,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"WorkloadNamePrefix"`:
 """
 function list_share_invitations(; aws_config::AbstractAWSConfig=global_aws_config())
-    return wellarchitected("GET", "/shareInvitations"; aws_config=aws_config)
+    return wellarchitected(
+        "GET", "/shareInvitations"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_share_invitations(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return wellarchitected("GET", "/shareInvitations", params; aws_config=aws_config)
+    return wellarchitected(
+        "GET",
+        "/shareInvitations",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -777,14 +849,25 @@ List the tags for a resource.
 function list_tags_for_resource(
     WorkloadArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return wellarchitected("GET", "/tags/$(WorkloadArn)"; aws_config=aws_config)
+    return wellarchitected(
+        "GET",
+        "/tags/$(WorkloadArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_tags_for_resource(
     WorkloadArn,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return wellarchitected("GET", "/tags/$(WorkloadArn)", params; aws_config=aws_config)
+    return wellarchitected(
+        "GET",
+        "/tags/$(WorkloadArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -803,7 +886,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"SharedWithPrefix"`: The AWS account ID or IAM role with which the workload is shared.
 """
 function list_workload_shares(WorkloadId; aws_config::AbstractAWSConfig=global_aws_config())
-    return wellarchitected("GET", "/workloads/$(WorkloadId)/shares"; aws_config=aws_config)
+    return wellarchitected(
+        "GET",
+        "/workloads/$(WorkloadId)/shares";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_workload_shares(
     WorkloadId,
@@ -811,7 +899,11 @@ function list_workload_shares(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return wellarchitected(
-        "GET", "/workloads/$(WorkloadId)/shares", params; aws_config=aws_config
+        "GET",
+        "/workloads/$(WorkloadId)/shares",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -828,12 +920,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"WorkloadNamePrefix"`:
 """
 function list_workloads(; aws_config::AbstractAWSConfig=global_aws_config())
-    return wellarchitected("POST", "/workloadsSummaries"; aws_config=aws_config)
+    return wellarchitected(
+        "POST",
+        "/workloadsSummaries";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_workloads(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return wellarchitected("POST", "/workloadsSummaries", params; aws_config=aws_config)
+    return wellarchitected(
+        "POST",
+        "/workloadsSummaries",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -853,6 +956,7 @@ function tag_resource(Tags, WorkloadArn; aws_config::AbstractAWSConfig=global_aw
         "/tags/$(WorkloadArn)",
         Dict{String,Any}("Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -866,6 +970,7 @@ function tag_resource(
         "/tags/$(WorkloadArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Tags" => Tags), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -890,6 +995,7 @@ function untag_resource(
         "/tags/$(WorkloadArn)",
         Dict{String,Any}("tagKeys" => tagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -903,6 +1009,7 @@ function untag_resource(
         "/tags/$(WorkloadArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tagKeys" => tagKeys), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -933,6 +1040,7 @@ function update_answer(
         "PATCH",
         "/workloads/$(WorkloadId)/lensReviews/$(LensAlias)/answers/$(QuestionId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_answer(
@@ -947,6 +1055,7 @@ function update_answer(
         "/workloads/$(WorkloadId)/lensReviews/$(LensAlias)/answers/$(QuestionId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -969,7 +1078,10 @@ function update_lens_review(
     LensAlias, WorkloadId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return wellarchitected(
-        "PATCH", "/workloads/$(WorkloadId)/lensReviews/$(LensAlias)"; aws_config=aws_config
+        "PATCH",
+        "/workloads/$(WorkloadId)/lensReviews/$(LensAlias)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_lens_review(
@@ -983,6 +1095,7 @@ function update_lens_review(
         "/workloads/$(WorkloadId)/lensReviews/$(LensAlias)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1007,6 +1120,7 @@ function update_share_invitation(
         "/shareInvitations/$(ShareInvitationId)",
         Dict{String,Any}("ShareInvitationAction" => ShareInvitationAction);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_share_invitation(
@@ -1026,6 +1140,7 @@ function update_share_invitation(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1059,7 +1174,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"WorkloadName"`:
 """
 function update_workload(WorkloadId; aws_config::AbstractAWSConfig=global_aws_config())
-    return wellarchitected("PATCH", "/workloads/$(WorkloadId)"; aws_config=aws_config)
+    return wellarchitected(
+        "PATCH",
+        "/workloads/$(WorkloadId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function update_workload(
     WorkloadId,
@@ -1067,7 +1187,11 @@ function update_workload(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return wellarchitected(
-        "PATCH", "/workloads/$(WorkloadId)", params; aws_config=aws_config
+        "PATCH",
+        "/workloads/$(WorkloadId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1091,6 +1215,7 @@ function update_workload_share(
         "/workloads/$(WorkloadId)/shares/$(ShareId)",
         Dict{String,Any}("PermissionType" => PermissionType);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_workload_share(
@@ -1107,6 +1232,7 @@ function update_workload_share(
             mergewith(_merge, Dict{String,Any}("PermissionType" => PermissionType), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1133,6 +1259,7 @@ function upgrade_lens_review(
         "/workloads/$(WorkloadId)/lensReviews/$(LensAlias)/upgrade",
         Dict{String,Any}("MilestoneName" => MilestoneName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function upgrade_lens_review(
@@ -1149,5 +1276,6 @@ function upgrade_lens_review(
             mergewith(_merge, Dict{String,Any}("MilestoneName" => MilestoneName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/workdocs.jl
+++ b/src/services/workdocs.jl
@@ -28,6 +28,7 @@ function abort_document_version_upload(
         "DELETE",
         "/api/v1/documents/$(DocumentId)/versions/$(VersionId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function abort_document_version_upload(
@@ -41,6 +42,7 @@ function abort_document_version_upload(
         "/api/v1/documents/$(DocumentId)/versions/$(VersionId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -59,13 +61,22 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   administrator credentials to access the API.
 """
 function activate_user(UserId; aws_config::AbstractAWSConfig=global_aws_config())
-    return workdocs("POST", "/api/v1/users/$(UserId)/activation"; aws_config=aws_config)
+    return workdocs(
+        "POST",
+        "/api/v1/users/$(UserId)/activation";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function activate_user(
     UserId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return workdocs(
-        "POST", "/api/v1/users/$(UserId)/activation", params; aws_config=aws_config
+        "POST",
+        "/api/v1/users/$(UserId)/activation",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -94,6 +105,7 @@ function add_resource_permissions(
         "/api/v1/resources/$(ResourceId)/permissions",
         Dict{String,Any}("Principals" => Principals);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function add_resource_permissions(
@@ -109,6 +121,7 @@ function add_resource_permissions(
             mergewith(_merge, Dict{String,Any}("Principals" => Principals), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -143,6 +156,7 @@ function create_comment(
         "/api/v1/documents/$(DocumentId)/versions/$(VersionId)/comment",
         Dict{String,Any}("Text" => Text);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_comment(
@@ -157,6 +171,7 @@ function create_comment(
         "/api/v1/documents/$(DocumentId)/versions/$(VersionId)/comment",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Text" => Text), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -186,6 +201,7 @@ function create_custom_metadata(
         "/api/v1/resources/$(ResourceId)/customMetadata",
         Dict{String,Any}("CustomMetadata" => CustomMetadata);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_custom_metadata(
@@ -201,6 +217,7 @@ function create_custom_metadata(
             mergewith(_merge, Dict{String,Any}("CustomMetadata" => CustomMetadata), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -225,6 +242,7 @@ function create_folder(ParentFolderId; aws_config::AbstractAWSConfig=global_aws_
         "/api/v1/folders",
         Dict{String,Any}("ParentFolderId" => ParentFolderId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_folder(
@@ -239,6 +257,7 @@ function create_folder(
             mergewith(_merge, Dict{String,Any}("ParentFolderId" => ParentFolderId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -265,6 +284,7 @@ function create_labels(
         "/api/v1/resources/$(ResourceId)/labels",
         Dict{String,Any}("Labels" => Labels);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_labels(
@@ -278,6 +298,7 @@ function create_labels(
         "/api/v1/resources/$(ResourceId)/labels",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Labels" => Labels), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -314,6 +335,7 @@ function create_notification_subscription(
             "SubscriptionType" => SubscriptionType,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_notification_subscription(
@@ -339,6 +361,7 @@ function create_notification_subscription(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -381,6 +404,7 @@ function create_user(
             "Username" => Username,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_user(
@@ -407,6 +431,7 @@ function create_user(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -425,13 +450,22 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   administrator credentials to access the API.
 """
 function deactivate_user(UserId; aws_config::AbstractAWSConfig=global_aws_config())
-    return workdocs("DELETE", "/api/v1/users/$(UserId)/activation"; aws_config=aws_config)
+    return workdocs(
+        "DELETE",
+        "/api/v1/users/$(UserId)/activation";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function deactivate_user(
     UserId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return workdocs(
-        "DELETE", "/api/v1/users/$(UserId)/activation", params; aws_config=aws_config
+        "DELETE",
+        "/api/v1/users/$(UserId)/activation",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -458,6 +492,7 @@ function delete_comment(
         "DELETE",
         "/api/v1/documents/$(DocumentId)/versions/$(VersionId)/comment/$(CommentId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_comment(
@@ -472,6 +507,7 @@ function delete_comment(
         "/api/v1/documents/$(DocumentId)/versions/$(VersionId)/comment/$(CommentId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -498,7 +534,10 @@ function delete_custom_metadata(
     ResourceId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return workdocs(
-        "DELETE", "/api/v1/resources/$(ResourceId)/customMetadata"; aws_config=aws_config
+        "DELETE",
+        "/api/v1/resources/$(ResourceId)/customMetadata";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_custom_metadata(
@@ -511,6 +550,7 @@ function delete_custom_metadata(
         "/api/v1/resources/$(ResourceId)/customMetadata",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -529,7 +569,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   administrator credentials to access the API.
 """
 function delete_document(DocumentId; aws_config::AbstractAWSConfig=global_aws_config())
-    return workdocs("DELETE", "/api/v1/documents/$(DocumentId)"; aws_config=aws_config)
+    return workdocs(
+        "DELETE",
+        "/api/v1/documents/$(DocumentId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_document(
     DocumentId,
@@ -537,7 +582,11 @@ function delete_document(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return workdocs(
-        "DELETE", "/api/v1/documents/$(DocumentId)", params; aws_config=aws_config
+        "DELETE",
+        "/api/v1/documents/$(DocumentId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -556,14 +605,25 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   administrator credentials to access the API.
 """
 function delete_folder(FolderId; aws_config::AbstractAWSConfig=global_aws_config())
-    return workdocs("DELETE", "/api/v1/folders/$(FolderId)"; aws_config=aws_config)
+    return workdocs(
+        "DELETE",
+        "/api/v1/folders/$(FolderId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_folder(
     FolderId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return workdocs("DELETE", "/api/v1/folders/$(FolderId)", params; aws_config=aws_config)
+    return workdocs(
+        "DELETE",
+        "/api/v1/folders/$(FolderId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -581,7 +641,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   administrator credentials to access the API.
 """
 function delete_folder_contents(FolderId; aws_config::AbstractAWSConfig=global_aws_config())
-    return workdocs("DELETE", "/api/v1/folders/$(FolderId)/contents"; aws_config=aws_config)
+    return workdocs(
+        "DELETE",
+        "/api/v1/folders/$(FolderId)/contents";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_folder_contents(
     FolderId,
@@ -589,7 +654,11 @@ function delete_folder_contents(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return workdocs(
-        "DELETE", "/api/v1/folders/$(FolderId)/contents", params; aws_config=aws_config
+        "DELETE",
+        "/api/v1/folders/$(FolderId)/contents",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -611,7 +680,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function delete_labels(ResourceId; aws_config::AbstractAWSConfig=global_aws_config())
     return workdocs(
-        "DELETE", "/api/v1/resources/$(ResourceId)/labels"; aws_config=aws_config
+        "DELETE",
+        "/api/v1/resources/$(ResourceId)/labels";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_labels(
@@ -620,7 +692,11 @@ function delete_labels(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return workdocs(
-        "DELETE", "/api/v1/resources/$(ResourceId)/labels", params; aws_config=aws_config
+        "DELETE",
+        "/api/v1/resources/$(ResourceId)/labels",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -642,6 +718,7 @@ function delete_notification_subscription(
         "DELETE",
         "/api/v1/organizations/$(OrganizationId)/subscriptions/$(SubscriptionId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_notification_subscription(
@@ -655,6 +732,7 @@ function delete_notification_subscription(
         "/api/v1/organizations/$(OrganizationId)/subscriptions/$(SubscriptionId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -673,12 +751,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   using administrative API actions, as in accessing the API using AWS credentials.
 """
 function delete_user(UserId; aws_config::AbstractAWSConfig=global_aws_config())
-    return workdocs("DELETE", "/api/v1/users/$(UserId)"; aws_config=aws_config)
+    return workdocs(
+        "DELETE",
+        "/api/v1/users/$(UserId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_user(
     UserId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return workdocs("DELETE", "/api/v1/users/$(UserId)", params; aws_config=aws_config)
+    return workdocs(
+        "DELETE",
+        "/api/v1/users/$(UserId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -711,12 +800,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   administrative API (SigV4) requests.
 """
 function describe_activities(; aws_config::AbstractAWSConfig=global_aws_config())
-    return workdocs("GET", "/api/v1/activities"; aws_config=aws_config)
+    return workdocs(
+        "GET", "/api/v1/activities"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_activities(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return workdocs("GET", "/api/v1/activities", params; aws_config=aws_config)
+    return workdocs(
+        "GET",
+        "/api/v1/activities",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -744,6 +841,7 @@ function describe_comments(
         "GET",
         "/api/v1/documents/$(DocumentId)/versions/$(VersionId)/comments";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_comments(
@@ -757,6 +855,7 @@ function describe_comments(
         "/api/v1/documents/$(DocumentId)/versions/$(VersionId)/comments",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -786,7 +885,10 @@ function describe_document_versions(
     DocumentId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return workdocs(
-        "GET", "/api/v1/documents/$(DocumentId)/versions"; aws_config=aws_config
+        "GET",
+        "/api/v1/documents/$(DocumentId)/versions";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_document_versions(
@@ -795,7 +897,11 @@ function describe_document_versions(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return workdocs(
-        "GET", "/api/v1/documents/$(DocumentId)/versions", params; aws_config=aws_config
+        "GET",
+        "/api/v1/documents/$(DocumentId)/versions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -827,7 +933,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_folder_contents(
     FolderId; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return workdocs("GET", "/api/v1/folders/$(FolderId)/contents"; aws_config=aws_config)
+    return workdocs(
+        "GET",
+        "/api/v1/folders/$(FolderId)/contents";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_folder_contents(
     FolderId,
@@ -835,7 +946,11 @@ function describe_folder_contents(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return workdocs(
-        "GET", "/api/v1/folders/$(FolderId)/contents", params; aws_config=aws_config
+        "GET",
+        "/api/v1/folders/$(FolderId)/contents",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -864,6 +979,7 @@ function describe_groups(searchQuery; aws_config::AbstractAWSConfig=global_aws_c
         "/api/v1/groups",
         Dict{String,Any}("searchQuery" => searchQuery);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_groups(
@@ -878,6 +994,7 @@ function describe_groups(
             mergewith(_merge, Dict{String,Any}("searchQuery" => searchQuery), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -903,6 +1020,7 @@ function describe_notification_subscriptions(
         "GET",
         "/api/v1/organizations/$(OrganizationId)/subscriptions";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_notification_subscriptions(
@@ -915,6 +1033,7 @@ function describe_notification_subscriptions(
         "/api/v1/organizations/$(OrganizationId)/subscriptions",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -940,7 +1059,10 @@ function describe_resource_permissions(
     ResourceId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return workdocs(
-        "GET", "/api/v1/resources/$(ResourceId)/permissions"; aws_config=aws_config
+        "GET",
+        "/api/v1/resources/$(ResourceId)/permissions";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_resource_permissions(
@@ -949,7 +1071,11 @@ function describe_resource_permissions(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return workdocs(
-        "GET", "/api/v1/resources/$(ResourceId)/permissions", params; aws_config=aws_config
+        "GET",
+        "/api/v1/resources/$(ResourceId)/permissions",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -981,6 +1107,7 @@ function describe_root_folders(
         "/api/v1/me/root",
         Dict{String,Any}("headers" => Dict{String,Any}("Authentication" => Authentication));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_root_folders(
@@ -1001,6 +1128,7 @@ function describe_root_folders(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1030,12 +1158,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"userIds"`: The IDs of the users.
 """
 function describe_users(; aws_config::AbstractAWSConfig=global_aws_config())
-    return workdocs("GET", "/api/v1/users"; aws_config=aws_config)
+    return workdocs(
+        "GET", "/api/v1/users"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_users(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return workdocs("GET", "/api/v1/users", params; aws_config=aws_config)
+    return workdocs(
+        "GET",
+        "/api/v1/users",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1058,6 +1194,7 @@ function get_current_user(Authentication; aws_config::AbstractAWSConfig=global_a
         "/api/v1/me",
         Dict{String,Any}("headers" => Dict{String,Any}("Authentication" => Authentication));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_current_user(
@@ -1078,6 +1215,7 @@ function get_current_user(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1097,14 +1235,25 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"includeCustomMetadata"`: Set this to TRUE to include custom metadata in the response.
 """
 function get_document(DocumentId; aws_config::AbstractAWSConfig=global_aws_config())
-    return workdocs("GET", "/api/v1/documents/$(DocumentId)"; aws_config=aws_config)
+    return workdocs(
+        "GET",
+        "/api/v1/documents/$(DocumentId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_document(
     DocumentId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return workdocs("GET", "/api/v1/documents/$(DocumentId)", params; aws_config=aws_config)
+    return workdocs(
+        "GET",
+        "/api/v1/documents/$(DocumentId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1129,7 +1278,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"marker"`: This value is not supported.
 """
 function get_document_path(DocumentId; aws_config::AbstractAWSConfig=global_aws_config())
-    return workdocs("GET", "/api/v1/documents/$(DocumentId)/path"; aws_config=aws_config)
+    return workdocs(
+        "GET",
+        "/api/v1/documents/$(DocumentId)/path";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_document_path(
     DocumentId,
@@ -1137,7 +1291,11 @@ function get_document_path(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return workdocs(
-        "GET", "/api/v1/documents/$(DocumentId)/path", params; aws_config=aws_config
+        "GET",
+        "/api/v1/documents/$(DocumentId)/path",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1166,6 +1324,7 @@ function get_document_version(
         "GET",
         "/api/v1/documents/$(DocumentId)/versions/$(VersionId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_document_version(
@@ -1179,6 +1338,7 @@ function get_document_version(
         "/api/v1/documents/$(DocumentId)/versions/$(VersionId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1198,14 +1358,25 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"includeCustomMetadata"`: Set to TRUE to include custom metadata in the response.
 """
 function get_folder(FolderId; aws_config::AbstractAWSConfig=global_aws_config())
-    return workdocs("GET", "/api/v1/folders/$(FolderId)"; aws_config=aws_config)
+    return workdocs(
+        "GET",
+        "/api/v1/folders/$(FolderId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_folder(
     FolderId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return workdocs("GET", "/api/v1/folders/$(FolderId)", params; aws_config=aws_config)
+    return workdocs(
+        "GET",
+        "/api/v1/folders/$(FolderId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1230,7 +1401,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"marker"`: This value is not supported.
 """
 function get_folder_path(FolderId; aws_config::AbstractAWSConfig=global_aws_config())
-    return workdocs("GET", "/api/v1/folders/$(FolderId)/path"; aws_config=aws_config)
+    return workdocs(
+        "GET",
+        "/api/v1/folders/$(FolderId)/path";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_folder_path(
     FolderId,
@@ -1238,7 +1414,11 @@ function get_folder_path(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return workdocs(
-        "GET", "/api/v1/folders/$(FolderId)/path", params; aws_config=aws_config
+        "GET",
+        "/api/v1/folders/$(FolderId)/path",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1261,12 +1441,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   accessing the API operation using IAM credentials.
 """
 function get_resources(; aws_config::AbstractAWSConfig=global_aws_config())
-    return workdocs("GET", "/api/v1/resources"; aws_config=aws_config)
+    return workdocs(
+        "GET", "/api/v1/resources"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_resources(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return workdocs("GET", "/api/v1/resources", params; aws_config=aws_config)
+    return workdocs(
+        "GET",
+        "/api/v1/resources",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1302,6 +1490,7 @@ function initiate_document_version_upload(
         "/api/v1/documents",
         Dict{String,Any}("ParentFolderId" => ParentFolderId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function initiate_document_version_upload(
@@ -1316,6 +1505,7 @@ function initiate_document_version_upload(
             mergewith(_merge, Dict{String,Any}("ParentFolderId" => ParentFolderId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1337,7 +1527,10 @@ function remove_all_resource_permissions(
     ResourceId; aws_config::AbstractAWSConfig=global_aws_config()
 )
     return workdocs(
-        "DELETE", "/api/v1/resources/$(ResourceId)/permissions"; aws_config=aws_config
+        "DELETE",
+        "/api/v1/resources/$(ResourceId)/permissions";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function remove_all_resource_permissions(
@@ -1350,6 +1543,7 @@ function remove_all_resource_permissions(
         "/api/v1/resources/$(ResourceId)/permissions",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1376,6 +1570,7 @@ function remove_resource_permission(
         "DELETE",
         "/api/v1/resources/$(ResourceId)/permissions/$(PrincipalId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function remove_resource_permission(
@@ -1389,6 +1584,7 @@ function remove_resource_permission(
         "/api/v1/resources/$(ResourceId)/permissions/$(PrincipalId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1412,7 +1608,12 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   supported.
 """
 function update_document(DocumentId; aws_config::AbstractAWSConfig=global_aws_config())
-    return workdocs("PATCH", "/api/v1/documents/$(DocumentId)"; aws_config=aws_config)
+    return workdocs(
+        "PATCH",
+        "/api/v1/documents/$(DocumentId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function update_document(
     DocumentId,
@@ -1420,7 +1621,11 @@ function update_document(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return workdocs(
-        "PATCH", "/api/v1/documents/$(DocumentId)", params; aws_config=aws_config
+        "PATCH",
+        "/api/v1/documents/$(DocumentId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1449,6 +1654,7 @@ function update_document_version(
         "PATCH",
         "/api/v1/documents/$(DocumentId)/versions/$(VersionId)";
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_document_version(
@@ -1462,6 +1668,7 @@ function update_document_version(
         "/api/v1/documents/$(DocumentId)/versions/$(VersionId)",
         params;
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1485,14 +1692,25 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   accepted values from the API.
 """
 function update_folder(FolderId; aws_config::AbstractAWSConfig=global_aws_config())
-    return workdocs("PATCH", "/api/v1/folders/$(FolderId)"; aws_config=aws_config)
+    return workdocs(
+        "PATCH",
+        "/api/v1/folders/$(FolderId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function update_folder(
     FolderId,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return workdocs("PATCH", "/api/v1/folders/$(FolderId)", params; aws_config=aws_config)
+    return workdocs(
+        "PATCH",
+        "/api/v1/folders/$(FolderId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1519,10 +1737,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"Type"`: The type of the user.
 """
 function update_user(UserId; aws_config::AbstractAWSConfig=global_aws_config())
-    return workdocs("PATCH", "/api/v1/users/$(UserId)"; aws_config=aws_config)
+    return workdocs(
+        "PATCH",
+        "/api/v1/users/$(UserId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function update_user(
     UserId, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return workdocs("PATCH", "/api/v1/users/$(UserId)", params; aws_config=aws_config)
+    return workdocs(
+        "PATCH",
+        "/api/v1/users/$(UserId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end

--- a/src/services/worklink.jl
+++ b/src/services/worklink.jl
@@ -35,6 +35,7 @@ function associate_domain(
             "FleetArn" => FleetArn,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_domain(
@@ -59,6 +60,7 @@ function associate_domain(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -88,6 +90,7 @@ function associate_website_authorization_provider(
             "AuthorizationProviderType" => AuthorizationProviderType, "FleetArn" => FleetArn
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_website_authorization_provider(
@@ -110,6 +113,7 @@ function associate_website_authorization_provider(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -136,6 +140,7 @@ function associate_website_certificate_authority(
         "/associateWebsiteCertificateAuthority",
         Dict{String,Any}("Certificate" => Certificate, "FleetArn" => FleetArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_website_certificate_authority(
@@ -155,6 +160,7 @@ function associate_website_certificate_authority(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -181,6 +187,7 @@ function create_fleet(FleetName; aws_config::AbstractAWSConfig=global_aws_config
         "/createFleet",
         Dict{String,Any}("FleetName" => FleetName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_fleet(
@@ -195,6 +202,7 @@ function create_fleet(
             mergewith(_merge, Dict{String,Any}("FleetName" => FleetName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -214,6 +222,7 @@ function delete_fleet(FleetArn; aws_config::AbstractAWSConfig=global_aws_config(
         "/deleteFleet",
         Dict{String,Any}("FleetArn" => FleetArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_fleet(
@@ -228,6 +237,7 @@ function delete_fleet(
             mergewith(_merge, Dict{String,Any}("FleetArn" => FleetArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -249,6 +259,7 @@ function describe_audit_stream_configuration(
         "/describeAuditStreamConfiguration",
         Dict{String,Any}("FleetArn" => FleetArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_audit_stream_configuration(
@@ -263,6 +274,7 @@ function describe_audit_stream_configuration(
             mergewith(_merge, Dict{String,Any}("FleetArn" => FleetArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -285,6 +297,7 @@ function describe_company_network_configuration(
         "/describeCompanyNetworkConfiguration",
         Dict{String,Any}("FleetArn" => FleetArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_company_network_configuration(
@@ -299,6 +312,7 @@ function describe_company_network_configuration(
             mergewith(_merge, Dict{String,Any}("FleetArn" => FleetArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -321,6 +335,7 @@ function describe_device(
         "/describeDevice",
         Dict{String,Any}("DeviceId" => DeviceId, "FleetArn" => FleetArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_device(
@@ -340,6 +355,7 @@ function describe_device(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -361,6 +377,7 @@ function describe_device_policy_configuration(
         "/describeDevicePolicyConfiguration",
         Dict{String,Any}("FleetArn" => FleetArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_device_policy_configuration(
@@ -375,6 +392,7 @@ function describe_device_policy_configuration(
             mergewith(_merge, Dict{String,Any}("FleetArn" => FleetArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -397,6 +415,7 @@ function describe_domain(
         "/describeDomain",
         Dict{String,Any}("DomainName" => DomainName, "FleetArn" => FleetArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_domain(
@@ -416,6 +435,7 @@ function describe_domain(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -438,6 +458,7 @@ function describe_fleet_metadata(
         "/describeFleetMetadata",
         Dict{String,Any}("FleetArn" => FleetArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_fleet_metadata(
@@ -452,6 +473,7 @@ function describe_fleet_metadata(
             mergewith(_merge, Dict{String,Any}("FleetArn" => FleetArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -473,6 +495,7 @@ function describe_identity_provider_configuration(
         "/describeIdentityProviderConfiguration",
         Dict{String,Any}("FleetArn" => FleetArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_identity_provider_configuration(
@@ -487,6 +510,7 @@ function describe_identity_provider_configuration(
             mergewith(_merge, Dict{String,Any}("FleetArn" => FleetArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -509,6 +533,7 @@ function describe_website_certificate_authority(
         "/describeWebsiteCertificateAuthority",
         Dict{String,Any}("FleetArn" => FleetArn, "WebsiteCaId" => WebsiteCaId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_website_certificate_authority(
@@ -528,6 +553,7 @@ function describe_website_certificate_authority(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -551,6 +577,7 @@ function disassociate_domain(
         "/disassociateDomain",
         Dict{String,Any}("DomainName" => DomainName, "FleetArn" => FleetArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disassociate_domain(
@@ -570,6 +597,7 @@ function disassociate_domain(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -596,6 +624,7 @@ function disassociate_website_authorization_provider(
             "AuthorizationProviderId" => AuthorizationProviderId, "FleetArn" => FleetArn
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disassociate_website_authorization_provider(
@@ -618,6 +647,7 @@ function disassociate_website_authorization_provider(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -640,6 +670,7 @@ function disassociate_website_certificate_authority(
         "/disassociateWebsiteCertificateAuthority",
         Dict{String,Any}("FleetArn" => FleetArn, "WebsiteCaId" => WebsiteCaId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disassociate_website_certificate_authority(
@@ -659,6 +690,7 @@ function disassociate_website_certificate_authority(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -683,6 +715,7 @@ function list_devices(FleetArn; aws_config::AbstractAWSConfig=global_aws_config(
         "/listDevices",
         Dict{String,Any}("FleetArn" => FleetArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_devices(
@@ -697,6 +730,7 @@ function list_devices(
             mergewith(_merge, Dict{String,Any}("FleetArn" => FleetArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -721,6 +755,7 @@ function list_domains(FleetArn; aws_config::AbstractAWSConfig=global_aws_config(
         "/listDomains",
         Dict{String,Any}("FleetArn" => FleetArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_domains(
@@ -735,6 +770,7 @@ function list_domains(
             mergewith(_merge, Dict{String,Any}("FleetArn" => FleetArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -751,12 +787,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   operation. If this value is null, it retrieves the first page.
 """
 function list_fleets(; aws_config::AbstractAWSConfig=global_aws_config())
-    return worklink("POST", "/listFleets"; aws_config=aws_config)
+    return worklink(
+        "POST", "/listFleets"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_fleets(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return worklink("POST", "/listFleets", params; aws_config=aws_config)
+    return worklink(
+        "POST",
+        "/listFleets",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -772,14 +816,25 @@ Retrieves a list of tags for the specified resource.
 function list_tags_for_resource(
     ResourceArn; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return worklink("GET", "/tags/$(ResourceArn)"; aws_config=aws_config)
+    return worklink(
+        "GET",
+        "/tags/$(ResourceArn)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function list_tags_for_resource(
     ResourceArn,
     params::AbstractDict{String};
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
-    return worklink("GET", "/tags/$(ResourceArn)", params; aws_config=aws_config)
+    return worklink(
+        "GET",
+        "/tags/$(ResourceArn)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -805,6 +860,7 @@ function list_website_authorization_providers(
         "/listWebsiteAuthorizationProviders",
         Dict{String,Any}("FleetArn" => FleetArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_website_authorization_providers(
@@ -819,6 +875,7 @@ function list_website_authorization_providers(
             mergewith(_merge, Dict{String,Any}("FleetArn" => FleetArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -845,6 +902,7 @@ function list_website_certificate_authorities(
         "/listWebsiteCertificateAuthorities",
         Dict{String,Any}("FleetArn" => FleetArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_website_certificate_authorities(
@@ -859,6 +917,7 @@ function list_website_certificate_authorities(
             mergewith(_merge, Dict{String,Any}("FleetArn" => FleetArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -881,6 +940,7 @@ function restore_domain_access(
         "/restoreDomainAccess",
         Dict{String,Any}("DomainName" => DomainName, "FleetArn" => FleetArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function restore_domain_access(
@@ -900,6 +960,7 @@ function restore_domain_access(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -922,6 +983,7 @@ function revoke_domain_access(
         "/revokeDomainAccess",
         Dict{String,Any}("DomainName" => DomainName, "FleetArn" => FleetArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function revoke_domain_access(
@@ -941,6 +1003,7 @@ function revoke_domain_access(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -964,6 +1027,7 @@ function sign_out_user(
         "/signOutUser",
         Dict{String,Any}("FleetArn" => FleetArn, "Username" => Username);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function sign_out_user(
@@ -983,6 +1047,7 @@ function sign_out_user(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1005,6 +1070,7 @@ function tag_resource(ResourceArn, Tags; aws_config::AbstractAWSConfig=global_aw
         "/tags/$(ResourceArn)",
         Dict{String,Any}("Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -1018,6 +1084,7 @@ function tag_resource(
         "/tags/$(ResourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Tags" => Tags), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1040,6 +1107,7 @@ function untag_resource(
         "/tags/$(ResourceArn)",
         Dict{String,Any}("tagKeys" => tagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -1053,6 +1121,7 @@ function untag_resource(
         "/tags/$(ResourceArn)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("tagKeys" => tagKeys), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1078,6 +1147,7 @@ function update_audit_stream_configuration(
         "/updateAuditStreamConfiguration",
         Dict{String,Any}("FleetArn" => FleetArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_audit_stream_configuration(
@@ -1092,6 +1162,7 @@ function update_audit_stream_configuration(
             mergewith(_merge, Dict{String,Any}("FleetArn" => FleetArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1126,6 +1197,7 @@ function update_company_network_configuration(
             "VpcId" => VpcId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_company_network_configuration(
@@ -1152,6 +1224,7 @@ function update_company_network_configuration(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1177,6 +1250,7 @@ function update_device_policy_configuration(
         "/updateDevicePolicyConfiguration",
         Dict{String,Any}("FleetArn" => FleetArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_device_policy_configuration(
@@ -1191,6 +1265,7 @@ function update_device_policy_configuration(
             mergewith(_merge, Dict{String,Any}("FleetArn" => FleetArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1216,6 +1291,7 @@ function update_domain_metadata(
         "/updateDomainMetadata",
         Dict{String,Any}("DomainName" => DomainName, "FleetArn" => FleetArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_domain_metadata(
@@ -1235,6 +1311,7 @@ function update_domain_metadata(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1260,6 +1337,7 @@ function update_fleet_metadata(FleetArn; aws_config::AbstractAWSConfig=global_aw
         "/UpdateFleetMetadata",
         Dict{String,Any}("FleetArn" => FleetArn);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_fleet_metadata(
@@ -1274,6 +1352,7 @@ function update_fleet_metadata(
             mergewith(_merge, Dict{String,Any}("FleetArn" => FleetArn), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1302,6 +1381,7 @@ function update_identity_provider_configuration(
             "FleetArn" => FleetArn, "IdentityProviderType" => IdentityProviderType
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_identity_provider_configuration(
@@ -1323,5 +1403,6 @@ function update_identity_provider_configuration(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/workmail.jl
+++ b/src/services/workmail.jl
@@ -27,6 +27,7 @@ function associate_delegate_to_resource(
             "ResourceId" => ResourceId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_delegate_to_resource(
@@ -50,6 +51,7 @@ function associate_delegate_to_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -74,6 +76,7 @@ function associate_member_to_group(
             "GroupId" => GroupId, "MemberId" => MemberId, "OrganizationId" => OrganizationId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_member_to_group(
@@ -97,6 +100,7 @@ function associate_member_to_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -124,6 +128,7 @@ function cancel_mailbox_export_job(
             "OrganizationId" => OrganizationId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function cancel_mailbox_export_job(
@@ -147,6 +152,7 @@ function cancel_mailbox_export_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -171,6 +177,7 @@ function create_alias(
             "Alias" => Alias, "EntityId" => EntityId, "OrganizationId" => OrganizationId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_alias(
@@ -194,6 +201,7 @@ function create_alias(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -216,6 +224,7 @@ function create_group(
         "CreateGroup",
         Dict{String,Any}("Name" => Name, "OrganizationId" => OrganizationId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_group(
@@ -234,6 +243,7 @@ function create_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -277,6 +287,7 @@ function create_mobile_device_access_rule(
             "ClientToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_mobile_device_access_rule(
@@ -301,6 +312,7 @@ function create_mobile_device_access_rule(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -340,6 +352,7 @@ function create_organization(Alias; aws_config::AbstractAWSConfig=global_aws_con
         "CreateOrganization",
         Dict{String,Any}("Alias" => Alias, "ClientToken" => string(uuid4()));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_organization(
@@ -355,6 +368,7 @@ function create_organization(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -380,6 +394,7 @@ function create_resource(
             "Name" => Name, "OrganizationId" => OrganizationId, "Type" => Type
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_resource(
@@ -401,6 +416,7 @@ function create_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -435,6 +451,7 @@ function create_user(
             "Password" => Password,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_user(
@@ -460,6 +477,7 @@ function create_user(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -481,6 +499,7 @@ function delete_access_control_rule(
         "DeleteAccessControlRule",
         Dict{String,Any}("Name" => Name, "OrganizationId" => OrganizationId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_access_control_rule(
@@ -499,6 +518,7 @@ function delete_access_control_rule(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -525,6 +545,7 @@ function delete_alias(
             "Alias" => Alias, "EntityId" => EntityId, "OrganizationId" => OrganizationId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_alias(
@@ -548,6 +569,7 @@ function delete_alias(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -569,6 +591,7 @@ function delete_group(
         "DeleteGroup",
         Dict{String,Any}("GroupId" => GroupId, "OrganizationId" => OrganizationId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_group(
@@ -587,6 +610,7 @@ function delete_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -615,6 +639,7 @@ function delete_mailbox_permissions(
             "OrganizationId" => OrganizationId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_mailbox_permissions(
@@ -638,6 +663,7 @@ function delete_mailbox_permissions(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -664,6 +690,7 @@ function delete_mobile_device_access_rule(
             "OrganizationId" => OrganizationId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_mobile_device_access_rule(
@@ -685,6 +712,7 @@ function delete_mobile_device_access_rule(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -717,6 +745,7 @@ function delete_organization(
             "ClientToken" => string(uuid4()),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_organization(
@@ -739,6 +768,7 @@ function delete_organization(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -761,6 +791,7 @@ function delete_resource(
         "DeleteResource",
         Dict{String,Any}("OrganizationId" => OrganizationId, "ResourceId" => ResourceId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_resource(
@@ -781,6 +812,7 @@ function delete_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -802,6 +834,7 @@ function delete_retention_policy(
         "DeleteRetentionPolicy",
         Dict{String,Any}("Id" => Id, "OrganizationId" => OrganizationId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_retention_policy(
@@ -820,6 +853,7 @@ function delete_retention_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -844,6 +878,7 @@ function delete_user(
         "DeleteUser",
         Dict{String,Any}("OrganizationId" => OrganizationId, "UserId" => UserId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_user(
@@ -862,6 +897,7 @@ function delete_user(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -886,6 +922,7 @@ function deregister_from_work_mail(
         "DeregisterFromWorkMail",
         Dict{String,Any}("EntityId" => EntityId, "OrganizationId" => OrganizationId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function deregister_from_work_mail(
@@ -906,6 +943,7 @@ function deregister_from_work_mail(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -927,6 +965,7 @@ function describe_group(
         "DescribeGroup",
         Dict{String,Any}("GroupId" => GroupId, "OrganizationId" => OrganizationId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_group(
@@ -945,6 +984,7 @@ function describe_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -966,6 +1006,7 @@ function describe_mailbox_export_job(
         "DescribeMailboxExportJob",
         Dict{String,Any}("JobId" => JobId, "OrganizationId" => OrganizationId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_mailbox_export_job(
@@ -984,6 +1025,7 @@ function describe_mailbox_export_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1004,6 +1046,7 @@ function describe_organization(
         "DescribeOrganization",
         Dict{String,Any}("OrganizationId" => OrganizationId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_organization(
@@ -1017,6 +1060,7 @@ function describe_organization(
             mergewith(_merge, Dict{String,Any}("OrganizationId" => OrganizationId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1039,6 +1083,7 @@ function describe_resource(
         "DescribeResource",
         Dict{String,Any}("OrganizationId" => OrganizationId, "ResourceId" => ResourceId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_resource(
@@ -1059,6 +1104,7 @@ function describe_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1080,6 +1126,7 @@ function describe_user(
         "DescribeUser",
         Dict{String,Any}("OrganizationId" => OrganizationId, "UserId" => UserId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_user(
@@ -1098,6 +1145,7 @@ function describe_user(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1126,6 +1174,7 @@ function disassociate_delegate_from_resource(
             "ResourceId" => ResourceId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disassociate_delegate_from_resource(
@@ -1149,6 +1198,7 @@ function disassociate_delegate_from_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1173,6 +1223,7 @@ function disassociate_member_from_group(
             "GroupId" => GroupId, "MemberId" => MemberId, "OrganizationId" => OrganizationId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disassociate_member_from_group(
@@ -1196,6 +1247,7 @@ function disassociate_member_from_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1230,6 +1282,7 @@ function get_access_control_effect(
             "UserId" => UserId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_access_control_effect(
@@ -1255,6 +1308,7 @@ function get_access_control_effect(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1275,6 +1329,7 @@ function get_default_retention_policy(
         "GetDefaultRetentionPolicy",
         Dict{String,Any}("OrganizationId" => OrganizationId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_default_retention_policy(
@@ -1288,6 +1343,7 @@ function get_default_retention_policy(
             mergewith(_merge, Dict{String,Any}("OrganizationId" => OrganizationId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1310,6 +1366,7 @@ function get_mailbox_details(
         "GetMailboxDetails",
         Dict{String,Any}("OrganizationId" => OrganizationId, "UserId" => UserId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_mailbox_details(
@@ -1328,6 +1385,7 @@ function get_mailbox_details(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1356,6 +1414,7 @@ function get_mobile_device_access_effect(
         "GetMobileDeviceAccessEffect",
         Dict{String,Any}("OrganizationId" => OrganizationId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_mobile_device_access_effect(
@@ -1369,6 +1428,7 @@ function get_mobile_device_access_effect(
             mergewith(_merge, Dict{String,Any}("OrganizationId" => OrganizationId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1389,6 +1449,7 @@ function list_access_control_rules(
         "ListAccessControlRules",
         Dict{String,Any}("OrganizationId" => OrganizationId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_access_control_rules(
@@ -1402,6 +1463,7 @@ function list_access_control_rules(
             mergewith(_merge, Dict{String,Any}("OrganizationId" => OrganizationId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1428,6 +1490,7 @@ function list_aliases(
         "ListAliases",
         Dict{String,Any}("EntityId" => EntityId, "OrganizationId" => OrganizationId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_aliases(
@@ -1448,6 +1511,7 @@ function list_aliases(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1475,6 +1539,7 @@ function list_group_members(
         "ListGroupMembers",
         Dict{String,Any}("GroupId" => GroupId, "OrganizationId" => OrganizationId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_group_members(
@@ -1493,6 +1558,7 @@ function list_group_members(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1516,6 +1582,7 @@ function list_groups(OrganizationId; aws_config::AbstractAWSConfig=global_aws_co
         "ListGroups",
         Dict{String,Any}("OrganizationId" => OrganizationId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_groups(
@@ -1529,6 +1596,7 @@ function list_groups(
             mergewith(_merge, Dict{String,Any}("OrganizationId" => OrganizationId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1554,6 +1622,7 @@ function list_mailbox_export_jobs(
         "ListMailboxExportJobs",
         Dict{String,Any}("OrganizationId" => OrganizationId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_mailbox_export_jobs(
@@ -1567,6 +1636,7 @@ function list_mailbox_export_jobs(
             mergewith(_merge, Dict{String,Any}("OrganizationId" => OrganizationId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1595,6 +1665,7 @@ function list_mailbox_permissions(
         "ListMailboxPermissions",
         Dict{String,Any}("EntityId" => EntityId, "OrganizationId" => OrganizationId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_mailbox_permissions(
@@ -1615,6 +1686,7 @@ function list_mailbox_permissions(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1635,6 +1707,7 @@ function list_mobile_device_access_rules(
         "ListMobileDeviceAccessRules",
         Dict{String,Any}("OrganizationId" => OrganizationId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_mobile_device_access_rules(
@@ -1648,6 +1721,7 @@ function list_mobile_device_access_rules(
             mergewith(_merge, Dict{String,Any}("OrganizationId" => OrganizationId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1664,12 +1738,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   not contain any tokens.
 """
 function list_organizations(; aws_config::AbstractAWSConfig=global_aws_config())
-    return workmail("ListOrganizations"; aws_config=aws_config)
+    return workmail(
+        "ListOrganizations"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function list_organizations(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return workmail("ListOrganizations", params; aws_config=aws_config)
+    return workmail(
+        "ListOrganizations", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1697,6 +1775,7 @@ function list_resource_delegates(
         "ListResourceDelegates",
         Dict{String,Any}("OrganizationId" => OrganizationId, "ResourceId" => ResourceId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_resource_delegates(
@@ -1717,6 +1796,7 @@ function list_resource_delegates(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1740,6 +1820,7 @@ function list_resources(OrganizationId; aws_config::AbstractAWSConfig=global_aws
         "ListResources",
         Dict{String,Any}("OrganizationId" => OrganizationId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_resources(
@@ -1753,6 +1834,7 @@ function list_resources(
             mergewith(_merge, Dict{String,Any}("OrganizationId" => OrganizationId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1773,6 +1855,7 @@ function list_tags_for_resource(
         "ListTagsForResource",
         Dict{String,Any}("ResourceARN" => ResourceARN);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags_for_resource(
@@ -1786,6 +1869,7 @@ function list_tags_for_resource(
             mergewith(_merge, Dict{String,Any}("ResourceARN" => ResourceARN), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1809,6 +1893,7 @@ function list_users(OrganizationId; aws_config::AbstractAWSConfig=global_aws_con
         "ListUsers",
         Dict{String,Any}("OrganizationId" => OrganizationId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_users(
@@ -1822,6 +1907,7 @@ function list_users(
             mergewith(_merge, Dict{String,Any}("OrganizationId" => OrganizationId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1866,6 +1952,7 @@ function put_access_control_rule(
             "OrganizationId" => OrganizationId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_access_control_rule(
@@ -1891,6 +1978,7 @@ function put_access_control_rule(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1931,6 +2019,7 @@ function put_mailbox_permissions(
             "PermissionValues" => PermissionValues,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_mailbox_permissions(
@@ -1956,6 +2045,7 @@ function put_mailbox_permissions(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1989,6 +2079,7 @@ function put_retention_policy(
             "OrganizationId" => OrganizationId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_retention_policy(
@@ -2012,6 +2103,7 @@ function put_retention_policy(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2043,6 +2135,7 @@ function register_to_work_mail(
             "Email" => Email, "EntityId" => EntityId, "OrganizationId" => OrganizationId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function register_to_work_mail(
@@ -2066,6 +2159,7 @@ function register_to_work_mail(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2091,6 +2185,7 @@ function reset_password(
             "OrganizationId" => OrganizationId, "Password" => Password, "UserId" => UserId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function reset_password(
@@ -2114,6 +2209,7 @@ function reset_password(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2163,6 +2259,7 @@ function start_mailbox_export_job(
             "S3Prefix" => S3Prefix,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_mailbox_export_job(
@@ -2194,6 +2291,7 @@ function start_mailbox_export_job(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2213,6 +2311,7 @@ function tag_resource(ResourceARN, Tags; aws_config::AbstractAWSConfig=global_aw
         "TagResource",
         Dict{String,Any}("ResourceARN" => ResourceARN, "Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -2231,6 +2330,7 @@ function tag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2252,6 +2352,7 @@ function untag_resource(
         "UntagResource",
         Dict{String,Any}("ResourceARN" => ResourceARN, "TagKeys" => TagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -2270,6 +2371,7 @@ function untag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2297,6 +2399,7 @@ function update_mailbox_quota(
             "UserId" => UserId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_mailbox_quota(
@@ -2320,6 +2423,7 @@ function update_mailbox_quota(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2367,6 +2471,7 @@ function update_mobile_device_access_rule(
             "OrganizationId" => OrganizationId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_mobile_device_access_rule(
@@ -2392,6 +2497,7 @@ function update_mobile_device_access_rule(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2418,6 +2524,7 @@ function update_primary_email_address(
             "Email" => Email, "EntityId" => EntityId, "OrganizationId" => OrganizationId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_primary_email_address(
@@ -2441,6 +2548,7 @@ function update_primary_email_address(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -2469,6 +2577,7 @@ function update_resource(
         "UpdateResource",
         Dict{String,Any}("OrganizationId" => OrganizationId, "ResourceId" => ResourceId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_resource(
@@ -2489,5 +2598,6 @@ function update_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/workmailmessageflow.jl
+++ b/src/services/workmailmessageflow.jl
@@ -17,7 +17,12 @@ Retrieves the raw content of an in-transit email message, in MIME format.
 function get_raw_message_content(
     messageId; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return workmailmessageflow("GET", "/messages/$(messageId)"; aws_config=aws_config)
+    return workmailmessageflow(
+        "GET",
+        "/messages/$(messageId)";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_raw_message_content(
     messageId,
@@ -25,7 +30,11 @@ function get_raw_message_content(
     aws_config::AbstractAWSConfig=global_aws_config(),
 )
     return workmailmessageflow(
-        "GET", "/messages/$(messageId)", params; aws_config=aws_config
+        "GET",
+        "/messages/$(messageId)",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -54,6 +63,7 @@ function put_raw_message_content(
         "/messages/$(messageId)",
         Dict{String,Any}("content" => content);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_raw_message_content(
@@ -67,5 +77,6 @@ function put_raw_message_content(
         "/messages/$(messageId)",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("content" => content), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/workspaces.jl
+++ b/src/services/workspaces.jl
@@ -25,6 +25,7 @@ function associate_connection_alias(
         "AssociateConnectionAlias",
         Dict{String,Any}("AliasId" => AliasId, "ResourceId" => ResourceId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_connection_alias(
@@ -43,6 +44,7 @@ function associate_connection_alias(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -64,6 +66,7 @@ function associate_ip_groups(
         "AssociateIpGroups",
         Dict{String,Any}("DirectoryId" => DirectoryId, "GroupIds" => GroupIds);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function associate_ip_groups(
@@ -82,6 +85,7 @@ function associate_ip_groups(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -104,6 +108,7 @@ function authorize_ip_rules(
         "AuthorizeIpRules",
         Dict{String,Any}("GroupId" => GroupId, "UserRules" => UserRules);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function authorize_ip_rules(
@@ -122,6 +127,7 @@ function authorize_ip_rules(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -157,6 +163,7 @@ function copy_workspace_image(
             "Name" => Name, "SourceImageId" => SourceImageId, "SourceRegion" => SourceRegion
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function copy_workspace_image(
@@ -180,6 +187,7 @@ function copy_workspace_image(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -208,6 +216,7 @@ function create_connection_alias(
         "CreateConnectionAlias",
         Dict{String,Any}("ConnectionString" => ConnectionString);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_connection_alias(
@@ -223,6 +232,7 @@ function create_connection_alias(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -251,7 +261,10 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function create_ip_group(GroupName; aws_config::AbstractAWSConfig=global_aws_config())
     return workspaces(
-        "CreateIpGroup", Dict{String,Any}("GroupName" => GroupName); aws_config=aws_config
+        "CreateIpGroup",
+        Dict{String,Any}("GroupName" => GroupName);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_ip_group(
@@ -265,6 +278,7 @@ function create_ip_group(
             mergewith(_merge, Dict{String,Any}("GroupName" => GroupName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -286,6 +300,7 @@ function create_tags(ResourceId, Tags; aws_config::AbstractAWSConfig=global_aws_
         "CreateTags",
         Dict{String,Any}("ResourceId" => ResourceId, "Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_tags(
@@ -302,6 +317,7 @@ function create_tags(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -344,6 +360,7 @@ function create_workspace_bundle(
             "UserStorage" => UserStorage,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_workspace_bundle(
@@ -371,6 +388,7 @@ function create_workspace_bundle(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -390,6 +408,7 @@ function create_workspaces(Workspaces; aws_config::AbstractAWSConfig=global_aws_
         "CreateWorkspaces",
         Dict{String,Any}("Workspaces" => Workspaces);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_workspaces(
@@ -403,6 +422,7 @@ function create_workspaces(
             mergewith(_merge, Dict{String,Any}("Workspaces" => Workspaces), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -429,6 +449,7 @@ function delete_connection_alias(AliasId; aws_config::AbstractAWSConfig=global_a
         "DeleteConnectionAlias",
         Dict{String,Any}("AliasId" => AliasId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_connection_alias(
@@ -438,6 +459,7 @@ function delete_connection_alias(
         "DeleteConnectionAlias",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("AliasId" => AliasId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -454,7 +476,10 @@ that is associated with a directory.
 """
 function delete_ip_group(GroupId; aws_config::AbstractAWSConfig=global_aws_config())
     return workspaces(
-        "DeleteIpGroup", Dict{String,Any}("GroupId" => GroupId); aws_config=aws_config
+        "DeleteIpGroup",
+        Dict{String,Any}("GroupId" => GroupId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_ip_group(
@@ -464,6 +489,7 @@ function delete_ip_group(
         "DeleteIpGroup",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("GroupId" => GroupId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -485,6 +511,7 @@ function delete_tags(ResourceId, TagKeys; aws_config::AbstractAWSConfig=global_a
         "DeleteTags",
         Dict{String,Any}("ResourceId" => ResourceId, "TagKeys" => TagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_tags(
@@ -503,6 +530,7 @@ function delete_tags(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -518,12 +546,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"BundleId"`: The identifier of the bundle.
 """
 function delete_workspace_bundle(; aws_config::AbstractAWSConfig=global_aws_config())
-    return workspaces("DeleteWorkspaceBundle"; aws_config=aws_config)
+    return workspaces(
+        "DeleteWorkspaceBundle"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function delete_workspace_bundle(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return workspaces("DeleteWorkspaceBundle", params; aws_config=aws_config)
+    return workspaces(
+        "DeleteWorkspaceBundle",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -543,6 +578,7 @@ function delete_workspace_image(ImageId; aws_config::AbstractAWSConfig=global_aw
         "DeleteWorkspaceImage",
         Dict{String,Any}("ImageId" => ImageId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function delete_workspace_image(
@@ -552,6 +588,7 @@ function delete_workspace_image(
         "DeleteWorkspaceImage",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("ImageId" => ImageId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -583,6 +620,7 @@ function deregister_workspace_directory(
         "DeregisterWorkspaceDirectory",
         Dict{String,Any}("DirectoryId" => DirectoryId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function deregister_workspace_directory(
@@ -596,6 +634,7 @@ function deregister_workspace_directory(
             mergewith(_merge, Dict{String,Any}("DirectoryId" => DirectoryId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -608,12 +647,16 @@ specified account.
 
 """
 function describe_account(; aws_config::AbstractAWSConfig=global_aws_config())
-    return workspaces("DescribeAccount"; aws_config=aws_config)
+    return workspaces(
+        "DescribeAccount"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_account(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return workspaces("DescribeAccount", params; aws_config=aws_config)
+    return workspaces(
+        "DescribeAccount", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -629,12 +672,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   provide this token to receive the next set of results.
 """
 function describe_account_modifications(; aws_config::AbstractAWSConfig=global_aws_config())
-    return workspaces("DescribeAccountModifications"; aws_config=aws_config)
+    return workspaces(
+        "DescribeAccountModifications";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_account_modifications(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return workspaces("DescribeAccountModifications", params; aws_config=aws_config)
+    return workspaces(
+        "DescribeAccountModifications",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -654,6 +706,7 @@ function describe_client_properties(
         "DescribeClientProperties",
         Dict{String,Any}("ResourceIds" => ResourceIds);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_client_properties(
@@ -667,6 +720,7 @@ function describe_client_properties(
             mergewith(_merge, Dict{String,Any}("ResourceIds" => ResourceIds), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -694,6 +748,7 @@ function describe_connection_alias_permissions(
         "DescribeConnectionAliasPermissions",
         Dict{String,Any}("AliasId" => AliasId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_connection_alias_permissions(
@@ -703,6 +758,7 @@ function describe_connection_alias_permissions(
         "DescribeConnectionAliasPermissions",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("AliasId" => AliasId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -722,12 +778,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"ResourceId"`: The identifier of the directory associated with the connection alias.
 """
 function describe_connection_aliases(; aws_config::AbstractAWSConfig=global_aws_config())
-    return workspaces("DescribeConnectionAliases"; aws_config=aws_config)
+    return workspaces(
+        "DescribeConnectionAliases"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_connection_aliases(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return workspaces("DescribeConnectionAliases", params; aws_config=aws_config)
+    return workspaces(
+        "DescribeConnectionAliases",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -744,12 +807,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   provide this token to receive the next set of results.
 """
 function describe_ip_groups(; aws_config::AbstractAWSConfig=global_aws_config())
-    return workspaces("DescribeIpGroups"; aws_config=aws_config)
+    return workspaces(
+        "DescribeIpGroups"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_ip_groups(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return workspaces("DescribeIpGroups", params; aws_config=aws_config)
+    return workspaces(
+        "DescribeIpGroups", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -766,7 +833,10 @@ Describes the specified tags for the specified WorkSpaces resource.
 """
 function describe_tags(ResourceId; aws_config::AbstractAWSConfig=global_aws_config())
     return workspaces(
-        "DescribeTags", Dict{String,Any}("ResourceId" => ResourceId); aws_config=aws_config
+        "DescribeTags",
+        Dict{String,Any}("ResourceId" => ResourceId);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_tags(
@@ -780,6 +850,7 @@ function describe_tags(
             mergewith(_merge, Dict{String,Any}("ResourceId" => ResourceId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -801,12 +872,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   that belong to your account, don't specify a value.
 """
 function describe_workspace_bundles(; aws_config::AbstractAWSConfig=global_aws_config())
-    return workspaces("DescribeWorkspaceBundles"; aws_config=aws_config)
+    return workspaces(
+        "DescribeWorkspaceBundles"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_workspace_bundles(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return workspaces("DescribeWorkspaceBundles", params; aws_config=aws_config)
+    return workspaces(
+        "DescribeWorkspaceBundles",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -824,12 +902,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   provide this token to receive the next set of results.
 """
 function describe_workspace_directories(; aws_config::AbstractAWSConfig=global_aws_config())
-    return workspaces("DescribeWorkspaceDirectories"; aws_config=aws_config)
+    return workspaces(
+        "DescribeWorkspaceDirectories";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_workspace_directories(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return workspaces("DescribeWorkspaceDirectories", params; aws_config=aws_config)
+    return workspaces(
+        "DescribeWorkspaceDirectories",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -855,6 +942,7 @@ function describe_workspace_image_permissions(
         "DescribeWorkspaceImagePermissions",
         Dict{String,Any}("ImageId" => ImageId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_workspace_image_permissions(
@@ -864,6 +952,7 @@ function describe_workspace_image_permissions(
         "DescribeWorkspaceImagePermissions",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("ImageId" => ImageId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -883,12 +972,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   provide this token to receive the next set of results.
 """
 function describe_workspace_images(; aws_config::AbstractAWSConfig=global_aws_config())
-    return workspaces("DescribeWorkspaceImages"; aws_config=aws_config)
+    return workspaces(
+        "DescribeWorkspaceImages"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_workspace_images(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return workspaces("DescribeWorkspaceImages", params; aws_config=aws_config)
+    return workspaces(
+        "DescribeWorkspaceImages",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -908,6 +1004,7 @@ function describe_workspace_snapshots(
         "DescribeWorkspaceSnapshots",
         Dict{String,Any}("WorkspaceId" => WorkspaceId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function describe_workspace_snapshots(
@@ -921,6 +1018,7 @@ function describe_workspace_snapshots(
             mergewith(_merge, Dict{String,Any}("WorkspaceId" => WorkspaceId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -949,12 +1047,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   DescribeWorkspaces with this identifier, no information is returned.
 """
 function describe_workspaces(; aws_config::AbstractAWSConfig=global_aws_config())
-    return workspaces("DescribeWorkspaces"; aws_config=aws_config)
+    return workspaces(
+        "DescribeWorkspaces"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function describe_workspaces(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return workspaces("DescribeWorkspaces", params; aws_config=aws_config)
+    return workspaces(
+        "DescribeWorkspaces", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -972,12 +1074,21 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function describe_workspaces_connection_status(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return workspaces("DescribeWorkspacesConnectionStatus"; aws_config=aws_config)
+    return workspaces(
+        "DescribeWorkspacesConnectionStatus";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function describe_workspaces_connection_status(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return workspaces("DescribeWorkspacesConnectionStatus", params; aws_config=aws_config)
+    return workspaces(
+        "DescribeWorkspacesConnectionStatus",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1001,6 +1112,7 @@ function disassociate_connection_alias(
         "DisassociateConnectionAlias",
         Dict{String,Any}("AliasId" => AliasId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disassociate_connection_alias(
@@ -1010,6 +1122,7 @@ function disassociate_connection_alias(
         "DisassociateConnectionAlias",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("AliasId" => AliasId), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1031,6 +1144,7 @@ function disassociate_ip_groups(
         "DisassociateIpGroups",
         Dict{String,Any}("DirectoryId" => DirectoryId, "GroupIds" => GroupIds);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function disassociate_ip_groups(
@@ -1049,6 +1163,7 @@ function disassociate_ip_groups(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1096,6 +1211,7 @@ function import_workspace_image(
             "IngestionProcess" => IngestionProcess,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function import_workspace_image(
@@ -1121,6 +1237,7 @@ function import_workspace_image(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1154,6 +1271,7 @@ function list_available_management_cidr_ranges(
         "ListAvailableManagementCidrRanges",
         Dict{String,Any}("ManagementCidrRangeConstraint" => ManagementCidrRangeConstraint);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_available_management_cidr_ranges(
@@ -1173,6 +1291,7 @@ function list_available_management_cidr_ranges(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1201,6 +1320,7 @@ function migrate_workspace(
         "MigrateWorkspace",
         Dict{String,Any}("BundleId" => BundleId, "SourceWorkspaceId" => SourceWorkspaceId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function migrate_workspace(
@@ -1221,6 +1341,7 @@ function migrate_workspace(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1240,12 +1361,16 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"DedicatedTenancySupport"`: The status of BYOL.
 """
 function modify_account(; aws_config::AbstractAWSConfig=global_aws_config())
-    return workspaces("ModifyAccount"; aws_config=aws_config)
+    return workspaces(
+        "ModifyAccount"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function modify_account(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return workspaces("ModifyAccount", params; aws_config=aws_config)
+    return workspaces(
+        "ModifyAccount", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -1268,6 +1393,7 @@ function modify_client_properties(
             "ClientProperties" => ClientProperties, "ResourceId" => ResourceId
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_client_properties(
@@ -1288,6 +1414,7 @@ function modify_client_properties(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1312,6 +1439,7 @@ function modify_selfservice_permissions(
             "ResourceId" => ResourceId, "SelfservicePermissions" => SelfservicePermissions
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_selfservice_permissions(
@@ -1333,6 +1461,7 @@ function modify_selfservice_permissions(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1359,6 +1488,7 @@ function modify_workspace_access_properties(
             "WorkspaceAccessProperties" => WorkspaceAccessProperties,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_workspace_access_properties(
@@ -1380,6 +1510,7 @@ function modify_workspace_access_properties(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1406,6 +1537,7 @@ function modify_workspace_creation_properties(
             "WorkspaceCreationProperties" => WorkspaceCreationProperties,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_workspace_creation_properties(
@@ -1427,6 +1559,7 @@ function modify_workspace_creation_properties(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1451,6 +1584,7 @@ function modify_workspace_properties(
             "WorkspaceId" => WorkspaceId, "WorkspaceProperties" => WorkspaceProperties
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_workspace_properties(
@@ -1472,6 +1606,7 @@ function modify_workspace_properties(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1496,6 +1631,7 @@ function modify_workspace_state(
         "ModifyWorkspaceState",
         Dict{String,Any}("WorkspaceId" => WorkspaceId, "WorkspaceState" => WorkspaceState);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function modify_workspace_state(
@@ -1516,6 +1652,7 @@ function modify_workspace_state(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1539,6 +1676,7 @@ function reboot_workspaces(
         "RebootWorkspaces",
         Dict{String,Any}("RebootWorkspaceRequests" => RebootWorkspaceRequests);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function reboot_workspaces(
@@ -1556,6 +1694,7 @@ function reboot_workspaces(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1581,6 +1720,7 @@ function rebuild_workspaces(
         "RebuildWorkspaces",
         Dict{String,Any}("RebuildWorkspaceRequests" => RebuildWorkspaceRequests);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function rebuild_workspaces(
@@ -1598,6 +1738,7 @@ function rebuild_workspaces(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1643,6 +1784,7 @@ function register_workspace_directory(
         "RegisterWorkspaceDirectory",
         Dict{String,Any}("DirectoryId" => DirectoryId, "EnableWorkDocs" => EnableWorkDocs);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function register_workspace_directory(
@@ -1663,6 +1805,7 @@ function register_workspace_directory(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1685,6 +1828,7 @@ function restore_workspace(WorkspaceId; aws_config::AbstractAWSConfig=global_aws
         "RestoreWorkspace",
         Dict{String,Any}("WorkspaceId" => WorkspaceId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function restore_workspace(
@@ -1698,6 +1842,7 @@ function restore_workspace(
             mergewith(_merge, Dict{String,Any}("WorkspaceId" => WorkspaceId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1719,6 +1864,7 @@ function revoke_ip_rules(
         "RevokeIpRules",
         Dict{String,Any}("GroupId" => GroupId, "UserRules" => UserRules);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function revoke_ip_rules(
@@ -1737,6 +1883,7 @@ function revoke_ip_rules(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1758,6 +1905,7 @@ function start_workspaces(
         "StartWorkspaces",
         Dict{String,Any}("StartWorkspaceRequests" => StartWorkspaceRequests);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function start_workspaces(
@@ -1775,6 +1923,7 @@ function start_workspaces(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1796,6 +1945,7 @@ function stop_workspaces(
         "StopWorkspaces",
         Dict{String,Any}("StopWorkspaceRequests" => StopWorkspaceRequests);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function stop_workspaces(
@@ -1813,6 +1963,7 @@ function stop_workspaces(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1848,6 +1999,7 @@ function terminate_workspaces(
         "TerminateWorkspaces",
         Dict{String,Any}("TerminateWorkspaceRequests" => TerminateWorkspaceRequests);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function terminate_workspaces(
@@ -1867,6 +2019,7 @@ function terminate_workspaces(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1902,6 +2055,7 @@ function update_connection_alias_permission(
             "AliasId" => AliasId, "ConnectionAliasPermission" => ConnectionAliasPermission
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_connection_alias_permission(
@@ -1923,6 +2077,7 @@ function update_connection_alias_permission(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1945,6 +2100,7 @@ function update_rules_of_ip_group(
         "UpdateRulesOfIpGroup",
         Dict{String,Any}("GroupId" => GroupId, "UserRules" => UserRules);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_rules_of_ip_group(
@@ -1963,6 +2119,7 @@ function update_rules_of_ip_group(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -1982,12 +2139,19 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"ImageId"`: The identifier of the image.
 """
 function update_workspace_bundle(; aws_config::AbstractAWSConfig=global_aws_config())
-    return workspaces("UpdateWorkspaceBundle"; aws_config=aws_config)
+    return workspaces(
+        "UpdateWorkspaceBundle"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function update_workspace_bundle(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return workspaces("UpdateWorkspaceBundle", params; aws_config=aws_config)
+    return workspaces(
+        "UpdateWorkspaceBundle",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -2030,6 +2194,7 @@ function update_workspace_image_permission(
             "SharedAccountId" => SharedAccountId,
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_workspace_image_permission(
@@ -2053,5 +2218,6 @@ function update_workspace_image_permission(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/services/xray.jl
+++ b/src/services/xray.jl
@@ -20,7 +20,11 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 """
 function batch_get_traces(TraceIds; aws_config::AbstractAWSConfig=global_aws_config())
     return xray(
-        "POST", "/Traces", Dict{String,Any}("TraceIds" => TraceIds); aws_config=aws_config
+        "POST",
+        "/Traces",
+        Dict{String,Any}("TraceIds" => TraceIds);
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function batch_get_traces(
@@ -35,6 +39,7 @@ function batch_get_traces(
             mergewith(_merge, Dict{String,Any}("TraceIds" => TraceIds), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -71,6 +76,7 @@ function create_group(GroupName; aws_config::AbstractAWSConfig=global_aws_config
         "/CreateGroup",
         Dict{String,Any}("GroupName" => GroupName);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_group(
@@ -85,6 +91,7 @@ function create_group(
             mergewith(_merge, Dict{String,Any}("GroupName" => GroupName), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -121,6 +128,7 @@ function create_sampling_rule(
         "/CreateSamplingRule",
         Dict{String,Any}("SamplingRule" => SamplingRule);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function create_sampling_rule(
@@ -135,6 +143,7 @@ function create_sampling_rule(
             mergewith(_merge, Dict{String,Any}("SamplingRule" => SamplingRule), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -150,12 +159,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"GroupName"`: The case-sensitive name of the group.
 """
 function delete_group(; aws_config::AbstractAWSConfig=global_aws_config())
-    return xray("POST", "/DeleteGroup"; aws_config=aws_config)
+    return xray(
+        "POST", "/DeleteGroup"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function delete_group(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return xray("POST", "/DeleteGroup", params; aws_config=aws_config)
+    return xray(
+        "POST",
+        "/DeleteGroup",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -172,12 +189,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   not both.
 """
 function delete_sampling_rule(; aws_config::AbstractAWSConfig=global_aws_config())
-    return xray("POST", "/DeleteSamplingRule"; aws_config=aws_config)
+    return xray(
+        "POST",
+        "/DeleteSamplingRule";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function delete_sampling_rule(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return xray("POST", "/DeleteSamplingRule", params; aws_config=aws_config)
+    return xray(
+        "POST",
+        "/DeleteSamplingRule",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -188,12 +216,20 @@ Retrieves the current encryption configuration for X-Ray data.
 
 """
 function get_encryption_config(; aws_config::AbstractAWSConfig=global_aws_config())
-    return xray("POST", "/EncryptionConfig"; aws_config=aws_config)
+    return xray(
+        "POST", "/EncryptionConfig"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_encryption_config(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return xray("POST", "/EncryptionConfig", params; aws_config=aws_config)
+    return xray(
+        "POST",
+        "/EncryptionConfig",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -208,12 +244,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"GroupName"`: The case-sensitive name of the group.
 """
 function get_group(; aws_config::AbstractAWSConfig=global_aws_config())
-    return xray("POST", "/GetGroup"; aws_config=aws_config)
+    return xray("POST", "/GetGroup"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function get_group(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return xray("POST", "/GetGroup", params; aws_config=aws_config)
+    return xray(
+        "POST", "/GetGroup", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -227,12 +265,14 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`: Pagination token.
 """
 function get_groups(; aws_config::AbstractAWSConfig=global_aws_config())
-    return xray("POST", "/Groups"; aws_config=aws_config)
+    return xray("POST", "/Groups"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
 end
 function get_groups(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return xray("POST", "/Groups", params; aws_config=aws_config)
+    return xray(
+        "POST", "/Groups", params; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 
 """
@@ -254,6 +294,7 @@ function get_insight(InsightId; aws_config::AbstractAWSConfig=global_aws_config(
         "/Insight",
         Dict{String,Any}("InsightId" => InsightId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_insight(
@@ -268,6 +309,7 @@ function get_insight(
             mergewith(_merge, Dict{String,Any}("InsightId" => InsightId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -295,6 +337,7 @@ function get_insight_events(InsightId; aws_config::AbstractAWSConfig=global_aws_
         "/InsightEvents",
         Dict{String,Any}("InsightId" => InsightId);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_insight_events(
@@ -309,6 +352,7 @@ function get_insight_events(
             mergewith(_merge, Dict{String,Any}("InsightId" => InsightId), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -344,6 +388,7 @@ function get_insight_impact_graph(
             "EndTime" => EndTime, "InsightId" => InsightId, "StartTime" => StartTime
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_insight_impact_graph(
@@ -366,6 +411,7 @@ function get_insight_impact_graph(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -399,6 +445,7 @@ function get_insight_summaries(
         "/InsightSummaries",
         Dict{String,Any}("EndTime" => EndTime, "StartTime" => StartTime);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_insight_summaries(
@@ -418,6 +465,7 @@ function get_insight_summaries(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -432,12 +480,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 - `"NextToken"`: Pagination token.
 """
 function get_sampling_rules(; aws_config::AbstractAWSConfig=global_aws_config())
-    return xray("POST", "/GetSamplingRules"; aws_config=aws_config)
+    return xray(
+        "POST", "/GetSamplingRules"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function get_sampling_rules(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return xray("POST", "/GetSamplingRules", params; aws_config=aws_config)
+    return xray(
+        "POST",
+        "/GetSamplingRules",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -453,12 +509,23 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
 function get_sampling_statistic_summaries(;
     aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return xray("POST", "/SamplingStatisticSummaries"; aws_config=aws_config)
+    return xray(
+        "POST",
+        "/SamplingStatisticSummaries";
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 function get_sampling_statistic_summaries(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return xray("POST", "/SamplingStatisticSummaries", params; aws_config=aws_config)
+    return xray(
+        "POST",
+        "/SamplingStatisticSummaries",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -480,6 +547,7 @@ function get_sampling_targets(
         "/SamplingTargets",
         Dict{String,Any}("SamplingStatisticsDocuments" => SamplingStatisticsDocuments);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_sampling_targets(
@@ -500,6 +568,7 @@ function get_sampling_targets(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -532,6 +601,7 @@ function get_service_graph(
         "/ServiceGraph",
         Dict{String,Any}("EndTime" => EndTime, "StartTime" => StartTime);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_service_graph(
@@ -551,6 +621,7 @@ function get_service_graph(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -585,6 +656,7 @@ function get_time_series_service_statistics(
         "/TimeSeriesServiceStatistics",
         Dict{String,Any}("EndTime" => EndTime, "StartTime" => StartTime);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_time_series_service_statistics(
@@ -604,6 +676,7 @@ function get_time_series_service_statistics(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -626,6 +699,7 @@ function get_trace_graph(TraceIds; aws_config::AbstractAWSConfig=global_aws_conf
         "/TraceGraph",
         Dict{String,Any}("TraceIds" => TraceIds);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_trace_graph(
@@ -640,6 +714,7 @@ function get_trace_graph(
             mergewith(_merge, Dict{String,Any}("TraceIds" => TraceIds), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -681,6 +756,7 @@ function get_trace_summaries(
         "/TraceSummaries",
         Dict{String,Any}("EndTime" => EndTime, "StartTime" => StartTime);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function get_trace_summaries(
@@ -700,6 +776,7 @@ function get_trace_summaries(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -727,6 +804,7 @@ function list_tags_for_resource(
         "/ListTagsForResource",
         Dict{String,Any}("ResourceARN" => ResourceARN);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function list_tags_for_resource(
@@ -741,6 +819,7 @@ function list_tags_for_resource(
             mergewith(_merge, Dict{String,Any}("ResourceARN" => ResourceARN), params)
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -770,6 +849,7 @@ function put_encryption_config(Type; aws_config::AbstractAWSConfig=global_aws_co
         "/PutEncryptionConfig",
         Dict{String,Any}("Type" => Type);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_encryption_config(
@@ -780,6 +860,7 @@ function put_encryption_config(
         "/PutEncryptionConfig",
         Dict{String,Any}(mergewith(_merge, Dict{String,Any}("Type" => Type), params));
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -806,6 +887,7 @@ function put_telemetry_records(
         "/TelemetryRecords",
         Dict{String,Any}("TelemetryRecords" => TelemetryRecords);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_telemetry_records(
@@ -822,6 +904,7 @@ function put_telemetry_records(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -865,6 +948,7 @@ function put_trace_segments(
         "/TraceSegments",
         Dict{String,Any}("TraceSegmentDocuments" => TraceSegmentDocuments);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function put_trace_segments(
@@ -883,6 +967,7 @@ function put_trace_segments(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -910,6 +995,7 @@ function tag_resource(ResourceARN, Tags; aws_config::AbstractAWSConfig=global_aw
         "/TagResource",
         Dict{String,Any}("ResourceARN" => ResourceARN, "Tags" => Tags);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function tag_resource(
@@ -929,6 +1015,7 @@ function tag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -953,6 +1040,7 @@ function untag_resource(
         "/UntagResource",
         Dict{String,Any}("ResourceARN" => ResourceARN, "TagKeys" => TagKeys);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function untag_resource(
@@ -972,6 +1060,7 @@ function untag_resource(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 
@@ -994,12 +1083,20 @@ Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys 
   with InsightsEnabled set to true.
 """
 function update_group(; aws_config::AbstractAWSConfig=global_aws_config())
-    return xray("POST", "/UpdateGroup"; aws_config=aws_config)
+    return xray(
+        "POST", "/UpdateGroup"; aws_config=aws_config, feature_set=SERVICE_FEATURE_SET
+    )
 end
 function update_group(
     params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()
 )
-    return xray("POST", "/UpdateGroup", params; aws_config=aws_config)
+    return xray(
+        "POST",
+        "/UpdateGroup",
+        params;
+        aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
+    )
 end
 
 """
@@ -1020,6 +1117,7 @@ function update_sampling_rule(
         "/UpdateSamplingRule",
         Dict{String,Any}("SamplingRuleUpdate" => SamplingRuleUpdate);
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end
 function update_sampling_rule(
@@ -1036,5 +1134,6 @@ function update_sampling_rule(
             ),
         );
         aws_config=aws_config,
+        feature_set=SERVICE_FEATURE_SET,
     )
 end

--- a/src/utilities/utilities.jl
+++ b/src/utilities/utilities.jl
@@ -115,5 +115,5 @@ function _assignment_to_kw!(expr::Expr)
 end
 
 function _assignment_to_kw!(x)
-    throw(ArgumentError("Expected assignment expression, instead found: `$x`"))
+    return throw(ArgumentError("Expected assignment expression, instead found: `$x`"))
 end

--- a/src/utilities/utilities.jl
+++ b/src/utilities/utilities.jl
@@ -103,3 +103,17 @@ function _generate_rest_resource(request_uri::String, args::AbstractDict{String,
 
     return request_uri
 end
+
+function _assignment_to_kw!(expr::Expr)
+    if expr.head === :(=)
+        expr.head = :kw
+    else
+        throw(ArgumentError("Expected assignment expression, instead found: `$expr`"))
+    end
+
+    return expr
+end
+
+function _assignment_to_kw!(x)
+    throw(ArgumentError("Expected assignment expression, instead found: `$x`"))
+end

--- a/test/AWSMetadataUtilities.jl
+++ b/test/AWSMetadataUtilities.jl
@@ -327,8 +327,8 @@ end
     Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys are:
     - `"OptionalParam"`: Optional param
     \"\"\"
-    sample_operation(RequiredParam1, RequiredParam2; aws_config::AbstractAWSConfig=global_aws_config()) = sample_service("POST", "/", Dict{String, Any}("RequiredParam1"=>RequiredParam1, "RequiredParam2"=>RequiredParam2); aws_config=aws_config)
-    sample_operation(RequiredParam1, RequiredParam2, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()) = sample_service("POST", "/", Dict{String, Any}(mergewith(_merge, Dict{String, Any}("RequiredParam1"=>RequiredParam1, "RequiredParam2"=>RequiredParam2), params)); aws_config=aws_config)
+    sample_operation(RequiredParam1, RequiredParam2; aws_config::AbstractAWSConfig=global_aws_config()) = sample_service("POST", "/", Dict{String, Any}("RequiredParam1"=>RequiredParam1, "RequiredParam2"=>RequiredParam2); aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
+    sample_operation(RequiredParam1, RequiredParam2, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()) = sample_service("POST", "/", Dict{String, Any}(mergewith(_merge, Dict{String, Any}("RequiredParam1"=>RequiredParam1, "RequiredParam2"=>RequiredParam2), params)); aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
     """
 
     result = _generate_high_level_definitions(service_name, protocol, operations, shapes)
@@ -375,8 +375,8 @@ end
             Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys are:
             - `"OptionalParam"`: This parameter is optional.
             \"\"\"
-            function_name(RequiredParam; aws_config::AbstractAWSConfig=global_aws_config()) = service_name("GET", "request_uri", Dict{String, Any}("RequiredParam"=>RequiredParam); aws_config=aws_config)
-            function_name(RequiredParam, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()) = service_name("GET", "request_uri", Dict{String, Any}(mergewith(_merge, Dict{String, Any}("RequiredParam"=>RequiredParam), params)); aws_config=aws_config)
+            function_name(RequiredParam; aws_config::AbstractAWSConfig=global_aws_config()) = service_name("GET", "request_uri", Dict{String, Any}("RequiredParam"=>RequiredParam); aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
+            function_name(RequiredParam, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()) = service_name("GET", "request_uri", Dict{String, Any}(mergewith(_merge, Dict{String, Any}("RequiredParam"=>RequiredParam), params)); aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
             """
 
             result = _generate_high_level_definition(
@@ -412,8 +412,8 @@ end
             Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys are:
             - `"OptionalParam"`: This parameter is optional.
             \"\"\"
-            function_name(RequiredParam; aws_config::AbstractAWSConfig=global_aws_config()) = service_name("FunctionName", Dict{String, Any}("RequiredParam"=>RequiredParam); aws_config=aws_config)
-            function_name(RequiredParam, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()) = service_name("FunctionName", Dict{String, Any}(mergewith(_merge, Dict{String, Any}("RequiredParam"=>RequiredParam), params)); aws_config=aws_config)
+            function_name(RequiredParam; aws_config::AbstractAWSConfig=global_aws_config()) = service_name("FunctionName", Dict{String, Any}("RequiredParam"=>RequiredParam); aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
+            function_name(RequiredParam, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()) = service_name("FunctionName", Dict{String, Any}(mergewith(_merge, Dict{String, Any}("RequiredParam"=>RequiredParam), params)); aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
             """
 
             result = _generate_high_level_definition(
@@ -462,8 +462,8 @@ end
             Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys are:
             - `"OptionalParam"`: This parameter i  s optional.
             \"\"\"
-            function_name(RequiredParam; aws_config::AbstractAWSConfig=global_aws_config()) = service_name("GET", "request_uri", Dict{String, Any}("OptionalParam"=>string(uuid4()), "headers"=>Dict{String, Any}("RequiredParam"=>RequiredParam)); aws_config=aws_config)
-            function_name(RequiredParam, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()) = service_name("GET", "request_uri", Dict{String, Any}(mergewith(_merge, Dict{String, Any}("OptionalParam"=>string(uuid4()), "headers"=>Dict{String, Any}("RequiredParam"=>RequiredParam)), params)); aws_config=aws_config)
+            function_name(RequiredParam; aws_config::AbstractAWSConfig=global_aws_config()) = service_name("GET", "request_uri", Dict{String, Any}("OptionalParam"=>string(uuid4()), "headers"=>Dict{String, Any}("RequiredParam"=>RequiredParam)); aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
+            function_name(RequiredParam, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()) = service_name("GET", "request_uri", Dict{String, Any}(mergewith(_merge, Dict{String, Any}("OptionalParam"=>string(uuid4()), "headers"=>Dict{String, Any}("RequiredParam"=>RequiredParam)), params)); aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
             """
             result = _generate_high_level_definition(
                 service_name,
@@ -498,8 +498,8 @@ end
             Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys are:
             - `"OptionalParam"`: This parameter i  s optional.
             \"\"\"
-            function_name(RequiredParam; aws_config::AbstractAWSConfig=global_aws_config()) = service_name("FunctionName", Dict{String, Any}("RequiredParam"=>RequiredParam, "OptionalParam"=>string(uuid4())); aws_config=aws_config)
-            function_name(RequiredParam, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()) = service_name("FunctionName", Dict{String, Any}(mergewith(_merge, Dict{String, Any}("RequiredParam"=>RequiredParam, "OptionalParam"=>string(uuid4())), params)); aws_config=aws_config)
+            function_name(RequiredParam; aws_config::AbstractAWSConfig=global_aws_config()) = service_name("FunctionName", Dict{String, Any}("RequiredParam"=>RequiredParam, "OptionalParam"=>string(uuid4())); aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
+            function_name(RequiredParam, params::AbstractDict{String}; aws_config::AbstractAWSConfig=global_aws_config()) = service_name("FunctionName", Dict{String, Any}(mergewith(_merge, Dict{String, Any}("RequiredParam"=>RequiredParam, "OptionalParam"=>string(uuid4())), params)); aws_config=aws_config, feature_set=SERVICE_FEATURE_SET)
             """
 
             result = _generate_high_level_definition(

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -61,3 +61,21 @@ end
 
     @test AWS._merge("a", "b") == expected
 end
+
+@testset "_assignment_to_kw!" begin
+    @testset "non-expression" begin
+        ex = :(true)
+        @test_throws ArgumentError AWS._assignment_to_kw!(ex)
+    end
+
+    @testset "non-assignment" begin
+        ex = :(a => true)
+        @test_throws ArgumentError AWS._assignment_to_kw!(ex)
+    end
+
+    @testset "assignment" begin
+        ex = :(a = true)
+        @test AWS._assignment_to_kw!(ex) == Expr(:kw, :a, true)
+        @test ex == Expr(:kw, :a, true)
+    end
+end


### PR DESCRIPTION
While working on #384 I encountered a situation where the change I was making was breaking so in order to have to make a major release I wanted to make the change opt-in. Unfortunately doing that would result in every single AWS.jl API call being modified to opt-in to the new behaviour making updating quite tedious. 

The `@service` feature support added in this PR allows end users to opt-in to new behaviour when using the `@service` macro (e.g. `@service S3 my_new_feature=true`). This interface is much more convenient and probably is a pattern we want to use for incorporating future behaviour. Currently this PR defines no features. Additionally for low-level API calls I've introduced the `set_features` function (e.g. `set_features(::Service; my_new_feature=true)`) which allows for setting the feature set to be used for a service instance.

The only issue I can think of with this is if an end user makes use of multiple `@service` calls to the same service in the same module then the last call will define the behaviour. As doing this will result in a module being redefined I don't think this is a situation anyone will notice. 