### PR TITLE
Consume buffer when creating AWSException

### DIFF
--- a/src/AWSExceptions.jl
+++ b/src/AWSExceptions.jl
@@ -55,6 +55,7 @@ function Base.show(io::IO, e::AWSException)
 end
 
 AWSException(e::HTTP.StatusError) = AWSException(e, String(copy(e.response.body)))
+AWSException(e::HTTP.StatusError, io::IOBuffer) = AWSException(e, String(take!(io)))
 
 function AWSException(e::HTTP.StatusError, stream::IO)
     seekstart(stream)


### PR DESCRIPTION
At least partially fixes #537. While investigating the depths of how AWS.jl
and HTTP.jl interact, and working on several PRs to improve HTTP.jl, I
noticed a pretty simple way to fix #537 in the most common case where
the user doesn't pass in their own response_stream. Because the default
response_stream is an `IOBuffer`, we can "consume" it's contents when
an AWSException is thrown and thus when the request is retried, the buffer
will be "clean" in that the exception response body has been extracted.