### PR TITLE
`IMDS.get` returns `nothing` with HTTP 404

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AWS"
 uuid = "fbe9abb3-538b-5e4e-ba9e-bc94f4f92ebc"
 license = "MIT"
-version = "1.90.1"
+version = "1.90.2"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/IMDS.jl
+++ b/src/IMDS.jl
@@ -129,10 +129,10 @@ end
 """
     get([session::Session], path::AbstractString) -> Union{String, Nothing}
 
-Retrieve the AWS instance metadata from the provided HTTP `path`. If no instance metadata is
-available (due to the instance metadata service being disabled or not being run from within
-an EC2 instance) then `nothing` will be returned. For details on available metadata see the
-official AWS documentation on:
+Retrieve the AWS instance metadata from the provided HTTP `path`. If the specific metadata
+resource is unavailable or the instance metadata is unavailable (due to the instance metadata
+service being disabled or not being run from within an EC2 instance) then `nothing` will be
+returned. For details on available metadata see the official AWS documentation on:
 ["Instance metadata and user data"](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html).
 
 # Arguments
@@ -143,7 +143,7 @@ function get(session::Session, path::AbstractString)
     response = try
         request(session, "GET", path)
     catch e
-        if e isa IMDSUnavailable
+        if e isa IMDSUnavailable || e isa StatusError && e.status == 404
             nothing
         else
             rethrow()

--- a/src/IMDS.jl
+++ b/src/IMDS.jl
@@ -16,6 +16,7 @@ using HTTP: HTTP
 using HTTP.Exceptions: ConnectError, StatusError
 using Mocking
 
+# Local-link address (https://en.wikipedia.org/wiki/Link-local_address)
 const IPv4_ADDRESS = "169.254.169.254"
 const DEFAULT_DURATION = 600  # 5 minutes, in seconds
 


### PR DESCRIPTION
Fixes: https://github.com/JuliaCloud/AWS.jl/issues/652. As https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html#instance-metadata-returns mentions that the IMDS service may return 404 when specific resources are unavailable it made sense to return `nothing` under that scenario for `IMDS.get`.