### PR TITLE
Add AWSException fallback to replicate old constructor

### DIFF
--- a/src/AWSExceptions.jl
+++ b/src/AWSExceptions.jl
@@ -31,6 +31,10 @@ struct AWSException <: Exception
     streamed_body::Union{String,Nothing}
 end
 
+function AWSException(code, message, info, cause)
+    return AWSException(code, message, info, cause, nothing)
+end
+
 function Base.show(io::IO, e::AWSException)
     print(io, AWSException, ": ", e.code)
     !isempty(e.message) && print(io, " -- ", e.message)


### PR DESCRIPTION
Fixes https://github.com/invenia/CloudWatchLogs.jl/issues/40

When AWSResponse changes went in, a new field was added. CloudWatchLogs.jl tests relied on the default constructor, so when a field was added, tests broke. This adds a fallback that replicates the old constructor. It's also a reasonable fallback I think, given that the final field is optional (could be `nothing`). 