### PR TITLE
Fix failures in IAM tests

### DIFF
--- a/src/AWSExceptions.jl
+++ b/src/AWSExceptions.jl
@@ -98,7 +98,11 @@ function AWSException(e::HTTP.StatusError, body::AbstractString)
             end
 
             # Extract API error code from XML error message...
-            if endswith(content_type, "/xml") || startswith(body, "<?xml")
+            if (
+                endswith(content_type, "/xml") ||
+                startswith(body, "<?xml") ||
+                startswith(body, r"<\w+ xmlns=")
+            )
                 info = parse_xml(body)
             end
         elseif parse(Int, HTTP.header(e.response, "Content-Length", "0")) > 0


### PR DESCRIPTION
The test is expecting an `AWSException` with code `"InvalidAction"` but the caught exception had code 404. It appears to be because the response body is XML but AWS didn't set the `Content-Type` header nor did it begin the response body with a clear indicator of the content type, so the body doesn't get properly parsed. To fix this, we can expand the set of things we look for to determine when to parse as XML. Previously we were only looking for `/xml` at the end of the content or `<?xml` at the beginning of the body, but the error response has neither, so here I've added a check for `<\w+ xmlns=` at the beginning of the body. This seems to be the expected format of an XML response when the `<?xml` line is absent. Documentation suggests that `<?xml` would only be absent in the case of an `ErrorResponse` but that the `Content-Type` header would be set to `text/xml`. Evidently not true in practice...

Should fix #683.