### PR TITLE
Retry request too skewed

### DIFF
--- a/src/utilities/request.jl
+++ b/src/utilities/request.jl
@@ -99,7 +99,7 @@ Submit the request to AWS.
 function submit_request(aws::AbstractAWSConfig, request::Request; return_headers=nothing)
     aws_response = nothing
     TOO_MANY_REQUESTS = 429
-    REQUEST_TIME_TOO_SKEWED = "RequestTimeTooSkewed"
+    TIME_SKEWED_CODES = ["RequestTimeTooSkewed"]
     EXPIRED_ERROR_CODES = ["ExpiredToken", "ExpiredTokenException", "RequestExpired"]
     REDIRECT_ERROR_CODES = [301, 302, 303, 304, 305, 307, 308]
     THROTTLING_ERROR_CODES = [
@@ -192,7 +192,7 @@ function submit_request(aws::AbstractAWSConfig, request::Request; return_headers
         end
 
         # https://github.com/JuliaCloud/AWS.jl/issues/496
-        if e.code == REQUEST_TIME_TOO_SKEWED
+        if e.code in TIME_SKEWED_CODES
             return true
         end
 

--- a/src/utilities/request.jl
+++ b/src/utilities/request.jl
@@ -99,6 +99,7 @@ Submit the request to AWS.
 function submit_request(aws::AbstractAWSConfig, request::Request; return_headers=nothing)
     aws_response = nothing
     TOO_MANY_REQUESTS = 429
+    REQUEST_TIME_TOO_SKEWED = "RequestTimeTooSkewed"
     EXPIRED_ERROR_CODES = ["ExpiredToken", "ExpiredTokenException", "RequestExpired"]
     REDIRECT_ERROR_CODES = [301, 302, 303, 304, 305, 307, 308]
     THROTTLING_ERROR_CODES = [
@@ -189,6 +190,12 @@ function submit_request(aws::AbstractAWSConfig, request::Request; return_headers
                 ),
             )
         end
+
+        # https://github.com/JuliaCloud/AWS.jl/issues/496
+        if e.code == REQUEST_TIME_TOO_SKEWED
+            return true
+        end
+
         return false
     end
 

--- a/test/patch.jl
+++ b/test/patch.jl
@@ -87,6 +87,26 @@ function _throttling_patch(retries::Ref{Int})
     return p
 end
 
+function _time_too_skewed_patch(retries::Ref{Int})
+    status = 403
+    body = """
+        <?xml version=\"1.0\" encoding=\"UTF-8\"?>\n
+        <Error>
+          <Code>RequestTimeTooSkewed</Code>
+          <Message>The difference between the request time and the current time is too large.</Message>
+          <RequestId>4442587FB7D0A2F9</RequestId>
+        </Error>
+        """
+
+    p = @patch function AWS._http_request(::AWS.AbstractBackend, request::Request, ::IO)
+        retries[] += 1
+        resp = _response(; status=status, body=body).response
+        err = HTTP.StatusError(status, request.request_method, request.resource, resp)
+        throw(AWS.AWSException(err, body))
+    end
+    return p
+end
+
 _cred_file_patch = @patch function dot_aws_credentials_file()
     return ""
 end

--- a/test/patch.jl
+++ b/test/patch.jl
@@ -87,7 +87,7 @@ function _throttling_patch(retries::Ref{Int})
     return p
 end
 
-function _time_too_skewed_patch(retries::Threads.Atomic{Int})
+function _time_too_skewed_patch(retries)
     status = 403
     body = """
         <?xml version=\"1.0\" encoding=\"UTF-8\"?>\n

--- a/test/patch.jl
+++ b/test/patch.jl
@@ -87,7 +87,7 @@ function _throttling_patch(retries::Ref{Int})
     return p
 end
 
-function _time_too_skewed_patch(retries::Ref{Int})
+function _time_too_skewed_patch(retries::Threads.Atomic{Int})
     status = 403
     body = """
         <?xml version=\"1.0\" encoding=\"UTF-8\"?>\n

--- a/test/unit/AWS.jl
+++ b/test/unit/AWS.jl
@@ -361,6 +361,34 @@ end
         @test retries[] == AWS.max_attempts(aws)
     end
 
+    @testset "RequestTimeTooSkewed" begin
+        request = Request(;
+            service="s3",
+            api_version="api_version",
+            request_method="GET",
+            url="https://s3.us-east-1.amazonaws.com/sample-bucket",
+            use_response_type=true,
+        )
+
+        retries = Ref{Int}(0)
+        exception = apply(Patches._time_too_skewed_patch(retries)) do
+            try
+                AWS.submit_request(aws, request)
+                return nothing
+            catch e
+                if e isa AWSException
+                    return e
+                else
+                    rethrow()
+                end
+            end
+        end
+
+        @test exception isa AWSException
+        @test exception.code == "RequestTimeTooSkewed"
+        @test retries[] == AWS.max_attempts(aws)
+    end
+
     @testset "Not authorized" begin
         request = Request(;
             service="s3",


### PR DESCRIPTION
closes #496
redo of #497 

I wanted to add a test but couldn't quickly find where to add it, so I asked opus to write the test (2nd commit) with the prompt:

> I have a very small diff in requst.jl to add a retry for `REQUEST_TIME_TOO_SKEWED`. I want to add a minimal test that it now gets retried, but I'm not sure there are any tests for retries - I can't find them. Propose a small test: where should it go, how should it work, etc. Existing tests are in the test dir.

in plan mode, which I then accepted its plan. I stopped it after it implemented and started running tests since I didn't want to waste tokens on it reading test output. Then I ran tests myself which passed. This used $0.42 of tokens.