### PR TITLE
Thread-safely and rate limiting for credentials refreshing

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ struct NoCredentials end
 
 AWS.region(aws::AnonymousGCS) = "" # No region
 AWS.credentials(aws::AnonymousGCS) = NoCredentials() # No credentials
-AWS.check_credentials(c::NoCredentials) = c # Skip credentials check
+AWS.refresh!(c::NoCredentials) = c # Skip credential refreshing
 AWS.sign!(aws::AnonymousGCS, ::AWS.Request) = nothing # Don't sign request
 function AWS.generate_service_url(aws::AnonymousGCS, service::String, resource::String)
     service == "s3" || throw(ArgumentError("Can only handle s3 requests to GCS"))
@@ -171,7 +171,7 @@ struct SimpleCredentials
     secret_key::String
     token::String
 end
-AWS.check_credentials(c::SimpleCredentials) = c
+AWS.refresh!(c::SimpleCredentials) = c
 ````
 
 as well as a custom url generator:

--- a/src/AWSCredentials.jl
+++ b/src/AWSCredentials.jl
@@ -72,6 +72,11 @@ mutable struct AWSCredentials
     account_number::String
     expiry::DateTime  # Implicit UTC timestamp
     renew::Union{Function,Nothing}  # Function which can be used to refresh credentials
+
+    # UTC timestamp when we created or last renewed the credentials. Only ever uses the
+    # system clock.
+    renewed_at::DateTime
+
     lock::ReentrantLock
 
     function AWSCredentials(
@@ -91,6 +96,7 @@ mutable struct AWSCredentials
             account_number,
             expiry,
             renew,
+            now(UTC),
             ReentrantLock(),
         )
     end
@@ -197,6 +203,14 @@ specified by `drift`).
 _is_expired(c::AWSCredentials; drift::Period=Minute(5)) = c.expiry - now(UTC) <= drift
 
 """
+    _is_recently_renewed(creds::AWSCredentials) -> Bool
+
+Determine if the credentials have been recently renewed to avoid issues with refreshing
+too often. We currently limit credential refreshing to occur once per minute.
+"""
+_is_recently_renewed(c::AWSCredentials) = now(UTC) - c.renewed_at <= Minute(1)
+
+"""
     refresh!(creds::AWSCredentials; force::Bool=false) -> AWSCredentials
 
 Refresh the credentials if they are expired or our about to. Using `force` will cause the
@@ -221,9 +235,9 @@ function refresh!(creds::AWSCredentials; force::Bool=false)
 
     # Refresh credentials when forced or they are about to expire and we haven't just
     # refreshed them.
-    if force || _is_expired(creds)
+    if force || _is_expired(creds) && !_is_recently_renewed(creds)
         @lock creds.lock begin
-            if force || _is_expired(creds)
+            if force || _is_expired(creds) && !_is_recently_renewed(creds)
                 new_creds = renew()
                 if new_creds === nothing
                     throw(NoCredentials("Can't find AWS credentials!"))

--- a/src/AWSCredentials.jl
+++ b/src/AWSCredentials.jl
@@ -10,7 +10,6 @@ export AWSCredentials,
     aws_get_profile_settings,
     aws_get_region,
     aws_user_arn,
-    check_credentials,
     credentials_from_webtoken,
     dot_aws_config,
     dot_aws_config_file,
@@ -57,7 +56,7 @@ and is as follows:
 
 Once the credentials are found, the method by which they were accessed is stored in the `renew` field
 and the `DateTime` at which they will expire is stored in the `expiry` field.
-This allows the credentials to be refreshed as needed using [`check_credentials`](@ref).
+This allows the credentials to be refreshed as needed using [`refresh!`](@ref).
 If `renew` is set to `nothing`, no attempt will be made to refresh the credentials.
 Any renewal function is expected to return `nothing` on failure or a populated `AWSCredentials` object on success.
 The `renew` field of the returned `AWSCredentials` will be discarded and does not need to be set.

--- a/src/AWSCredentials.jl
+++ b/src/AWSCredentials.jl
@@ -197,51 +197,48 @@ specified by `drift`).
 _is_expired(c::AWSCredentials; drift::Period=Minute(5)) = c.expiry - now(UTC) <= drift
 
 """
-    check_credentials(
-        aws_creds::AWSCredentials, force_refresh::Bool=false
-    ) -> AWSCredentials
+    refresh!(creds::AWSCredentials; force::Bool=false) -> AWSCredentials
 
-Checks current AWSCredentials, refreshing them if they are soon to expire. If
-`force_refresh` is `true` the credentials will be renewed immediately
+Refresh the credentials if they are expired or our about to. Using `force` will cause the
+credentials to be renewed immediately.
 
 # Arguments
-- `aws_creds::AWSCredentials`: AWSCredentials to be checked / refreshed
+- `creds::AWSCredentials`: The `AWSCredentials` to be updated in-place.
 
 # Keywords
-- `force_refresh::Bool=false`: `true` to refresh the credentials
+- `force::Bool=false`: Renew the credentials immediately. Should only be used interactively
+   as renewing too frequently can cause issues with some credential backends.
 
 # Throws
-- `error("Can't find AWS credentials!")`: If no credentials can be found
+- `NoCredentials("Can't find AWS credentials!")`: When no credentials could be found when executing
+  the `renew` function associated with `creds`.
 """
-function check_credentials(aws_creds::AWSCredentials; force_refresh::Bool=false)
-    credential_method = aws_creds.renew
+function refresh!(creds::AWSCredentials; force::Bool=false)
+    renew = creds.renew
 
     # Return existing credentials if no `renew` function was defined
-    credential_method === nothing && return aws_creds
+    renew === nothing && return creds
 
-    # Refresh credentials when forced or they are about to expire
-    if force_refresh || _is_expired(aws_creds)
-        expired_at = aws_creds.expiry
-        @lock aws_creds.lock begin
-
-            # Avoid renewing the credentials immediately if they have renewed while we were
-            # awaiting the lock to be released.
-            if aws_creds.expiry <= expired_at
-                new_aws_creds = credential_method()
-                if new_aws_creds === nothing
+    # Refresh credentials when forced or they are about to expire and we haven't just
+    # refreshed them.
+    if force || _is_expired(creds)
+        @lock creds.lock begin
+            if force || _is_expired(creds)
+                new_creds = renew()
+                if new_creds === nothing
                     throw(NoCredentials("Can't find AWS credentials!"))
                 end
 
+                # Mutate `creds` with fields from `new_creds`
                 for f in _AWS_CREDENTIALS_REFRESH_FIELDS
-                    setfield!(aws_creds, f, getfield(new_aws_creds, f))
+                    setfield!(creds, f, getfield(new_creds, f))
                 end
             end
         end
     end
 
-    return aws_creds
+    return creds
 end
-check_credentials(aws_creds::Nothing) = aws_creds
 
 """
     ec2_instance_credentials(profile::AbstractString) -> AWSCredentials

--- a/src/AWSCredentials.jl
+++ b/src/AWSCredentials.jl
@@ -56,7 +56,7 @@ and is as follows:
 
 Once the credentials are found, the method by which they were accessed is stored in the `renew` field
 and the `DateTime` at which they will expire is stored in the `expiry` field.
-This allows the credentials to be refreshed as needed using [`refresh!`](@ref).
+This allows the credentials to be refreshed as needed using [`refresh!`](@ref AWS.refresh!).
 If `renew` is set to `nothing`, no attempt will be made to refresh the credentials.
 Any renewal function is expected to return `nothing` on failure or a populated `AWSCredentials` object on success.
 The `renew` field of the returned `AWSCredentials` will be discarded and does not need to be set.

--- a/src/AWSCredentials.jl
+++ b/src/AWSCredentials.jl
@@ -261,19 +261,27 @@ function ec2_instance_credentials(profile::AbstractString)
         source == "Ec2InstanceMetadata" || return nothing
     end
 
-    info = IMDS.get("/latest/meta-data/iam/info")
-    info === nothing && return nothing
-    info = JSON.parse(info; dicttype=Dict)
-
     # Get credentials for the role associated to the instance via instance profile.
     name = IMDS.get("/latest/meta-data/iam/security-credentials/")
+    name === nothing && return nothing
+
     creds = IMDS.get("/latest/meta-data/iam/security-credentials/$name")
+    creds === nothing && return nothing
     parsed = JSON.parse(creds; dicttype=Dict)
+
+    # Retrieve the ARN (optional)
+    info = IMDS.get("/latest/meta-data/iam/info")
+    instance_profile_arn = if info !== nothing
+        JSON.parse(info; dicttype=Dict)["InstanceProfileArn"]
+    else
+        ""
+    end
+
     instance_profile_creds = AWSCredentials(
         parsed["AccessKeyId"],
         parsed["SecretAccessKey"],
         parsed["Token"],
-        info["InstanceProfileArn"];
+        instance_profile_arn;
         expiry=DateTime(rstrip(parsed["Expiration"], 'Z')),
         renew=() -> ec2_instance_credentials(profile),
     )

--- a/src/AWSCredentials.jl
+++ b/src/AWSCredentials.jl
@@ -33,15 +33,16 @@ localhost_is_lambda() = haskey(ENV, "LAMBDA_TASK_ROOT")
     AWSCredentials
 
 When you interact with AWS, you specify your [AWS Security Credentials](http://docs.aws.amazon.com/general/latest/gr/aws-security-credentials.html)
-to verify who you are and whether you have permission to access the resources that you are requesting.
-AWS uses the security credentials to authenticate and authorize your requests.
-The fields `access_key_id` and `secret_key` hold the access keys used to authenticate API requests
-(see [Creating, Modifying, and Viewing Access Keys](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html#Using_CreateAccessKey)).
-[Temporary Security Credentials](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp.html) require the extra session `token` field.
-The `user_arn` and `account_number` fields are used to cache the result of the [`aws_user_arn`](@ref) and [`aws_account_number`](@ref) functions.
+to verify who you are and whether you have permission to access the resources that you are
+requesting. AWS uses the security credentials to authenticate and authorize your requests.
+The fields `access_key_id` and `secret_key` hold the access keys used to authenticate API
+requests (see [Creating, Modifying, and Viewing Access Keys](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html#Using_CreateAccessKey)).
+[Temporary Security Credentials](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp.html)
+require the extra session `token` field. The `user_arn` and `account_number` fields are used
+to cache the result of the [`aws_user_arn`](@ref) and [`aws_account_number`](@ref) functions.
 
-AWS.jl searches for credentials in multiple locations and stops once any credentials are found.
-The credential preference order mostly [mirrors the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-authentication.html#cli-chap-authentication-precedence)
+AWS.jl searches for credentials in multiple locations and stops once any credentials are
+found. The credential preference order mostly [mirrors the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-authentication.html#cli-chap-authentication-precedence)
 and is as follows:
 
 1. Credentials or a profile passed directly to the `AWSCredentials`
@@ -54,14 +55,16 @@ and is as follows:
 8. [Amazon ECS container credentials](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html)
 9. [Amazon EC2 instance metadata](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html)
 
-Once the credentials are found, the method by which they were accessed is stored in the `renew` field
-and the `DateTime` at which they will expire is stored in the `expiry` field.
-This allows the credentials to be refreshed as needed using [`refresh!`](@ref AWS.refresh!).
-If `renew` is set to `nothing`, no attempt will be made to refresh the credentials.
-Any renewal function is expected to return `nothing` on failure or a populated `AWSCredentials` object on success.
-The `renew` field of the returned `AWSCredentials` will be discarded and does not need to be set.
+Once the credentials are found, the method by which they were accessed is stored in the
+`renew` field and the `DateTime` at which they will expire is stored in the `expiry` field.
+This allows the credentials to be refreshed as needed using `refresh!`. If `renew` is set to
+`nothing`, no attempt will be made to refresh the credentials. Any renewal function is
+expected to return `nothing` on failure or a populated `AWSCredentials` object on success.
+The `renew` field of the returned `AWSCredentials` will be discarded and does not need to be
+set.
 
-To specify the profile to use from `~/.aws/credentials`, do, for example, `AWSCredentials(profile="profile-name")`.
+To specify the profile to use from `~/.aws/credentials`, do, for example,
+`AWSCredentials(profile="profile-name")`.
 """
 mutable struct AWSCredentials
     access_key_id::String
@@ -215,16 +218,19 @@ _is_recently_renewed(c::AWSCredentials) = now(UTC) - c.renewed_at <= Minute(1)
 Refresh the credentials if they are expired or our about to. Using `force` will cause the
 credentials to be renewed immediately.
 
-# Arguments
+## Arguments
+
 - `creds::AWSCredentials`: The `AWSCredentials` to be updated in-place.
 
-# Keywords
+## Keywords
+
 - `force::Bool=false`: Renew the credentials immediately. Should only be used interactively
    as renewing too frequently can cause issues with some credential backends.
 
-# Throws
-- `NoCredentials("Can't find AWS credentials!")`: When no credentials could be found when executing
-  the `renew` function associated with `creds`.
+## Throws
+
+- `NoCredentials("Can't find AWS credentials!")`: When no credentials could be found when
+  executing the `renew` function associated with `creds`.
 """
 function refresh!(creds::AWSCredentials; force::Bool=false)
     renew = creds.renew

--- a/src/AWSCredentials.jl
+++ b/src/AWSCredentials.jl
@@ -70,8 +70,9 @@ mutable struct AWSCredentials
     token::String
     user_arn::String
     account_number::String
-    expiry::DateTime
+    expiry::DateTime  # Implicit UTC timestamp
     renew::Union{Function,Nothing}  # Function which can be used to refresh credentials
+    lock::ReentrantLock
 
     function AWSCredentials(
         access_key_id,
@@ -83,9 +84,27 @@ mutable struct AWSCredentials
         renew=nothing,
     )
         return new(
-            access_key_id, secret_key, token, user_arn, account_number, expiry, renew
+            access_key_id,
+            secret_key,
+            token,
+            user_arn,
+            account_number,
+            expiry,
+            renew,
+            ReentrantLock(),
         )
     end
+end
+
+# When renewing the AWS credentials these are the fields we'll refresh. We specifically want
+# to avoid mutating the these fields over the lifetime of the credentials:
+#
+# - `renew`: The refresh process should not accidentally mutate the `renew` function.
+# - `lock`: The lock associated with the credentials should not change over the lifetime of
+#   the credentials. If it does we could encounter issues with thread-safety.
+const _AWS_CREDENTIALS_REFRESH_FIELDS = let
+    exclude = (:renew, :lock)
+    setdiff(fieldnames(AWSCredentials), exclude)
 end
 
 # Needs to be included after struct AWSCredentials for compilation
@@ -169,11 +188,13 @@ function Base.show(io::IO, c::AWSCredentials)
     )
 end
 
-function Base.copyto!(dest::AWSCredentials, src::AWSCredentials)
-    for f in fieldnames(typeof(dest))
-        setfield!(dest, f, getfield(src, f))
-    end
-end
+"""
+    _is_expired(creds::AWSCredentials; drift::Period=Minute(5)) -> Bool
+
+Determine if the credentials have expired or are about to expire (within the duration
+specified by `drift`).
+"""
+_is_expired(c::AWSCredentials; drift::Period=Minute(5)) = c.expiry - now(UTC) <= drift
 
 """
     check_credentials(
@@ -193,17 +214,28 @@ Checks current AWSCredentials, refreshing them if they are soon to expire. If
 - `error("Can't find AWS credentials!")`: If no credentials can be found
 """
 function check_credentials(aws_creds::AWSCredentials; force_refresh::Bool=false)
-    if force_refresh || _will_expire(aws_creds)
-        credential_method = aws_creds.renew
+    credential_method = aws_creds.renew
 
-        if credential_method !== nothing
-            new_aws_creds = credential_method()
+    # Return existing credentials if no `renew` function was defined
+    credential_method === nothing && return aws_creds
 
-            new_aws_creds === nothing && throw(NoCredentials("Can't find AWS credentials!"))
-            copyto!(aws_creds, new_aws_creds)
+    # Refresh credentials when forced or they are about to expire
+    if force_refresh || _is_expired(aws_creds)
+        expired_at = aws_creds.expiry
+        @lock aws_creds.lock begin
 
-            # Ensure credential_method is not overwritten by the new credentials
-            aws_creds.renew = credential_method
+            # Avoid renewing the credentials immediately if they have renewed while we were
+            # awaiting the lock to be released.
+            if aws_creds.expiry <= expired_at
+                new_aws_creds = credential_method()
+                if new_aws_creds === nothing
+                    throw(NoCredentials("Can't find AWS credentials!"))
+                end
+
+                for f in _AWS_CREDENTIALS_REFRESH_FIELDS
+                    setfield!(aws_creds, f, getfield(new_aws_creds, f))
+                end
+            end
         end
     end
 

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -278,7 +278,7 @@ function Base.copyto!(dest::AWSCredentials, src::AWSCredentials)
     end
 end
 
-@deprecate check_credentials(aws_creds::AWSCredentials; force_refresh::Bool=false) refresh!(aws_creds; force=force_refresh)
+@deprecate check_credentials(aws_creds::AWSCredentials; force_refresh::Bool=false) refresh!(aws_creds; force=force_refresh) true
 
 function check_credentials(aws_creds::Nothing; force_refresh::Bool=true)
     Base.depwarn(

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -277,3 +277,13 @@ function Base.copyto!(dest::AWSCredentials, src::AWSCredentials)
         setfield!(dest, f, getfield(src, f))
     end
 end
+
+@deprecate check_credentials(aws_creds::AWSCredentials; force_refresh::Bool=false) refresh!(aws_creds; force=force_refresh)
+
+function check_credentials(aws_creds::Nothing; force_refresh::Bool=true)
+    Base.depwarn(
+        "`check_credentials(::Nothing)` is deprecated and will be removed in the future.",
+        :check_credentials!,
+    )
+    return nothing
+ end

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -265,3 +265,15 @@ function global_aws_config(config::AbstractAWSConfig)
 end
 
 @deprecate_binding AWSMetadata APIGeneration false
+
+function Base.copyto!(dest::AWSCredentials, src::AWSCredentials)
+    Base.depwarn(
+        "`copyto!(dest::AWSCredentials, src::AWSCredentials)` is deprecated and will be " *
+        "removed in the future.",
+        :copyto!,
+    )
+
+    for f in fieldnames(typeof(dest))
+        setfield!(dest, f, getfield(src, f))
+    end
+end

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -278,7 +278,9 @@ function Base.copyto!(dest::AWSCredentials, src::AWSCredentials)
     end
 end
 
-@deprecate check_credentials(aws_creds::AWSCredentials; force_refresh::Bool=false) refresh!(aws_creds; force=force_refresh) true
+@deprecate check_credentials(aws_creds::AWSCredentials; force_refresh::Bool=false) refresh!(
+    aws_creds; force=force_refresh
+) true
 
 function check_credentials(aws_creds::Nothing; force_refresh::Bool=true)
     Base.depwarn(
@@ -286,4 +288,4 @@ function check_credentials(aws_creds::Nothing; force_refresh::Bool=true)
         :check_credentials!,
     )
     return nothing
- end
+end

--- a/src/utilities/credentials.jl
+++ b/src/utilities/credentials.jl
@@ -158,13 +158,6 @@ function _aws_get_profile(; default="default")
 end
 
 """
-Check if credentials will expire within 5 minutes
-"""
-function _will_expire(aws_creds::AWSCredentials)
-    return aws_creds.expiry - now(UTC) <= Minute(5)
-end
-
-"""
 Retrieve the EC2 meta data from the local AWS endpoint. Return the EC2 metadata request
 body, or `nothing` if not running on an EC2 instance.
 """

--- a/src/utilities/request.jl
+++ b/src/utilities/request.jl
@@ -164,7 +164,7 @@ function submit_request(aws::AbstractAWSConfig, request::Request; return_headers
         # Handle ExpiredToken...
         # https://github.com/aws/aws-sdk-go/blob/v1.31.5/aws/request/retryer.go#L98
         if e isa AWSException && e.code in EXPIRED_ERROR_CODES
-            check_credentials(credentials(aws); force_refresh=true)
+            refresh!(credentials(aws); force=true)
             return true
         end
 

--- a/src/utilities/sign.jl
+++ b/src/utilities/sign.jl
@@ -18,7 +18,7 @@ function sign_aws2!(aws::AbstractAWSConfig, request::Request, time::DateTime)
 
     request.headers["Content-Type"] = "application/x-www-form-urlencoded; charset=utf-8"
 
-    creds = check_credentials(credentials(aws))
+    creds = refresh!(credentials(aws))
     signing_key = Vector{UInt8}(creds.secret_key)
 
     query["AWSAccessKeyId"] = creds.access_key_id
@@ -53,7 +53,7 @@ function sign_aws4!(aws::AbstractAWSConfig, request::Request, time::DateTime)
     # Authentication scope...
     authentication_scope = [date, region(aws), request.service, "aws4_request"]
 
-    creds = check_credentials(credentials(aws))
+    creds = refresh!(credentials(aws))
     signing_key = Vector{UInt8}("AWS4$(creds.secret_key)")
 
     for scope in authentication_scope

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,11 @@
 using AWS
-using AWS: AWSCredentials, AWSServices, _is_expired, assume_role_creds
+using AWS:
+    AWSCredentials,
+    AWSServices,
+    _is_expired,
+    _is_recently_renewed,
+    assume_role_creds,
+    refresh!
 using AWS.AWSExceptions:
     AWSException, IMDSUnavailable, InvalidFileName, NoCredentials, ProtocolNotDefined
 using AWS.APIGeneration:

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using AWS
-using AWS: AWSCredentials, AWSServices, assume_role_creds
+using AWS: AWSCredentials, AWSServices, _is_expired, assume_role_creds
 using AWS.AWSExceptions:
     AWSException, IMDSUnavailable, InvalidFileName, NoCredentials, ProtocolNotDefined
 using AWS.APIGeneration:

--- a/test/unit/AWSCredentials.jl
+++ b/test/unit/AWSCredentials.jl
@@ -402,14 +402,14 @@ end
             drift = Minute(5)  # Needs to be kept in sync with the `drift` keyword default
             offsets = (-drift - Minute(1), -drift, zero(drift), drift, drift + Minute(1))
             for offset in offsets
-                @testset let offset = offset, drift = drift
+                # @testset let offset = offset, drift = drift
                     c = AWSCredentials("", ""; expiry=now(UTC) + offset)
                     if offset <= drift
                         @test _is_expired(c)
                     else
                         @test !_is_expired(c)
                     end
-                end
+                # end
             end
         end
     end

--- a/test/unit/AWSCredentials.jl
+++ b/test/unit/AWSCredentials.jl
@@ -417,9 +417,7 @@ end
     function create_credentials(; expired_at, created_at)
         function renew_credentials()
             return AWSCredentials(
-                "RENEWED_ACCESS_KEY_ID",
-                "RENEWED_SECRET_KEY";
-                expiry=now(UTC) + Hour(1),
+                "RENEWED_ACCESS_KEY_ID", "RENEWED_SECRET_KEY"; expiry=now(UTC) + Hour(1)
             )
         end
 
@@ -457,8 +455,6 @@ end
         @test _is_recently_renewed(renewed_creds)
         @test renewed_creds.renew === nothing
     end
-
-
 
     @testset "refresh!" begin
         @testset "renew unset" begin
@@ -603,8 +599,7 @@ end
                     )
                 else
                     AWSCredentials(
-                        "TOO_MANY_REFRESHES_ACCESS_KEY_ID",
-                        "TOO_MANY_REFRESHES_SECRET_KEY"
+                        "TOO_MANY_REFRESHES_ACCESS_KEY_ID", "TOO_MANY_REFRESHES_SECRET_KEY"
                     )
                 end
             end
@@ -634,7 +629,6 @@ end
             @test _is_recently_renewed(creds)
         end
     end
-
 
     mktempdir() do dir
         config_file = joinpath(dir, "config")

--- a/test/unit/AWSCredentials.jl
+++ b/test/unit/AWSCredentials.jl
@@ -403,12 +403,12 @@ end
             offsets = (-drift - Minute(1), -drift, zero(drift), drift, drift + Minute(1))
             for offset in offsets
                 # @testset let offset = offset, drift = drift
-                    c = AWSCredentials("", ""; expiry=now(UTC) + offset)
-                    if offset <= drift
-                        @test _is_expired(c)
-                    else
-                        @test !_is_expired(c)
-                    end
+                c = AWSCredentials("", ""; expiry=now(UTC) + offset)
+                if offset <= drift
+                    @test _is_expired(c)
+                else
+                    @test !_is_expired(c)
+                end
                 # end
             end
         end

--- a/test/unit/AWSCredentials.jl
+++ b/test/unit/AWSCredentials.jl
@@ -414,84 +414,134 @@ end
         end
     end
 
-    @testset "Renewal" begin
-        # Credentials shouldn't throw an error if no renew function is supplied
-        creds = AWSCredentials("access_key_id", "secret_key"; renew=nothing)
-        newcreds = check_credentials(creds; force_refresh=true)
-
-        # Creds should remain unchanged if no renew function exists
-        @test creds === newcreds
-        @test creds.access_key_id == "access_key_id"
-        @test creds.secret_key == "secret_key"
-        @test creds.renew === nothing
-
-        # Creds should error if the renew function returns nothing
-        creds = AWSCredentials("access_key_id", "secret_key"; renew=() -> nothing)
-        @test_throws NoCredentials check_credentials(creds; force_refresh=true)
-
-        # Creds should remain unchanged
-        @test creds.access_key_id == "access_key_id"
-        @test creds.secret_key == "secret_key"
-
-        # Creds fields should be updated to use most of the returned AWSCredentials fields
-        function gen_credentials()
-            i = 0
-            return () -> (i += 1; AWSCredentials("NEW_ID_$i", "NEW_KEY_$i"))
+    function create_credentials(; expired_at)
+        function renew_credentials()
+            return AWSCredentials(
+                "RENEWED_ACCESS_KEY_ID",
+                "RENEWED_SECRET_KEY";
+                expiry=now(UTC) + Hour(1),
+            )
         end
 
         creds = AWSCredentials(
-            "access_key_id", "secret_key"; renew=gen_credentials(), expiry=now(UTC)
+            "ORG_ACCESS_KEY_ID",
+            "ORG_SECRET_KEY";
+            renew=renew_credentials,
+            expiry=expired_at,
         )
 
-        expected_renew = creds.renew
-        expected_lock = creds.lock
-
-        @test creds.renew !== nothing
-        renewed = creds.renew()
-
-        @test creds.access_key_id == "access_key_id"
-        @test creds.secret_key == "secret_key"
-        @test _is_expired(creds)
-        @test creds.renew === expected_renew
-        @test creds.lock === expected_lock
-
-        @test renewed.access_key_id === "NEW_ID_1"
-        @test renewed.secret_key == "NEW_KEY_1"
-        @test !_is_expired(renewed)
-        @test renewed.renew === nothing
-        @test renewed.renew !== expected_renew
-        @test renewed.lock !== expected_lock
-
-        # Check renewal on when expired
-        newcreds = check_credentials(creds; force_refresh=false)
-        @test creds === newcreds
-        @test creds.access_key_id == "NEW_ID_2"
-        @test creds.secret_key == "NEW_KEY_2"
-        @test !_is_expired(creds)
-        @test creds.renew !== nothing
-        @test creds.renew === expected_renew
-        @test creds.lock === expected_lock
-
-        # Check renewal doesn't happen if not forced or not expired
-        newcreds = check_credentials(creds; force_refresh=false)
-        @test creds === newcreds
-        @test creds.access_key_id == "NEW_ID_2"
-        @test creds.secret_key == "NEW_KEY_2"
-        @test !_is_expired(creds)
-        @test creds.renew !== nothing
-        @test creds.renew === expected_renew
-        @test creds.lock === expected_lock
-
-        # Check forced renewal works
-        newcreds = check_credentials(creds; force_refresh=true)
-        @test creds === newcreds
-        @test creds.access_key_id == "NEW_ID_3"
-        @test creds.secret_key == "NEW_KEY_3"
-        @test !_is_expired(creds)
-        @test creds.renew !== nothing
-        @test creds.renew === expected_renew
-        @test creds.lock === expected_lock
+        return creds
     end
+
+    @testset "renew not in-place" begin
+        creds = create_credentials(;
+            expired_at=now(UTC),            # expired
+        )
+        @test _is_expired(creds)
+        @test !_is_recently_renewed(creds)
+
+        renewed_creds = creds.renew()
+
+        @test creds !== renewed_creds
+
+        @test creds.access_key_id == "ORG_ACCESS_KEY_ID"
+        @test creds.secret_key == "ORG_SECRET_KEY"
+        @test _is_expired(creds)
+
+        @test renewed_creds.access_key_id === "RENEWED_ACCESS_KEY_ID"
+        @test renewed_creds.secret_key == "RENEWED_SECRET_KEY"
+        @test !_is_expired(renewed_creds)
+        @test renewed_creds.renew === nothing
+    end
+
+
+
+    @testset "refresh!" begin
+        @testset "renew unset" begin
+            # Credentials shouldn't throw an error if the renew field is unset
+            creds = AWSCredentials("ACCESS_KEY_ID", "SECRET_KEY"; renew=nothing)
+            newcreds = refresh!(creds)
+
+            # Credentials remain unchanged
+            @test creds === newcreds
+            @test creds.access_key_id == "ACCESS_KEY_ID"
+            @test creds.secret_key == "SECRET_KEY"
+            @test creds.renew === nothing
+        end
+
+        @testset "no new credentials" begin
+            # Throw an error if the renew function returns `nothing` indicating the renew
+            # could not find any new credentials.
+            creds = AWSCredentials("ACCESS_KEY_ID", "SECRET_KEY"; renew=() -> nothing)
+            @test_throws NoCredentials refresh!(creds; force=true)
+
+            # Credentials remain unchanged
+            @test creds.access_key_id == "ACCESS_KEY_ID"
+            @test creds.secret_key == "SECRET_KEY"
+        end
+
+        @testset "in-place mutation" begin
+            creds = create_credentials(;
+                expired_at=now(UTC),            # expired
+            )
+            @test _is_expired(creds)
+
+            # Keep track of the fields we expect to be be unchanged after mutating
+            expected_renew = creds.renew
+            expected_lock = creds.lock
+
+            renewed_creds = refresh!(creds)
+
+            @test renewed_creds === creds
+            @test creds.access_key_id == "RENEWED_ACCESS_KEY_ID"
+            @test creds.secret_key == "RENEWED_SECRET_KEY"
+            @test !_is_expired(creds)
+
+            # The `renew` and `lock` fields are unchanged
+            @test creds.renew === expected_renew
+            @test creds.lock === expected_lock
+        end
+
+        @testset "expired" begin
+            creds = create_credentials(;
+                expired_at=now(UTC) - Hour(1),  # expired
+            )
+            @test _is_expired(creds)
+
+            refresh!(creds)
+
+            @test creds.access_key_id == "RENEWED_ACCESS_KEY_ID"
+            @test creds.secret_key == "RENEWED_SECRET_KEY"
+            @test !_is_expired(creds)
+        end
+
+        @testset "not expired" begin
+            creds = create_credentials(;
+                expired_at=now(UTC) + Hour(1),  # not expired
+            )
+            @test !_is_expired(creds)
+
+            refresh!(creds)
+
+            @test creds.access_key_id == "ORG_ACCESS_KEY_ID"
+            @test creds.secret_key == "ORG_SECRET_KEY"
+            @test !_is_expired(creds)
+        end
+
+        @testset "force" begin
+            creds = create_credentials(;
+                expired_at=now(UTC) + Hour(1),  # not expired
+            )
+            @test !_is_expired(creds)
+
+            refresh!(creds; force=true)
+
+            @test creds.access_key_id == "RENEWED_ACCESS_KEY_ID"
+            @test creds.secret_key == "RENEWED_SECRET_KEY"
+            @test !_is_expired(creds)
+        end
+    end
+
 
     mktempdir() do dir
         config_file = joinpath(dir, "config")
@@ -603,7 +653,7 @@ end
 
                     @test renew() isa AWSCredentials
 
-                    creds = check_credentials(config.credentials)
+                    creds = refresh!(config.credentials)
 
                     @test creds.access_key_id == "TEST_ACCESS_ID"
                     @test creds.secret_key == "TEST_ACCESS_KEY"
@@ -615,7 +665,7 @@ end
 
                     # Check force_refresh
                     creds.access_key_id = "WRONG_ACCESS_KEY"
-                    creds = check_credentials(creds; force_refresh=true)
+                    refresh!(creds; force=true)
                     @test creds.access_key_id == "TEST_ACCESS_ID"
                 end
             end
@@ -635,7 +685,7 @@ end
                     # Check profile persists on renewal
                     creds.access_key_id = "WRONG_ACCESS_ID2"
                     creds.secret_key = "WRONG_ACCESS_KEY2"
-                    creds = check_credentials(creds; force_refresh=true)
+                    refresh!(creds; force=true)
 
                     @test creds.access_key_id == "RIGHT_ACCESS_ID2"
                     @test creds.secret_key == "RIGHT_ACCESS_KEY2"
@@ -1424,22 +1474,23 @@ end
             ) do
                 apply(patch) do
                     result = credentials_from_webtoken()
+                    init_expired_at = result.expiry
 
                     @test result.access_key_id == access_key
                     @test result.secret_key == secret_key
                     @test result.token == session_token
                     @test result.user_arn == "$(role_arn)/$(session_name)"
                     @test result.renew == credentials_from_webtoken
-                    expiry = result.expiry
+
                     sleep(0.1)
-                    result = check_credentials(result)
+                    refresh!(result)
 
                     @test result.access_key_id == access_key
                     @test result.secret_key == secret_key
                     @test result.token == session_token
                     @test result.user_arn == "$(role_arn)/$(session_name)"
                     @test result.renew == credentials_from_webtoken
-                    @test expiry != result.expiry
+                    @test result.expiry > init_expired_at
                 end
             end
 
@@ -1540,18 +1591,19 @@ end
                 "AWS_ACCESS_KEY_ID" => test_values["AccessKeyId"],
                 "AWS_SECRET_ACCESS_KEY" => test_values["SecretAccessKey"],
             ) do
-                testAWSCredentials = AWSCredentials(
-                    test_values["AccessKeyId"],
-                    test_values["SecretAccessKey"];
+                creds = AWSCredentials(
+                    "FOO",
+                    "BAR";
                     expiry=Dates.now(UTC) - Minute(10),
                     renew=env_var_credentials,
                 )
 
-                result = check_credentials(testAWSCredentials; force_refresh=true)
-                @test result.access_key_id == testAWSCredentials.access_key_id
-                @test result.secret_key == testAWSCredentials.secret_key
-                @test result.expiry == typemax(DateTime)
-                @test result.renew == testAWSCredentials.renew
+                refresh!(creds; force=true)
+
+                @test creds.access_key_id == test_values["AccessKeyId"]
+                @test creds.secret_key == test_values["SecretAccessKey"]
+                @test creds.expiry == typemax(DateTime)
+                @test creds.renew === env_var_credentials
             end
         end
     end

--- a/test/unit/AWSCredentials.jl
+++ b/test/unit/AWSCredentials.jl
@@ -380,6 +380,38 @@ end
         @test creds.account_number == ""
         @test creds.expiry == typemax(DateTime)
         @test creds.renew === nothing
+        @test creds.lock isa ReentrantLock
+    end
+
+    @testset "_is_expired" begin
+        @testset "basic" begin
+            # Has already expired
+            c = AWSCredentials("", ""; expiry=now(UTC) + Second(-1))
+            @test _is_expired(c; drift=Minute(0))
+
+            # Expired now
+            c = AWSCredentials("", ""; expiry=now(UTC))
+            @test _is_expired(c; drift=Minute(0))
+
+            # Will expire
+            c = AWSCredentials("", ""; expiry=now(UTC) + Second(1))
+            @test !_is_expired(c; drift=Minute(0))
+        end
+
+        @testset "default drift" begin
+            drift = Minute(5)  # Needs to be kept in sync with the `drift` keyword default
+            offsets = (-drift - Minute(1), -drift, zero(drift), drift, drift + Minute(1))
+            for offset in offsets
+                @testset let offset = offset, drift = drift
+                    c = AWSCredentials("", ""; expiry=now(UTC) + offset)
+                    if offset <= drift
+                        @test _is_expired(c)
+                    else
+                        @test !_is_expired(c)
+                    end
+                end
+            end
+        end
     end
 
     @testset "Renewal" begin
@@ -401,7 +433,7 @@ end
         @test creds.access_key_id == "access_key_id"
         @test creds.secret_key == "secret_key"
 
-        # Creds should take on value of a returned AWSCredentials except renew function
+        # Creds fields should be updated to use most of the returned AWSCredentials fields
         function gen_credentials()
             i = 0
             return () -> (i += 1; AWSCredentials("NEW_ID_$i", "NEW_KEY_$i"))
@@ -411,48 +443,54 @@ end
             "access_key_id", "secret_key"; renew=gen_credentials(), expiry=now(UTC)
         )
 
+        expected_renew = creds.renew
+        expected_lock = creds.lock
+
         @test creds.renew !== nothing
         renewed = creds.renew()
 
         @test creds.access_key_id == "access_key_id"
         @test creds.secret_key == "secret_key"
-        @test creds.expiry <= now(UTC)
-        @test AWS._will_expire(creds)
+        @test _is_expired(creds)
+        @test creds.renew === expected_renew
+        @test creds.lock === expected_lock
 
         @test renewed.access_key_id === "NEW_ID_1"
         @test renewed.secret_key == "NEW_KEY_1"
+        @test !_is_expired(renewed)
         @test renewed.renew === nothing
-        @test renewed.expiry == typemax(DateTime)
-        @test !AWS._will_expire(renewed)
-        renew = creds.renew
+        @test renewed.renew !== expected_renew
+        @test renewed.lock !== expected_lock
 
-        # Check renewal on time out
+        # Check renewal on when expired
         newcreds = check_credentials(creds; force_refresh=false)
         @test creds === newcreds
         @test creds.access_key_id == "NEW_ID_2"
         @test creds.secret_key == "NEW_KEY_2"
+        @test !_is_expired(creds)
         @test creds.renew !== nothing
-        @test creds.renew === renew
-        @test creds.expiry == typemax(DateTime)
-        @test !AWS._will_expire(creds)
+        @test creds.renew === expected_renew
+        @test creds.lock === expected_lock
 
-        # Check renewal doesn't happen if not forced or timed out
+        # Check renewal doesn't happen if not forced or not expired
         newcreds = check_credentials(creds; force_refresh=false)
         @test creds === newcreds
         @test creds.access_key_id == "NEW_ID_2"
         @test creds.secret_key == "NEW_KEY_2"
+        @test !_is_expired(creds)
         @test creds.renew !== nothing
-        @test creds.renew === renew
-        @test creds.expiry == typemax(DateTime)
+        @test creds.renew === expected_renew
+        @test creds.lock === expected_lock
 
         # Check forced renewal works
         newcreds = check_credentials(creds; force_refresh=true)
         @test creds === newcreds
         @test creds.access_key_id == "NEW_ID_3"
         @test creds.secret_key == "NEW_KEY_3"
+        @test !_is_expired(creds)
         @test creds.renew !== nothing
-        @test creds.renew === renew
-        @test creds.expiry == typemax(DateTime)
+        @test creds.renew === expected_renew
+        @test creds.lock === expected_lock
     end
 
     mktempdir() do dir
@@ -553,7 +591,7 @@ end
 
             @testset "Refresh" begin
                 withenv("AWS_DEFAULT_PROFILE" => "test") do
-                    # Check credentials refresh on timeout
+                    # Check credentials refresh when expired
                     config = AWSConfig()
                     creds = config.credentials
                     creds.access_key_id = "EXPIRED_ACCESS_ID"

--- a/test/unit/AWSCredentials.jl
+++ b/test/unit/AWSCredentials.jl
@@ -414,7 +414,7 @@ end
         end
     end
 
-    function create_credentials(; expired_at)
+    function create_credentials(; expired_at, created_at)
         function renew_credentials()
             return AWSCredentials(
                 "RENEWED_ACCESS_KEY_ID",
@@ -429,6 +429,7 @@ end
             renew=renew_credentials,
             expiry=expired_at,
         )
+        creds.renewed_at = created_at
 
         return creds
     end
@@ -436,6 +437,7 @@ end
     @testset "renew not in-place" begin
         creds = create_credentials(;
             expired_at=now(UTC),            # expired
+            created_at=now(UTC) - Hour(1),  # was not created recently
         )
         @test _is_expired(creds)
         @test !_is_recently_renewed(creds)
@@ -447,10 +449,12 @@ end
         @test creds.access_key_id == "ORG_ACCESS_KEY_ID"
         @test creds.secret_key == "ORG_SECRET_KEY"
         @test _is_expired(creds)
+        @test !_is_recently_renewed(creds)
 
         @test renewed_creds.access_key_id === "RENEWED_ACCESS_KEY_ID"
         @test renewed_creds.secret_key == "RENEWED_SECRET_KEY"
         @test !_is_expired(renewed_creds)
+        @test _is_recently_renewed(renewed_creds)
         @test renewed_creds.renew === nothing
     end
 
@@ -483,8 +487,10 @@ end
         @testset "in-place mutation" begin
             creds = create_credentials(;
                 expired_at=now(UTC),            # expired
+                created_at=now(UTC) - Hour(1),  # not recently renewed
             )
             @test _is_expired(creds)
+            @test !_is_recently_renewed(creds)
 
             # Keep track of the fields we expect to be be unchanged after mutating
             expected_renew = creds.renew
@@ -496,49 +502,136 @@ end
             @test creds.access_key_id == "RENEWED_ACCESS_KEY_ID"
             @test creds.secret_key == "RENEWED_SECRET_KEY"
             @test !_is_expired(creds)
+            @test _is_recently_renewed(creds)
 
             # The `renew` and `lock` fields are unchanged
             @test creds.renew === expected_renew
             @test creds.lock === expected_lock
         end
 
-        @testset "expired" begin
+        @testset "expired / not recently renewed" begin
             creds = create_credentials(;
                 expired_at=now(UTC) - Hour(1),  # expired
+                created_at=now(UTC) - Hour(1),  # not recently renewed
             )
             @test _is_expired(creds)
+            @test !_is_recently_renewed(creds)
 
             refresh!(creds)
 
             @test creds.access_key_id == "RENEWED_ACCESS_KEY_ID"
             @test creds.secret_key == "RENEWED_SECRET_KEY"
             @test !_is_expired(creds)
+            @test _is_recently_renewed(creds)
         end
 
-        @testset "not expired" begin
+        @testset "expired / recently renewed" begin
+            creds = create_credentials(;
+                expired_at=now(UTC) - Hour(1),  # expired
+                created_at=now(UTC),            # recently renewed
+            )
+            @test _is_expired(creds)
+            @test _is_recently_renewed(creds)
+
+            # Even though the credentials are expired we avoid renewing them as we just
+            # recently updated them.
+            refresh!(creds)
+
+            @test creds.access_key_id == "ORG_ACCESS_KEY_ID"
+            @test creds.secret_key == "ORG_SECRET_KEY"
+            @test _is_expired(creds)
+            @test _is_recently_renewed(creds)
+        end
+
+        @testset "not expired / not recently renewed" begin
             creds = create_credentials(;
                 expired_at=now(UTC) + Hour(1),  # not expired
+                created_at=now(UTC) - Hour(1),  # not recently renewed
             )
             @test !_is_expired(creds)
+            @test !_is_recently_renewed(creds)
 
             refresh!(creds)
 
             @test creds.access_key_id == "ORG_ACCESS_KEY_ID"
             @test creds.secret_key == "ORG_SECRET_KEY"
             @test !_is_expired(creds)
+            @test !_is_recently_renewed(creds)
+        end
+
+        @testset "not expired / recently renewed" begin
+            creds = create_credentials(;
+                expired_at=now(UTC) + Hour(1),  # not expired
+                created_at=now(UTC),            # recently renewed
+            )
+            @test !_is_expired(creds)
+            @test _is_recently_renewed(creds)
+
+            refresh!(creds)
+
+            @test creds.access_key_id == "ORG_ACCESS_KEY_ID"
+            @test creds.secret_key == "ORG_SECRET_KEY"
+            @test !_is_expired(creds)
+            @test _is_recently_renewed(creds)
         end
 
         @testset "force" begin
             creds = create_credentials(;
                 expired_at=now(UTC) + Hour(1),  # not expired
+                created_at=now(UTC),            # recently renewed
             )
             @test !_is_expired(creds)
+            @test _is_recently_renewed(creds)
 
             refresh!(creds; force=true)
 
             @test creds.access_key_id == "RENEWED_ACCESS_KEY_ID"
             @test creds.secret_key == "RENEWED_SECRET_KEY"
             @test !_is_expired(creds)
+            @test _is_recently_renewed(creds)
+        end
+
+        @testset "rate limit" begin
+            count = Threads.Atomic{Int}(0)
+            function renew_credentials()
+                count[] += 1
+                return if count[] == 1
+                    AWSCredentials(
+                        "REFRESHED_ACCESS_KEY_ID",
+                        "REFRESHED_SECRET_KEY";
+                        expiry=now(UTC) + Hour(1),
+                    )
+                else
+                    AWSCredentials(
+                        "TOO_MANY_REFRESHES_ACCESS_KEY_ID",
+                        "TOO_MANY_REFRESHES_SECRET_KEY"
+                    )
+                end
+            end
+
+            creds = AWSCredentials(
+                "EXPIRED_ACCESS_KEY_ID",
+                "EXPIRED_SECRET_KEY";
+                expiry=now(UTC) - Hour(1),  # expired
+                renew=renew_credentials,
+            )
+            creds.renewed_at = now(UTC) - Hour(1)  # not recently renewed
+
+            @test _is_expired(creds)
+            @test !_is_recently_renewed(creds)
+
+            # All of these threads should attempt to update the credentials. However, only the
+            # first thread to acquire the lock will do so as the remaining threads will be
+            # skip calling `renew`.
+            Threads.@threads for i in 1:10
+                refresh!(creds)
+            end
+
+            @test count[] == 1
+            @test creds.access_key_id == "REFRESHED_ACCESS_KEY_ID"
+            @test creds.secret_key == "REFRESHED_SECRET_KEY"
+            @test !_is_expired(creds)
+            @test _is_recently_renewed(creds)
         end
     end
 
@@ -647,6 +740,7 @@ end
                     creds.access_key_id = "EXPIRED_ACCESS_ID"
                     creds.secret_key = "EXPIRED_ACCESS_KEY"
                     creds.expiry = now(UTC)
+                    creds.renewed_at = now(UTC) - Hour(1)
 
                     @test creds.renew !== nothing
                     renew = creds.renew
@@ -1475,6 +1569,7 @@ end
                 apply(patch) do
                     result = credentials_from_webtoken()
                     init_expired_at = result.expiry
+                    init_renewed_at = result.renewed_at
 
                     @test result.access_key_id == access_key
                     @test result.secret_key == secret_key
@@ -1482,7 +1577,7 @@ end
                     @test result.user_arn == "$(role_arn)/$(session_name)"
                     @test result.renew == credentials_from_webtoken
 
-                    sleep(0.1)
+                    result.renewed_at -= Hour(1)  # ignore rate limiting
                     refresh!(result)
 
                     @test result.access_key_id == access_key
@@ -1490,7 +1585,8 @@ end
                     @test result.token == session_token
                     @test result.user_arn == "$(role_arn)/$(session_name)"
                     @test result.renew == credentials_from_webtoken
-                    @test result.expiry > init_expired_at
+                    @test result.expiry >= init_expired_at
+                    @test result.renewed_at > init_renewed_at
                 end
             end
 

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -77,7 +77,7 @@ end
 
 AWS.region(c::MinioConfig) = c.region
 AWS.credentials(c::MinioConfig) = c.creds
-AWS.check_credentials(c::SimpleCredentials) = c
+AWS.refresh!(c::SimpleCredentials) = c
 
 function AWS.generate_service_url(aws::MinioConfig, service::String, resource::String)
     service == "s3" || throw(ArgumentError("Can only handle s3 requests to Minio"))


### PR DESCRIPTION
Fixes #698. Addresses some thread-safety issues with credential refreshing along with reducing how often we attempt to refresh credentials. Specifically, when using the IMDS as a credential provider the service can become unresponsive with rapid requests. I currently set the limit for refreshing to be 1 minute but we could drop that down to a few seconds if we need to.