### PR TITLE
Update credential precedence to match AWS CLI

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AWS"
 uuid = "fbe9abb3-538b-5e4e-ba9e-bc94f4f92ebc"
 license = "MIT"
-version = "1.85.0"
+version = "1.86.0"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/AWSCredentials.jl
+++ b/src/AWSCredentials.jl
@@ -397,7 +397,9 @@ end
 """
     dot_aws_credentials(profile=nothing) -> Union{AWSCredential, Nothing}
 
-Retrieve AWSCredentials from the `~/.aws/credentials` file
+Retrieve `AWSCredentials` from the AWS CLI credentials file. The credential file defaults to
+"~/.aws/credentials" but can be specified using the env variable
+`AWS_SHARED_CREDENTIALS_FILE`.
 
 # Arguments
 - `profile`: Specific profile used to get AWSCredentials, default is `nothing`
@@ -458,9 +460,11 @@ end
 """
     dot_aws_config(profile=nothing) -> Union{AWSCredential, Nothing}
 
-Retrieve AWSCredentials for the default or specified profile from the `~/.aws/config` file.
-If this fails, try to retrieve credentials from `_aws_get_role()`, otherwise return
-`nothing`.
+Retrieve `AWSCredentials` from the AWS CLI configuration file. The configuration file
+defaults to "~/.aws/config" but can be specified using the env variable  `AWS_CONFIG_FILE`.
+When no credentials can be found for the given `profile` then the associated
+`source_profile` will be used to recursively look up credentials of parent profiles. If
+still no credentials can be found then `nothing` will be returned.
 
 # Arguments
 - `profile`: Specific profile used to get AWSCredentials, default is `nothing`

--- a/src/AWSCredentials.jl
+++ b/src/AWSCredentials.jl
@@ -465,7 +465,6 @@ function dot_aws_config(profile=nothing)
 
         credential_process = get(settings, "credential_process", nothing)
         access_key = get(settings, "aws_access_key_id", nothing)
-        sso_start_url = get(settings, "sso_start_url", nothing)
 
         if !isnothing(credential_process)
             cmd = Cmd(Base.shell_split(credential_process))
@@ -473,9 +472,6 @@ function dot_aws_config(profile=nothing)
         elseif !isnothing(access_key)
             access_key, secret_key, token = _aws_get_credential_details(p, ini)
             return AWSCredentials(access_key, secret_key, token)
-        elseif !isnothing(sso_start_url)
-            access_key, secret_key, token, expiry = _aws_get_sso_credential_details(p, ini)
-            return AWSCredentials(access_key, secret_key, token; expiry=expiry)
         else
             return _aws_get_role(p, ini)
         end

--- a/src/AWSCredentials.jl
+++ b/src/AWSCredentials.jl
@@ -435,8 +435,6 @@ function sso_credentials(profile=nothing)
         if !isnothing(sso_start_url)
             access_key, secret_key, token, expiry = _aws_get_sso_credential_details(p, ini)
             return AWSCredentials(access_key, secret_key, token; expiry=expiry)
-        else
-            return _aws_get_role(p, ini)
         end
     end
 

--- a/src/AWSCredentials.jl
+++ b/src/AWSCredentials.jl
@@ -48,11 +48,11 @@ and is as follows:
 
 1. Credentials or a profile passed directly to the `AWSCredentials`
 2. [Environment variables](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html)
-3. [AWS Single Sign-On (SSO)](http://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sso.html) provided via the AWS configuration file
-4. [AWS credentials file](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html) (e.g. "~/.aws/credentials")
-5. [External process](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sourcing-external.html) set via `credential_process` in the AWS configuration file
-6. [AWS configuration file](http://docs.aws.amazon.com/cli/latest/userguide/cli-config-files.html) set via `aws_access_key_id` in the AWS configuration file
-7. Assume Role provider via the aws config file
+3. [Web Identity](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-role.html#cli-configure-role-oidc)
+4. [AWS Single Sign-On (SSO)](http://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sso.html) provided via the AWS configuration file
+5. [AWS credentials file](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html) (e.g. "~/.aws/credentials")
+6. [External process](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sourcing-external.html) set via `credential_process` in the AWS configuration file
+7. [AWS configuration file](http://docs.aws.amazon.com/cli/latest/userguide/cli-config-files.html) set via `aws_access_key_id` in the AWS configuration file
 8. [Amazon EC2 instance metadata](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html)
 9. [Amazon ECS container credentials](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html)
 
@@ -123,10 +123,10 @@ function AWSCredentials(; profile=nothing, throw_cred_error=true)
     # EC2 credentials when the `AWS_CONTAINER_*` environmental variables are set.
     functions = [
         () -> env_var_credentials(explicit_profile),
+        credentials_from_webtoken,
         () -> sso_credentials(profile),
         () -> dot_aws_credentials(profile),
         () -> dot_aws_config(profile),
-        credentials_from_webtoken,
         ecs_instance_credentials,
         () -> ec2_instance_credentials(profile),
     ]

--- a/src/AWSCredentials.jl
+++ b/src/AWSCredentials.jl
@@ -122,8 +122,9 @@ function AWSCredentials(; profile=nothing, throw_cred_error=true)
         () -> dot_aws_credentials(profile),
         () -> dot_aws_config(profile),
         credentials_from_webtoken,
-        ecs_instance_credentials,
+        () -> ecs_instance_credentials(; require_env=true),
         () -> ec2_instance_credentials(profile),
+        () -> ecs_instance_credentials(; require_env=false),
     ]
 
     # Loop through our search locations until we get credentials back
@@ -317,13 +318,18 @@ function ec2_instance_credentials(profile::AbstractString)
 end
 
 """
-    ecs_instance_credentials() -> Union{AWSCredential, Nothing}
+    ecs_instance_credentials(; require_env::Bool=true) -> Union{AWSCredential, Nothing}
 
-Retrieve credentials from the local endpoint. Return `nothing` if not running on an ECS
-instance.
+Retrieve credentials from the ECS credential endpoint. Return `nothing` if the ECS
+credential endpoint is not available.
 
 More information can be found at:
-https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html
+- https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html
+- https://docs.aws.amazon.com/sdkref/latest/guide/feature-container-credentials.html
+
+# Keywords
+- `require_env::Bool`: Only attempt to connect to the ECS credential endpoint when the
+  environmental variable `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` is set.
 
 # Returns
 - `AWSCredentials`: AWSCredentials from `ECS` credentials URI, `nothing` if the Env Var is
@@ -333,14 +339,18 @@ https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html
 - `StatusError`: If the response status is >= 300
 - `ParsingError`: Invalid HTTP request target
 """
-function ecs_instance_credentials()
-    if !haskey(ENV, "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI")
+function ecs_instance_credentials(; require_env::Bool=true)
+    if require_env && !haskey(ENV, "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI")
         return nothing
     end
 
-    uri = ENV["AWS_CONTAINER_CREDENTIALS_RELATIVE_URI"]
-
-    response = @mock HTTP.request("GET", "http://169.254.170.2$uri")
+    path = get(ENV, "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI", "")
+    response = try
+        @mock HTTP.request("GET", "http://169.254.170.2$path"; retry=false, connect_timeout=5)
+    catch e
+        e isa HTTP.Exceptions.ConnectError && return nothing
+        rethrow()
+    end
     new_creds = String(response.body)
     new_creds = JSON.parse(new_creds)
 

--- a/src/AWSCredentials.jl
+++ b/src/AWSCredentials.jl
@@ -42,20 +42,22 @@ The fields `access_key_id` and `secret_key` hold the access keys used to authent
 [Temporary Security Credentials](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp.html) require the extra session `token` field.
 The `user_arn` and `account_number` fields are used to cache the result of the [`aws_user_arn`](@ref) and [`aws_account_number`](@ref) functions.
 
-AWS.jl searches for credentials in a series of possible locations and stops as soon as it finds credentials.
-The order of precedence for this search is as follows:
+AWS.jl searches for credentials in multiple locations and stops once credentials are found.
+The credential preference order [mirrors the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-authentication.html#cli-chap-authentication-precedence)
+and is as follows:
 
-1. Passing credentials directly to the `AWSCredentials` constructor
+1. Credentials or a profile passed directly to the `AWSCredentials`
 2. [Environment variables](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html)
-3. Shared credential file [(~/.aws/credentials)](http://docs.aws.amazon.com/cli/latest/userguide/cli-config-files.html)
-4. AWS config file [(~/.aws/config)](http://docs.aws.amazon.com/cli/latest/userguide/cli-config-files.html).
-   This includes [Single Sign-On (SSO)](http://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sso.html) credentials.
-   SSO users should follow the configuration instructions at the above link, and use `aws sso login` to log in.
-5. Assume Role provider via the aws config file
-6. Instance metadata service on an Amazon EC2 instance that has an IAM role configured
+3. [AWS Single Sign-On (SSO)](http://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sso.html) provided via the AWS configuration file
+4. [AWS credentials file](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html) (e.g. "~/.aws/credentials")
+5. [External process](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sourcing-external.html) set via `credential_process` in the AWS configuration file
+6. [AWS configuration file](http://docs.aws.amazon.com/cli/latest/userguide/cli-config-files.html) set via `aws_access_key_id` in the AWS configuration file
+7. Assume Role provider via the aws config file
+8. [Amazon EC2 instance metadata](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html)
+9. [Amazon ECS container credentials](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html)
 
 Once the credentials are found, the method by which they were accessed is stored in the `renew` field
-and the DateTime at which they will expire is stored in the `expiry` field.
+and the `DateTime` at which they will expire is stored in the `expiry` field.
 This allows the credentials to be refreshed as needed using [`check_credentials`](@ref).
 If `renew` is set to `nothing`, no attempt will be made to refresh the credentials.
 Any renewal function is expected to return `nothing` on failure or a populated `AWSCredentials` object on success.

--- a/src/AWSCredentials.jl
+++ b/src/AWSCredentials.jl
@@ -320,7 +320,7 @@ function ec2_instance_credentials(profile::AbstractString)
 end
 
 """
-    ecs_instance_credentials() -> Union{AWSCredential, Nothing}
+    ecs_instance_credentials() -> Union{AWSCredentials, Nothing}
 
 Retrieve credentials from the ECS credential endpoint. Return `nothing` if the ECS
 credential endpoint is not available.
@@ -372,7 +372,7 @@ function ecs_instance_credentials()
 end
 
 """
-    env_var_credentials(explicit_profile::Bool=false) -> Union{AWSCredential, Nothing}
+    env_var_credentials(explicit_profile::Bool=false) -> Union{AWSCredentials, Nothing}
 
 Use AWS environmental variables (e.g. AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, etc.)
 to create AWSCredentials.
@@ -395,7 +395,7 @@ function env_var_credentials(explicit_profile::Bool=false)
 end
 
 """
-    dot_aws_credentials(profile=nothing) -> Union{AWSCredential, Nothing}
+    dot_aws_credentials(profile=nothing) -> Union{AWSCredentials, Nothing}
 
 Retrieve `AWSCredentials` from the AWS CLI credentials file. The credential file defaults to
 "~/.aws/credentials" but can be specified using the env variable
@@ -427,13 +427,13 @@ function dot_aws_credentials_file()
 end
 
 """
-    sso_credentials(profile=nothing) -> Union{AWSCredential, Nothing}
+    sso_credentials(profile=nothing) -> Union{AWSCredentials, Nothing}
 
 Retrieve credentials via AWS single sign-on settings defined in the `profile` within the AWS
 config file. If no SSO settings are found for the `profile` `nothing` is returned.
 
 # Arguments
-- `profile`: Specific profile used to get `AWSCredential`s, default is `nothing`
+- `profile`: Specific profile used to get `AWSCredentials`, default is `nothing`
 """
 function sso_credentials(profile=nothing)
     config_file = @mock dot_aws_config_file()
@@ -458,7 +458,7 @@ function sso_credentials(profile=nothing)
 end
 
 """
-    dot_aws_config(profile=nothing) -> Union{AWSCredential, Nothing}
+    dot_aws_config(profile=nothing) -> Union{AWSCredentials, Nothing}
 
 Retrieve `AWSCredentials` from the AWS CLI configuration file. The configuration file
 defaults to "~/.aws/config" but can be specified using the env variable  `AWS_CONFIG_FILE`.

--- a/src/AWSCredentials.jl
+++ b/src/AWSCredentials.jl
@@ -113,8 +113,8 @@ function AWSCredentials(; profile=nothing, throw_cred_error=true)
     explicit_profile = !isnothing(profile)
     profile = @something profile _aws_get_profile()
 
-    # Define our search options, expected to be callable with no arguments.
-    # Throw NoCredentials if none are found
+    # Define the credential preference order
+    # https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-authentication.html#cli-chap-authentication-precedence
     functions = [
         () -> env_var_credentials(explicit_profile),
         () -> sso_credentials(profile),

--- a/src/AWSCredentials.jl
+++ b/src/AWSCredentials.jl
@@ -409,6 +409,15 @@ function dot_aws_credentials_file()
     end
 end
 
+"""
+    sso_credentials(profile=nothing) -> Union{AWSCredential, Nothing}
+
+Retrieve credentials via AWS single sign-on settings defined in the `profile` within the AWS
+config file. If no SSO settings are found for the `profile` `nothing` is returned.
+
+# Arguments
+- `profile`: Specific profile used to get `AWSCredential`s, default is `nothing`
+"""
 function sso_credentials(profile=nothing)
     config_file = @mock dot_aws_config_file()
 
@@ -437,8 +446,8 @@ end
     dot_aws_config(profile=nothing) -> Union{AWSCredential, Nothing}
 
 Retrieve AWSCredentials for the default or specified profile from the `~/.aws/config` file.
-Single sign-on profiles are also valid. If this fails, try to retrieve credentials from
-`_aws_get_role()`, otherwise return `nothing`
+If this fails, try to retrieve credentials from `_aws_get_role()`, otherwise return
+`nothing`.
 
 # Arguments
 - `profile`: Specific profile used to get AWSCredentials, default is `nothing`

--- a/src/AWSCredentials.jl
+++ b/src/AWSCredentials.jl
@@ -477,6 +477,7 @@ function dot_aws_config(profile=nothing)
 
         credential_process = get(settings, "credential_process", nothing)
         access_key = get(settings, "aws_access_key_id", nothing)
+        sso_start_url = get(settings, "sso_start_url", nothing)
 
         if !isnothing(credential_process)
             cmd = Cmd(Base.shell_split(credential_process))
@@ -484,6 +485,13 @@ function dot_aws_config(profile=nothing)
         elseif !isnothing(access_key)
             access_key, secret_key, token = _aws_get_credential_details(p, ini)
             return AWSCredentials(access_key, secret_key, token)
+        elseif !isnothing(sso_start_url)
+            Base.depwarn(
+                "SSO support in `dot_aws_config` is deprecated, use `sso_credentials` instead.",
+                :dot_aws_config,
+            )
+            access_key, secret_key, token, expiry = _aws_get_sso_credential_details(p, ini)
+            return AWSCredentials(access_key, secret_key, token; expiry=expiry)
         else
             return _aws_get_role(p, ini)
         end

--- a/src/AWSCredentials.jl
+++ b/src/AWSCredentials.jl
@@ -23,7 +23,8 @@ export AWSCredentials,
     external_process_credentials,
     localhost_is_ec2,
     localhost_is_lambda,
-    localhost_maybe_ec2
+    localhost_maybe_ec2,
+    sso_credentials
 
 function localhost_maybe_ec2()
     return localhost_is_ec2() || isfile("/sys/devices/virtual/dmi/id/product_uuid")

--- a/src/utilities/credentials.jl
+++ b/src/utilities/credentials.jl
@@ -71,7 +71,7 @@ function _aws_get_role(role::AbstractString, ini::Inifile)
     duration_seconds = get(settings, "duration_seconds", nothing)
 
     credentials = nothing
-    for f in (dot_aws_credentials, dot_aws_config)
+    for f in (sso_credentials, dot_aws_credentials, dot_aws_config)
         credentials = f(source_profile)
         credentials === nothing || break
     end

--- a/test/AWSCredentials.jl
+++ b/test/AWSCredentials.jl
@@ -428,23 +428,21 @@ end
                 "AWS_SHARED_CREDENTIALS_FILE" => creds_file,
                 "AWS_CONFIG_FILE" => config_file,
             ) do
-
                 @testset "explicit profile preferred" begin
                     isfile(config_file) && rm(config_file)
                     write(creds_file, basic_creds_content)
 
-                    withenv(
-                        "AWS_PROFILE" => "profile1",
-                    ) do
-                        creds = AWSCredentials(profile="profile2")
+                    withenv("AWS_PROFILE" => "profile1") do
+                        creds = AWSCredentials(; profile="profile2")
                         @test creds.access_key_id == "AKI2"
                     end
 
                     withenv(
                         "AWS_ACCESS_KEY_ID" => "AKI0",
                         "AWS_SECRET_ACCESS_KEY" => "SAK0",
+                        # format trick: using this comment to force use of multiple lines
                     ) do
-                        creds = AWSCredentials(profile="profile2")
+                        creds = AWSCredentials(; profile="profile2")
                         @test creds.access_key_id == "AKI2"
                     end
                 end
@@ -474,6 +472,7 @@ end
                     withenv(
                         "AWS_DEFAULT_PROFILE" => "profile1",
                         "AWS_PROFILE" => "profile2",
+                        # format trick: using this comment to force use of multiple lines
                     ) do
                         creds = AWSCredentials()
                         @test creds.access_key_id == "AKI2"
@@ -487,12 +486,12 @@ end
                         [profile profile1]
                         sso_start_url = https://my-sso-portal.awsapps.com/start
                         sso_role_name = role1
-                        """
+                        """,
                     )
                     write(creds_file, basic_creds_content)
 
                     apply(Patches.sso_service_patches("AKI0", "SAK0")) do
-                        creds = AWSCredentials(profile="profile1")
+                        creds = AWSCredentials(; profile="profile1")
                         @test creds.access_key_id == "AKI0"
                     end
                 end
@@ -502,17 +501,18 @@ end
                         "Version" => 1,
                         "AccessKeyId" => "AKI0",
                         "SecretAccessKey" => "SAK0",
+                        # format trick: using this comment to force use of multiple lines
                     )
                     write(
                         config_file,
                         """
                         [profile profile1]
                         credential_process = echo '$(JSON.json(json))'
-                        """
+                        """,
                     )
                     write(creds_file, basic_creds_content)
 
-                    creds = AWSCredentials(profile="profile1")
+                    creds = AWSCredentials(; profile="profile1")
                     @test creds.access_key_id == "AKI1"
                 end
 
@@ -521,6 +521,7 @@ end
                         "Version" => 1,
                         "AccessKeyId" => "AKI0",
                         "SecretAccessKey" => "SAK0",
+                        # format trick: using this comment to force use of multiple lines
                     )
                     write(
                         config_file,
@@ -529,11 +530,11 @@ end
                         aws_access_key_id = AKI1
                         aws_secret_access_key = SAK1
                         credential_process = echo '$(JSON.json(json))'
-                        """
+                        """,
                     )
                     isfile(creds_file) && rm(creds_file)
 
-                    creds = AWSCredentials(profile="profile1")
+                    creds = AWSCredentials(; profile="profile1")
                     @test creds.access_key_id == "AKI0"
                 end
             end

--- a/test/AWSCredentials.jl
+++ b/test/AWSCredentials.jl
@@ -1057,7 +1057,7 @@ end
     @testset "Credentials Not Found" begin
         patches = [
             @patch function HTTP.request(method::String, url, args...; kwargs...)
-                throw(HTTP.Exceptions.ConnectError(url, "host is unreachable"))
+                throw(HTTP.Exceptions.ConnectError(string(url), "host is unreachable"))
             end
             Patches._cred_file_patch
             Patches._config_file_patch

--- a/test/AWSCredentials.jl
+++ b/test/AWSCredentials.jl
@@ -600,7 +600,7 @@ end
                     )
                     isfile(creds_file) && rm(creds_file)
 
-                    apply(http_request_patcher([ecs_metadata])) do
+                    apply(http_request_patcher([ec2_metadata])) do
                         @test isnothing(AWS._aws_get_profile(; default=nothing))
 
                         creds = AWSCredentials()
@@ -610,7 +610,7 @@ end
 
                 # Note: The AWS CLI behavior was not tested here as this scenario is
                 # challenging to test for.
-                @testset "EC2 instance credentials over container credentials" begin
+                @testset "EC2 instance credentials over ECS container credentials" begin
                     isfile(config_file) && rm(config_file)
                     isfile(creds_file) && rm(creds_file)
 

--- a/test/AWSCredentials.jl
+++ b/test/AWSCredentials.jl
@@ -959,12 +959,16 @@ end
             end
         end
 
+        # When the environmental variable isn't set then the ECS credential provider is
+        # unavailable.
         withenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI" => nothing) do
             @test ecs_instance_credentials() === nothing
         end
 
+        # Specifying the environmental variable results in us attempting to connect to the
+        # ECS credential provider.
         withenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI" => "/invalid") do
-            # Should internally generate a `ConnectError`
+            # Internally throws a `ConnectError` exception
             @test ecs_instance_credentials() === nothing
         end
     end

--- a/test/AWSCredentials.jl
+++ b/test/AWSCredentials.jl
@@ -725,7 +725,7 @@ end
                         test_values["AccessKeyId"], test_values["SecretAccessKey"]
                     ),
                 ) do
-                    specified_result = dot_aws_config(test_values["Test-SSO-Profile"])
+                    specified_result = sso_credentials(test_values["Test-SSO-Profile"])
 
                     @test specified_result.access_key_id == test_values["AccessKeyId"]
                     @test specified_result.secret_key == test_values["SecretAccessKey"]

--- a/test/AWSCredentials.jl
+++ b/test/AWSCredentials.jl
@@ -13,6 +13,8 @@ macro test_ecode(error_codes, expr)
     end
 end
 
+const EXPIRATION_FMT = dateformat"yyyy-mm-dd\THH:MM:SS\Z"
+
 @testset "Load Credentials" begin
     user = aws_user_arn(aws)
     @test occursin(r"^arn:aws:(iam|sts)::[0-9]+:[^:]+$", user)
@@ -425,12 +427,11 @@ end
                 aws_secret_access_key = SAK2
                 """
 
-            ec2_expiration = floor(now(UTC), Second)
             ec2_json = Dict(
                 "AccessKeyId" => "AKI_EC2",
                 "SecretAccessKey" => "SAK_EC2",
                 "Token" => "TOK_EC2",
-                "Expiration" => Dates.format(ec2_expiration, dateformat"yyyy-mm-dd\THH:MM:SS\Z"),
+                "Expiration" => Dates.format(now(UTC), EXPIRATION_FMT),
             )
 
             function ec2_metadata(url::AbstractString)
@@ -447,12 +448,11 @@ end
                 end
             end
 
-            ecs_expiration = floor(now(UTC), Second)
             ecs_json = Dict(
                 "AccessKeyId" => "AKI_ECS",
                 "SecretAccessKey" => "SAK_ECS",
                 "Token" => "TOK_ECS",
-                "Expiration" => Dates.format(ecs_expiration, dateformat"yyyy-mm-dd\THH:MM:SS\Z"),
+                "Expiration" => Dates.format(now(UTC), EXPIRATION_FMT),
             )
 
             function ecs_metadata(url::AbstractString)
@@ -978,7 +978,7 @@ end
             "AccessKeyId" => "access-key",
             "SecretAccessKey" => "secret-key",
             "SessionToken" => "session-token",
-            "Expiration" => Dates.format(expiration, dateformat"yyyy-mm-dd\THH:MM:SS\Z"),
+            "Expiration" => Dates.format(expiration, EXPIRATION_FMT),
         )
         creds = external_process_credentials(gen_process(temporary_resp))
         @test creds.access_key_id == temporary_resp["AccessKeyId"]
@@ -995,7 +995,7 @@ end
             "Version" => 1,
             "AccessKeyId" => "access-key",
             "SecretAccessKey" => "secret-key",
-            "Expiration" => Dates.format(expiration, dateformat"yyyy-mm-dd\THH:MM:SS\Z"),
+            "Expiration" => Dates.format(expiration, EXPIRATION_FMT),
         )
         ex = KeyError("SessionToken")
         @test_throws ex external_process_credentials(gen_process(missing_token_resp))

--- a/test/AWSCredentials.jl
+++ b/test/AWSCredentials.jl
@@ -488,6 +488,25 @@ end
                         @test creds.access_key_id == "AKI0"
                     end
                 end
+
+                @testset "Credential file over credential_process" begin
+                    json = Dict(
+                        "Version" => 1,
+                        "AccessKeyId" => "AKI0",
+                        "SecretAccessKey" => "SAK0",
+                    )
+                    write(
+                        config_file,
+                        """
+                        [profile profile1]
+                        credential_process = echo '$(JSON.json(json))'
+                        """
+                    )
+                    write(creds_file, basic_creds_content)
+
+                    creds = AWSCredentials(profile="profile1")
+                    @test creds.access_key_id == "AKI1"
+                end
             end
         end
     end

--- a/test/AWSCredentials.jl
+++ b/test/AWSCredentials.jl
@@ -400,7 +400,15 @@ end
         end
     end
 
-    @testset "Precedence" begin
+    # Verify that the search order for credentials mirrors the behavior of the AWS CLI
+    # (version 2.11.13). Whenever support is added for new credential types new tests should
+    # be added to this test set. To determine the credential preference order used by AWS
+    # CLI it is recommended you use a set of valid credentials and a set of invalid
+    # credentials to determine the precedence.
+    #
+    # Documentation on credential preference for the AWS SDK for .NET:
+    # https://docs.aws.amazon.com/sdk-for-net/v3/developer-guide/creds-assign.html
+    @testset "Credential Precedence" begin
         mktempdir() do dir
             config_file = joinpath(dir, "config")
             creds_file = joinpath(dir, "creds")


### PR DESCRIPTION
I noticed there were some credential precedence ordering differences between AWS.jl and AWS CLI. I ended up doing some experimentation with pairing different AWS CLI settings to determine the precedence ordering used by AWS CLI. Here are the results of those tests:

- aws `--profile` used over env `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`
- aws `--profile` used over env `AWS_PROFILE`
- env `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` used over env `AWS_PROFILE`
- env `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` used over config file `sso_*`
- config file `sso_*` used over `~/.aws/credentials` (if exists)
- `~/.aws/credentials` (if exists) used over config file `credential_process`
- config file `credential_process` used over config file `aws_access_key_id`/`aws_secret_access_key`
- config file `aws_access_key_id`/`aws_secret_access_key` used over EC2 instance metadata
- config file `aws_access_key_id`/`aws_secret_access_key` used over `AWS_CONTAINER_CREDENTIALS_FULL_URI`

Using `aws-cli/2.11.13 Python/3.11.3 Darwin/22.4.0 source/arm64 prompt/off`

Notes:
- Defining `sso_account_id` or `sso_role_name` in a profile without other `sso_*` keys results in an error about missing required configuration. Defining `sso_start_url` and `sso_region` by themselves doesn't produce this error.
- Specifying the AWS credential file with `AWS_SHARED_CREDENTIALS_FILE` just replaces `~/.aws/credentials`
- Tested this by specifying bad credentials in one source and valid ones in the other. As I didn't have an SSO setup to test against I could only force these to fail.
- Some additional testing was done to verify that the credential preference ordering is linear. I didn't find any examples of non-linear ordering.