### PR TITLE
attempt to increase compat bounds for Compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -22,7 +22,7 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 XMLDict = "228000da-037f-5747-90a9-8195ccbf91a5"
 
 [compat]
-Compat = "3.29"
+Compat = "4.2"
 GitHub = "5"
 HTTP = "1"
 IniFile = "0.5"


### PR DESCRIPTION
I have not attempted to test this but it is starting to wreak havoc for me.  I figured this was better than just opening an issue.

Btw something is wrong with tagbot for Compat.jl, the github tags are out of sync with the registry.