### PR TITLE
Changing groupName for GroupName in delete_placement_group

### DIFF
--- a/src/services/ec2.jl
+++ b/src/services/ec2.jl
@@ -9553,7 +9553,7 @@ function delete_placement_group(
 )
     return ec2(
         "DeletePlacementGroup",
-        Dict{String,Any}("groupName" => groupName);
+        Dict{String,Any}("GroupName" => groupName);
         aws_config=aws_config,
         feature_set=SERVICE_FEATURE_SET,
     )
@@ -9566,7 +9566,7 @@ function delete_placement_group(
     return ec2(
         "DeletePlacementGroup",
         Dict{String,Any}(
-            mergewith(_merge, Dict{String,Any}("groupName" => groupName), params)
+            mergewith(_merge, Dict{String,Any}("GroupName" => groupName), params)
         );
         aws_config=aws_config,
         feature_set=SERVICE_FEATURE_SET,


### PR DESCRIPTION
When I try using delete_placement_group I get an error:

```
julia> Ec2.delete_placement_group("test")
ERROR: AWS.AWSExceptions.AWSException: UnknownParameter -- The parameter groupName is not recognized
HTTP.Exceptions.StatusError(400, "POST", "/", HTTP.Messages.Response:
```

I changed in ec2.jl for 'GroupName' and it worked. 