### PR TITLE
Make `@service` only define a module once

### DIFF
--- a/test/AWS.jl
+++ b/test/AWS.jl
@@ -1,6 +1,10 @@
 @testset "service module" begin
     @service S3
     @test :S3 in names(Main)
+    @service S3 use_response_type = true
+    features = S3.SERVICE_FEATURE_SET
+    @service S3
+    @test features === S3.SERVICE_FEATURE_SET  # ensures the module wasn't replaced
 end
 
 @testset "global config, kwargs" begin


### PR DESCRIPTION
Currently, `@service` defines a module every time it's called. That works fine but the downside is that you get module redefinition warnings if you happen to call `@service` again. The most plausible reason why one would want to redefine the module would be to enable/disable particular features in some region of code. To facilitate that use case while avoiding redefinition warnings, we can make `@service` check for an existing module, define one if it can't find one, and if it can then modify the feature set associated with the module in place. With this change, `@service S3` (e.g.) effectively expands to:

```julia
if isdefined(Main, :S3)
    AWS.set_features!(S3.SERVICE_FEATURE_SET)
else
    module S3
        # contents
    end
end
```

The `set_features!` call uses the features specified in the macro call as keyword arguments. No arguments uses defaults. Notably this design requires that `FeatureSet` be made mutable, which seems fine IMO.