### PR TITLE
Always use us-east-1 as the signing region for IAM

### DIFF
--- a/src/utilities/sign.jl
+++ b/src/utilities/sign.jl
@@ -50,8 +50,14 @@ function sign_aws4!(aws::AbstractAWSConfig, request::Request, time::DateTime)
     date = Dates.format(time, dateformat"yyyymmdd")
     datetime = Dates.format(time, dateformat"yyyymmdd\THHMMSS\Z")
 
+    # TODO 1: Pass the signing region in with the request as done in aws-sdk-js
+    #   https://github.com/aws/aws-sdk-js/blob/f017a848edb61456cf002c5c00bd5c7cca8a132f/lib/signers/v4.js#L101
+    # TODO 2: Autodetect this from the service configuration somehow
+    #   https://github.com/aws/aws-sdk-js/blob/307e82673b48577fce4389e4ce03f95064e8fe0d/lib/request.js#L316
+    signing_region = request.service == "iam" ? "us-east-1" : region(aws)
+
     # Authentication scope...
-    authentication_scope = [date, region(aws), request.service, "aws4_request"]
+    authentication_scope = [date, signing_region, request.service, "aws4_request"]
 
     creds = check_credentials(credentials(aws))
     signing_key = "AWS4$(creds.secret_key)"


### PR DESCRIPTION
Without this, temporary credentials arising from assuming a role from a
profile using an MFA token (in non-default region!) cannot connect to
IAM.

Specifically, I've got a profile set up in the following form in .aws/config

```ini
[profile main]
region = ap-southeast-2

[default]
region = ap-southeast-2
source_profile = main
mfa_serial = arn:aws:iam::1111111111111:mfa/User
role_arn = arn:aws:iam::1111111111111:role/OrganizationAccountAccessRole
duration_seconds = 14400
```

With this, I get an error of the following kind when calling IAM:

```
julia> conf = AWSConfig()
Enter MFA code for arn:aws:iam::...:mfa/...: 
AWSConfig((... 2021-10-08T10:15:10), "ap-southeast-2", "json")


julia> AWS.AWSServices.iam("ListRolePolicies", Dict("RoleName"=>"ChrisFosterTestRole"); aws_config=conf)
ERROR: AWS.AWSExceptions.AWSException: SignatureDoesNotMatch -- Credential should be scoped to a valid region, not 'ap-southeast-2'.

HTTP.ExceptionRequest.StatusError(403, "POST", "/", HTTP.Messages.Response:
"""
HTTP/1.1 403 Forbidden
x-amzn-RequestId: 0e2bf76b-1c85-4313-882d-e25948e1a333
Content-Type: text/xml
Content-Length: 322
Date: Fri, 08 Oct 2021 06:45:05 GMT

[Message Body was streamed]""")

<ErrorResponse xmlns="https://iam.amazonaws.com/doc/2010-05-08/">
  <Error>
    <Type>Sender</Type>
    <Code>SignatureDoesNotMatch</Code>
    <Message>Credential should be scoped to a valid region, not 'ap-southeast-2'. </Message>
  </Error>
  <RequestId>0e2bf76b-1c85-4313-882d-e25948e1a333</RequestId>
</ErrorResponse>
```

Currently this is rather hacky compared to `aws-sdk-js`, but I've run out of time to shave this yak any further right now, so I thought I'd just put up a the current somewhat ugly version of the solution.