### PR TITLE
Get the region from the IMDS

### DIFF
--- a/src/AWSCredentials.jl
+++ b/src/AWSCredentials.jl
@@ -232,7 +232,12 @@ end
 Determine the AWS region of the machine executing this code if running inside of an EC2
 instance, otherwise `nothing` is returned.
 """
-ec2_instance_region() = ec2_instance_metadata("/latest/meta-data/placement/region")
+ec2_instance_region() =
+    try
+        ec2_instance_metadata("/latest/meta-data/placement/region")
+    catch
+        nothing
+    end
 
 """
     ec2_instance_credentials(profile::AbstractString) -> AWSCredentials

--- a/src/AWSCredentials.jl
+++ b/src/AWSCredentials.jl
@@ -550,7 +550,8 @@ precedence mirrors what is [used by the AWS CLI](https://docs.aws.amazon.com/cli
 1. Environmental variable: as specified by the `AWS_DEFAULT_REGION` environmental variable.
 2. AWS configuration file: `region` as specified by the `profile` in the configuration
    file, typically "~/.aws/config".
-3. Default region: use the specified `default`, typically "$DEFAULT_REGION".
+3. Instance metadata service on an Amazon EC2 instance that has an IAM role configured
+4. Default region: use the specified `default`, typically "$DEFAULT_REGION".
 
 # Keywords
 - `profile`: Name of the AWS configuration profile, if any. Defaults to `nothing` which
@@ -564,6 +565,7 @@ function aws_get_region(; profile=nothing, config=nothing, default=DEFAULT_REGIO
     @something(
         get(ENV, "AWS_DEFAULT_REGION", nothing),
         get(_aws_profile_config(config, profile), "region", nothing),
+        ec2_instance_region(),
         Some(default),
     )
 end

--- a/test/AWSCredentials.jl
+++ b/test/AWSCredentials.jl
@@ -798,5 +798,17 @@ end
                 @test aws_get_region() == AWS.DEFAULT_REGION
             end
         end
+
+        @testset "instance profile" begin
+            withenv("AWS_DEFAULT_REGION" => nothing, "AWS_CONFIG_FILE" => tempname()) do
+                patch = @patch function HTTP.request(method::String, url; kwargs...)
+                    return HTTP.Response("ap-atlantis-1")  # Made up region
+                end
+
+                apply(patch) do
+                    @test aws_get_region() == "ap-atlantis-1"
+                end
+            end
+        end
     end
 end


### PR DESCRIPTION
This PR adds a step in `aws_get_region` to try the IMDS. This is in line with what the [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html#cli-configure-quickstart-precedence) does.
