### PR TITLE
Fix parsing body if it is empty

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AWS"
 uuid = "fbe9abb3-538b-5e4e-ba9e-bc94f4f92ebc"
 license = "MIT"
-version = "1.90.3"
+version = "1.90.4"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -112,7 +112,15 @@ function legacy_response(
 
     body_str = String(copy(body))
 
-    if occursin(r"/xml", mime)
+    if isempty(body_str)
+        return (
+            if return_headers
+                (nothing, response_dict_type(response.headers))
+            else
+                nothing
+            end
+        )
+    elseif occursin(r"/xml", mime)
         if return_headers
             Base.depwarn(
                 "The keyword `return_headers` is deprecated, " *


### PR DESCRIPTION
I ran into a problem where calling `s3:UploadPart` on Localstack resulted in this exception:

```julia
caused by: ArgumentError: empty XML string
Stacktrace:
  [1] parsexml(xmlstring::String; options::@Kwargs{})
    @ EzXML ~/.julia/packages/EzXML/DL8na/src/document.jl:111
  [2] parsexml
    @ ~/.julia/packages/EzXML/DL8na/src/document.jl:109 [inlined]
  [3] parse_xml
    @ ~/.julia/packages/XMLDict/vlQGP/src/XMLDict.jl:60 [inlined]
  [4] legacy_response(request::Request, response::AWS.Response{IOBuffer}; return_headers::Bool)
    @ AWS ~/.julia/dev/AWS/src/deprecated.jl:135
  [5] submit_request(aws::LocalstackAWSConfig, request::Request; return_headers::Bool)
    @ AWS ~/.julia/dev/AWS/src/utilities/request.jl:205
  [6] (::RestXMLService)(request_method::String, request_uri::String, args::Dict{String, Any}; aws_config::LocalstackAWSConfig, feature_set::AWS.FeatureSet)
    @ AWS ~/.julia/dev/AWS/src/AWS.jl:287
  [7] RestXMLService
    @ ~/.julia/packages/AWS/SchLh/src/AWS.jl:251 [inlined]
  [8] upload_part(Bucket::String, Key::String, partNumber::Int64, uploadId::String, params::Dict{String, Any}; aws_config::LocalstackAWSConfig)
    @ S3 ~/.julia/packages/AWS/SchLh/src/services/s3.jl:6684
```

This happens because Localstack returns a response with MIME type `application/xml` but an empty body:

```julia
┌ Debug: HTTP/1.1 200 OK <= (PUT /bucket/key?partNumber=1&uploadId=abcd HTTP/1.1)
└ @ HTTP.StreamRequest ~/.julia/packages/HTTP/bDoga/src/clientlayers/StreamRequest.jl:82
┌ Debug: HTTP.Messages.Response:
│ """
│ HTTP/1.1 200 OK
│ Content-Type: application/xml
│ ETag: "d91eee630304854ddffe980b15498fc6"
│ x-amz-request-id: f210cf53-d234-455b-b5c7-0d42c8d3bc2a
│ x-amz-id-2: s9lzHYrFp76ZVxRcpX9+5cjAnEH2ROuNkd2BHfIa6UkFVdtjf5mKR3/eTPFvsiP/XV/VLi31234=
│ Connection: close
│ Content-Length: 0
│ date: Fri, 12 Jan 2024 19:36:41 GMT
│ server: hypercorn-h11
│ 
│ [Message Body was streamed]"""
└ @ HTTP.StreamRequest ~/.julia/packages/HTTP/bDoga/src/clientlayers/StreamRequest.jl:83
body_str = ""
```

This PR fixes that case.
