### PR TITLE
Throw `IMDSUnavailable` when encountering `IOError`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AWS"
 uuid = "fbe9abb3-538b-5e4e-ba9e-bc94f4f92ebc"
 license = "MIT"
-version = "1.90.0"
+version = "1.90.1"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/test/IMDS.jl
+++ b/test/IMDS.jl
@@ -83,8 +83,9 @@ end
 
 @testset "IMDS" begin
     @testset "is_connection_exception" begin
+        url = "http://169.254.169.254/latest/api/token"
         connect_timeout = HTTP.ConnectionPool.ConnectTimeout("169.254.169.254", 80)
-        e = HTTP.Exceptions.ConnectError("http://169.254.169.254/latest/api/token", connect_timeout)
+        e = HTTP.Exceptions.ConnectError(url, connect_timeout)
         @test IMDS.is_connection_exception(e)
 
         request = HTTP.Request("PUT", "/latest/api/token", [], HTTP.nobody)


### PR DESCRIPTION
Fixes: https://github.com/JuliaCloud/AWS.jl/issues/649