### PR TITLE
Remove mention of Downloads.jl having threading issues

### DIFF
--- a/src/utilities/downloads_backend.jl
+++ b/src/utilities/downloads_backend.jl
@@ -12,7 +12,7 @@ which is the `Downloads.Downloader` to use. If set to `nothing`, the default,
 then a global downloader object will be used.
 
 Downloads.jl tends to perform better under concurrent operation than HTTP.jl,
-particularly with `@async` / `asyncmap`.
+particularly with `@async` / `asyncmap`. Note that threading (e.g. `@spawn` or `@threads`) with Downloads.jl is broken on Julia releases prior to 1.8 (https://github.com/JuliaLang/Downloads.jl/issues/182#issuecomment-1069269944).
 """
 struct DownloadsBackend <: AWS.AbstractBackend
     downloader::Union{Nothing,Downloads.Downloader}


### PR DESCRIPTION
The issues mentioned in the comment are closed, and seem fixed based on a cursory look at the comments there:
- https://github.com/JuliaLang/Downloads.jl/issues/110 (closed in Nov 2021)
- https://github.com/JuliaLang/Downloads.jl/issues/182 (closed in Apr 2022)

Is it fair to say Downloads.jl doesn't have threading issues anymore? I have zero knowledge around this, just trying to understand how safe it is to use this backend for our use case (at Invenia) where threading might be used.
