### PR TITLE
Create `assume_role` function

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AWS"
 uuid = "fbe9abb3-538b-5e4e-ba9e-bc94f4f92ebc"
 license = "MIT"
-version = "1.88.0"
+version = "1.89.0"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/AWS.jl
+++ b/src/AWS.jl
@@ -19,7 +19,7 @@ export @service
 export _merge
 export AbstractAWSConfig, AWSConfig, AWSExceptions, AWSServices, Request
 export ec2_instance_metadata, ec2_instance_region
-export generate_service_url, global_aws_config, set_user_agent
+export assume_role, generate_service_url, global_aws_config, set_user_agent
 export sign!, sign_aws2!, sign_aws4!
 export JSONService, RestJSONService, RestXMLService, QueryService, set_features
 
@@ -36,6 +36,7 @@ include(joinpath("utilities", "request.jl"))
 include(joinpath("utilities", "response.jl"))
 include(joinpath("utilities", "sign.jl"))
 include(joinpath("utilities", "downloads_backend.jl"))
+include(joinpath("utilities", "role.jl"))
 
 include("deprecated.jl")
 

--- a/src/utilities/role.jl
+++ b/src/utilities/role.jl
@@ -1,0 +1,105 @@
+"""
+    assume_role(role; kwargs...) -> AWSConfig
+    assume_role(::Type{AWSConfig}, role; kwargs...) -> AWSConfig
+    assume_role(::Type{AWSCredentials}, role; kwargs...) -> AWSCredentials
+
+Assumes the IAM `role` via temporary credentials. The current user or role (specified via
+the `aws_config` keyword) must be included in the trust policy of the `role`.
+
+[Role chaining](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_terms-and-concepts.html#iam-term-role-chaining)
+must be manually specified by nesting `assume_role` calls together (e.g. "role-a" has
+permissions to assume "role-b": `assume_role("role-a"; aws_config=assume_role("role_a")`).
+
+# Arguments
+- `role::AbstractString`: The AWS IAM role to assume. Either a full role ARN or just the
+  role name. If only the role name is specified the role will be assumed to reside in the
+  same account used in `aws_config`.
+
+# Keywords
+- `aws_config::AbstractAWSConfig` (optional): User or role attempting to assume the
+  specified `role`
+- `duration::Integer` (optional): Role session duration in seconds.
+- `mfa_serial::AbstractString` (optional): The identification number of the MFA device that
+  is associated with the user making the `AssumeRole` API call. Either a serial number for a
+  hardware device ("GAHT12345678") or an ARN for a virtual device
+  ("arn:aws:iam::123456789012:mfa/user"). When specified a MFA token must be provided via
+  `token` or an interactive prompt.
+- `token::AbstractString` (optional): The value provided by the MFA device. Only can be
+  specified when `mfa_serial` is set.
+- `session_name::AbstractString` (optional): The unique role session name associated with
+  this API request.
+"""
+function assume_role end
+
+assume_role(role; kwargs...) = assume_role(AWSConfig, role; kwargs...)
+
+function assume_role(::Type{AWSConfig}, role; aws_config=global_aws_config(), kwargs...)
+    creds = assume_role(AWSCredentials, role; aws_config, kwargs...)
+    return AWSConfig(creds, aws_config.region, aws_config.output, aws_config.max_attempts)
+end
+
+function assume_role(
+    ::Type{AWSCredentials},
+    role::AbstractString;
+    aws_config::AbstractAWSConfig=global_aws_config(),
+    duration::Union{Integer,Nothing}=nothing,
+    mfa_serial::Union{AbstractString,Nothing}=nothing,
+    token::Union{AbstractString,Nothing}=nothing,
+    session_name::Union{AbstractString,Nothing}=nothing,
+)
+    if startswith(role, "arn:aws:iam")
+        account_id = ""  # Avoiding unnecessary parsing ARN and expensive API call
+        role_arn = role
+    else
+        account_id = aws_account_number(aws_config)
+        role_arn = "arn:aws:iam::$account_id:role/$role"
+    end
+
+    params = Dict{String,Any}("RoleArn" => role_arn)
+    if session_name !== nothing
+        params["RoleSessionName"] = session_name
+    else
+        params["RoleSessionName"] = _role_session_name(
+            "AWS.jl-",
+            ENV["USER"],
+            "-" * Dates.format(now(UTC), dateformat"yyyymmdd\THHMMSS\Z"),
+        )
+    end
+
+    if duration !== nothing
+        params["DurationSeconds"] = duration
+    end
+
+    if mfa_serial !== nothing && token !== nothing
+        params["SerialNumber"] = mfa_serial
+        params["TokenCode"] = token
+    elseif mfa_serial !== nothing && token === nothing
+        params["SerialNumber"] = mfa_serial
+        token = Base.getpass("Enter MFA code for $mfa_serial")
+        params["TokenCode"] = Base.shred!(token) do t
+            read(t, String)
+        end
+    elseif mfa_serial === nothing && token !== nothing
+        throw(ArgumentError("Keyword `token` cannot be be specified when `mfa_serial` is not set"))
+    end
+
+    response = AWSServices.sts(
+        "AssumeRole",
+        params;
+        aws_config,
+        feature_set=AWS.FeatureSet(; use_response_type=true),
+    )
+    body = parse(response)
+    role_creds = body["AssumeRoleResult"]["Credentials"]
+    role_user = body["AssumeRoleResult"]["AssumedRoleUser"]
+    return AWSCredentials(
+        role_creds["AccessKeyId"],
+        role_creds["SecretAccessKey"],
+        role_creds["SessionToken"],
+        role_user["Arn"],
+        account_id;  # May as well populate "account_number" field when we have it
+        expiry=DateTime(rstrip(role_creds["Expiration"], 'Z')),
+        # Avoid passing the `token` into the credential renew function as it will be expired
+        renew=() -> assume_role(AWSCredentials, role_arn; aws_config, duration, mfa_serial, session_name),
+    )
+end

--- a/src/utilities/role.jl
+++ b/src/utilities/role.jl
@@ -31,7 +31,9 @@ assume "role-b": `assume_role(assume_role(AWSConfig(), "role-a"), "role-b")`).
 """
 function assume_role end
 
-assume_role(principal, role; kwargs...) = assume_role(AWSConfig, principal, role; kwargs...)
+function assume_role(principal, role; kwargs...)
+    return assume_role(typeof(principal), principal, role; kwargs...)
+end
 
 function assume_role(::Type{AWSConfig}, principal::AWSConfig, role; kwargs...)
     creds = assume_role(AWSCredentials, principal, role; kwargs...)

--- a/src/utilities/role.jl
+++ b/src/utilities/role.jl
@@ -115,9 +115,7 @@ function assume_role_creds(
     role_user = body["AssumeRoleResult"]["AssumedRoleUser"]
     renew = function ()
         # Avoid passing the `token` into the credential renew function as it will be expired
-        return assume_role(
-            AWSCredentials, principal, role_arn; duration, mfa_serial, session_name
-        )
+        return assume_role_creds(principal, role_arn; duration, mfa_serial, session_name)
     end
 
     return AWSCredentials(

--- a/test/resources/aws_jl_test.yaml
+++ b/test/resources/aws_jl_test.yaml
@@ -1,4 +1,7 @@
-# `aws cloudformation create-stack --stack-name AWS-jl-test --template-body file://aws_jl_test.yaml --capabilities CAPABILITY_NAMED_IAM`
+# ```
+# aws cloudformation update-stack --stack-name AWS-jl-test --template-body file://aws_jl_test.yaml --capabilities CAPABILITY_NAMED_IAM --region us-east-1
+# ```
+
 ---
 AWSTemplateFormatVersion: 2010-09-09
 Description: >-
@@ -43,6 +46,24 @@ Resources:
                   - !Sub repo:${GitHubOrg}/${GitHubRepo}:pull_request
                   - !Sub repo:${GitHubOrg}/${GitHubRepo}:ref:refs/heads/master
                   - !Sub repo:${GitHubOrg}/${GitHubRepo}:ref:refs/tags/*
+          # - Effect: Allow
+          #   Principal:
+          #     AWS: !Sub arn:aws:iam::${AWS::AccountId}:root
+          #   Action: sts:AssumeRole
+
+  PublicCIAssumePolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: PublicCIAssumeRoles
+      Roles:
+        - !Ref PublicCIRole
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action:
+              - sts:AssumeRole
+            Resource: !Sub arn:aws:iam::${AWS::AccountId}:role/*
 
   StackInfoPolicy:
     Type: AWS::IAM::ManagedPolicy
@@ -173,3 +194,72 @@ Resources:
               - sqs:SendMessageBatch
               - sqs:SetQueueAttributes
             Resource: !Sub arn:aws:sqs:*:${AWS::AccountId}:aws-jl-test-*
+
+  ###
+  ### Testset specific roles/policies
+  ###
+
+  AssumeRoleTestsetRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub ${GitHubRepo}-AssumeRoleTestset
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: !GetAtt PublicCIRole.Arn
+            Action: sts:AssumeRole
+
+  AssumeRoleTestsetPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: !Sub ${GitHubRepo}-AssumeRoleTestset
+      Roles:
+        - !Ref AssumeRoleTestsetRole
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action: sts:AssumeRole
+            Resource: !GetAtt RoleA.Arn
+
+  # No permissions are required to perform the `sts:GetCallerIdentity` action
+  # https://docs.aws.amazon.com/STS/latest/APIReference/API_GetCallerIdentity.html
+
+  RoleA:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub ${GitHubRepo}-RoleA
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: !GetAtt AssumeRoleTestsetRole.Arn
+            Action: sts:AssumeRole
+
+  RoleAPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: !Sub ${GitHubRepo}-RoleA
+      Roles:
+        - !Ref RoleA
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action: sts:AssumeRole
+            Resource: !GetAtt RoleB.Arn
+
+  RoleB:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub ${GitHubRepo}-RoleB
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: !GetAtt RoleA.Arn
+            Action: sts:AssumeRole

--- a/test/role.jl
+++ b/test/role.jl
@@ -1,0 +1,87 @@
+function get_assumed_role(aws_config::AbstractAWSConfig=global_aws_config())
+    r = AWSServices.sts(
+        "GetCallerIdentity";
+        aws_config,
+        feature_set=AWS.FeatureSet(; use_response_type=true),
+    )
+    result = parse(r)
+    arn = result["GetCallerIdentityResult"]["Arn"]
+    m = match(r":assumed-role/(?<role>[^/]+)", arn)
+    if m !== nothing
+        return m["role"]
+    else
+        error("Caller Identity ARN is not an assumed role: $arn")
+    end
+end
+
+get_assumed_role(creds::AWSCredentials) = get_assumed_role(AWSConfig(; creds))
+
+@testset "assume_role" begin
+    # In order to mitigate the effects of using `assume_role` in order to test itself we'll
+    # use the lowest-level call with as many defaults as possible.
+    base_config = aws
+    creds = assume_role(AWSCredentials, base_config, testset_role("AssumeRoleTestset"))
+    config = AWSConfig(; creds)
+    @test get_assumed_role(config) == testset_role("AssumeRoleTestset")
+
+    role_a = testset_role("RoleA")
+    role_b = testset_role("RoleB")
+
+    @testset "basic" begin
+        creds = assume_role(AWSCredentials, config, role_a)
+        @test creds isa AWSCredentials
+        @test creds.token != ""  # Temporary credentials
+        @test creds.renew !== nothing
+
+        cfg = assume_role(AWSConfig, config, role_a)
+        @test cfg isa AWSConfig
+        @test cfg.credentials isa AWSCredentials
+        @test cfg.region == config.region
+        @test cfg.output == config.output
+        @test cfg.max_attempts == config.max_attempts
+    end
+
+    @testset "role name/ARN" begin
+        account_id = aws_account_number(config)
+
+        creds = assume_role(AWSCredentials, config, role_a)
+        @test contains(creds.user_arn, r":assumed-role/" * (role_a * '/'))
+        @test creds.account_number == account_id
+
+        creds = assume_role(AWSCredentials, config, "arn:aws:iam::$account_id:role/$role_a")
+        @test contains(creds.user_arn, r":assumed-role/" * (role_a * '/'))
+        @test creds.account_number == ""
+    end
+
+    @testset "duration" begin
+        drift = Second(1)
+
+        creds = assume_role(AWSCredentials, config, role_a; duration=nothing)
+        t = floor(now(UTC), Second)
+        @test t <= creds.expiry <= t + Second(3600) + drift
+
+        creds = assume_role(AWSCredentials, config, role_a; duration=900)
+        t = floor(now(UTC), Second)
+        @test t <= creds.expiry <= t + Second(900) + drift
+    end
+
+    @testset "session_name" begin
+        session_prefix = "AWS.jl-" * ENV["USER"]
+        creds = assume_role(AWSCredentials, config, role_a; session_name=nothing)
+        @test contains(creds.user_arn, r":assumed-role/" * (role_a * '/' * session_prefix) * r"-\d{8}T\d{6}Z$")
+        @test get_assumed_role(creds) == role_a
+
+        session_name = "assume-role-session-name-testset-" * randstring(5)
+        creds = assume_role(AWSCredentials, config, role_a; session_name)
+        @test contains(creds.user_arn, r":assumed-role/" * (role_a * '/' * session_name) * r"$")
+        @test get_assumed_role(creds) == role_a
+    end
+
+    @testset "role chaining" begin
+        cfg = assume_role(assume_role(config, role_a), role_b)
+        @test get_assumed_role(cfg) == role_b
+
+        cfg = config |> assume_role(role_a) |> assume_role(role_b)
+        @test get_assumed_role(cfg) == role_b
+    end
+end

--- a/test/role.jl
+++ b/test/role.jl
@@ -68,12 +68,14 @@ get_assumed_role(creds::AWSCredentials) = get_assumed_role(AWSConfig(; creds))
     @testset "session_name" begin
         session_prefix = "AWS.jl-" * ENV["USER"]
         creds = assume_role(AWSCredentials, config, role_a; session_name=nothing)
-        @test contains(creds.user_arn, r":assumed-role/" * (role_a * '/' * session_prefix) * r"-\d{8}T\d{6}Z$")
+        regex = r":assumed-role/" * (role_a * '/' * session_prefix) * r"-\d{8}T\d{6}Z$"
+        @test contains(creds.user_arn, regex)
         @test get_assumed_role(creds) == role_a
 
         session_name = "assume-role-session-name-testset-" * randstring(5)
         creds = assume_role(AWSCredentials, config, role_a; session_name)
-        @test contains(creds.user_arn, r":assumed-role/" * (role_a * '/' * session_name) * r"$")
+        regex = r":assumed-role/" * (role_a * '/' * session_name) * r"$"
+        @test contains(creds.user_arn, regex)
         @test get_assumed_role(creds) == role_a
     end
 
@@ -81,7 +83,9 @@ get_assumed_role(creds::AWSCredentials) = get_assumed_role(AWSConfig(; creds))
         cfg = assume_role(assume_role(config, role_a), role_b)
         @test get_assumed_role(cfg) == role_b
 
+        #! format: off
         cfg = config |> assume_role(role_a) |> assume_role(role_b)
+        #! format: on
         @test get_assumed_role(cfg) == role_b
     end
 end

--- a/test/role.jl
+++ b/test/role.jl
@@ -79,6 +79,19 @@ get_assumed_role(creds::AWSCredentials) = get_assumed_role(AWSConfig(; creds))
         @test get_assumed_role(creds) == role_a
     end
 
+    @testset "renew" begin
+        creds = assume_role_creds(config, role_a; duration=nothing)
+        @test creds.renew isa Function
+        @test get_assumed_role(creds) == role_a
+
+        new_creds = creds.renew()
+        @test new_creds isa AWSCredentials
+        @test get_assumed_role(new_creds) == role_a
+        @test new_creds.access_key_id != creds.access_key_id
+        @test new_creds.secret_key != creds.secret_key
+        @test new_creds.expiry >= creds.expiry
+    end
+
     @testset "role chaining" begin
         cfg = assume_role(assume_role(config, role_a), role_b)
         @test get_assumed_role(cfg) == role_b

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -50,6 +50,8 @@ function _now_formatted()
     return lowercase(Dates.format(now(Dates.UTC), dateformat"yyyymmdd\THHMMSSsss\Z"))
 end
 
+testset_role(role_name) = "AWS.jl-$role_name"
+
 @testset "AWS.jl" begin
     include("AWSExceptions.jl")
     include("AWSMetadataUtilities.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -62,6 +62,7 @@ end
         AWS.DEFAULT_BACKEND[] = backend()
         include("AWS.jl")
         include("AWSCredentials.jl")
+        include("role.jl")
         include("issues.jl")
 
         if TEST_MINIO

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,5 @@
 using AWS
-using AWS: AWSCredentials
-using AWS: AWSServices
+using AWS: AWSCredentials, AWSServices, assume_role_creds
 using AWS.AWSExceptions: AWSException, InvalidFileName, NoCredentials, ProtocolNotDefined
 using AWS.AWSMetadata:
     ServiceFile,


### PR DESCRIPTION
Fixes #623. The `assume_role` function allows Julia users to easily assume another IAM role from within Julia. A version of this function was introduced into the test utilities of AWSS3.jl in https://github.com/JuliaCloud/AWSS3.jl/pull/287 as this was particularly useful for assuming testset specific roles.