### PR TITLE
Update minor version to 1.75.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AWS"
 uuid = "fbe9abb3-538b-5e4e-ba9e-bc94f4f92ebc"
 license = "MIT"
-version = "1.74.1"
+version = "1.75.0"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"


### PR DESCRIPTION
MR to update the version in case @ericphanson @omus don't think the retry changes are ready to be tagged as-is. Otherwise I will backport https://github.com/JuliaCloud/AWS.jl/pull/557 to 1.74