### PR TITLE
Update for correct bucket naming for list_objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ For example again, to list the objects in an S3 bucket:
 using AWS: @service
 @service S3
 
-S3.list_objects("/your-bucket")
+S3.list_objects("your-bucket")
 ```
 
 The high-level function calls are wrapped around the low-level function calls, meaning you can still pass along any low-level `kwargs` such as `aws_config` when making these requests.


### PR DESCRIPTION
This works:
a = S3.list_objects_v2("your-bucket")

This does not (as described in readme)
a = S3.list_objects_v2("/your-bucket")

Also NOTE that this is opposite for s3("GET",
using AWS.AWSServices: s3
s3("GET", "/your-bucket")
and this does not
using AWS.AWSServices: s3
s3("GET", "your-bucket")

Documentation also needs updating