### PR TITLE
Avoid duplicate `include`s causing warnings in tests

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,57 +1,60 @@
-using AWS
-using AWS: AWSCredentials, AWSServices, assume_role_creds
-using AWS.AWSExceptions:
-    AWSException, IMDSUnavailable, InvalidFileName, NoCredentials, ProtocolNotDefined
-using AWS.AWSMetadata:
-    ServiceFile,
-    _clean_documentation,
-    _filter_latest_service_version,
-    _generate_low_level_definition,
-    _generate_high_level_definition,
-    _generate_high_level_definitions,
-    _get_service_files,
-    _get_service_and_version,
-    _get_function_parameters,
-    _clean_uri,
-    _format_name,
-    _splitline,
-    _wraplines,
-    _validindex
-using Base64
-using Compat: mergewith
-using Dates
-using Downloads
-using GitHub
-using HTTP
-using IniFile: Inifile
-using JSON
-using OrderedCollections: LittleDict, OrderedDict
-using MbedTLS: digest, MD_SHA256, MD_MD5
-using Mocking
-using Pkg
-using Random
-using Suppressor
-using Test
-using UUIDs
-using XMLDict
-using StableRNGs
+const TOP_LEVEL_STUFF = quote
+    using AWS
+    using AWS: AWSCredentials, AWSServices, assume_role_creds
+    using AWS.AWSExceptions:
+        AWSException, IMDSUnavailable, InvalidFileName, NoCredentials, ProtocolNotDefined
+    using AWS.AWSMetadata:
+        ServiceFile,
+        _clean_documentation,
+        _filter_latest_service_version,
+        _generate_low_level_definition,
+        _generate_high_level_definition,
+        _generate_high_level_definitions,
+        _get_service_files,
+        _get_service_and_version,
+        _get_function_parameters,
+        _clean_uri,
+        _format_name,
+        _splitline,
+        _wraplines,
+        _validindex
+    using Base64
+    using Compat: mergewith
+    using Dates
+    using Downloads
+    using GitHub
+    using HTTP
+    using IniFile: Inifile
+    using JSON
+    using OrderedCollections: LittleDict, OrderedDict
+    using MbedTLS: digest, MD_SHA256, MD_MD5
+    using Mocking
+    using Pkg
+    using Random
+    using Suppressor
+    using Test
+    using UUIDs
+    using XMLDict
+    using StableRNGs
 
-Mocking.activate()
+    Mocking.activate()
 
-include("patch.jl")
-include("resources/totp.jl")
+    include("patch.jl")
+    include("resources/totp.jl")
+
+    function _now_formatted()
+        return lowercase(Dates.format(now(Dates.UTC), dateformat"yyyymmdd\THHMMSSsss\Z"))
+    end
+
+    testset_role(role_name) = string("AWS.jl-", role_name)
+end
+eval(TOP_LEVEL_STUFF)  # ensure things are loaded/defined in Main
 
 const TEST_MINIO = begin
     all(k -> haskey(ENV, k), ("MINIO_ACCESS_KEY", "MINIO_SECRET_KEY", "MINIO_REGION_NAME"))
 end
 
 aws = AWSConfig()
-
-function _now_formatted()
-    return lowercase(Dates.format(now(Dates.UTC), dateformat"yyyymmdd\THHMMSSsss\Z"))
-end
-
-testset_role(role_name) = "AWS.jl-$role_name"
 
 @testset "AWS.jl" begin
     include("AWSExceptions.jl")
@@ -63,14 +66,17 @@ testset_role(role_name) = "AWS.jl-$role_name"
     backends = [AWS.HTTPBackend, AWS.DownloadsBackend]
     @testset "Backend: $(nameof(backend))" for backend in backends
         AWS.DEFAULT_BACKEND[] = backend()
-        include("AWS.jl")
-        include("IMDS.jl")
-        include("AWSCredentials.jl")
-        include("role.jl")
-        include("issues.jl")
+        M = Module(Symbol(:Test, nameof(backend)))
+        Core.eval(M, TOP_LEVEL_STUFF)  # ensure things are loaded/defined in this module too
+        Core.eval(M, :(using ..Main: aws))
+        Core.include(M, "AWS.jl")
+        Core.include(M, "IMDS.jl")
+        Core.include(M, "AWSCredentials.jl")
+        Core.include(M, "role.jl")
+        Core.include(M, "issues.jl")
 
         if TEST_MINIO
-            include("minio.jl")
+            Core.include(M, "minio.jl")
         end
     end
 end


### PR DESCRIPTION
Currently we're calling `include` in a loop over supported backends. The files being `include`d contain definitions which get overwritten when `include` is called a second time, resulting in a lot of warnings that make the test logs noisy. The approach taken here to address this is to wrap things in expressions, define an anonymous module inside of the loop over backends, `Core.eval` the expressions into the anonymous module, and `Core.include` the files into it. There are better ways to do this but this *should* get the job done with minimal required changes.

Fixes #685.