### PR TITLE
Use OIDC to assume CI AWS role

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -42,10 +42,6 @@ jobs:
       MINIO_REGION_NAME: aregion
     steps:
       - uses: actions/checkout@v2
-      - name: Show JWT from GH OIDC
-        run: |
-          curl -s -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=sts.amazonaws.com" | tee JSON
-          echo "$JSON" | jq -r .value | cut -d. -f2 | base64 -d | jq
       - name: Assume AWS role
         uses: aws-actions/configure-aws-credentials@v2
         with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -41,6 +41,9 @@ jobs:
       MINIO_REGION_NAME: aregion
     steps:
       - uses: actions/checkout@v2
+      - name: Show JWT from GH OIDC
+        run: |
+          curl -s -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=sts.amazonaws.com" | jq -r .value | cut -d. -f2 | base64 -d | jq
       - name: Assume AWS role
         uses: aws-actions/configure-aws-credentials@v2
         with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -6,7 +6,6 @@ on:
       - master
       - staging
       - trying
-      - cv/oidc-ci-role
     tags: '*'
   schedule:
     - cron: '0 2 * * *'  # Daily at 2 a.m. UTC

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -45,6 +45,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/AWS.jl
+          aws-region: us-east-1
       - name: MinIO server setup
         run: |
           case "$RUNNER_OS" in

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -43,7 +43,8 @@ jobs:
       - uses: actions/checkout@v2
       - name: Show JWT from GH OIDC
         run: |
-          curl -s -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=sts.amazonaws.com" | jq -r .value | cut -d. -f2 | base64 -d | jq
+          curl -s -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=sts.amazonaws.com" | tee JSON
+          echo "$JSON" | jq -r .value | cut -d. -f2 | base64 -d | jq
       - name: Assume AWS role
         uses: aws-actions/configure-aws-credentials@v2
         with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Assume AWS role
         uses: aws-actions/configure-aws-credentials@v2
         with:
-          role-to-assume: arn:aws:iam::{{ secret.AWS_ACCOUNT_ID }}:role/AWS.jl
+          role-to-assume: arn:aws:iam::{{ secrets.AWS_ACCOUNT_ID }}:role/AWS.jl
           aws-region: us-east-1
       - name: MinIO server setup
         run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -45,7 +45,6 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/AWS.jl
-          aws-region: us-east-1
       - name: MinIO server setup
         run: |
           case "$RUNNER_OS" in

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Assume AWS role
         uses: aws-actions/configure-aws-credentials@v2
         with:
-          role-to-assume: arn:aws:iam::{{ secrets.AWS_ACCOUNT_ID }}:role/AWS.jl
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/AWS.jl
           aws-region: us-east-1
       - name: MinIO server setup
         run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,6 +12,11 @@ on:
 jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
+    permissions:
+      # Required for interacting with GitHub's OIDC Token endpoint:
+      # https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services#adding-permissions-settings
+      id-token: write
+      contents: read  # Required for `actions/checkout`
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     continue-on-error: ${{ matrix.version == 'nightly' }}
@@ -36,6 +41,11 @@ jobs:
       MINIO_REGION_NAME: aregion
     steps:
       - uses: actions/checkout@v2
+      - name: Assume AWS role
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: arn:aws:iam::{{ secret.AWS_ACCOUNT_ID }}:role/AWS.jl
+          aws-region: us-east-1
       - name: MinIO server setup
         run: |
           case "$RUNNER_OS" in
@@ -73,9 +83,6 @@ jobs:
           git config --global user.name Tester
           git config --global user.email te@st.er
       - uses: julia-actions/julia-runtest@latest
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
   slack:
     name: Notify Slack Failure
     needs: test

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -6,6 +6,7 @@ on:
       - master
       - staging
       - trying
+      - cv/oidc-ci-role
     tags: '*'
   schedule:
     - cron: '0 2 * * *'  # Daily at 2 a.m. UTC

--- a/test/AWSConfig.jl
+++ b/test/AWSConfig.jl
@@ -7,10 +7,9 @@
         patch = Patches._assume_role_patch("AssumeRole"; access_key=access_key_id)
 
         config = withenv(
+            [k => nothing for k in filter(startswith("AWS_"), keys(ENV))]...,
             "AWS_CONFIG_FILE" => joinpath(config_dir, "config"),
             "AWS_SHARED_CREDENTIALS_FILE" => joinpath(config_dir, "credentials"),
-            "AWS_ACCESS_KEY_ID" => nothing,
-            "AWS_SECRET_ACCESS_KEY" => nothing,
         ) do
             apply(patch) do
                 AWSConfig(; profile="default")
@@ -23,13 +22,17 @@
     @testset "default profile section names" begin
         allowed_default_sections = ["default", "profile default"]
         mktemp() do config_path, _
-            for default_section_str in allowed_default_sections
-                config = """
-                [$default_section_str]
-                region = xx-yy-1
-                """
-                write(config_path, config)
-                @test aws_get_region(; profile="default", config=config_path) == "xx-yy-1"
+            withenv(
+                [k => nothing for k in filter(startswith("AWS_"), keys(ENV))]...,
+            ) do
+                for default_section_str in allowed_default_sections
+                    config = """
+                    [$default_section_str]
+                    region = xx-yy-1
+                    """
+                    write(config_path, config)
+                    @test aws_get_region(; profile="default", config=config_path) == "xx-yy-1"
+                end
             end
         end
     end

--- a/test/AWSConfig.jl
+++ b/test/AWSConfig.jl
@@ -22,16 +22,15 @@
     @testset "default profile section names" begin
         allowed_default_sections = ["default", "profile default"]
         mktemp() do config_path, _
-            withenv(
-                [k => nothing for k in filter(startswith("AWS_"), keys(ENV))]...,
-            ) do
+            withenv([k => nothing for k in filter(startswith("AWS_"), keys(ENV))]...) do
                 for default_section_str in allowed_default_sections
                     config = """
                     [$default_section_str]
                     region = xx-yy-1
                     """
                     write(config_path, config)
-                    @test aws_get_region(; profile="default", config=config_path) == "xx-yy-1"
+                    region = aws_get_region(; profile="default", config=config_path)
+                    @test region == "xx-yy-1"
                 end
             end
         end

--- a/test/resources/aws_jl_test.yaml
+++ b/test/resources/aws_jl_test.yaml
@@ -29,6 +29,9 @@ Resources:
         Statement:
           - Effect: Allow
             Principal:
+              # Requires that an Identify Provider has been manually added in the AWS account.
+              # https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc.html#manage-oidc-provider-console
+              # https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services#adding-the-identity-provider-to-aws
               Federated: !Sub arn:aws:iam::${AWS::AccountId}:oidc-provider/token.actions.githubusercontent.com
             Action: sts:AssumeRoleWithWebIdentity
             Condition:
@@ -39,7 +42,6 @@ Resources:
                 #     - !Sub repo:${GitHubOrg}/${GitHubRepo}:ref:refs/heads/staging
               StringLike:
                 token.actions.githubusercontent.com:sub: !Sub repo:${GitHubOrg}/${GitHubRepo}:*
-
 
   StackInfoPolicy:
     Type: AWS::IAM::ManagedPolicy

--- a/test/resources/aws_jl_test.yaml
+++ b/test/resources/aws_jl_test.yaml
@@ -37,11 +37,10 @@ Resources:
             Condition:
               StringEquals:
                 token.actions.githubusercontent.com:aud: sts.amazonaws.com
-                # token.actions.githubusercontent.com:sub:
-                #     - !Sub repo:${GitHubOrg}/${GitHubRepo}:ref:refs/heads/trying
-                #     - !Sub repo:${GitHubOrg}/${GitHubRepo}:ref:refs/heads/staging
-              StringLike:
-                token.actions.githubusercontent.com:sub: !Sub repo:${GitHubOrg}/${GitHubRepo}:*
+                token.actions.githubusercontent.com:sub:
+                    - !Sub repo:${GitHubOrg}/${GitHubRepo}:ref:refs/heads/trying
+                    - !Sub repo:${GitHubOrg}/${GitHubRepo}:ref:refs/heads/staging
+                    - !Sub repo:${GitHubOrg}/${GitHubRepo}:ref:refs/heads/master
 
   StackInfoPolicy:
     Type: AWS::IAM::ManagedPolicy

--- a/test/resources/aws_jl_test.yaml
+++ b/test/resources/aws_jl_test.yaml
@@ -1,20 +1,49 @@
+# `aws cloudformation create-stack --stack-name AWS-jl-test --template-body file://aws_jl_test.yaml --capabilities CAPABILITY_NAMED_IAM`
 ---
 AWSTemplateFormatVersion: 2010-09-09
 Description: >-
   A stack for testing AWS.jl from public CI
 
 Parameters:
-  PublicCIUser:
-    Description: User which can assume the testing role
+  GitHubOrg:
+    Description: GitHub organization used as part of assuming the CI role
     Type: String
+    AllowedPattern: ^[\w.-]+$
+    Default: JuliaCloud
+
+  GitHubRepo:
+    Description: GitHub repository used as part of assuming the CI role
+    Type: String
+    AllowedPattern: ^[\w.-]+$
+    Default: AWS.jl
+
 
 Resources:
+  PublicCIRole:
+    Type: AWS::IAM::Role
+    Properties:
+      Description: Role used for testing
+      RoleName: !Ref GitHubRepo
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Federated: !Sub arn:aws:iam::${AWS::AccountId}:oidc-provider/token.actions.githubusercontent.com
+            Action: sts:AssumeRoleWithWebIdentity
+            Condition:
+              StringEquals:
+                token.actions.githubusercontent.com:aud: sts.amazonaws.com
+                token.actions.githubusercontent.com:sub:
+                    - !Sub repo:${GitHubOrg}/${GitHubRepo}:ref:refs/heads/trying
+                    - !Sub repo:${GitHubOrg}/${GitHubRepo}:ref:refs/heads/staging
+
   StackInfoPolicy:
     Type: AWS::IAM::ManagedPolicy
     Properties:
       Description: Allow access to stack outputs
-      Users:
-        - !Ref PublicCIUser
+      Roles:
+        - !Ref PublicCIRole
       PolicyDocument:
         Version: 2012-10-17
         Statement:
@@ -22,12 +51,12 @@ Resources:
             Action: cloudformation:DescribeStacks
             Resource: !Sub arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/${AWS::StackName}/*
 
-  IAMPolicy:
+  IAMTestPolicy:
     Type: AWS::IAM::Policy
     Properties:
-      PolicyName: IAMPolicy
-      Users:
-        - !Ref PublicCIUser
+      PolicyName: !Sub ${GitHubRepo}-IAMTestPolicy
+      Roles:
+        - !Ref PublicCIRole
       PolicyDocument:
         Version: 2012-10-17
         Statement:
@@ -38,12 +67,12 @@ Resources:
               - iam:DeletePolicy
             Resource:
               - !Sub arn:aws:iam::${AWS::AccountId}:policy/aws-jl-test-*
-  SecretsManagerPolicy:
+  SecretsManagerTestPolicy:
     Type: AWS::IAM::Policy
     Properties:
-      PolicyName: SecretsManagerTestPolicy
-      Users:
-        - !Ref PublicCIUser
+      PolicyName: !Sub ${GitHubRepo}-SecretsManagerTestPolicy
+      Roles:
+        - !Ref PublicCIRole
       PolicyDocument:
         Version: 2012-10-17
         Statement:
@@ -58,9 +87,9 @@ Resources:
   GlacierTestPolicy:
     Type: AWS::IAM::Policy
     Properties:
-      PolicyName: GlacierTestPolicy
-      Users:
-        - !Ref PublicCIUser
+      PolicyName: !Sub ${GitHubRepo}-GlacierTestPolicy
+      Roles:
+        - !Ref PublicCIRole
       PolicyDocument:
         Version: 2012-10-17
         Statement:
@@ -77,9 +106,9 @@ Resources:
   S3TestPolicy:
     Type: AWS::IAM::Policy
     Properties:
-      PolicyName: S3TestPolicy
-      Users:
-        - !Ref PublicCIUser
+      PolicyName: !Sub ${GitHubRepo}-S3TestPolicy
+      Roles:
+        - !Ref PublicCIRole
       PolicyDocument:
         Version: 2012-10-17
         Statement:
@@ -116,9 +145,9 @@ Resources:
   SQSTestPolicy:
     Type: AWS::IAM::Policy
     Properties:
-      PolicyName: SQSTestPolicy
-      Users:
-        - !Ref PublicCIUser
+      PolicyName: !Sub ${GitHubRepo}-SQSTestPolicy
+      Roles:
+        - !Ref PublicCIRole
       PolicyDocument:
         Version: 2012-10-17
         Statement:

--- a/test/resources/aws_jl_test.yaml
+++ b/test/resources/aws_jl_test.yaml
@@ -34,9 +34,12 @@ Resources:
             Condition:
               StringEquals:
                 token.actions.githubusercontent.com:aud: sts.amazonaws.com
-                token.actions.githubusercontent.com:sub:
-                    - !Sub repo:${GitHubOrg}/${GitHubRepo}:ref:refs/heads/trying
-                    - !Sub repo:${GitHubOrg}/${GitHubRepo}:ref:refs/heads/staging
+                # token.actions.githubusercontent.com:sub:
+                #     - !Sub repo:${GitHubOrg}/${GitHubRepo}:ref:refs/heads/trying
+                #     - !Sub repo:${GitHubOrg}/${GitHubRepo}:ref:refs/heads/staging
+              StringLike:
+                token.actions.githubusercontent.com:sub: !Sub repo:${GitHubOrg}/${GitHubRepo}:*
+
 
   StackInfoPolicy:
     Type: AWS::IAM::ManagedPolicy


### PR DESCRIPTION
Using OpenID Connect in our GitHub Actions workflows to authenticate with AWS. For details see:
- https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services
- https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect

The primary benefit of this is that we no longer have to specify AWS credentials as GitHub Action secrets which is more secure as there are no longer any secrets that could be leaked. I've already deployed the update version of the `aws_jl_test.yaml` CloudFormation template and currently this co-exists with the old CloudFormation stack.

Sibling PR: https://github.com/JuliaCloud/AWSS3.jl/pull/284