### PR TITLE
Test `isopen` on `response_stream`

### DIFF
--- a/test/issues.jl
+++ b/test/issues.jl
@@ -103,7 +103,7 @@ try
             if AWS.DEFAULT_BACKEND[] isa AWS.HTTPBackend
                 @test !isopen(stream)
             else
-                @test !isopen(stream)
+                @test_broken isopen(stream)
             end
 
             stream = Base.BufferStream()

--- a/test/issues.jl
+++ b/test/issues.jl
@@ -107,7 +107,11 @@ try
             end
 
             stream = Base.BufferStream()
-            S3.get_object(BUCKET_NAME, file_name, Dict("response_stream" => stream, "return_stream" => true))
+            S3.get_object(
+                BUCKET_NAME,
+                file_name,
+                Dict("response_stream" => stream, "return_stream" => true),
+            )
             if AWS.DEFAULT_BACKEND[] isa AWS.HTTPBackend
                 @test !isopen(stream)
             else

--- a/test/issues.jl
+++ b/test/issues.jl
@@ -91,7 +91,6 @@ try
 
             # The tests below validate the current behavior of how streams are handled.
             # Note: Avoid using `eof` for these tests can hang when using an unclosed `Base.BufferStream`
-            
 
             stream = S3.get_object(BUCKET_NAME, file_name, Dict("return_stream" => true))
             if AWS.DEFAULT_BACKEND[] isa AWS.HTTPBackend

--- a/test/issues.jl
+++ b/test/issues.jl
@@ -89,7 +89,9 @@ try
         try
             S3.put_object(BUCKET_NAME, file_name)
 
+            # The tests below validate the current behavior of how streams are handled.
             # Note: Avoid using `eof` for these tests can hang when using an unclosed `Base.BufferStream`
+            
 
             stream = S3.get_object(BUCKET_NAME, file_name, Dict("return_stream" => true))
             if AWS.DEFAULT_BACKEND[] isa AWS.HTTPBackend
@@ -103,6 +105,7 @@ try
             if AWS.DEFAULT_BACKEND[] isa AWS.HTTPBackend
                 @test !isopen(stream)
             else
+                # See: https://github.com/JuliaCloud/AWS.jl/issues/471
                 @test_broken isopen(stream)
             end
 

--- a/test/issues.jl
+++ b/test/issues.jl
@@ -88,10 +88,31 @@ try
 
         try
             S3.put_object(BUCKET_NAME, file_name)
+
+            # Note: Avoid using `eof` for these tests can hang when using an unclosed `Base.BufferStream`
+
             stream = S3.get_object(BUCKET_NAME, file_name, Dict("return_stream" => true))
-            println("test #466")  # So we know if this is the reason for tests hanging.
-            @test eof(stream)  # This will hang if #466 not fixed and using HTTP.jl v0.9.15+
-            println("#466 fixed")
+            if AWS.DEFAULT_BACKEND[] isa AWS.HTTPBackend
+                @test !isopen(stream)
+            else
+                @test isopen(stream)
+            end
+
+            stream = Base.BufferStream()
+            S3.get_object(BUCKET_NAME, file_name, Dict("response_stream" => stream))
+            if AWS.DEFAULT_BACKEND[] isa AWS.HTTPBackend
+                @test !isopen(stream)
+            else
+                @test !isopen(stream)
+            end
+
+            stream = Base.BufferStream()
+            S3.get_object(BUCKET_NAME, file_name, Dict("response_stream" => stream, "return_stream" => true))
+            if AWS.DEFAULT_BACKEND[] isa AWS.HTTPBackend
+                @test !isopen(stream)
+            else
+                @test isopen(stream)
+            end
         finally
             S3.delete_object(BUCKET_NAME, file_name)
         end

--- a/test/minio.jl
+++ b/test/minio.jl
@@ -62,6 +62,9 @@ try
     @test sort(getindex.(objs_prefix["Contents"], "Key")) == ["empty", "myobject"]
     @test objs_prefix["CommonPrefixes"]["Prefix"] == "foo/"
 
+    # Duplicated testset from "test/issues.jl". Useful for testing outside the CI. Ideally,
+    # the tests should be revised such that local testing works without having to duplicate
+    # testsets.
     @testset "issue 466" begin
         file_name = "hang.txt"
 
@@ -82,7 +85,7 @@ try
             if AWS.DEFAULT_BACKEND[] isa AWS.HTTPBackend
                 @test !isopen(stream)
             else
-                @test !isopen(stream)
+                @test_broken isopen(stream)
             end
 
             stream = Base.BufferStream()

--- a/test/minio.jl
+++ b/test/minio.jl
@@ -89,7 +89,11 @@ try
             end
 
             stream = Base.BufferStream()
-            S3.get_object("anewbucket", file_name, Dict("response_stream" => stream, "return_stream" => true))
+            S3.get_object(
+                "anewbucket",
+                file_name,
+                Dict("response_stream" => stream, "return_stream" => true),
+            )
             if AWS.DEFAULT_BACKEND[] isa AWS.HTTPBackend
                 @test !isopen(stream)
             else


### PR DESCRIPTION
Follow up to #467 and #466. The original test for issue #466 used `eof` which could cause the tests to hang if the code was configured incorrectly. The tests have been revised to use `isopen` which doesn't have this issue.

I further improved upon the tests by checking the behaviour of using `"response_stream"` and `"return_stream"`. As it turns out it has revealed a bug with the `DownloadsBackend` which I won't be fixing at this time (#471)

Finally, I also duplicated this test suite for MinIO as this allows this behaviour to be tested locally and not just on the CI. I can remove this if desired.