### PR TITLE
Flush I/O before reading from test file

### DIFF
--- a/test/AWS.jl
+++ b/test/AWS.jl
@@ -841,6 +841,7 @@ end
             # GET with an IO target
             mktemp() do f, io
                 S3.get_object(bucket_name, file_name, Dict("response_stream" => io))
+                flush(io)
                 @test read(f, String) == body
             end
         finally

--- a/test/minio.jl
+++ b/test/minio.jl
@@ -42,6 +42,7 @@ try
     # Test retrieving an object into a stream target
     mktemp() do f, io
         S3.get_object("anewbucket", "myobject", Dict("response_stream" => io))
+        flush(io)
         @test read(f, String) == "Hi from Minio"
     end
 


### PR DESCRIPTION
This failure occurred when running the CI tests on #453:
```
 high-level s3: Test Failed at /Users/runner/work/AWS.jl/AWS.jl/test/AWS.jl:844
  Expression: read(f, String) == body
   Evaluated: "" == "sample-file-body"
Stacktrace:
 [1] (::var"#41#43"{String, String, String})(f::String, io::IOStream)
   @ Main ~/work/AWS.jl/AWS.jl/test/AWS.jl:844
 [2] mktemp(fn::var"#41#43"{String, String, String}, parent::String)
   @ Base.Filesystem ./file.jl:703
 [3] mktemp(fn::Function)
   @ Base.Filesystem ./file.jl:701
 [4] macro expansion
   @ ~/work/AWS.jl/AWS.jl/test/AWS.jl:842 [inlined]
 [5] macro expansion
   @ /Users/julia/buildbot/worker/package_macos64/build/usr/share/julia/stdlib/v1.6/Test/src/Test.jl:1151 [inlined]
 [6] macro expansion
   @ ~/work/AWS.jl/AWS.jl/test/AWS.jl:801 [inlined]
 [7] macro expansion
   @ /Users/julia/buildbot/worker/package_macos64/build/usr/share/julia/stdlib/v1.6/Test/src/Test.jl:1151 [inlined]
 [8] top-level scope
   @ ~/work/AWS.jl/AWS.jl/test/AWS.jl:800
WARNING: replacing module S3.
WARNING: replacing module S3.
Backend: HTTPBackend: Test Failed at /Users/runner/work/AWS.jl/AWS.jl/test/minio.jl:45
  Expression: read(f, String) == "Hi from Minio"
   Evaluated: "" == "Hi from Minio"
Stacktrace:
  [1] (::var"#162#163")(f::String, io::IOStream)
    @ Main ~/work/AWS.jl/AWS.jl/test/minio.jl:45
  [2] mktemp(fn::var"#162#163", parent::String)
    @ Base.Filesystem ./file.jl:703
  [3] mktemp(fn::Function)
    @ Base.Filesystem ./file.jl:701
  [4] top-level scope
    @ ~/work/AWS.jl/AWS.jl/test/minio.jl:43
  [5] include
    @ ./client.jl:444 [inlined]
  [6] macro expansion
    @ ~/work/AWS.jl/AWS.jl/test/runtests.jl:66 [inlined]
  [7] macro expansion
    @ /Users/julia/buildbot/worker/package_macos64/build/usr/share/julia/stdlib/v1.6/Test/src/Test.jl:1226 [inlined]
  [8] macro expansion
    @ ~/work/AWS.jl/AWS.jl/test/runtests.jl:59 [inlined]
  [9] macro expansion
    @ /Users/julia/buildbot/worker/package_macos64/build/usr/share/julia/stdlib/v1.6/Test/src/Test.jl:1151 [inlined]
 [10] top-level scope
    @ ~/work/AWS.jl/AWS.jl/test/runtests.jl:52
```
– https://github.com/JuliaCloud/AWS.jl/runs/3726649750

As it turns out I already noticed this test as part of #458 but [originally thought it was a minor difference with `AWS.Response`](https://github.com/JuliaCloud/AWS.jl/pull/458#discussion_r716135918). It turns out that it is just a stochastic when using the HTTPBackend. 