### PR TITLE
Treat 'RoleArn' as an optional field when fetching ECS credentials

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AWS"
 uuid = "fbe9abb3-538b-5e4e-ba9e-bc94f4f92ebc"
 license = "MIT"
-version = "1.74.0"
+version = "1.74.1"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/AWSCredentials.jl
+++ b/src/AWSCredentials.jl
@@ -339,7 +339,8 @@ function ecs_instance_credentials()
         new_creds["AccessKeyId"],
         new_creds["SecretAccessKey"],
         new_creds["Token"],
-        new_creds["RoleArn"];
+        # The RoleArn field may not be present for Amazon SageMaker jobs
+        get(new_creds, "RoleArn", "");
         expiry=expiry,
         renew=ecs_instance_credentials,
     )


### PR DESCRIPTION
Port the following changes made to AWSCore.jl: https://github.com/JuliaCloud/AWSCore.jl/pull/139

> The [ECS developers guide](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html) implies that the `RoleArn` field should always be returned when querying the container's credential endpoint, however this isn't always the case for Amazon SageMaker jobs.
>
>Amazon avoids this in [botocore](https://github.com/boto/botocore/blob/21b06efb39da61fe4101ab9709140dc1e51dc33d/botocore/credentials.py#L1886-L1889) by not accessing the `RoleArn` field.