### PR TITLE
Support providing a full URI to the ECS credential provider

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AWS"
 uuid = "fbe9abb3-538b-5e4e-ba9e-bc94f4f92ebc"
 license = "MIT"
-version = "1.86.0"
+version = "1.87.0"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/AWSCredentials.jl
+++ b/src/AWSCredentials.jl
@@ -346,10 +346,15 @@ function ecs_instance_credentials()
     # interpreting this to mean than ECS credential provider should only be used if any of
     # the `AWS_CONTAINER_CREDENTIALS_*_URI` variables are set.
     # – https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html
-    if haskey(ENV, "AWS_CONTAINER_CREDENTIALS_FULL_URI")
-        endpoint = ENV["AWS_CONTAINER_CREDENTIALS_FULL_URI"]
-    elseif haskey(ENV, "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI")
+    #
+    # > Note: This setting (`AWS_CONTAINER_CREDENTIALS_FULL_URI`) is an alternative to
+    # > `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` and will only be used if
+    # > `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` is not set.
+    # – https://docs.aws.amazon.com/sdkref/latest/guide/feature-container-credentials.html
+    if haskey(ENV, "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI")
         endpoint = "http://169.254.170.2" * ENV["AWS_CONTAINER_CREDENTIALS_RELATIVE_URI"]
+    elseif haskey(ENV, "AWS_CONTAINER_CREDENTIALS_FULL_URI")
+        endpoint = ENV["AWS_CONTAINER_CREDENTIALS_FULL_URI"]
     else
         return nothing
     end

--- a/src/AWSCredentials.jl
+++ b/src/AWSCredentials.jl
@@ -343,17 +343,24 @@ More information can be found at:
 function ecs_instance_credentials()
     # The Amazon ECS agent will automatically populate the environmental variable
     # `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` when running inside of an ECS task. We're
-    # interpreting this to mean than ECS credential provider should only be used if the
-    # `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` variable is set.
+    # interpreting this to mean than ECS credential provider should only be used if any of
+    # the `AWS_CONTAINER_CREDENTIALS_*_URI` variables are set.
     # – https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html
-    if haskey(ENV, "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI")
+    if haskey(ENV, "AWS_CONTAINER_CREDENTIALS_FULL_URI")
+        endpoint = ENV["AWS_CONTAINER_CREDENTIALS_FULL_URI"]
+    elseif haskey(ENV, "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI")
         endpoint = "http://169.254.170.2" * ENV["AWS_CONTAINER_CREDENTIALS_RELATIVE_URI"]
     else
         return nothing
     end
 
+    headers = Pair{String,String}[]
+    if haskey(ENV, "AWS_CONTAINER_AUTHORIZATION_TOKEN")
+        push!(headers, "Authorization" => ENV["AWS_CONTAINER_AUTHORIZATION_TOKEN"])
+    end
+
     response = try
-        @mock HTTP.request("GET", endpoint; retry=false, connect_timeout=5)
+        @mock HTTP.request("GET", endpoint, headers; retry=false, connect_timeout=5)
     catch e
         e isa HTTP.Exceptions.ConnectError && return nothing
         rethrow()


### PR DESCRIPTION
Discovered that our ECS credential support was lacking support for the [`AWS_CONTAINER_CREDENTIALS_FULL_URI` and the `AWS_CONTAINER_AUTHORIZATION_TOKEN`](https://docs.aws.amazon.com/sdkref/latest/guide/feature-container-credentials.html) while I was working on `aws-vault` support (#612). With `aws-vault` you can use `aws-vault exec --ecs-server` to run the tool in server mode which emulates the ECS credential provider and uses these environmental variables.