### PR TITLE
Support `credential_process` config setting

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AWS"
 uuid = "fbe9abb3-538b-5e4e-ba9e-bc94f4f92ebc"
 license = "MIT"
-version = "1.84.1"
+version = "1.85.0"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/Project.toml
+++ b/Project.toml
@@ -23,7 +23,7 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 XMLDict = "228000da-037f-5747-90a9-8195ccbf91a5"
 
 [compat]
-Compat = "3.29, 4"
+Compat = "3.32, 4"
 GitHub = "5"
 HTTP = "1"
 IniFile = "0.5"

--- a/src/AWS.jl
+++ b/src/AWS.jl
@@ -1,6 +1,6 @@
 module AWS
 
-using Compat: Compat, @something
+using Compat: Compat, @compat, @something
 using Base64
 using Dates
 using Downloads: Downloads, Downloader, Curl

--- a/src/AWSCredentials.jl
+++ b/src/AWSCredentials.jl
@@ -8,22 +8,22 @@ using ..AWSExceptions
 
 export AWSCredentials,
     aws_account_number,
-    aws_get_region,
     aws_get_profile_settings,
+    aws_get_region,
     aws_user_arn,
     check_credentials,
+    credentials_from_webtoken,
     dot_aws_config,
+    dot_aws_config_file,
     dot_aws_credentials,
     dot_aws_credentials_file,
-    dot_aws_config_file,
     ec2_instance_credentials,
     ecs_instance_credentials,
     env_var_credentials,
+    external_process_credentials,
     localhost_is_ec2,
-    localhost_maybe_ec2,
     localhost_is_lambda,
-    credentials_from_webtoken,
-    external_process_credentials
+    localhost_maybe_ec2
 
 function localhost_maybe_ec2()
     return localhost_is_ec2() || isfile("/sys/devices/virtual/dmi/id/product_uuid")

--- a/src/AWSCredentials.jl
+++ b/src/AWSCredentials.jl
@@ -430,7 +430,7 @@ function dot_aws_config(profile=nothing)
 
         if !isnothing(credential_process)
             cmd = Cmd(Base.shell_split(credential_process))
-            return credential_process_credentials(cmd)
+            return external_process_credentials(cmd)
         elseif !isnothing(access_key)
             access_key, secret_key, token = _aws_get_credential_details(p, ini)
             return AWSCredentials(access_key, secret_key, token)
@@ -563,7 +563,7 @@ function credentials_from_webtoken()
     )
 end
 
-function credential_process_credentials(cmd::Base.AbstractCmd)
+function external_process_credentials(cmd::Base.AbstractCmd)
     nt = open(cmd, "r") do io
         _read_credential_process(io)
     end
@@ -572,7 +572,7 @@ function credential_process_credentials(cmd::Base.AbstractCmd)
         nt.secret_access_key,
         nt.session_token;
         expiry=@something(nt.expiration, typemax(DateTime)),
-        renew=() -> credential_process_credentials(cmd),
+        renew=() -> external_process_credentials(cmd),
     )
 end
 

--- a/src/AWSCredentials.jl
+++ b/src/AWSCredentials.jl
@@ -22,7 +22,8 @@ export AWSCredentials,
     localhost_is_ec2,
     localhost_maybe_ec2,
     localhost_is_lambda,
-    credentials_from_webtoken
+    credentials_from_webtoken,
+    external_process_credentials
 
 function localhost_maybe_ec2()
     return localhost_is_ec2() || isfile("/sys/devices/virtual/dmi/id/product_uuid")
@@ -577,7 +578,7 @@ function external_process_credentials(cmd::Base.AbstractCmd)
     return AWSCredentials(
         nt.access_key_id,
         nt.secret_access_key,
-        nt.session_token;
+        @something(nt.session_token, "");
         expiry=@something(nt.expiration, typemax(DateTime)),
         renew=() -> external_process_credentials(cmd),
     )

--- a/src/AWSCredentials.jl
+++ b/src/AWSCredentials.jl
@@ -563,6 +563,13 @@ function credentials_from_webtoken()
     )
 end
 
+"""
+    external_process_credentials(cmd::Base.AbstractCmd) -> AWSCredentials
+
+Sources AWS credentials from an external process as defined in the AWS CLI config file.
+See https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sourcing-external.html
+for details.
+"""
 function external_process_credentials(cmd::Base.AbstractCmd)
     nt = open(cmd, "r") do io
         _read_credential_process(io)

--- a/src/utilities/credentials.jl
+++ b/src/utilities/credentials.jl
@@ -226,8 +226,8 @@ function _read_credential_process(io::IO)
     version = json["Version"]
     if version != 1
         error(
-            "Credential process returned unhandled version $version:\n" *
-            sprint(JSON.print, json, 2)
+            "Credential process returned unhandled version $version:\n",
+            sprint(JSON.print, json, 2),
         )
     end
 

--- a/src/utilities/credentials.jl
+++ b/src/utilities/credentials.jl
@@ -213,6 +213,12 @@ function _aws_get_sso_credential_details(profile::AbstractString, ini::Inifile)
     return (access_key, secret_key, token, expiry)
 end
 
+"""
+    _read_credential_process(io::IO) -> NamedTuple
+
+Parse the AWS CLI external process output out as defined in:
+https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sourcing-external.html
+"""
 function _read_credential_process(io::IO)
     # `JSON.parse` chokes on `Base.Process` I/O streams.
     json = JSON.parse(read(io, String))

--- a/src/utilities/credentials.jl
+++ b/src/utilities/credentials.jl
@@ -241,5 +241,5 @@ function _read_credential_process(io::IO)
         nothing
     end
 
-    return (; access_key_id, secret_access_key, session_token, expiration)
+    return @compat (; access_key_id, secret_access_key, session_token, expiration)
 end

--- a/test/AWSCredentials.jl
+++ b/test/AWSCredentials.jl
@@ -511,6 +511,43 @@ end
         end
     end
 
+    @testset "~/.aws/config - Credential Process" begin
+        mktempdir() do dir
+            credential_process_file = joinpath(dir, "cred_process")
+            open(credential_process_file, "w") do io
+                println(io, "#!/bin/sh")
+                println(io, "cat <<EOF")
+                JSON.print(io, Dict(
+                    "Version" => 1,
+                    "AccessKeyId" => test_values["Test-AccessKeyId"],
+                    "SecretAccessKey" => test_values["Test-SecretAccessKey"],
+                ))
+                println(io, "\nEOF")
+            end
+            chmod(credential_process_file, 0o700)
+
+            config_file = joinpath(dir, "config")
+            open(config_file, "w") do io
+                write(
+                    io,
+                    """
+                    [profile $(test_values["Test-Config-Profile"])]
+                    credential_process = $(abspath(credential_process_file))
+                    """,
+                )
+            end
+
+            withenv("AWS_CONFIG_FILE" => config_file) do
+                specified_result = dot_aws_config(test_values["Test-Config-Profile"])
+
+                @test specified_result.access_key_id == test_values["Test-AccessKeyId"]
+                @test specified_result.secret_key == test_values["Test-SecretAccessKey"]
+                @test isempty(specified_result.token)
+                @test specified_result.expiry == typemax(DateTime)
+            end
+        end
+    end
+
     @testset "~/.aws/creds - Default Profile" begin
         mktemp() do creds_file, creds_io
             write(
@@ -694,6 +731,57 @@ end
                 end
             end
         end
+    end
+
+    @testset "Credential Process" begin
+        gen_process(json) = Cmd(["echo", JSON.json(json)])
+
+        long_term_resp = Dict(
+            "Version" => 1,
+            "AccessKeyId" => "access-key",
+            "SecretAccessKey" => "secret-key",
+        )
+        creds = external_process_credentials(gen_process(long_term_resp))
+        @test creds.access_key_id == long_term_resp["AccessKeyId"]
+        @test creds.secret_key == long_term_resp["SecretAccessKey"]
+        @test isempty(creds.token)
+        @test creds.expiry == typemax(DateTime)
+
+        expiration = floor(now(UTC), Second)
+        temporary_resp = Dict(
+            "Version" => 1,
+            "AccessKeyId" => "access-key",
+            "SecretAccessKey" => "secret-key",
+            "SessionToken" => "session-token",
+            "Expiration" => Dates.format(expiration, dateformat"yyyy-mm-dd\THH:MM:SS\Z"),
+        )
+        creds = external_process_credentials(gen_process(temporary_resp))
+        @test creds.access_key_id == temporary_resp["AccessKeyId"]
+        @test creds.secret_key == temporary_resp["SecretAccessKey"]
+        @test creds.token == temporary_resp["SessionToken"]
+        @test creds.expiry == expiration
+
+        unhandled_version_resp = Dict(
+            "Version" => 2,
+        )
+        ex = ErrorException("Credential process returned unhandled version 2:\n{\n  \"Version\": 2\n}\n")
+        @test_throws ex external_process_credentials(gen_process(unhandled_version_resp))
+
+        missing_token_resp = Dict(
+            "Version" => 1,
+            "AccessKeyId" => "access-key",
+            "SecretAccessKey" => "secret-key",
+            "Expiration" => Dates.format(expiration, dateformat"yyyy-mm-dd\THH:MM:SS\Z"),
+        )
+        @test_throws KeyError("SessionToken") external_process_credentials(gen_process(missing_token_resp))
+
+        missing_expiration_resp = Dict(
+            "Version" => 1,
+            "AccessKeyId" => "access-key",
+            "SecretAccessKey" => "secret-key",
+            "SessionToken" => "session-token",
+        )
+        @test_throws KeyError("Expiration") external_process_credentials(gen_process(missing_expiration_resp))
     end
 
     @testset "Credentials Not Found" begin

--- a/test/AWSCredentials.jl
+++ b/test/AWSCredentials.jl
@@ -788,9 +788,7 @@ end
         @test creds.token == temporary_resp["SessionToken"]
         @test creds.expiry == expiration
 
-        unhandled_version_resp = Dict(
-            "Version" => 2,
-        )
+        unhandled_version_resp = Dict("Version" => 2)
         json = JSON.print(unhandled_version_resp, 2)
         ex = ErrorException("Credential process returned unhandled version 2:\n$json")
         @test_throws ex external_process_credentials(gen_process(unhandled_version_resp))
@@ -801,7 +799,7 @@ end
             "SecretAccessKey" => "secret-key",
             "Expiration" => Dates.format(expiration, dateformat"yyyy-mm-dd\THH:MM:SS\Z"),
         )
-        ex =  KeyError("SessionToken")
+        ex = KeyError("SessionToken")
         @test_throws ex external_process_credentials(gen_process(missing_token_resp))
 
         missing_expiration_resp = Dict(

--- a/test/AWSCredentials.jl
+++ b/test/AWSCredentials.jl
@@ -789,7 +789,7 @@ end
         @test creds.expiry == expiration
 
         unhandled_version_resp = Dict("Version" => 2)
-        json = JSON.print(unhandled_version_resp, 2)
+        json = sprint(JSON.print, unhandled_version_resp, 2)
         ex = ErrorException("Credential process returned unhandled version 2:\n$json")
         @test_throws ex external_process_credentials(gen_process(unhandled_version_resp))
 


### PR DESCRIPTION
Adds support for the AWS config setting [`credential_process`](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sourcing-external.html). I want to add support for this feature as I want I'm using [`aws-vault`'s integration](https://github.com/99designs/aws-vault/blob/master/USAGE.md#use-case-2-aws-vault-is-a-master-credentials-vault-for-aws-sdk) which means I can store my AWS credentials in one place.

As part of this I encountered that if you have an `~/.aws/credentials` file that the `credential_process` setting was ignored. This made me do some testing into if the credential preference order mirrors what the AWS CLI does. The results of these tests found the following:

- config file `sso_*` used over `~/.aws/credentials`
- `~/.aws/credentials` used over config file `credential_process`
- config file `credential_process` used over config file `aws_access_key_id`/`aws_secret_access_key`

This was using the AWS CLI version `aws-cli/2.11.13 Python/3.11.3 Darwin/22.4.0 source/arm64 prompt/off`. In this PR the `credential_process` is preferred over config file `aws_access_key_id`/`aws_secret_access_key` but the `sso_*` credentials have the wrong preference ordering. I'll try to address the credential preference ordering issues in another PR.
