### PR TITLE
The parameter for Object Data should be "body" not "Body".

### DIFF
--- a/src/services/s3.jl
+++ b/src/services/s3.jl
@@ -5628,7 +5628,7 @@ GetBucketVersioning.  For more information about related Amazon S3 APIs, see the
 
 # Optional Parameters
 Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys are:
-- `"Body"`: Object data.
+- `"body"`: Object data.
 - `"Cache-Control"`:  Can be used to specify caching behavior along the request/reply
   chain. For more information, see
   http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9.
@@ -6616,7 +6616,7 @@ CompleteMultipartUpload     AbortMultipartUpload     ListParts     ListMultipart
 
 # Optional Parameters
 Optional parameters can be passed as a `params::Dict{String,<:Any}`. Valid keys are:
-- `"Body"`: Object data.
+- `"body"`: Object data.
 - `"Content-Length"`: Size of the body in bytes. This parameter is useful when the size of
   the body cannot be determined automatically.
 - `"Content-MD5"`: The base64-encoded 128-bit MD5 digest of the part data. This parameter


### PR DESCRIPTION
Using "Body" as optional parameter creates empty object. "body" should be used.

This code: 
```
using AWS: @service
@service S3

function upload_file_to_s3(bucket_name, file_path)
    file_name = basename(file_path)
    open(file_path, "r") do file
        S3.put_object(bucket_name, file_name, Dict("Body" => read(file, String)))
    end
    println("File $file_name uploaded to $bucket_name.")
end

template_file="./README.md"
bucket_name="my-unique-bucket-name"
upload_file_to_s3(bucket_name, template_file)
```

Creates an empty object. If you use "body" instead of "Body", it creates the object with the expected content. The documentation uses "Body".