### PR TITLE
Fix SQS tests assuming the query service response structure

### DIFF
--- a/test/AWS.jl
+++ b/test/AWS.jl
@@ -820,7 +820,7 @@ end
                 queue_url,
             )
 
-            message_id = response["DeleteMessageBatchResult"]["DeleteMessageBatchResultEntry"]["Id"]
+            message_id = only(response["Successful"])["Id"]
             @test message_id == expected_message_id
 
             SQS.send_message(expected_message, queue_url)
@@ -878,7 +878,7 @@ end
                 ),
             )
 
-            message_id = response["DeleteMessageBatchResult"]["DeleteMessageBatchResultEntry"]["Id"]
+            message_id = only(response["Successful"])["Id"]
             @test message_id == expected_message_id
 
             # Send message

--- a/test/AWS.jl
+++ b/test/AWS.jl
@@ -809,7 +809,7 @@ end
             SQS.send_message(expected_message, queue_url)
 
             response = SQS.receive_message(queue_url)
-            receipt_handle = response["Message"]["ReceiptHandle"]
+            receipt_handle = only(response["Messages"])["ReceiptHandle"]
 
             response = SQS.delete_message_batch(
                 [
@@ -826,7 +826,7 @@ end
             SQS.send_message(expected_message, queue_url)
 
             result = SQS.receive_message(queue_url)
-            message = result["Message"]["Body"]
+            message = only(result["Messages"])["Body"]
             @test message == expected_message
         finally
             SQS.delete_queue(queue_url)
@@ -863,7 +863,7 @@ end
             response = AWSServices.sqs(
                 "ReceiveMessage", LittleDict("QueueUrl" => queue_url)
             )
-            receipt_handle = response["Message"]["ReceiptHandle"]
+            receipt_handle = only(response["Messages"])["ReceiptHandle"]
 
             response = AWSServices.sqs(
                 "DeleteMessageBatch",
@@ -889,7 +889,7 @@ end
 
             # Receive Message
             result = AWSServices.sqs("ReceiveMessage", LittleDict("QueueUrl" => queue_url))
-            message = result["Message"]["Body"]
+            message = only(result["Messages"])["Body"]
             @test message == expected_message
         finally
             AWSServices.sqs("DeleteQueue", LittleDict("QueueUrl" => queue_url))

--- a/test/AWS.jl
+++ b/test/AWS.jl
@@ -809,7 +809,7 @@ end
             SQS.send_message(expected_message, queue_url)
 
             response = SQS.receive_message(queue_url)
-            receipt_handle = response["ReceiveMessageResult"]["Message"]["ReceiptHandle"]
+            receipt_handle = response["Message"]["ReceiptHandle"]
 
             response = SQS.delete_message_batch(
                 [
@@ -826,7 +826,7 @@ end
             SQS.send_message(expected_message, queue_url)
 
             result = SQS.receive_message(queue_url)
-            message = result["ReceiveMessageResult"]["Message"]["Body"]
+            message = result["Message"]["Body"]
             @test message == expected_message
         finally
             SQS.delete_queue(queue_url)
@@ -863,7 +863,7 @@ end
             response = AWSServices.sqs(
                 "ReceiveMessage", LittleDict("QueueUrl" => queue_url)
             )
-            receipt_handle = response["ReceiveMessageResult"]["Message"]["ReceiptHandle"]
+            receipt_handle = response["Message"]["ReceiptHandle"]
 
             response = AWSServices.sqs(
                 "DeleteMessageBatch",
@@ -889,7 +889,7 @@ end
 
             # Receive Message
             result = AWSServices.sqs("ReceiveMessage", LittleDict("QueueUrl" => queue_url))
-            message = result["ReceiveMessageResult"]["Message"]["Body"]
+            message = result["Message"]["Body"]
             @test message == expected_message
         finally
             AWSServices.sqs("DeleteQueue", LittleDict("QueueUrl" => queue_url))

--- a/test/AWS.jl
+++ b/test/AWS.jl
@@ -869,7 +869,7 @@ end
                 "DeleteMessageBatch",
                 LittleDict(
                     "QueueUrl" => queue_url,
-                    "DeleteMessageBatchRequestEntry" => [
+                    "Entries" => [
                         LittleDict(
                             "Id" => expected_message_id,
                             "ReceiptHandle" => receipt_handle,

--- a/test/AWS.jl
+++ b/test/AWS.jl
@@ -792,7 +792,7 @@ end
         function _get_queue_url(queue_name)
             result = SQS.get_queue_url(queue_name)
 
-            return result["GetQueueUrlResult"]["QueueUrl"]
+            return result["QueueUrl"]
         end
 
         # Create Queue
@@ -842,7 +842,7 @@ end
         function _get_queue_url(queue_name)
             result = AWSServices.sqs("GetQueueUrl", LittleDict("QueueName" => queue_name))
 
-            return result["GetQueueUrlResult"]["QueueUrl"]
+            return result["QueueUrl"]
         end
 
         # Create Queue


### PR DESCRIPTION
In #637, SQS changed from a `QueryService` to a `JSONService` ([expectedly](https://aws.amazon.com/blogs/aws/new-for-amazon-sqs-update-the-aws-sdk-to-reduce-latency/)). The response obtained when interacting with SQS using the query protocol [includes a field](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-xml-api-responses.html#sqs-api-successful-response-structure) called `<ActionName>Result`, where `<ActionName>` is the action requested. The JSON protocol [does not include that field](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-json-api-responses.html#sqs-json-api-successful-response-structure). Thus I believe we can fix (or at least partially fix) #683 by simply deleting that additional `getindex` call.