### PR TITLE
Use GitHub merge queues

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,5 +1,6 @@
 name: CI
 on:
+  merge_group:
   pull_request:
   push:
     branches:
@@ -10,6 +11,7 @@ on:
 jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
+    if: ${{ github.event_name != 'pull_request' }}  # Avoid running on PRs as OIDC will fail when running on a fork
     permissions:
       # Required for interacting with GitHub's OIDC Token endpoint:
       # - Checking out the repository (`contents: read`)

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,9 +1,15 @@
 name: TagBot
 on:
-  schedule:
-    - cron: 0 * * * *
+  issue_comment:
+    types:
+      - created
+  workflow_dispatch:
+    inputs:
+      lookback:
+        default: "3"
 jobs:
   TagBot:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot' }}
     runs-on: ubuntu-latest
     steps:
       - uses: JuliaRegistries/TagBot@v1

--- a/.github/workflows/blue_style_formatter.yml
+++ b/.github/workflows/blue_style_formatter.yml
@@ -1,5 +1,6 @@
 name: Format suggestions
 on:
+  merge_group:
   pull_request:
 # These permissions are needed to:
 # - Delete old caches: https://github.com/julia-actions/cache#usage


### PR DESCRIPTION
In order to address #703 we need to deal with OIDC only being available from the current repository and not from forks. It appears that GitHub merge queues can help with the situation. The only real downside here compared to the old Bors system is that you cannot execute the tests without attempting a merge. This means that reviewers need to look over the code first (we required this before anyway) and approve the PR before tests are run. If they do so the PR can enter the merge queue and will be merged only if the CI tests pass.

In order to test this properly I've enabled the GitHub merge queue on the `master` branch.