### PR TITLE
Drop use of bors to trigger CI tests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - 1
+          - "1"  # Latest release
         os:
           - ubuntu-latest
           - macOS-latest
@@ -31,7 +31,7 @@ jobs:
         include:
           # Add a job using the earliest version of Julia supported by this package
           - os: ubuntu-latest
-            version: 1.6
+            version: "1.6"
             arch: x64
     env:
       MINIO_ACCESS_KEY: minio

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,11 +1,9 @@
 name: CI
-# Run on master, any tag or any pull request
 on:
+  pull_request:
   push:
     branches:
       - master
-      - staging
-      - trying
     tags: '*'
   schedule:
     - cron: '0 2 * * *'  # Daily at 2 a.m. UTC

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 ## AWS.jl
 
 [![CI](https://github.com/JuliaCloud/AWS.jl/workflows/CI/badge.svg)](https://github.com/JuliaCloud/AWS.jl/actions?query=workflow%3ACI)
-[![Bors: enabled](https://bors.tech/images/badge_small.svg)](https://app.bors.tech/repositories/6778)
 [![Code Style: Blue](https://img.shields.io/badge/code%20style-blue-4495d1.svg)](https://github.com/invenia/BlueStyle)
 [![ColPrac: Contributor's Guide on Collaborative Practices for Community Packages](https://img.shields.io/badge/ColPrac-Contributor's%20Guide-blueviolet)](https://github.com/SciML/ColPrac)
 

--- a/bors.toml
+++ b/bors.toml
@@ -1,6 +1,0 @@
-status = [
-    "Julia 1.6 - ubuntu-latest - x64",
-    "Julia 1 - macOS-latest - x64",
-    "Julia 1 - ubuntu-latest - x64",
-]
-delete-merged-branches = true

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,7 +1,6 @@
 ## AWS.jl
 
 [![CI](https://github.com/JuliaCloud/AWS.jl/workflows/CI/badge.svg)](https://github.com/JuliaCloud/AWS.jl/actions?query=workflow%3ACI)
-[![Bors: enabled](https://bors.tech/images/badge_small.svg)](https://app.bors.tech/repositories/6778)
 [![Code Style: Blue](https://img.shields.io/badge/code%20style-blue-4495d1.svg)](https://github.com/invenia/BlueStyle)
 [![ColPrac: Contributor's Guide on Collaborative Practices for Community Packages](https://img.shields.io/badge/ColPrac-Contributor's%20Guide-blueviolet)](https://github.com/SciML/ColPrac)
 

--- a/test/resources/aws_jl_test.yaml
+++ b/test/resources/aws_jl_test.yaml
@@ -37,10 +37,12 @@ Resources:
             Condition:
               StringEquals:
                 token.actions.githubusercontent.com:aud: sts.amazonaws.com
+              StringLike:
+                # Allow pull requests, the master branch, and any tag to assume this role
                 token.actions.githubusercontent.com:sub:
-                    - !Sub repo:${GitHubOrg}/${GitHubRepo}:ref:refs/heads/trying
-                    - !Sub repo:${GitHubOrg}/${GitHubRepo}:ref:refs/heads/staging
-                    - !Sub repo:${GitHubOrg}/${GitHubRepo}:ref:refs/heads/master
+                  - !Sub repo:${GitHubOrg}/${GitHubRepo}:pull_request
+                  - !Sub repo:${GitHubOrg}/${GitHubRepo}:ref:refs/heads/master
+                  - !Sub repo:${GitHubOrg}/${GitHubRepo}:ref:refs/tags/*
 
   StackInfoPolicy:
     Type: AWS::IAM::ManagedPolicy


### PR DESCRIPTION
See: https://github.com/JuliaCloud/AWS.jl/issues/630. A couple of repo level changes were required to make this functional (documented [here](https://github.com/JuliaCloud/AWS.jl/issues/630#issuecomment-1581290496)). If we decide to roll this back we need to also roll those changes back.