### PR TITLE
Fix JuliaFormatter to 1.0.34

### DIFF
--- a/.github/workflows/blue_style_formatter.yml
+++ b/.github/workflows/blue_style_formatter.yml
@@ -12,7 +12,7 @@ jobs:
         with:
           version: 1
       - run: |
-          julia  -e 'using Pkg; Pkg.add("JuliaFormatter")'
+          julia  -e 'using Pkg; Pkg.add(name="JuliaFormatter", version="1.0.34")'
           julia  -e 'using JuliaFormatter; format(".", BlueStyle(); verbose=true)'
       - uses: reviewdog/action-suggester@v1
         with:

--- a/.github/workflows/update_apis.yml
+++ b/.github/workflows/update_apis.yml
@@ -24,7 +24,7 @@ jobs:
           GITHUB_AUTH: ${{ secrets.GITHUB_TOKEN }}
       - name: FormatCode
         run: |
-          julia -e 'using Pkg; Pkg.add("JuliaFormatter")'
+          julia -e 'using Pkg; Pkg.add(name="JuliaFormatter", version="1.0.34")'
           julia -e 'using JuliaFormatter; format(".", BlueStyle(); verbose=true)'
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3


### PR DESCRIPTION
This downgrades and fixes JuliaFormatter to 1.0.34. I believe this should get rid of the formatting changes in #637.  [1.0.34](https://github.com/domluna/JuliaFormatter.jl/releases/tag/v1.0.34) was the latest JuliaFormatter version when the last API update was merged in #636. My suggestion is to get #637 in with the old formatting, and then figure out how to re-format the generated code.

Note: 1.0.34 doesn't seem to cause any formatting changes on master, so in that sense should be safe to merge.