### PR TITLE
RFC: Support S3 Acceleration, and move to Virtualhost Requests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -38,8 +38,8 @@ julia = "1.6"
 
 [extras]
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
-Suppressor = "fd094767-a336-5f1f-9728-57cf17d0bbfb"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
+Suppressor = "fd094767-a336-5f1f-9728-57cf17d0bbfb"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 

--- a/src/AWS.jl
+++ b/src/AWS.jl
@@ -227,7 +227,7 @@ function generate_service_url(
 
     # S3 virtualhosts cannot have periods in their bucket names, default to path style in these cases
     if service == "s3" && !contains(resource, ".")
-        return s3_virtualhost(service, resource, region; s3_acceleration=s3_acceleration)
+        return s3_virtualhost(service, resource, reg; s3_acceleration=s3_acceleration)
     end
 
     regionless_services = ("iam", "route53")

--- a/src/AWS.jl
+++ b/src/AWS.jl
@@ -217,7 +217,12 @@ end
 # Needs to be included after the definition of struct otherwise it cannot find them
 include("AWSServices.jl")
 
-function generate_service_url(aws::AbstractAWSConfig, service::String, resource::String; s3_acceleration::Bool=use_s3_acceleration[])
+function generate_service_url(
+    aws::AbstractAWSConfig,
+    service::String,
+    resource::String;
+    s3_acceleration::Bool=use_s3_acceleration[],
+)
     reg = region(aws)
 
     # S3 virtualhosts cannot have periods in their bucket names, default to path style in these cases
@@ -236,7 +241,12 @@ function generate_service_url(aws::AbstractAWSConfig, service::String, resource:
     )
 end
 
-function s3_virtualhost(service::AbstractString, resource::AbstractString, region::AbstractString; s3_acceleration=nothing)
+function s3_virtualhost(
+    service::AbstractString,
+    resource::AbstractString,
+    region::AbstractString;
+    s3_acceleration=nothing,
+)
     if something(s3_acceleration, use_s3_acceleration[])
         service = "s3-accelerated"
     end
@@ -313,8 +323,10 @@ function (service::RestXMLService)(
     end
 
     request.url = generate_service_url(
-        aws_config, service.endpoint_prefix, request.resource;
-        s3_acceleration=s3_acceleration
+        aws_config,
+        service.endpoint_prefix,
+        request.resource;
+        s3_acceleration=s3_acceleration,
     )
 
     return submit_request(aws_config, request; return_headers=return_headers)

--- a/src/utilities/utilities.jl
+++ b/src/utilities/utilities.jl
@@ -159,3 +159,9 @@ function Base.iterate(exp::AWSExponentialBackoff, i=1)
     delay = min(b * r^i, exp.max_backoff)
     return delay, i + 1
 end
+
+function _generate_path_url(service, reg, resource)
+    return string(
+        "https://", service, ".", isempty(reg) ? "" : "$reg.", SERVICE_HOST[], resource
+    )
+end


### PR DESCRIPTION
## Problem

AWS apparently has plans to [deprecate path-styled requests](https://aws.amazon.com/blogs/aws/amazon-s3-path-deprecation-plan-the-rest-of-the-story/) in the future, these style is currently what we are doing and look like:

> https://s3.us-east-1.amazonaws.com/mattbr-open-world/foobar

The new style of requests are virtualhost, which look like:

> https://mattbr-open-world.s3.amazonaws.com/foobar

We also would like to make use of [S3 Transfer Acceleration](https://docs.aws.amazon.com/AmazonS3/latest/userguide/transfer-acceleration.html#transfer-acceleration-getting-started). Which uses virtualhost however instead of just `s3` it's `s3-accelerated`.

The only caveat for virtualhost which I've come across from the documentation is that the bucket cannot have a `.` character in its name (which is a valid character currently).

## Solution

This PR has a proposed solution for it with our existing code. It does get a bit messy as there are a few use cases we want to handle here. Specifically for S3 Acceleration, this option is disabled by default and is on a per-bucket and request basis. I've added a `use_s3_acceleration = Ref{Bool}(false)` which users can set much like the default `AWSConfig` to allow all requests to use acceleration. If you only wish to accelerate on certain requests the argument `s3_acceleration` can be passed along.

The other quirky part when making requests we cannot pass along an HTTP `resource`, we need to directly specify this in the `URL` of the requests for what we're targeting. This gets a bit messy as a request such as:

```julia
S3.get_object("mattbr-open-world, "foobar")
```

Will go to the [underlying code](https://github.com/JuliaCloud/AWS.jl/blob/de0d4c30b7e735a0303af6e4aa92b60c4962dad9/src/services/s3.jl#L2626) and pass the resource along as `/mattbr-open-world/foobar`. We need the ability to split out the `bucket` from the `key` as well as maintain the `query` arguments as well. This PR handles these cases, and I've commented what it's doing, but it's not that nice.

Thoughts?