### PR TITLE
Rename formatting workflow job name

### DIFF
--- a/.github/workflows/JuliaFormatter.yml
+++ b/.github/workflows/JuliaFormatter.yml
@@ -1,4 +1,4 @@
-name: Format suggestions
+name: JuliaFormatter
 on:
   merge_group:
   pull_request:
@@ -11,6 +11,7 @@ permissions:
   pull-requests: write
 jobs:
   format:
+    name: Format
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Since we want to add the formatting job as a required check for merging it made sense to me to change the name at this time.