### PR TITLE
Fix AWSException construction for JSON-encoded responses with invalid bodies

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AWS"
 uuid = "fbe9abb3-538b-5e4e-ba9e-bc94f4f92ebc"
 license = "MIT"
-version = "1.84.0"
+version = "1.84.1"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/AWSExceptions.jl
+++ b/src/AWSExceptions.jl
@@ -110,7 +110,7 @@ function AWSException(e::HTTP.StatusError, body::AbstractString)
     end
 
     # Sometimes info is a string, in which case there is nothing else to do
-    if (info isa AbstractDict)
+    if info isa AbstractDict
         # There are times when Errors or Error are returned back
         info = get(info, "Errors", info)
         info = get(info, "Error", info)

--- a/src/AWSExceptions.jl
+++ b/src/AWSExceptions.jl
@@ -109,15 +109,18 @@ function AWSException(e::HTTP.StatusError, body::AbstractString)
         end
     end
 
-    # There are times when Errors or Error are returned back
-    info = get(info, "Errors", info)
-    info = get(info, "Error", info)
+    # Sometimes info is a string, in which case there is nothing else to do
+    if (info isa AbstractDict)
+        # There are times when Errors or Error are returned back
+        info = get(info, "Errors", info)
+        info = get(info, "Error", info)
 
-    code = get(info, "Code", code)
+        code = get(info, "Code", code)
 
-    # There are also times when the response back is (M|m)essage
-    message = get(info, "Message", message)
-    message = get(info, "message", message)
+        # There are also times when the response back is (M|m)essage
+        message = get(info, "Message", message)
+        message = get(info, "message", message)
+    end
 
     streamed_body = !HTTP.isbytes(e.response.body) ? body : nothing
 


### PR DESCRIPTION
This PR fixes a bug I ran into when receiving a JSON-encoded response with an invalid JSON body.
I received this response from a custom API GW endpoint, not from an official AWS endpoint.
