### PR TITLE
Improve exception when IAM Identity Center auth is used

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AWS"
 uuid = "fbe9abb3-538b-5e4e-ba9e-bc94f4f92ebc"
 license = "MIT"
-version = "1.87.0"
+version = "1.87.1"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/AWSCredentials.jl
+++ b/src/AWSCredentials.jl
@@ -462,6 +462,15 @@ function sso_credentials(profile=nothing)
         settings = _aws_profile_config(ini, p)
         isempty(settings) && return nothing
 
+        # AWS IAM Identity Center authentication is not yet supported in AWS.jl
+        sso_session = get(settings, "sso_session", nothing)
+        if !isnothing(sso_session)
+            error("IAM Identity Center authentication is not yet supported by AWS.jl. " *
+                  "See https://github.com/JuliaCloud/AWS.jl/issues/628")
+        end
+
+        # Legacy SSO configuration
+        # https://docs.aws.amazon.com/cli/latest/userguide/sso-configure-profile-legacy.html#sso-configure-profile-manual
         sso_start_url = get(settings, "sso_start_url", nothing)
 
         if !isnothing(sso_start_url)

--- a/src/AWSCredentials.jl
+++ b/src/AWSCredentials.jl
@@ -465,8 +465,10 @@ function sso_credentials(profile=nothing)
         # AWS IAM Identity Center authentication is not yet supported in AWS.jl
         sso_session = get(settings, "sso_session", nothing)
         if !isnothing(sso_session)
-            error("IAM Identity Center authentication is not yet supported by AWS.jl. " *
-                  "See https://github.com/JuliaCloud/AWS.jl/issues/628")
+            error(
+                "IAM Identity Center authentication is not yet supported by AWS.jl. " *
+                "See https://github.com/JuliaCloud/AWS.jl/issues/628",
+            )
         end
 
         # Legacy SSO configuration


### PR DESCRIPTION
AWS.jl currently doesn't support authentication via IAM Identity Center (successor to AWS SSO) (https://github.com/JuliaCloud/AWS.jl/issues/628) which results in a `NoCredentials` exception being raised which is misleading. This PR simply throws a more helpful exception when users attempt to use this currently unsupported authentication method.