### PR TITLE
Refactor requests write to `response_stream` once

### DIFF
--- a/src/utilities/downloads_backend.jl
+++ b/src/utilities/downloads_backend.jl
@@ -53,8 +53,8 @@ function _http_request(backend::DownloadsBackend, request::Request, response_str
     # need to do this on per-request downloaders, because we
     # set our global one with this hook already.
     if backend.downloader !== nothing && downloader.easy_hook === nothing
-        downloader.easy_hook = (easy, info) ->
-            Curl.setopt(easy, Curl.CURLOPT_FOLLOWLOCATION, false)
+        downloader.easy_hook =
+            (easy, info) -> Curl.setopt(easy, Curl.CURLOPT_FOLLOWLOCATION, false)
     end
 
     local buffer

--- a/src/utilities/downloads_backend.jl
+++ b/src/utilities/downloads_backend.jl
@@ -41,56 +41,41 @@ function read_body(x::IO)
 end
 
 function _http_request(backend::DownloadsBackend, request::Request, response_stream::IO)
-    # If we pass `output`, older versions of Downloads.jl will
-    # expect a message body in the response. Specifically, it sets
-    # <https://curl.se/libcurl/c/CURLOPT_NOBODY.html>
-    # only when we do not pass the `output` argument.
-    # See <https://github.com/JuliaLang/Downloads.jl/issues/131>.
-    #
-    # When the method is `HEAD`, the response may have a Content-Length
-    # but not send any content back (which appears to be correct,
-    # <https://stackoverflow.com/a/18925736/12486544>).
-    #
-    # Thus, if we did not set `CURLOPT_NOBODY`, and it gets a Content-Length
-    # back, it will hang waiting for that body.
-    #
-    # Therefore, we do not pass an `output` when the `request_method` is `HEAD`.
-    # (Note: this is fixed on the latest Downloads.jl, but we include this workaround
-    #  for compatability).
-    output = request.request_method != "HEAD" ? response_stream : nothing
-
     # HTTP.jl sets this header automatically.
     request.headers["Content-Length"] = string(body_length(request.content))
 
     # We pass an `input` only when we have content we wish to send.
     input = !isempty(request.content) ? IOBuffer(request.content) : nothing
 
-    max_attempts = 4
-    attempt = 0
-    @repeat max_attempts try
-        attempt += 1
-        downloader = @something(backend.downloader, get_downloader())
-        # set the hook so that we don't follow redirects. Only
-        # need to do this on per-request downloaders, because we
-        # set our global one with this hook already.
-        if backend.downloader !== nothing && downloader.easy_hook === nothing
-            downloader.easy_hook =
-                (easy, info) -> Curl.setopt(easy, Curl.CURLOPT_FOLLOWLOCATION, false)
+    downloader = @something(backend.downloader, get_downloader())
+
+    # set the hook so that we don't follow redirects. Only
+    # need to do this on per-request downloaders, because we
+    # set our global one with this hook already.
+    if backend.downloader !== nothing && downloader.easy_hook === nothing
+        downloader.easy_hook = function (easy, info)
+            Curl.setopt(easy, Curl.CURLOPT_FOLLOWLOCATION, false)
         end
+    end
 
-        # We seekstart on every attempt, otherwise every attempt
-        # but the first will send an empty payload.
-        input !== nothing && seekstart(input)
+    local buffer
+    local response
+    try
+        @repeat 4 try
+            # Use a sacrificial I/O stream so that we only write the `response_stream` once
+            # even with multiple attempts.
+            buffer = Base.BufferStream()
 
-        # Because Downloads will write incomplete stream failures to the provided output buffer
-        # a sacrificial buffer is needed so that incomplete data can be discarded
-        buffer = isnothing(output) ? nothing : Base.BufferStream()
-        should_write = true
-        response = try
-            @mock Downloads.request(
+            # Rewind the input on each attempt otherwise every subsequent attempt will send an
+            # empty payload.
+            input !== nothing && seekstart(input)
+
+            response = @mock Downloads.request(
                 request.url;
                 input=input,
-                output=buffer,
+                # Compatibility with Downloads.jl versions below v1.5.2
+                # See: https://github.com/JuliaLang/Downloads.jl/issues/131
+                output=request.request_method != "HEAD" ? buffer : nothing,
                 method=request.request_method,
                 headers=request.headers,
                 verbose=false,
@@ -98,42 +83,32 @@ function _http_request(backend::DownloadsBackend, request::Request, response_str
                 downloader=downloader,
             )
         catch e
-            if e isa Downloads.RequestError && e.code == 18
-                # Downloads.RequestError 18 indicates an incomplete transfer, so don't pass the buffer forward
-                should_write = false
-            end
-            rethrow()
-        finally
-            if !isnothing(output)
-                close(buffer)
-                # Transfer the contents of the `BufferStream` into `response_stream` variable.
-                # but only if no EOFError error because of a broken connection OR it's the final attempt.
-                # i.e. Multiple EOFError retries shouldn't be passed to the `response_stream`
-                if should_write || attempt == max_attempts
-                    write(response_stream, buffer)
-                end
-            end
-        end
-
-        http_response = HTTP.Response(
-            response.status, response.headers; body=body_was_streamed, request=nothing
-        )
-
-        if HTTP.iserror(http_response)
-            target = HTTP.resource(HTTP.URI(request.url))
-            throw(
-                HTTP.StatusError(
-                    http_response.status, request.request_method, target, http_response
-                ),
+            @delay_retry if (
+                (isa(e, HTTP.StatusError) && AWS._http_status(e) >= 500) ||
+                isa(e, Downloads.RequestError)
             )
+            end
         end
+    finally
+        close(buffer)
 
-        return AWS.Response(http_response, response_stream)
-    catch e
-        @delay_retry if (
-            (isa(e, HTTP.StatusError) && AWS._http_status(e) >= 500) ||
-            isa(e, Downloads.RequestError)
-        )
-        end
+        # Transfer the contents of the `BufferStream` into `response_stream` variable.
+        write(response_stream, buffer)
     end
+
+    http_response = HTTP.Response(
+        response.status, response.headers; body=body_was_streamed, request=nothing
+    )
+
+    if HTTP.iserror(http_response)
+        target = HTTP.resource(HTTP.URI(request.url))
+        throw(
+            HTTP.StatusError(
+                http_response.status, request.request_method, target, http_response
+            ),
+        )
+    end
+
+    return AWS.Response(http_response, response_stream)
+
 end

--- a/src/utilities/downloads_backend.jl
+++ b/src/utilities/downloads_backend.jl
@@ -53,9 +53,8 @@ function _http_request(backend::DownloadsBackend, request::Request, response_str
     # need to do this on per-request downloaders, because we
     # set our global one with this hook already.
     if backend.downloader !== nothing && downloader.easy_hook === nothing
-        downloader.easy_hook = function (easy, info)
+        downloader.easy_hook = (easy, info) ->
             Curl.setopt(easy, Curl.CURLOPT_FOLLOWLOCATION, false)
-        end
     end
 
     local buffer
@@ -110,5 +109,4 @@ function _http_request(backend::DownloadsBackend, request::Request, response_str
     end
 
     return AWS.Response(http_response, response_stream)
-
 end

--- a/src/utilities/request.jl
+++ b/src/utilities/request.jl
@@ -153,8 +153,8 @@ function _http_request(http_backend::HTTPBackend, request::Request, response_str
     local response
     try
         @repeat 4 try
-            # Use a sacrificial I/O stream so that we only write the `response_stream` once
-            # even with multiple attempted requests. Additionally this works around the
+            # Use a sacrificial I/O stream so that we only write to the `response_stream`
+            # once even with multiple attempted requests. Additionally this works around the
             # HTTP.jl issue (https://github.com/JuliaWeb/HTTP.jl/issues/543) where the
             # `response_stream` is closed automatically. Effectively, this works as if we're
             # not using streaming I/O at all, as we write all data at once, but only


### PR DESCRIPTION
Follow up to: https://github.com/JuliaCloud/AWS.jl/pull/516#discussion_r756212793

By making the repeat try/catch the innermost one we can eliminate having to keep track of the number of attempts.