### PR TITLE
Minor fixes for `assume_role`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,6 +26,7 @@ jobs:
         os:
           - ubuntu-latest
           - macOS-latest
+          - windows-latest
         arch:
           - x64
         include:
@@ -35,55 +36,14 @@ jobs:
             arch: x64
     steps:
       - uses: actions/checkout@v2
-      - name: Assume AWS role
-        uses: aws-actions/configure-aws-credentials@v2
-        with:
-          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/AWS.jl
-          aws-region: us-east-1
-      - name: MinIO server setup
-        if: runner.os != 'Windows'
-        env:
-          MINIO_ACCESS_KEY: minio
-          MINIO_SECRET_KEY: minio123
-          MINIO_REGION_NAME: aregion
-        shell: bash
-        run: |
-          case "$RUNNER_OS" in
-            Linux)
-              host_os="linux-amd64"
-              ;;
-            macOS)
-              host_os="darwin-amd64"
-              ;;
-            *)
-              echo "$RUNNER_OS not supported" >&2
-              exit 1
-              ;;
-          esac
-          curl -sSLO "https://dl.minio.io/server/minio/release/${host_os}/minio"
-          mkdir data
-          chmod +x ./minio
-          ./minio server --compat --quiet data 2>&1 > minio.log &
-          env | grep ^MINIO_ | tee -a "$GITHUB_ENV"
       - uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v1
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
-      - uses: julia-actions/julia-buildpkg@latest
-      - run: |
-          git config --global user.name Tester
-          git config --global user.email te@st.er
-      - uses: julia-actions/julia-runtest@latest
+      - shell: julia --color=yes {0}
+        run: |
+          _whoami() = readchomp(`id -un`)
+          @show _whoami() readchomp(`whoami`)
   docs:
     name: Documentation
     runs-on: ubuntu-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,7 +26,6 @@ jobs:
         os:
           - ubuntu-latest
           - macOS-latest
-          - windows-latest
         arch:
           - x64
         include:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -34,10 +34,6 @@ jobs:
           - os: ubuntu-latest
             version: "1.6"
             arch: x64
-    env:
-      MINIO_ACCESS_KEY: minio
-      MINIO_SECRET_KEY: minio123
-      MINIO_REGION_NAME: aregion
     steps:
       - uses: actions/checkout@v2
       - name: Assume AWS role
@@ -46,7 +42,13 @@ jobs:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/AWS.jl
           aws-region: us-east-1
       - name: MinIO server setup
+        if: runner.os != 'Windows'
+        shell: bash
         run: |
+          echo "MINIO_ACCESS_KEY=minio" | tee -a "$GITHUB_ENV"
+          echo "MINIO_SECRET_KEY=minio123" | tee -a "$GITHUB_ENV"
+          echo "MINIO_REGION_NAME=aregion" | tee -a "$GITHUB_ENV"
+
           case "$RUNNER_OS" in
             Linux)
               host_os="linux-amd64"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -42,7 +42,7 @@ jobs:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/AWS.jl
           aws-region: us-east-1
       - name: MinIO server setup
-        if: runner.os != 'Windows'
+        # if: runner.os != 'Windows'
         env:
           MINIO_ACCESS_KEY: minio
           MINIO_SECRET_KEY: minio123

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,7 +26,6 @@ jobs:
         os:
           - ubuntu-latest
           - macOS-latest
-          - windows-latest
         arch:
           - x64
         include:
@@ -36,14 +35,55 @@ jobs:
             arch: x64
     steps:
       - uses: actions/checkout@v2
+      - name: Assume AWS role
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/AWS.jl
+          aws-region: us-east-1
+      - name: MinIO server setup
+        if: runner.os != 'Windows'
+        env:
+          MINIO_ACCESS_KEY: minio
+          MINIO_SECRET_KEY: minio123
+          MINIO_REGION_NAME: aregion
+        shell: bash
+        run: |
+          case "$RUNNER_OS" in
+            Linux)
+              host_os="linux-amd64"
+              ;;
+            macOS)
+              host_os="darwin-amd64"
+              ;;
+            *)
+              echo "$RUNNER_OS not supported" >&2
+              exit 1
+              ;;
+          esac
+          curl -sSLO "https://dl.minio.io/server/minio/release/${host_os}/minio"
+          mkdir data
+          chmod +x ./minio
+          ./minio server --compat --quiet data 2>&1 > minio.log &
+          env | grep ^MINIO_ | tee -a "$GITHUB_ENV"
       - uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - shell: julia --color=yes {0}
-        run: |
-          _whoami() = readchomp(`id -un`)
-          @show _whoami() readchomp(`whoami`)
+      - uses: actions/cache@v1
+        env:
+          cache-name: cache-artifacts
+        with:
+          path: ~/.julia/artifacts
+          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-test-${{ env.cache-name }}-
+            ${{ runner.os }}-test-
+            ${{ runner.os }}-
+      - uses: julia-actions/julia-buildpkg@latest
+      - run: |
+          git config --global user.name Tester
+          git config --global user.email te@st.er
+      - uses: julia-actions/julia-runtest@latest
   docs:
     name: Documentation
     runs-on: ubuntu-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -61,7 +61,7 @@ jobs:
               exit 1
               ;;
           esac
-          curl -LO "https://dl.minio.io/server/minio/release/${host_os}/minio"
+          curl -sSLO "https://dl.minio.io/server/minio/release/${host_os}/minio"
           mkdir data
           chmod +x ./minio
           ./minio server --compat --quiet data 2>&1 > minio.log &

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -42,7 +42,7 @@ jobs:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/AWS.jl
           aws-region: us-east-1
       - name: MinIO server setup
-        # if: runner.os != 'Windows'
+        if: runner.os != 'Windows'
         env:
           MINIO_ACCESS_KEY: minio
           MINIO_SECRET_KEY: minio123

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -43,12 +43,12 @@ jobs:
           aws-region: us-east-1
       - name: MinIO server setup
         if: runner.os != 'Windows'
+        env:
+          MINIO_ACCESS_KEY: minio
+          MINIO_SECRET_KEY: minio123
+          MINIO_REGION_NAME: aregion
         shell: bash
         run: |
-          echo "MINIO_ACCESS_KEY=minio" | tee -a "$GITHUB_ENV"
-          echo "MINIO_SECRET_KEY=minio123" | tee -a "$GITHUB_ENV"
-          echo "MINIO_REGION_NAME=aregion" | tee -a "$GITHUB_ENV"
-
           case "$RUNNER_OS" in
             Linux)
               host_os="linux-amd64"
@@ -65,6 +65,7 @@ jobs:
           mkdir data
           chmod +x ./minio
           ./minio server --compat --quiet data 2>&1 > minio.log &
+          env | grep ^MINIO_ | tee -a "$GITHUB_ENV"
       - uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.version }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,6 +26,7 @@ jobs:
         os:
           - ubuntu-latest
           - macOS-latest
+          - windows-latest
         arch:
           - x64
         include:

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AWS"
 uuid = "fbe9abb3-538b-5e4e-ba9e-bc94f4f92ebc"
 license = "MIT"
-version = "1.89.0"
+version = "1.89.1"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/utilities/role.jl
+++ b/src/utilities/role.jl
@@ -81,7 +81,7 @@ function assume_role_creds(
     else
         params["RoleSessionName"] = _role_session_name(
             "AWS.jl-",
-            ENV["USER"],
+            _whoami(),
             "-" * Dates.format(now(UTC), dateformat"yyyymmdd\THHMMSS\Z"),
         )
     end
@@ -128,3 +128,15 @@ function assume_role_creds(
         renew,
     )
 end
+
+"""
+    _whoami() -> String
+
+The identity the current user has assumed (i.e. effective user name). May differ from the
+logged in user if the current user has been assumed, perhaps by means of `su`.
+
+Note that the environmental variables `USER` or `USERNAME` are
+[not Bash built-in variables](https://tldp.org/LDP/abs/html/internalvariables.html#AMIROOT)
+and are typically not present in containers.
+"""
+_whoami() = readchomp(`id -un`)  # The `whoami` utility is marked as obsolete

--- a/src/utilities/role.jl
+++ b/src/utilities/role.jl
@@ -132,11 +132,11 @@ end
 """
     _whoami() -> AbstractString
 
-The identity the current user has assumed (i.e. effective user name). May differ from the
+The identity of the current user (i.e. effective user name). May differ from the
 logged in user if the current user has been assumed, perhaps by means of `su`.
 
 Note that the environmental variables `USER` or `USERNAME` are
 [not Bash built-in variables](https://tldp.org/LDP/abs/html/internalvariables.html#AMIROOT)
-and are typically not present in containers.
+and by default are not present in containers.
 """
 _whoami() = readchomp(`id -un`)  # The `whoami` utility is marked as obsolete

--- a/src/utilities/role.jl
+++ b/src/utilities/role.jl
@@ -130,7 +130,7 @@ function assume_role_creds(
 end
 
 """
-    _whoami() -> String
+    _whoami() -> AbstractString
 
 The identity the current user has assumed (i.e. effective user name). May differ from the
 logged in user if the current user has been assumed, perhaps by means of `su`.

--- a/test/role.jl
+++ b/test/role.jl
@@ -16,6 +16,12 @@ end
 
 get_assumed_role(creds::AWSCredentials) = get_assumed_role(AWSConfig(; creds))
 
+@testset "_whoami" begin
+    user = AWS._whoami()
+    @test user isa String
+    @test !isempty(user)
+end
+
 @testset "assume_role / assume_role_creds" begin
     # In order to mitigate the effects of using `assume_role` in order to test itself we'll
     # use the lowest-level call with as many defaults as possible.
@@ -68,9 +74,9 @@ get_assumed_role(creds::AWSCredentials) = get_assumed_role(AWSConfig(; creds))
     end
 
     @testset "session_name" begin
-        session_prefix = "AWS.jl-" * ENV["USER"]
+        session_prefix = "AWS.jl-"
         creds = assume_role_creds(config, role_a; session_name=nothing)
-        regex = r":assumed-role/" * (role_a * '/' * session_prefix) * r"-\d{8}T\d{6}Z$"
+        regex = r":assumed-role/" * (role_a * '/' * session_prefix) * r".*-\d{8}T\d{6}Z$"
         @test contains(creds.user_arn, regex)
         @test get_assumed_role(creds) == role_a
 

--- a/test/role.jl
+++ b/test/role.jl
@@ -18,7 +18,7 @@ get_assumed_role(creds::AWSCredentials) = get_assumed_role(AWSConfig(; creds))
 
 @testset "_whoami" begin
     user = AWS._whoami()
-    @test user isa String
+    @test user isa AbstractString
     @test !isempty(user)
 end
 

--- a/test/role.jl
+++ b/test/role.jl
@@ -54,15 +54,17 @@ get_assumed_role(creds::AWSCredentials) = get_assumed_role(AWSConfig(; creds))
     end
 
     @testset "duration" begin
-        drift = Second(1)
+        # Have seen up to 3 seconds of drift on CI jobs
+        drift = Second(5)
 
         creds = assume_role_creds(config, role_a; duration=nothing)
         t = floor(now(UTC), Second)
         @test t <= creds.expiry <= t + Second(3600) + drift
 
-        creds = assume_role_creds(config, role_a; duration=900)
+        duration = 900  # Minimum allowed duration
+        creds = assume_role_creds(config, role_a; duration)
         t = floor(now(UTC), Second)
-        @test t <= creds.expiry <= t + Second(900) + drift
+        @test t <= creds.expiry <= t + Second(duration) + drift
     end
 
     @testset "session_name" begin


### PR DESCRIPTION
Follow up to https://github.com/JuliaCloud/AWS.jl/pull/638.

- Fixes macOS CI failures with "duration" testset due to clock drift: 
    
    ```julia
     duration: Test Failed at /Users/runner/work/AWS.jl/AWS.jl/test/role.jl:61
      Expression: t <= creds.expiry <= t + Second(3600) + drift
       Evaluated: DateTime("2023-06-27T03:00:55") <= DateTime("2023-06-27T04:00:58") <= DateTime("2023-06-27T04:00:56")
    ```
    – https://github.com/JuliaCloud/AWS.jl/actions/runs/5385251099/jobs/9774060149

- Fixes issue with `ENV["USER"]` being undefined in container based environments
- Fixes MinIO CI setup step to fail gracefully (by specifying shell) and skip the MinIO based tests if a Windows runner is used