### PR TITLE
Avoid hiding streamed content with internal errors

### DIFF
--- a/src/utilities/response.jl
+++ b/src/utilities/response.jl
@@ -37,7 +37,7 @@ function mime_type(r::Response)
 
     T = if occursin(r"/xml", mime) || magic_bytes == b"<?xml"
         MIME"application/xml"
-    elseif occursin(r"/x-amz-json-1.[01]$", mime) || endswith(mime, "json")
+    elseif occursin(r"/x-amz-json-1\.[01]$", mime) || endswith(mime, "json")
         MIME"application/json"
     elseif startswith(mime, "text/")
         MIME"text/plain"


### PR DESCRIPTION
I encountered this when working on AWSS3 where the error returned was:
```
XMLError: XML declaration allowed only at the start of the document from XML parser (code: 64, line: 2)
```
but the streaming content was not shown so I couldn't investigate further. With a POC version of this PR I managed to see the streaming content:
```
  <?xml version="1.0" encoding="UTF-8"?>
  <Error><Code>NotImplemented</Code><Message>A header you provided implies functionality that is not implemented</Message><BucketName>ocaws.jl.test.20211029t193302z</BucketName><Resource>/ocaws.jl.test.20211029t193302z</Resource><RequestId>16B29752DB5BE300</RequestId><HostId>b3a8880e-5b1b-44ff-9155-7653d625b88e</HostId></Error><?xml version="1.0" encoding="UTF-8"?>
  <Error><Code>NotImplemented</Code><Message>A header you provided implies functionality that is not implemented</Message><BucketName>ocaws.jl.test.20211029t193302z</BucketName><Resource>/ocaws.jl.test.20211029t193302z</Resource><RequestId>16B29752DF0ACDB8</RequestId><HostId>b3a8880e-5b1b-44ff-9155-7653d625b88e</HostId></Error><?xml version="1.0" encoding="UTF-8"?>
  <Error><Code>NotImplemented</Code><Message>A header you provided implies functionality that is not implemented</Message><BucketName>ocaws.jl.test.20211029t193302z</BucketName><Resource>/ocaws.jl.test.20211029t193302z</Resource><RequestId>16B29752FF5DD3F8</RequestId><HostId>b3a8880e-5b1b-44ff-9155-7653d625b88e</HostId></Error><?xml version="1.0" encoding="UTF-8"?>
  <Error><Code>NotImplemented</Code><Message>A header you provided implies functionality that is not implemented</Message><BucketName>ocaws.jl.test.20211029t193302z</BucketName><Resource>/ocaws.jl.test.20211029t193302z</Resource><RequestId>16B2975417EDF488</RequestId><HostId>b3a8880e-5b1b-44ff-9155-7653d625b88e</HostId></Error>
```

This change should ensure that internal parsing failures don't mask the actual failure being returned from the API.