### PR TITLE
Allow failures from OIDC debug step

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -42,6 +42,7 @@ jobs:
       - uses: actions/checkout@v5
       - name: Debug OIDC Claims
         if: ${{ env.RUN_INTEGRATION_TESTS == 'true' }}
+        continue-on-error: true
         uses: steve-todorov/oidc-debugger-action@v1
         with:
           audience: sts.amazonaws.com


### PR DESCRIPTION
Noticed this failure which only occurred once it ran on `master`. As this step is only here for debugging purposes we can continue on failures

https://github.com/JuliaCloud/AWS.jl/actions/runs/19514947303/job/55864204971