### PR TITLE
Support data retrevial from Instance Metadata Service Version 2 (IMDSv2)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AWS"
 uuid = "fbe9abb3-538b-5e4e-ba9e-bc94f4f92ebc"
 license = "MIT"
-version = "1.89.1"
+version = "1.90.0"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -71,6 +71,7 @@ makedocs(;
         "Home" => "index.md",
         "Backends" => "backends.md",
         "AWS" => "aws.md",
+        "IMDS" => "imds.md",
         "Services" => _generate_high_level_services_docs(),
     ],
     strict=true,

--- a/docs/src/imds.md
+++ b/docs/src/imds.md
@@ -1,0 +1,16 @@
+# IMDS
+
+```@meta
+CurrentModule = AWS
+```
+
+Provides a Julia interface for accessing AWS instance metadata.
+
+### Documentation
+
+```@docs
+AWS.IMDS
+AWS.IMDS.Session
+AWS.IMDS.get
+AWS.IMDS.region
+```

--- a/src/AWS.jl
+++ b/src/AWS.jl
@@ -18,7 +18,7 @@ using XMLDict
 export @service
 export _merge
 export AbstractAWSConfig, AWSConfig, AWSExceptions, AWSServices, Request
-export ec2_instance_metadata, ec2_instance_region
+export IMDS
 export assume_role, generate_service_url, global_aws_config, set_user_agent
 export sign!, sign_aws2!, sign_aws4!
 export JSONService, RestJSONService, RestXMLService, QueryService, set_features
@@ -31,6 +31,7 @@ include("AWSExceptions.jl")
 include("AWSCredentials.jl")
 include("AWSConfig.jl")
 include("AWSMetadata.jl")
+include("IMDS.jl")
 
 include(joinpath("utilities", "request.jl"))
 include(joinpath("utilities", "response.jl"))

--- a/src/AWSCredentials.jl
+++ b/src/AWSCredentials.jl
@@ -656,7 +656,7 @@ function aws_get_region(; profile=nothing, config=nothing, default=DEFAULT_REGIO
     @something(
         get(ENV, "AWS_DEFAULT_REGION", nothing),
         get(_aws_profile_config(config, profile), "region", nothing),
-        IMDS.region(),
+        @mock(IMDS.region()),
         Some(default),
     )
 end

--- a/src/AWSCredentials.jl
+++ b/src/AWSCredentials.jl
@@ -213,45 +213,6 @@ end
 check_credentials(aws_creds::Nothing) = aws_creds
 
 """
-    ec2_instance_metadata(path::AbstractString) -> Union{String, Nothing}
-
-Retrieve the AWS EC2 instance metadata as a string using the provided `path`. If no instance
-metadata is available (typically due to not running within an EC2 instance) then `nothing`
-will be returned. See the AWS documentation for details on what metadata is available:
-https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html
-
-# Arguments
-- `path`: The URI path to used to specify that metadata to return
-"""
-function ec2_instance_metadata(path::AbstractString)
-    uri = HTTP.URI(; scheme="http", host="169.254.169.254", path=path)
-    request = try
-        @mock HTTP.request("GET", uri; connect_timeout=1)
-    catch e
-        if e isa HTTP.ConnectError
-            nothing
-        else
-            rethrow()
-        end
-    end
-
-    return request !== nothing ? String(request.body) : nothing
-end
-
-"""
-    ec2_instance_region() -> Union{String, Nothing}
-
-Determine the AWS region of the machine executing this code if running inside of an EC2
-instance, otherwise `nothing` is returned.
-"""
-ec2_instance_region() =
-    try
-        ec2_instance_metadata("/latest/meta-data/placement/region")
-    catch
-        nothing
-    end
-
-"""
     ec2_instance_credentials(profile::AbstractString) -> AWSCredentials
 
 Parse the EC2 metadata to retrieve AWSCredentials.
@@ -269,13 +230,13 @@ function ec2_instance_credentials(profile::AbstractString)
         source == "Ec2InstanceMetadata" || return nothing
     end
 
-    info = ec2_instance_metadata("/latest/meta-data/iam/info")
+    info = IMDS.get("/latest/meta-data/iam/info")
     info === nothing && return nothing
     info = JSON.parse(info)
 
     # Get credentials for the role associated to the instance via instance profile.
-    name = ec2_instance_metadata("/latest/meta-data/iam/security-credentials/")
-    creds = ec2_instance_metadata("/latest/meta-data/iam/security-credentials/$name")
+    name = IMDS.get("/latest/meta-data/iam/security-credentials/")
+    creds = IMDS.get("/latest/meta-data/iam/security-credentials/$name")
     parsed = JSON.parse(creds)
     instance_profile_creds = AWSCredentials(
         parsed["AccessKeyId"],
@@ -695,7 +656,7 @@ function aws_get_region(; profile=nothing, config=nothing, default=DEFAULT_REGIO
     @something(
         get(ENV, "AWS_DEFAULT_REGION", nothing),
         get(_aws_profile_config(config, profile), "region", nothing),
-        ec2_instance_region(),
+        IMDS.region(),
         Some(default),
     )
 end

--- a/src/AWSExceptions.jl
+++ b/src/AWSExceptions.jl
@@ -10,7 +10,9 @@ export AWSException, IMDSUnavailable, ProtocolNotDefined, InvalidFileName, NoCre
 struct IMDSUnavailable <: Exception end
 
 function Base.show(io::IO, e::IMDSUnavailable)
-    println(io, "$IMDSUnavailable: The Instance Metadata Service is unavailable on the host")
+    msg = "$IMDSUnavailable: The Instance Metadata Service is unavailable on the host"
+    println(io, msg)
+    return nothing
 end
 
 struct ProtocolNotDefined <: Exception

--- a/src/AWSExceptions.jl
+++ b/src/AWSExceptions.jl
@@ -5,7 +5,13 @@ using JSON
 using XMLDict
 using XMLDict: XMLDictElement
 
-export AWSException, ProtocolNotDefined, InvalidFileName, NoCredentials
+export AWSException, IMDSUnavailable, ProtocolNotDefined, InvalidFileName, NoCredentials
+
+struct IMDSUnavailable <: Exception end
+
+function Base.show(io::IO, e::IMDSUnavailable)
+    println(io, "$IMDSUnavailable: The Instance Metadata Service is unavailable on the host")
+end
 
 struct ProtocolNotDefined <: Exception
     message::String

--- a/src/IMDS.jl
+++ b/src/IMDS.jl
@@ -143,6 +143,9 @@ end
 
 Determine the AWS region of the machine executing this code if running inside of an EC2
 instance, otherwise `nothing` is returned.
+
+# Arguments
+- `session` (optional): The IMDS `Session` used to store the IMDSv2 token.
 """
 region(session::Session) = get(session, "/latest/meta-data/placement/region")
 

--- a/src/IMDS.jl
+++ b/src/IMDS.jl
@@ -144,15 +144,7 @@ end
 Determine the AWS region of the machine executing this code if running inside of an EC2
 instance, otherwise `nothing` is returned.
 """
-function region(session::Session)
-    # TODO: The try/catch is used to work around testing scenarios which require IMDS to not
-    # be present.
-    return try
-        get(session, "/latest/meta-data/placement/region")
-    catch
-        nothing
-    end
-end
+region(session::Session) = get(session, "/latest/meta-data/placement/region")
 
 const _SESSION = Ref{Session}()
 

--- a/src/IMDS.jl
+++ b/src/IMDS.jl
@@ -37,8 +37,6 @@ function refresh_token!(session::Session, duration::Integer=session.duration)
     uri = HTTP.URI(; scheme="http", host=IPv4_ADDRESS, path="/latest/api/token")
     r = _http_request("PUT", uri, headers; status_exception=false)
 
-    # @show r
-
     # Store the session token when we receive an HTTP 200. If we receive an HTTP 404 assume
     # that the server is only supports IMDSv1. Otherwise throw the `StatusError`.
     if r.status == 200
@@ -47,7 +45,7 @@ function refresh_token!(session::Session, duration::Integer=session.duration)
         session.expiration = t + duration
     elseif r.status == 404
         session.duration = 0
-        session.expiration = typemax(Int64)  # Use IMDSv1 indefinitly
+        session.expiration = typemax(Int64)  # Use IMDSv1 indefinitely
     else
         throw(HTTP.Exceptions.StatusError(r.status, r.request.method, r.request.target, r))
     end
@@ -75,11 +73,14 @@ function _http_request(args...; status_exception=true, kwargs...)
         # Always throw status exceptions so we can determine if the IMDS service is available
         @mock HTTP.request(args...; connect_timeout=1, retry=false, kwargs..., status_exception=true)
     catch e
-        # TODO: Verify that when running on EC2 instances where IMDS is turned off that a 403 is returned
+        # When running outside of an EC2 instance the link-local address will be unavailable
+        # and connections will fail. On EC2 instances where IMDS is disabled a HTTP 403 is
+        # returned.
         # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html#instance-metadata-returns
         if e isa HTTP.Exceptions.ConnectError || e isa HTTP.Exceptions.StatusError && e.status == 403
             throw(IMDSUnavailable())
-        # Return the status exception when `status_exception=false`
+        # Return the status exception when `status_exception=false`. We must always cause
+        # `HTTP.request` to throw status errors for our `IMDSUnavailable` check.
         elseif !status_exception && e isa HTTP.Exceptions.StatusError
             e.response
         else
@@ -94,8 +95,9 @@ end
     get([session::Session], path::AbstractString) -> Union{String, Nothing}
 
 Retrieve the AWS instance metadata from the provided HTTP `path`. If no instance metadata is
-available (typically due to being executed outside of an EC2 instance) then `nothing` will
-be returned. For details on available metadata see the official AWS documentation on:
+available (due to the instance metadata service being disabled or not being run from within
+an EC2 instance) then `nothing` will be returned. For details on available metadata see the
+official AWS documentation on:
 ["Instance metadata and user data"](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html).
 
 # Arguments
@@ -122,13 +124,7 @@ end
 Determine the AWS region of the machine executing this code if running inside of an EC2
 instance, otherwise `nothing` is returned.
 """
-function region(session::Session)
-    # return try
-        get(session, "/latest/meta-data/placement/region")
-    # catch
-    #     nothing
-    # end
-end
+region(session::Session) = get(session, "/latest/meta-data/placement/region")
 
 const _SESSION = Ref{Session}()
 

--- a/src/IMDS.jl
+++ b/src/IMDS.jl
@@ -1,0 +1,140 @@
+"""
+    IMDS
+
+Front-end for retrieving AWS instance metadata via the Instance Metadata Service (IMDS). For
+details on available metadata see the official AWS documentation on:
+["Instance metadata and user data"](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html).
+
+The IMDS module supports instances using either IMDSv1 or IMDSv2 (preferring IMDSv2 for
+security reasons).
+"""
+module IMDS
+
+using ..AWSExceptions: IMDSUnavailable
+
+using HTTP: HTTP
+using Mocking
+
+const IPv4_ADDRESS = "169.254.169.254"
+
+mutable struct Session
+    duration::Int
+    token::String
+    expiration::Int64
+end
+
+Session(; duration=21600) = Session(duration, "", 0)
+
+token_expired(session::Session) = time() - session.expiration > 0
+
+function refresh_token!(session::Session, duration::Integer=session.duration)
+    t = floor(Int64, time())
+    headers = ["X-aws-ec2-metadata-token-ttl-seconds" => string(duration)]
+
+    # For IMDSv2, you must use `/latest/api/token` when retrieving the token instead of a
+    # version specific path.
+    # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html#imds-considerations
+    uri = HTTP.URI(; scheme="http", host=IPv4_ADDRESS, path="/latest/api/token")
+    r = _http_request("PUT", uri, headers; status_exception=false)
+
+    # Store the session token when we receive an HTTP 200. If we receive an HTTP 404 assume
+    # that the server is only supports IMDSv1. Otherwise throw the `StatusError`.
+    if r.status == 200
+        session.token = String(r.body)
+        session.duration = duration
+        session.expiration = t + duration - 10
+    elseif r.status == 404
+        session.duration = 0
+        session.expiration = typemax(Int64)  # Use IMDSv1 indefinitly
+    else
+        throw(HTTP.Exceptions.StatusError(r.status, r.request.method, r.request.target, r))
+    end
+
+    return session
+end
+
+function request(session::Session, method::AbstractString, path::AbstractString; kwargs...)
+    # Attempt to generate token for use with IMDSv2. If we're unable to generate a token
+    # we'll fall back on using IMDSv1. We prefer using IMDSv2 as instances can be configured
+    # to disable IMDSv1 access: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-IMDS-new-instances.html#configure-IMDS-new-instances
+    token_expired(session) && refresh_token!(session)
+    headers = Pair{String,String}[]
+    !isempty(session.token) && push!(headers, "X-aws-ec2-metadata-token" => session.token)
+
+    # Only using the IPv4 endpoint as the IPv6 endpoint has to be explicitly enabled and
+    # does not disable IPv4 support.
+    # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-IMDS-new-instances.html#configure-IMDS-new-instances-ipv4-ipv6-endpoints
+    uri = HTTP.URI(; scheme="http", host=IPv4_ADDRESS, path)
+    return _http_request(method, uri, headers; kwargs...)
+end
+
+function _http_request(args...; status_exception=true, kwargs...)
+    response = try
+        # Always throw status exceptions so we can determine if the IMDS service is available
+        @mock HTTP.request(args...; connect_timeout=1, retry=false, kwargs..., status_exception=true)
+    catch e
+        # TODO: Verify that when running on EC2 instances where IMDS is turned off that a 403 is returned
+        # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html#instance-metadata-returns
+        if e isa HTTP.Exceptions.ConnectError || e isa HTTP.Exceptions.StatusError && e.status == 403
+            throw(IMDSUnavailable())
+        # Return the status exception when `status_exception=false`
+        elseif !status_exception && e isa HTTP.Exceptions.StatusError
+            e.response
+        else
+            rethrow()
+        end
+    end
+
+    return response
+end
+
+"""
+    get([session::Session], path::AbstractString) -> Union{String, Nothing}
+
+Retrieve the AWS instance metadata from the provided HTTP `path`. If no instance metadata is
+available (typically due to being executed outside of an EC2 instance) then `nothing` will
+be returned. For details on available metadata see the official AWS documentation on:
+["Instance metadata and user data"](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html).
+
+# Arguments
+- `session` (optional): The IMDS `Session` used to store the IMDSv2 token.
+- `path`: The HTTP path to used to specify the metadata to return.
+"""
+function get(session::Session, path::AbstractString)
+    response = try
+        request(session, "GET", path)
+    catch e
+        if e isa IMDSUnavailable
+            nothing
+        else
+            rethrow()
+        end
+    end
+
+    return !isnothing(response) ? String(response.body) : nothing
+end
+
+"""
+    region([session::Session]) -> Union{String, Nothing}
+
+Determine the AWS region of the machine executing this code if running inside of an EC2
+instance, otherwise `nothing` is returned.
+"""
+function region(session::Session)
+    # return try
+        get(session, "/latest/meta-data/placement/region")
+    # catch
+    #     nothing
+    # end
+end
+
+const _SESSION = Ref{Session}()
+
+function __init__()
+    _SESSION[] = Session()
+end
+
+get(path::AbstractString) = get(_SESSION[], path)
+region() = region(_SESSION[])
+
+end

--- a/src/IMDS.jl
+++ b/src/IMDS.jl
@@ -37,12 +37,14 @@ function refresh_token!(session::Session, duration::Integer=session.duration)
     uri = HTTP.URI(; scheme="http", host=IPv4_ADDRESS, path="/latest/api/token")
     r = _http_request("PUT", uri, headers; status_exception=false)
 
+    # @show r
+
     # Store the session token when we receive an HTTP 200. If we receive an HTTP 404 assume
     # that the server is only supports IMDSv1. Otherwise throw the `StatusError`.
     if r.status == 200
         session.token = String(r.body)
         session.duration = duration
-        session.expiration = t + duration - 10
+        session.expiration = t + duration
     elseif r.status == 404
         session.duration = 0
         session.expiration = typemax(Int64)  # Use IMDSv1 indefinitly

--- a/src/IMDS.jl
+++ b/src/IMDS.jl
@@ -25,6 +25,13 @@ mutable struct Session
     expiration::Int64
 end
 
+const _SESSION = Ref{Session}()
+
+function __init__()
+    _SESSION[] = Session()
+    return nothing
+end
+
 """
     Session(; duration=$DEFAULT_DURATION)
 
@@ -138,6 +145,8 @@ function get(session::Session, path::AbstractString)
     return !isnothing(response) ? String(response.body) : nothing
 end
 
+get(path::AbstractString) = get(_SESSION[], path)
+
 """
     region([session::Session]) -> Union{String, Nothing}
 
@@ -148,15 +157,6 @@ instance, otherwise `nothing` is returned.
 - `session` (optional): The IMDS `Session` used to store the IMDSv2 token.
 """
 region(session::Session) = get(session, "/latest/meta-data/placement/region")
-
-const _SESSION = Ref{Session}()
-
-function __init__()
-    _SESSION[] = Session()
-    return nothing
-end
-
-get(path::AbstractString) = get(_SESSION[], path)
 region() = region(_SESSION[])
 
 end

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -207,3 +207,6 @@ function legacy_response(
         return (return_headers ? (body, response.headers) : body)
     end
 end
+
+@deprecate ec2_instance_metadata(path::AbstractString) IMDS.get(path)
+@deprecate ec2_instance_region() IMDS.region()

--- a/test/AWSCredentials.jl
+++ b/test/AWSCredentials.jl
@@ -44,32 +44,6 @@ end
     @test AWS._role_session_name("a"^22, "b"^22, "c"^22) == "a"^22 * "b"^20 * "c"^22
 end
 
-@testset "ec2_instance_metadata" begin
-    @testset "connect timeout" begin
-        apply(Patches._instance_metadata_timeout_patch) do
-            @test AWS.ec2_instance_metadata("/latest/meta-data") === nothing
-        end
-    end
-end
-
-@testset "ec2_instance_region" begin
-    @testset "available" begin
-        patch = @patch function HTTP.request(method::String, url; kwargs...)
-            return HTTP.Response("ap-atlantis-1")  # Made up region
-        end
-
-        apply(patch) do
-            @test AWS.ec2_instance_region() == "ap-atlantis-1"
-        end
-    end
-
-    @testset "unavailable" begin
-        apply(Patches._instance_metadata_timeout_patch) do
-            @test AWS.ec2_instance_region() === nothing
-        end
-    end
-end
-
 @testset "aws_get_profile_settings" begin
     @testset "no profile" begin
         @test aws_get_profile_settings("foo", Inifile()) === nothing

--- a/test/AWSCredentials.jl
+++ b/test/AWSCredentials.jl
@@ -917,7 +917,7 @@ end
             session_token=session_token,
             role_arn=role_arn,
         )
-        ec2_metadata_patch = @patch function HTTP.request(method::String, url; kwargs...)
+        ec2_metadata_patch = @patch function HTTP.request(method, url, args...; kwargs...)
             url = string(url)
             security_credentials = test_values["Security-Credentials"]
 
@@ -1325,7 +1325,7 @@ end
 
         @testset "instance profile" begin
             withenv("AWS_DEFAULT_REGION" => nothing, "AWS_CONFIG_FILE" => tempname()) do
-                patch = @patch function HTTP.request(method::String, url; kwargs...)
+                patch = @patch function HTTP.request(method, url, args...; kwargs...)
                     return HTTP.Response("ap-atlantis-1")  # Made up region
                 end
 

--- a/test/IMDS.jl
+++ b/test/IMDS.jl
@@ -240,6 +240,17 @@ end
             @test IMDS.region(session) === nothing
         end
 
+        # Running on a webserver which doesn't understand our requests and returns HTTP 404.
+        # This exact scenario occurs in GHA CI.
+        router = Router([
+            response_route("PUT", "/**", HTTP.Response(404)),
+            response_route("GET", "/**", HTTP.Response(404)),
+        ])
+        apply(_imds_patch(router)) do
+            session = IMDS.Session()
+            @test IMDS.region(session) === nothing
+        end
+
         # Requested metadata available via IMDSv1
         router = Router([response_route("GET", path, HTTP.Response(region))])
         apply(_imds_patch(router)) do

--- a/test/IMDS.jl
+++ b/test/IMDS.jl
@@ -1,0 +1,33 @@
+@testset "IMDS" begin
+    @testset "get" begin
+        @testset "connect timeout" begin
+            apply(Patches._instance_metadata_timeout_patch) do
+                @test IMDS.get("/latest/meta-data") === nothing
+            end
+        end
+    end
+
+    @testset "region" begin
+        @testset "available" begin
+            patch = @patch function HTTP.request(method, uri::HTTP.URI, args...; kwargs...)
+                if method == "GET" && uri.path == "/latest/meta-data/placement/region"
+                    HTTP.Response("ap-atlantis-1")  # Made up region
+                elseif method == "PUT" && uri.path == "/latest/api/token"
+                    HTTP.Response(404)
+                else
+                    HTTP.Response(501; request=HTTP.Request(method, uri.path))
+                end
+            end
+
+            apply(patch) do
+                @test IMDS.region() == "ap-atlantis-1"
+            end
+        end
+
+        @testset "unavailable" begin
+            apply(Patches._instance_metadata_timeout_patch) do
+                @test IMDS.region() === nothing
+            end
+        end
+    end
+end

--- a/test/IMDS.jl
+++ b/test/IMDS.jl
@@ -1,7 +1,139 @@
+using HTTP.Messages: field_name_isequal
+using HTTP.Pairs: getbyfirst
+
+function get_header(h::Vector{<:Pair}, k, d="")
+    return getbyfirst(h, k, k => d, field_name_isequal)[2]
+end
+
+function _imds_patch(; available=true, token=nothing, status=nothing, region=nothing, instance_id=nothing)
+    patch = @patch function HTTP.request(method, uri::HTTP.URI, headers=[], body=""; kwargs...)
+        if !available && uri.host == "169.254.169.254"
+            connect_timeout = HTTP.ConnectionPool.ConnectTimeout(uri.host, uri.port)
+            throw(HTTP.ConnectError(string(uri), connect_timeout))
+        elseif !available
+            error("Internal error: patch misconfigured")
+        end
+
+        header_token = get_header(headers, "X-aws-ec2-metadata-token", nothing)
+        if token !== nothing
+            ttl = get_header(headers, "X-aws-ec2-metadata-token-ttl-seconds", nothing)
+            # @show token ttl
+            if method == "PUT" && uri.path == "/latest/api/token" && ttl !== nothing
+                return HTTP.Response(token)
+            elseif token != header_token
+                # TODO: Assuming response for IMDSv2 only setup
+                return HTTP.Response(401)
+            end
+        elseif header_token !== nothing
+            error("Internal error: Unexpected use of token header: $header_token")
+        end
+
+        if status !== nothing
+            request = HTTP.Request(method, uri.path, headers, body)
+            return HTTP.Response(status; request)
+        elseif region !== nothing && method == "GET" && uri.path == "/latest/meta-data/placement/region"
+            return HTTP.Response(region)
+        elseif instance_id !== nothing && method == "GET" && uri.path == "/latest/meta-data/instance-id"
+            return HTTP.Response(instance_id)
+        else
+            return HTTP.Response(404)
+        end
+    end
+end
+
+# function _imds_v1_patch(; available=false, region=nothing)
+
+
+#     patch = @patch function HTTP.request(method, uri::URI, args...; kwargs...)
+#         if !available && uri.host == "169.254.169.254"
+#             connect_timeout = HTTP.ConnectionPool.ConnectTimeout(uri.host, uri.port)
+#             throw(HTTP.ConnectError(string(uri), connect_timeout))
+#         elseif region !== nothing && method == "GET" && uri.path == "/latest/meta-data/placement/region"
+#             HTTP.Response("ap-atlantis-1")  # Made up region
+#         elseif available
+#             HTTP.Response(404)
+#         else
+#             error("Internal error: patch misconfigured")
+#         end
+#     end
+# end
+
 @testset "IMDS" begin
+    @testset "refresh_token!" begin
+        # IMDS is unavailable
+        apply(_imds_patch(; available=false)) do
+            session = IMDS.Session()
+            @test isempty(session.token)
+            @test session.duration == 21600
+            @test IMDS.token_expired(session)
+
+            @test_throws IMDSUnavailable IMDS.refresh_token!(session)
+        end
+
+        # HTTP server is available but non-functional
+        apply(_imds_patch(; available=true, status=500)) do
+            session = IMDS.Session()
+            @test_throws HTTP.Exceptions.StatusError IMDS.refresh_token!(session)
+        end
+
+        # IMDSv1 is available
+        apply(_imds_patch(; available=true)) do
+            session = IMDS.Session()
+            @test IMDS.refresh_token!(session) === session
+            @test isempty(session.token)
+            @test session.duration == 0
+            @test session.expiration == typemax(Int64)
+        end
+
+        # IMDSv2 is available
+        apply(_imds_patch(; available=true, token="foo")) do
+            session = IMDS.Session(; duration=60)
+            t = floor(Int64, time())
+            @test IMDS.refresh_token!(session) === session
+            @test session.token == "foo"
+            @test session.duration == 60
+            @test 0 <= session.expiration - (t + session.duration) <= 5
+        end
+    end
+
+    @testset "request" begin
+        path = "/latest/meta-data/instance-id"
+
+        # IMDS is unavailable
+        apply(_imds_patch(; available=false)) do
+            session = IMDS.Session()
+            @test_throws IMDSUnavailable IMDS.request(session, "GET", path)
+        end
+
+        # Requested metadata is missing
+        apply(_imds_patch(; available=true, token="token")) do
+            session = IMDS.Session()
+            @show IMDS.request(session, "GET", path)
+            @test_throws HTTP.Exceptions.StatusError IMDS.request(session, "GET", path)
+        end
+
+        # Requested metadata available via IMDSv1
+        apply(_imds_patch(; available=true, instance_id="123")) do
+            session = IMDS.Session()
+            r = IMDS.request(session, "GET", path)
+            @test r isa HTTP.Response
+            @test r.status == 200
+            @test String(r.body) == "123"
+        end
+
+        # Requested metadata available via IMDSv2
+        apply(_imds_patch(; available=true, token="token", instance_id="123")) do
+            session = IMDS.Session()
+            r = IMDS.request(session, "GET", path)
+            @test r isa HTTP.Response
+            @test r.status == 200
+            @test String(r.body) == "123"
+        end
+    end
+#=
     @testset "get" begin
         @testset "connect timeout" begin
-            apply(Patches._instance_metadata_timeout_patch) do
+            apply(_imds_patch(; available=false)) do
                 @test IMDS.get("/latest/meta-data") === nothing
             end
         end
@@ -9,25 +141,16 @@
 
     @testset "region" begin
         @testset "available" begin
-            patch = @patch function HTTP.request(method, uri::HTTP.URI, args...; kwargs...)
-                if method == "GET" && uri.path == "/latest/meta-data/placement/region"
-                    HTTP.Response("ap-atlantis-1")  # Made up region
-                elseif method == "PUT" && uri.path == "/latest/api/token"
-                    HTTP.Response(404)
-                else
-                    HTTP.Response(501; request=HTTP.Request(method, uri.path))
-                end
-            end
-
-            apply(patch) do
+            apply(_imds_patch(; region="ap-atlantis-1")) do
                 @test IMDS.region() == "ap-atlantis-1"
             end
         end
 
         @testset "unavailable" begin
-            apply(Patches._instance_metadata_timeout_patch) do
+            apply(_imds_patch(; available=false)) do
                 @test IMDS.region() === nothing
             end
         end
     end
+=#
 end

--- a/test/IMDS.jl
+++ b/test/IMDS.jl
@@ -87,7 +87,7 @@ end
         apply(_imds_patch(; listening=false)) do
             session = IMDS.Session()
             @test isempty(session.token)
-            @test session.duration == 21600
+            @test session.duration == IMDS.DEFAULT_DURATION
             @test IMDS.token_expired(session)
 
             @test_throws IMDSUnavailable IMDS.refresh_token!(session)
@@ -218,13 +218,15 @@ end
 
         # Running outside of an EC2 instancee
         apply(_imds_patch(; listening=false)) do
-            @test IMDS.get(path) === nothing
+            session = IMDS.Session()
+            @test IMDS.get(session, path) === nothing
         end
 
         # Requested metadata available via IMDSv1
         router = Router([response_route("GET", path, HTTP.Response(instance_id))])
         apply(_imds_patch(router)) do
-            @test IMDS.get(path) == instance_id
+            session = IMDS.Session()
+            @test IMDS.get(session, path) == instance_id
         end
     end
 
@@ -234,13 +236,15 @@ end
 
         # Running outside of an EC2 instance
         apply(_imds_patch(; listening=false)) do
-            @test IMDS.region() === nothing
+            session = IMDS.Session()
+            @test IMDS.region(session) === nothing
         end
 
         # Requested metadata available via IMDSv1
         router = Router([response_route("GET", path, HTTP.Response(region))])
         apply(_imds_patch(router)) do
-            @test IMDS.region() == region
+            session = IMDS.Session()
+            @test IMDS.region(session) == region
         end
     end
 end

--- a/test/IMDS.jl
+++ b/test/IMDS.jl
@@ -54,6 +54,8 @@ function response_route(method, path, response::HTTP.Response)
     return Route(method, path, handler)
 end
 
+# Use Mocking to re-route requests to 169.254.169.254 without having to actually start an
+# HTTP.jl server. Should result in faster running tests.
 function _imds_patch(router::HTTP.Router=HTTP.Router(); listening=true, enabled=true)
     patch = @patch function HTTP.request(method, url, headers=[], body=HTTP.nobody; status_exception=true, kwargs...)
         uri = HTTP.URI(url)

--- a/test/IMDS.jl
+++ b/test/IMDS.jl
@@ -241,14 +241,16 @@ end
         end
 
         # Running on a webserver which doesn't understand our requests and returns HTTP 404.
-        # This exact scenario occurs in GHA CI.
+        # This exact scenario occurs in GHA CI and can be reproduced locally with the
+        # `aws-vault exec --ec2-server` which provides a very limited implementation of
+        # IMDSv1.
         router = Router([
             response_route("PUT", "/**", HTTP.Response(404)),
             response_route("GET", "/**", HTTP.Response(404)),
         ])
         apply(_imds_patch(router)) do
             session = IMDS.Session()
-            @test IMDS.region(session) === nothing
+            @test_throws HTTP.Exceptions.StatusError IMDS.region(session)
         end
 
         # Requested metadata available via IMDSv1

--- a/test/patch.jl
+++ b/test/patch.jl
@@ -147,9 +147,7 @@ _github_tree_patch = @patch function tree(repo, tree_obj; kwargs...)
     end
 end
 
-_instance_metadata_timeout_patch = @patch function HTTP.request(
-    method::String, url; kwargs...
-)
+_instance_metadata_timeout_patch = @patch function HTTP.request(args...; kwargs...)
     return throw(
         HTTP.ConnectError(
             "http://169.254.169.254/latest/meta-data/iam/info",

--- a/test/patch.jl
+++ b/test/patch.jl
@@ -147,15 +147,6 @@ _github_tree_patch = @patch function tree(repo, tree_obj; kwargs...)
     end
 end
 
-_instance_metadata_timeout_patch = @patch function HTTP.request(args...; kwargs...)
-    return throw(
-        HTTP.ConnectError(
-            "http://169.254.169.254/latest/meta-data/iam/info",
-            HTTP.ConnectionPool.ConnectTimeout("169.254.169.254", "80"),
-        ),
-    )
-end
-
 # This patch causes `HTTP.request` to return all of its keyword arguments
 # except `require_ssl_verification` and `response_stream`. This is used to
 # test which other options are being passed to `HTTP.Request` inside of

--- a/test/patch.jl
+++ b/test/patch.jl
@@ -229,4 +229,9 @@ function sso_service_patches(access_key_id, secret_access_key)
 
     return [p, _sso_access_token_patch]
 end
+
+function _imds_region_patch(region)
+    return @patch IMDS.region() = region
+end
+
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using AWS
 using AWS: AWSCredentials, AWSServices, assume_role_creds
-using AWS.AWSExceptions: AWSException, IMDSUnavailable, InvalidFileName, NoCredentials, ProtocolNotDefined
+using AWS.AWSExceptions:
+    AWSException, IMDSUnavailable, InvalidFileName, NoCredentials, ProtocolNotDefined
 using AWS.AWSMetadata:
     ServiceFile,
     _clean_documentation,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -64,6 +64,7 @@ testset_role(role_name) = "AWS.jl-$role_name"
     @testset "Backend: $(nameof(backend))" for backend in backends
         AWS.DEFAULT_BACKEND[] = backend()
         include("AWS.jl")
+        include("IMDS.jl")
         include("AWSCredentials.jl")
         include("role.jl")
         include("issues.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
 using AWS
 using AWS: AWSCredentials, AWSServices, assume_role_creds
-using AWS.AWSExceptions: AWSException, InvalidFileName, NoCredentials, ProtocolNotDefined
+using AWS.AWSExceptions: AWSException, IMDSUnavailable, InvalidFileName, NoCredentials, ProtocolNotDefined
 using AWS.AWSMetadata:
     ServiceFile,
     _clean_documentation,


### PR DESCRIPTION
Supports retrieval of instance metadata from IMDSv2. AWS.jl already has support for IMDSv1 so that functionality was refactored into the `IMDS` submodule. With this new functionality AWS users can use AWS.jl on instances which [require the use of IMDSv2](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-options.html) for security reasons.

For an extensive review of IMDSv2, see [Add defense in depth against open firewalls, reverse proxies, and SSRF vulnerabilities with enhancements to the EC2 Instance Metadata Service](http://aws.amazon.com/blogs/security/defense-in-depth-open-firewalls-reverse-proxies-ssrf-vulnerabilities-ec2-instance-metadata-service/).

Fixes https://github.com/JuliaCloud/AWS.jl/issues/640.