### PR TITLE
Fallback to IMDSv1 when IMDSv2 token request reaches hop limit

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AWS"
 uuid = "fbe9abb3-538b-5e4e-ba9e-bc94f4f92ebc"
 license = "MIT"
-version = "1.90.2"
+version = "1.90.3"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/IMDS.jl
+++ b/src/IMDS.jl
@@ -15,6 +15,7 @@ using ..AWSExceptions: IMDSUnavailable
 using HTTP: HTTP
 using HTTP.Exceptions: ConnectError, StatusError
 using Mocking
+using URIs: URI
 
 # Local-link address (https://en.wikipedia.org/wiki/Link-local_address)
 const IPv4_ADDRESS = "169.254.169.254"
@@ -55,7 +56,7 @@ function refresh_token!(session::Session, duration::Integer=session.duration)
     # For IMDSv2, you must use `/latest/api/token` when retrieving the token instead of a
     # version specific path.
     # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html#imds-considerations
-    uri = HTTP.URI(; scheme="http", host=IPv4_ADDRESS, path="/latest/api/token")
+    uri = URI(; scheme="http", host=IPv4_ADDRESS, path="/latest/api/token")
     r = _http_request("PUT", uri, headers; status_exception=false)
 
     # Store the session token when we receive an HTTP 200. If we receive an HTTP 404 assume
@@ -87,7 +88,7 @@ function request(session::Session, method::AbstractString, path::AbstractString;
     # Only using the IPv4 endpoint as the IPv6 endpoint has to be explicitly enabled and
     # does not disable IPv4 support.
     # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-IMDS-new-instances.html#configure-IMDS-new-instances-ipv4-ipv6-endpoints
-    uri = HTTP.URI(; scheme="http", host=IPv4_ADDRESS, path)
+    uri = URI(; scheme="http", host=IPv4_ADDRESS, path)
     return _http_request(method, uri, headers; kwargs...)
 end
 

--- a/src/IMDS.jl
+++ b/src/IMDS.jl
@@ -66,6 +66,11 @@ function refresh_token!(session::Session, duration::Integer=session.duration)
         # allow for IMDSv2 use in container based environments:
         # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html#imds-considerations
         if is_ttl_expired_exception(e)
+            @warn "IMDSv2 token request rejected due to reaching hop limit. Consider " *
+                "increasing the hop limit to avoid delays upon initial use:\n" *
+                "https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/" *
+                "instancedata-data-retrieval.html#imds-considerations"
+
             session.duration = 0
             session.expiration = typemax(Int64)  # Use IMDSv1 indefinitely
             return session

--- a/test/IMDS.jl
+++ b/test/IMDS.jl
@@ -242,7 +242,9 @@ end
         ])
         apply(_imds_patch(router)) do
             session = IMDS.Session()
-            r = IMDS.request(session, "GET", path; status_exception=false)
+            r = @test_warn r"IMDSv2 token request rejected due to reaching hop limit" begin
+                IMDS.request(session, "GET", path; status_exception=false)
+            end
             @test r isa HTTP.Response
             @test r.status == 200
             @test String(r.body) == instance_id

--- a/test/IMDS.jl
+++ b/test/IMDS.jl
@@ -243,7 +243,8 @@ end
         ])
         apply(_imds_patch(router)) do
             session = IMDS.Session()
-            r = @test_warn r"IMDSv2 token request rejected due to reaching hop limit" begin
+            msg_regex = r"IMDSv2 token request rejected due to reaching hop limit"
+            r = @test_logs (:warn, msg_regex) begin
                 IMDS.request(session, "GET", path; status_exception=false)
             end
             @test r isa HTTP.Response


### PR DESCRIPTION
Fixes https://github.com/JuliaCloud/AWS.jl/issues/654, mitigates #651, and modifies PR https://github.com/JuliaCloud/AWS.jl/pull/650 to no longer report the `ETIMEOUT` as a connection error. It turns out that particular error indicates that the IMDSv2 PUT request for a token has reached the max hop limit and the server is rejecting the packet. This PR updates the IMDS code to classify this error as a TTL expiration and fall back to using IMDSv1 rather than treating the IMDS service as being unavailable.

The TTL timeout is rather slow so users should [consider increasing their hop limit in order to allow IMDSv2 to be used](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html#imds-considerations) in these scenarios. I'll add a warning to inform users of this