### PR TITLE
Add workflow_dispatch trigger to update_apis workflow

### DIFF
--- a/.github/workflows/update_apis.yml
+++ b/.github/workflows/update_apis.yml
@@ -2,6 +2,7 @@ name: AWS
 on:
   schedule:
     - cron: '0 6 * * *'  # Daily at 6 a.m. UTC
+  workflow_dispatch:
 
 jobs:
   AWS:


### PR DESCRIPTION
Suggestion tangentially related to #637 and #676: [`on: workflow_dispatch`](https://docs.github.com/en/actions/using-workflows/manually-running-a-workflow) would allow the update_apis workflow to be triggered on-demand as well. Might be useful for triggering the API update right after a formatting PR etc is merged.