### PR TITLE
add support for AWS_REGION env variable

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AWS"
 uuid = "fbe9abb3-538b-5e4e-ba9e-bc94f4f92ebc"
 license = "MIT"
-version = "1.92.1"
+version = "1.93.0"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/AWSCredentials.jl
+++ b/src/AWSCredentials.jl
@@ -638,11 +638,12 @@ end
 Determine the current AWS region that should be used for AWS requests. The order of
 precedence mirrors what is [used by the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html#cli-configure-quickstart-precedence):
 
-1. Environmental variable: as specified by the `AWS_DEFAULT_REGION` environmental variable.
-2. AWS configuration file: `region` as specified by the `profile` in the configuration
+1. Environment variable: `AWS_REGION`.
+2. Environment variable: `AWS_DEFAULT_REGION` (used if `AWS_REGION` is not set).
+3. AWS configuration file: `region` as specified by the `profile` in the configuration
    file, typically "~/.aws/config".
-3. Instance metadata service on an Amazon EC2 instance that has an IAM role configured
-4. Default region: use the specified `default`, typically "$DEFAULT_REGION".
+4. Instance metadata service on an Amazon EC2 instance that has an IAM role configured.
+5. Default region: use the specified `default`, typically "$DEFAULT_REGION".
 
 # Keywords
 - `profile`: Name of the AWS configuration profile, if any. Defaults to `nothing` which
@@ -654,6 +655,7 @@ precedence mirrors what is [used by the AWS CLI](https://docs.aws.amazon.com/cli
 """
 function aws_get_region(; profile=nothing, config=nothing, default=DEFAULT_REGION)
     @something(
+        get(ENV, "AWS_REGION", nothing),
         get(ENV, "AWS_DEFAULT_REGION", nothing),
         get(_aws_profile_config(config, profile), "region", nothing),
         @mock(IMDS.region()),

--- a/src/AWSCredentials.jl
+++ b/src/AWSCredentials.jl
@@ -639,7 +639,7 @@ Determine the current AWS region that should be used for AWS requests. The order
 precedence mirrors what is [used by the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html#cli-configure-quickstart-precedence):
 
 1. Environment variable: `AWS_REGION`.
-2. Environment variable: `AWS_DEFAULT_REGION` (used if `AWS_REGION` is not set).
+2. Environment variable: `AWS_DEFAULT_REGION`
 3. AWS configuration file: `region` as specified by the `profile` in the configuration
    file, typically "~/.aws/config".
 4. Instance metadata service on an Amazon EC2 instance that has an IAM role configured.

--- a/test/AWSCredentials.jl
+++ b/test/AWSCredentials.jl
@@ -1279,7 +1279,10 @@ end
         end
 
         @testset "specified profile" begin
-            withenv("AWS_DEFAULT_REGION" => nothing) do
+            withenv(
+                "AWS_DEFAULT_REGION" => nothing,
+                "AWS_REGION" => nothing,
+            ) do
                 @test aws_get_region(; config=ini, profile="test") == "ap-northeast-1"
                 @test aws_get_region(; config=config_file, profile="test") ==
                     "ap-northeast-1"
@@ -1296,7 +1299,10 @@ end
         end
 
         @testset "unknown profile" begin
-            withenv("AWS_DEFAULT_REGION" => nothing) do
+            withenv(
+                "AWS_DEFAULT_REGION" => nothing,
+                "AWS_REGION" => nothing,
+            ) do
                 apply(Patches._imds_region_patch(nothing)) do
                     @test aws_get_region(; config=ini, profile="unknown") ==
                         AWS.DEFAULT_REGION
@@ -1319,7 +1325,10 @@ end
 
         @testset "default keyword" begin
             default = nothing
-            withenv("AWS_DEFAULT_REGION" => nothing) do
+            withenv(
+                "AWS_DEFAULT_REGION" => nothing,
+                "AWS_REGION" => nothing,
+            ) do
                 apply(Patches._imds_region_patch(nothing)) do
                     @test aws_get_region(; config=ini, profile="unknown", default) ===
                         default
@@ -1342,7 +1351,11 @@ end
         end
 
         @testset "no such config file" begin
-            withenv("AWS_DEFAULT_REGION" => nothing, "AWS_CONFIG_FILE" => tempname()) do
+            withenv(
+                "AWS_DEFAULT_REGION" => nothing,
+                "AWS_REGION" => nothing,
+                "AWS_CONFIG_FILE" => tempname()
+            ) do
                 apply(Patches._imds_region_patch(nothing)) do
                     @test aws_get_region() == AWS.DEFAULT_REGION
                 end
@@ -1350,7 +1363,11 @@ end
         end
 
         @testset "instance profile" begin
-            withenv("AWS_DEFAULT_REGION" => nothing, "AWS_CONFIG_FILE" => tempname()) do
+            withenv(
+                "AWS_DEFAULT_REGION" => nothing,
+                "AWS_REGION" => nothing,
+                "AWS_CONFIG_FILE" => tempname()
+            ) do
                 apply(Patches._imds_region_patch("ap-atlantis-1")) do
                     @test aws_get_region() == "ap-atlantis-1"
                 end

--- a/test/AWSCredentials.jl
+++ b/test/AWSCredentials.jl
@@ -1279,10 +1279,7 @@ end
         end
 
         @testset "specified profile" begin
-            withenv(
-                "AWS_DEFAULT_REGION" => nothing,
-                "AWS_REGION" => nothing,
-            ) do
+            withenv("AWS_DEFAULT_REGION" => nothing, "AWS_REGION" => nothing) do
                 @test aws_get_region(; config=ini, profile="test") == "ap-northeast-1"
                 @test aws_get_region(; config=config_file, profile="test") ==
                     "ap-northeast-1"
@@ -1299,10 +1296,7 @@ end
         end
 
         @testset "unknown profile" begin
-            withenv(
-                "AWS_DEFAULT_REGION" => nothing,
-                "AWS_REGION" => nothing,
-            ) do
+            withenv("AWS_DEFAULT_REGION" => nothing, "AWS_REGION" => nothing) do
                 apply(Patches._imds_region_patch(nothing)) do
                     @test aws_get_region(; config=ini, profile="unknown") ==
                         AWS.DEFAULT_REGION
@@ -1325,10 +1319,7 @@ end
 
         @testset "default keyword" begin
             default = nothing
-            withenv(
-                "AWS_DEFAULT_REGION" => nothing,
-                "AWS_REGION" => nothing,
-            ) do
+            withenv("AWS_DEFAULT_REGION" => nothing, "AWS_REGION" => nothing) do
                 apply(Patches._imds_region_patch(nothing)) do
                     @test aws_get_region(; config=ini, profile="unknown", default) ===
                         default
@@ -1354,7 +1345,7 @@ end
             withenv(
                 "AWS_DEFAULT_REGION" => nothing,
                 "AWS_REGION" => nothing,
-                "AWS_CONFIG_FILE" => tempname()
+                "AWS_CONFIG_FILE" => tempname(),
             ) do
                 apply(Patches._imds_region_patch(nothing)) do
                     @test aws_get_region() == AWS.DEFAULT_REGION
@@ -1366,7 +1357,7 @@ end
             withenv(
                 "AWS_DEFAULT_REGION" => nothing,
                 "AWS_REGION" => nothing,
-                "AWS_CONFIG_FILE" => tempname()
+                "AWS_CONFIG_FILE" => tempname(),
             ) do
                 apply(Patches._imds_region_patch("ap-atlantis-1")) do
                     @test aws_get_region() == "ap-atlantis-1"

--- a/test/AWSCredentials.jl
+++ b/test/AWSCredentials.jl
@@ -1245,21 +1245,21 @@ end
         ini = read(Inifile(), IOBuffer(config_str))
 
         @testset "environmental variable (AWS_REGION)" begin
-             withenv("AWS_REGION" => "eu-west-1", "AWS_DEFAULT_REGION" => nothing) do
-                 @test aws_get_region(; config=ini, profile="default") == "eu-west-1"
-                 @test aws_get_region() == "eu-west-1"
-             end
-             
-             withenv("AWS_REGION" => nothing, "AWS_DEFAULT_REGION" => "us-gov-east-1") do
+            withenv("AWS_REGION" => "eu-west-1", "AWS_DEFAULT_REGION" => nothing) do
+                @test aws_get_region(; config=ini, profile="default") == "eu-west-1"
+                @test aws_get_region() == "eu-west-1"
+            end
+
+            withenv("AWS_REGION" => nothing, "AWS_DEFAULT_REGION" => "us-gov-east-1") do
                 @test aws_get_region(; config=ini, profile="default") == "us-gov-east-1"
                 @test aws_get_region() == "us-gov-east-1"
             end
 
-             withenv("AWS_REGION" => "eu-west-1", "AWS_DEFAULT_REGION" => "us-gov-east-1") do
-                 @test aws_get_region(; config=ini, profile="default") == "eu-west-1"
-                 @test aws_get_region() == "eu-west-1"
-             end
-         end
+            withenv("AWS_REGION" => "eu-west-1", "AWS_DEFAULT_REGION" => "us-gov-east-1") do
+                @test aws_get_region(; config=ini, profile="default") == "eu-west-1"
+                @test aws_get_region() == "eu-west-1"
+            end
+        end
 
         @testset "default profile" begin
             withenv("AWS_REGION" => nothing, "AWS_DEFAULT_REGION" => nothing) do
@@ -1268,7 +1268,7 @@ end
             end
 
             withenv(
-                "AWS_REGION" => nothing, # Ensure not set
+                "AWS_REGION" => nothing,
                 "AWS_DEFAULT_REGION" => nothing,
                 "AWS_CONFIG_FILE" => config_file,
                 "AWS_PROFILE" => nothing,
@@ -1286,6 +1286,7 @@ end
             end
 
             withenv(
+                "AWS_REGION" => nothing,
                 "AWS_DEFAULT_REGION" => nothing,
                 "AWS_CONFIG_FILE" => config_file,
                 "AWS_PROFILE" => "test",
@@ -1305,6 +1306,7 @@ end
             end
 
             withenv(
+                "AWS_REGION" => nothing,
                 "AWS_DEFAULT_REGION" => nothing,
                 "AWS_CONFIG_FILE" => config_file,
                 "AWS_PROFILE" => "unknown",
@@ -1328,6 +1330,7 @@ end
             end
 
             withenv(
+                "AWS_REGION" => nothing,
                 "AWS_DEFAULT_REGION" => nothing,
                 "AWS_CONFIG_FILE" => config_file,
                 "AWS_PROFILE" => "unknown",

--- a/test/AWSCredentials.jl
+++ b/test/AWSCredentials.jl
@@ -1244,6 +1244,13 @@ end
         write(config_file, config_str)
         ini = read(Inifile(), IOBuffer(config_str))
 
+        @testset "environmental variable (DEFAULT)" begin
+            withenv("AWS_REGION" => nothing, "AWS_DEFAULT_REGION" => "us-gov-east-1") do
+                @test aws_get_region(; config=ini, profile="default") == "us-gov-east-1"
+                @test aws_get_region() == "us-gov-east-1"
+            end
+        end
+
         @testset "environmental variable" begin
             withenv("AWS_DEFAULT_REGION" => "us-gov-east-1") do
                 @test aws_get_region(; config=ini, profile="default") == "us-gov-east-1"
@@ -1251,13 +1258,26 @@ end
             end
         end
 
+        @testset "environmental variable (AWS_REGION)" begin
+             withenv("AWS_REGION" => "eu-west-1", "AWS_DEFAULT_REGION" => nothing) do
+                 @test aws_get_region(; config=ini, profile="default") == "eu-west-1"
+                 @test aws_get_region() == "eu-west-1"
+             end
+
+             withenv("AWS_REGION" => "eu-west-1", "AWS_DEFAULT_REGION" => "us-gov-east-1") do
+                 @test aws_get_region(; config=ini, profile="default") == "eu-west-1"
+                 @test aws_get_region() == "eu-west-1"
+             end
+         end
+
         @testset "default profile" begin
-            withenv("AWS_DEFAULT_REGION" => nothing) do
+            withenv("AWS_REGION" => nothing, "AWS_DEFAULT_REGION" => nothing) do
                 @test aws_get_region(; config=ini, profile="default") == "us-west-2"
                 @test aws_get_region(; config=config_file, profile="default") == "us-west-2"
             end
 
             withenv(
+                "AWS_REGION" => nothing, # Ensure not set
                 "AWS_DEFAULT_REGION" => nothing,
                 "AWS_CONFIG_FILE" => config_file,
                 "AWS_PROFILE" => nothing,

--- a/test/AWSCredentials.jl
+++ b/test/AWSCredentials.jl
@@ -1244,25 +1244,16 @@ end
         write(config_file, config_str)
         ini = read(Inifile(), IOBuffer(config_str))
 
-        @testset "environmental variable (DEFAULT)" begin
-            withenv("AWS_REGION" => nothing, "AWS_DEFAULT_REGION" => "us-gov-east-1") do
-                @test aws_get_region(; config=ini, profile="default") == "us-gov-east-1"
-                @test aws_get_region() == "us-gov-east-1"
-            end
-        end
-
-        @testset "environmental variable" begin
-            withenv("AWS_DEFAULT_REGION" => "us-gov-east-1") do
-                @test aws_get_region(; config=ini, profile="default") == "us-gov-east-1"
-                @test aws_get_region() == "us-gov-east-1"
-            end
-        end
-
         @testset "environmental variable (AWS_REGION)" begin
              withenv("AWS_REGION" => "eu-west-1", "AWS_DEFAULT_REGION" => nothing) do
                  @test aws_get_region(; config=ini, profile="default") == "eu-west-1"
                  @test aws_get_region() == "eu-west-1"
              end
+             
+             withenv("AWS_REGION" => nothing, "AWS_DEFAULT_REGION" => "us-gov-east-1") do
+                @test aws_get_region(; config=ini, profile="default") == "us-gov-east-1"
+                @test aws_get_region() == "us-gov-east-1"
+            end
 
              withenv("AWS_REGION" => "eu-west-1", "AWS_DEFAULT_REGION" => "us-gov-east-1") do
                  @test aws_get_region(; config=ini, profile="default") == "eu-west-1"


### PR DESCRIPTION
## Description

In this PR we add support for AWS_REGION which is a preferred environment variable to obtain the region with the AWS CLI. 

https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html

Closes https://github.com/JuliaCloud/AWS.jl/issues/702

## Testing

- Added a test to ensure AWS_DEFAULT_REGION is still being used
- Added a test to ensure AWS_REGION gets higher priority
- Modified aws_get_region accordingly 