### PR TITLE
rm stale notes about HTTP.jl concurrency issues

### DIFF
--- a/src/utilities/downloads_backend.jl
+++ b/src/utilities/downloads_backend.jl
@@ -11,8 +11,7 @@ It has one field,
 which is the `Downloads.Downloader` to use. If set to `nothing`, the default,
 then a global downloader object will be used.
 
-Downloads.jl tends to perform better under concurrent operation than HTTP.jl,
-particularly with `@async` / `asyncmap`. Note that threading (e.g. `@spawn` or `@threads`) with Downloads.jl is broken on Julia releases prior to 1.8 (https://github.com/JuliaLang/Downloads.jl/issues/182#issuecomment-1069269944).
+Note that threading (e.g. `@spawn` or `@threads`) with Downloads.jl is broken on Julia releases prior to 1.8 (https://github.com/JuliaLang/Downloads.jl/issues/182#issuecomment-1069269944).
 """
 struct DownloadsBackend <: AWS.AbstractBackend
     downloader::Union{Nothing,Downloads.Downloader}

--- a/src/utilities/request.jl
+++ b/src/utilities/request.jl
@@ -19,10 +19,7 @@ which defaults to an empty dictionary. This field provides
 default options to use, which can be any of the keyword
 arguments to [`HTTP.request`](https://juliaweb.github.io/HTTP.jl/stable/public_interface/#HTTP.request). These options are overwritten by any per-request options.
 
-This is the default backend, and the only option until AWS.jl v1.57.0. Therefore, it has
-been used more often in practice, and may be more mature. Note, however, HTTP.jl currently
-(March 2022) has issues with concurrency (see [HTTP.jl#517](https://github.com/JuliaWeb/HTTP.jl/issues/517)). Therefore, it may be advisable to switch to the [`DownloadsBackend`](@ref) if you
-are using concurrency.
+This is the default backend.
 """
 struct HTTPBackend <: AbstractBackend
     http_options::AbstractDict{Symbol,<:Any}


### PR DESCRIPTION
The linked issue has been closed and I think there are a lot less issues these days. I also don't know that Downloads is better for concurrency than HTTP anymore so I've removed that note.