### PR TITLE
Support HTTP.jl 2 only

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -22,7 +22,7 @@ XMLDict = "228000da-037f-5747-90a9-8195ccbf91a5"
 
 [compat]
 CodecBase = "0.3"
-HTTP = "1.10"
+HTTP = "2"
 IniFile = "0.5"
 JSON = "1"
 MD5 = "0.2"

--- a/src/AWS.jl
+++ b/src/AWS.jl
@@ -51,6 +51,7 @@ export AWSCredentials,
 const DEFAULT_REGION = "us-east-1"
 
 include(joinpath("utilities", "utilities.jl"))
+include(joinpath("utilities", "exception_classification.jl"))
 
 include("AWSExceptions.jl")
 include("AWSCredentials.jl")

--- a/src/AWSCredentials.jl
+++ b/src/AWSCredentials.jl
@@ -359,7 +359,7 @@ function ecs_instance_credentials()
     response = try
         @mock HTTP.request("GET", endpoint, headers; retry=false, connect_timeout=5)
     catch e
-        e isa HTTP.Exceptions.ConnectError && return nothing
+        is_connection_exception(e) && return nothing
         rethrow()
     end
     new_creds = String(response.body)

--- a/src/AWSExceptions.jl
+++ b/src/AWSExceptions.jl
@@ -124,7 +124,15 @@ function AWSException(e::HTTP.StatusError, body::AbstractString)
         message = get(info, "message", message)
     end
 
-    streamed_body = !HTTP.isbytes(e.response.body) ? body : nothing
+    # When using HTTP.jl `response_stream` the body will not be stored inside the response. A
+    # real streamed request leaves `body` as a literal `nothing`; test doubles built through
+    # HTTP.jl's keyword `Response` constructors can only reproduce this as `HTTP.EmptyBody()`,
+    # since those constructors normalize a `nothing` body argument into `EmptyBody()`.
+    streamed_body = if isnothing(e.response.body) || e.response.body isa HTTP.EmptyBody
+        body
+    else
+        nothing
+    end
 
     return AWSException(code, message, info, e, streamed_body)
 end

--- a/src/IMDS.jl
+++ b/src/IMDS.jl
@@ -125,8 +125,8 @@ function request(
     # > When token usage is set to `required` (IMDSv2), requests without a valid token or
     # > with an expired token receive a `401 - Unauthorized` HTTP error code.
     # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html#instance-metadata-v2-how-it-works
-    function retry_if(attempt, err, req, resp)
-        if allow_refresh && resp isa HTTP.Response && resp.status == 401 && !isempty(session.token)
+    function retry_if(attempt, err, req, resp::HTTP.Response)
+        if allow_refresh && resp.status == 401 && !isempty(session.token)
             refresh_token!(session)
             allow_refresh = false  # Ensure we only refresh the token once in this `retry_if`
             HTTP.setheader(req, "X-aws-ec2-metadata-token" => session.token)
@@ -135,6 +135,7 @@ function request(
             return false
         end
     end
+    retry_if(attempt, err, req, resp::Nothing) = false
 
     return _http_request(method, uri, headers; retry_if, status_exception)
 end

--- a/src/IMDS.jl
+++ b/src/IMDS.jl
@@ -10,10 +10,10 @@ security reasons).
 """
 module IMDS
 
+using ..AWS: is_connection_exception, is_ttl_expired_exception
 using ..AWSExceptions: IMDSUnavailable
 
 using HTTP: HTTP
-using HTTP.Exceptions: ConnectError, StatusError
 using Mocking
 using URIs: URI
 
@@ -91,9 +91,7 @@ function refresh_token!(session::Session, duration::Integer=session.duration)
         session.duration = 0
         session.expiration = typemax(Int64)  # Use IMDSv1 indefinitely
     else
-        # Could also populate the `StatusError` via `r.request.method` and
-        # `r.request.target` however `r.request` may not be populated under test scenarios.
-        throw(StatusError(r.status, "PUT", uri.path, r))
+        throw(HTTP.StatusError(r.status, r))
     end
 
     return session
@@ -112,7 +110,7 @@ function request(
         refresh_token!(session)
         allow_refresh = false
     end
-    headers = HTTP.Header[]
+    headers = HTTP.Headers()
     if !isempty(session.token)
         HTTP.setheader(headers, "X-aws-ec2-metadata-token" => session.token)
     end
@@ -127,19 +125,18 @@ function request(
     # > When token usage is set to `required` (IMDSv2), requests without a valid token or
     # > with an expired token receive a `401 - Unauthorized` HTTP error code.
     # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html#instance-metadata-v2-how-it-works
-    retry_delays = [0]
-    function retry_check(s, e, request, response, response_body)
-        if allow_refresh && e isa StatusError && e.status == 401 && !isempty(session.token)
+    function retry_if(attempt, err, req, resp)
+        if allow_refresh && resp isa HTTP.Response && resp.status == 401 && !isempty(session.token)
             refresh_token!(session)
-            allow_refresh = false
-            HTTP.setheader(request.headers, "X-aws-ec2-metadata-token" => session.token)
+            allow_refresh = false  # Ensure we only refresh the token once in this `retry_if`
+            HTTP.setheader(req, "X-aws-ec2-metadata-token" => session.token)
             return true
         else
             return false
         end
     end
 
-    return _http_request(method, uri, headers; retry_delays, retry_check, status_exception)
+    return _http_request(method, uri, headers; retry_if, status_exception)
 end
 
 function _http_request(args...; status_exception=true, kwargs...)
@@ -156,14 +153,14 @@ function _http_request(args...; status_exception=true, kwargs...)
         # and connections will fail. On EC2 instances where IMDS is disabled a HTTP 403 is
         # returned.
         # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html#instance-metadata-returns
-        if is_connection_exception(e) || e isa StatusError && e.status == 403
+        if is_connection_exception(e) || e isa HTTP.StatusError && e.status == 403
             throw(IMDSUnavailable())
 
         #! format: off
         # Return the status exception when `status_exception=false`. We must always cause
         # `HTTP.request` to throw status errors for our `IMDSUnavailable` check.
         #! format: on
-        elseif !status_exception && e isa StatusError
+        elseif !status_exception && e isa HTTP.StatusError
             e.response
         else
             rethrow()
@@ -172,16 +169,6 @@ function _http_request(args...; status_exception=true, kwargs...)
 
     return response
 end
-
-is_connection_exception(e::ConnectError) = true
-is_connection_exception(e::Exception) = false
-
-# https://github.com/JuliaCloud/AWS.jl/issues/654
-# https://github.com/JuliaCloud/AWS.jl/issues/649
-function is_ttl_expired_exception(e::HTTP.Exceptions.RequestError)
-    return e.error == Base.IOError("read: connection timed out (ETIMEDOUT)", -110)
-end
-is_ttl_expired_exception(e::Exception) = false
 
 """
     get([session::Session], path::AbstractString) -> Union{String, Nothing}
@@ -200,7 +187,7 @@ function get(session::Session, path::AbstractString)
     response = try
         request(session, "GET", path)
     catch e
-        if e isa IMDSUnavailable || e isa StatusError && e.status == 404
+        if e isa IMDSUnavailable || e isa HTTP.StatusError && e.status == 404
             nothing
         else
             rethrow()

--- a/src/utilities/credentials.jl
+++ b/src/utilities/credentials.jl
@@ -153,24 +153,6 @@ function _aws_get_profile(; default="default")
 end
 
 """
-Retrieve the EC2 meta data from the local AWS endpoint. Return the EC2 metadata request
-body, or `nothing` if not running on an EC2 instance.
-"""
-function _ec2_metadata(metadata_endpoint::String)
-    try
-        request = @mock HTTP.request(
-            "GET", "http://169.254.169.254/latest/meta-data/$metadata_endpoint"
-        )
-
-        return request === nothing ? nothing : String(request.body)
-    catch e
-        e isa HTTP.RequestError || e isa HTTP.StatusError && e.status == 404 || rethrow(e)
-    end
-
-    return nothing
-end
-
-"""
 Retrieve the existing SSO access token from AWS CLI cache using the SSO session name.
 """
 function _sso_cache_access_token(session_name::AbstractString)

--- a/src/utilities/downloads_backend.jl
+++ b/src/utilities/downloads_backend.jl
@@ -120,13 +120,12 @@ function _http_request(backend::DownloadsBackend, request::Request, response_str
     return AWS.Response(response, response_stream)
 end
 
-function _http_response(req::Request, res::Downloads.Response; throw::Bool=true)
-    response = HTTP.Response(res.status, res.headers; body=IOBuffer(), request=nothing)
+function _http_response(request::Request, response::Downloads.Response; throw::Bool=true)
+    req = _as_http_request(request)
+    resp = HTTP.Response(response.status; response.headers, request=req)
 
-    if throw && HTTP.iserror(response)
-        target = HTTP.resource(HTTP.URI(req.url))
-        e = HTTP.StatusError(res.status, req.request_method, target, response)
-        Base.throw(e)
+    if throw && HTTP._status_throws(resp)
+        throw(HTTP.StatusError(resp.status, resp))
     end
 
     return response

--- a/src/utilities/exception_classification.jl
+++ b/src/utilities/exception_classification.jl
@@ -10,6 +10,12 @@ is_connection_exception(e::Exception) = false
 # A hop-limit rejection manifests as a read timeout. May surface as an `IOError` or
 # a `HTTP.TimeoutError` whose `operation` is not "request_timeout", "read_idle_timeout"
 # configured, as an `HTTP.TimeoutError` whose `operation` is not "connect"/"tls_handshake".
-is_ttl_expired_exception(e::Base.IOError) = e == Base.IOError("read: connection timed out (ETIMEDOUT)", -110)
-is_ttl_expired_exception(e::HTTP.TimeoutError) = !(e.operation in ("connect", "tls_handshake"))
+function is_ttl_expired_exception(e::Base.IOError)
+	return e == Base.IOError("read: connection timed out (ETIMEDOUT)", -110)
+end
+
+function is_ttl_expired_exception(e::HTTP.TimeoutError)
+	return !(e.operation in ("connect", "tls_handshake"))
+end
+
 is_ttl_expired_exception(e::Exception) = false

--- a/src/utilities/exception_classification.jl
+++ b/src/utilities/exception_classification.jl
@@ -1,0 +1,15 @@
+# Determine if an exception is a HTTP connection failure. A connection-phase timeout surfaces
+# as a `TimeoutError` with `operation` of "connect"/"tls_handshake".
+is_connection_exception(e::HTTP.ConnectError) = true
+is_connection_exception(e::HTTP.TimeoutError) = e.operation in ("connect", "tls_handshake")
+is_connection_exception(e::Exception) = false
+
+# https://github.com/JuliaCloud/AWS.jl/issues/654
+# https://github.com/JuliaCloud/AWS.jl/issues/649
+#
+# A hop-limit rejection manifests as a read timeout. May surface as an `IOError` or
+# a `HTTP.TimeoutError` whose `operation` is not "request_timeout", "read_idle_timeout"
+# configured, as an `HTTP.TimeoutError` whose `operation` is not "connect"/"tls_handshake".
+is_ttl_expired_exception(e::Base.IOError) = e == Base.IOError("read: connection timed out (ETIMEDOUT)", -110)
+is_ttl_expired_exception(e::HTTP.TimeoutError) = !(e.operation in ("connect", "tls_handshake"))
+is_ttl_expired_exception(e::Exception) = false

--- a/src/utilities/request.jl
+++ b/src/utilities/request.jl
@@ -25,10 +25,6 @@ struct HTTPBackend <: AbstractBackend
     http_options::AbstractDict{Symbol,<:Any}
 end
 
-function statuserror(status, resp)
-    return HTTP.StatusError(status, resp.request.method, resp.request.target, resp)
-end
-
 function HTTPBackend(; kwargs...)
     return if isempty(kwargs)
         HTTPBackend(LittleDict{Symbol,Any}())
@@ -126,7 +122,7 @@ function submit_request(aws::AbstractAWSConfig, request::Request)
             if HTTP.header(response, "Location") != ""
                 request.url = HTTP.header(response, "Location")
             else
-                e = statuserror(response.status, response)
+                e = HTTP.StatusError(response.status, response)
                 throw(AWSException(e, stream))
             end
         end
@@ -162,12 +158,12 @@ function submit_request(aws::AbstractAWSConfig, request::Request)
         # Throttle handling
         # https://github.com/boto/botocore/blob/1.16.17/botocore/data/_retry.json
         # https://docs.aws.amazon.com/general/latest/gr/api-retries.html
-        if _http_status(e.cause) == TOO_MANY_REQUESTS || e.code in THROTTLING_ERROR_CODES
+        if e.cause.status == TOO_MANY_REQUESTS || e.code in THROTTLING_ERROR_CODES
             return true
         end
 
         # Handle BadDigest error and CRC32 check sum failure
-        if _header(e.cause, "crc32body") == "x-amz-crc32" ||
+        if HTTP.header(e.cause.response, "crc32body") == "x-amz-crc32" ||
             e.code in ("BadDigest", "RequestTimeout", "RequestTimeoutException")
             return true
         end
@@ -220,6 +216,7 @@ function _http_request(http_backend::HTTPBackend, request::Request, response_str
             redirect=false,
             retry=false,
             response_stream=buffer,
+            status_exception=true,
             http_options...,
         )
 
@@ -229,9 +226,9 @@ function _http_request(http_backend::HTTPBackend, request::Request, response_str
     end
 
     check = function (s, e)
-        return isa(e, HTTP.ConnectError) ||
-               isa(e, HTTP.RequestError) ||
-               (isa(e, HTTP.StatusError) && _http_status(e) >= 500)
+        return is_connection_exception(e) ||
+               HTTP.isrecoverable(e) ||
+               e isa HTTP.StatusError && e.status >= 500
     end
 
     delays = AWSExponentialBackoff(; max_attempts=4)
@@ -251,5 +248,14 @@ function _http_request(http_backend::HTTPBackend, request::Request, response_str
     return @mock Response(response, response_stream)
 end
 
-_http_status(e::HTTP.StatusError) = e.status
-_header(e::HTTP.StatusError, k, d="") = HTTP.header(e.response, k, d)
+# Lossy conversion of an `AWS.Request` into an `HTTP.Request`
+function _as_http_request(request::Request)
+    uri = HTTP.URI(request.url)
+    target = string(HTTP.URI(; uri.path, uri.query, uri.fragment))
+    return HTTP.Request(
+        request.request_method,
+        target;
+        headers=HTTP.mkheaders(request.headers),
+        host=uri.host,
+    )
+end

--- a/test/patch.jl
+++ b/test/patch.jl
@@ -2,19 +2,21 @@ module Patches
 
 using AWS
 using Dates
-using Downloads: Downloads
 using HTTP
 using Mocking
+
+using AWS: _as_http_request
+using Downloads: Downloads
 using OrderedCollections: LittleDict
 using ...Main: http_header
 
 version = v"1.1.0"
 status = 200
 headers = Pair[
-    "x-amz-id-2" => "x-amz-id-2",
-    "x-amz-request-id" => "x-amz-request-id",
+    "X-Amz-Id-2" => "x-amz-id-2",
+    "X-Amz-Request-Id" => "x-amz-request-id",
     "Date" => "Tue, 16 Jun 2020 21:29:18 GMT",
-    "x-amz-bucket-region" => "us-east-1",
+    "X-Amz-Bucket-Region" => "us-east-1",
     "Content-Type" => "application/xml",
     "Transfer-Encoding" => "chunked",
     "Server" => "AmazonS3",
@@ -48,15 +50,8 @@ function _response(;
     headers::Array=headers,
     body::String=body,
 )
-    response = HTTP.Messages.Response()
-
-    response.version = version
-    response.status = status
-    response.headers = headers
-    response.body = b"[Message Body was streamed]"
-
+    response = HTTP.Response(status, headers; body=b"[Message Body was streamed]")
     b = IOBuffer(body)
-
     return AWS.Response(response, b)
 end
 
@@ -79,8 +74,9 @@ function _throttling_patch(retries::Ref{Int})
 
     p = @patch function AWS._http_request(::AWS.AbstractBackend, request::Request, ::IO)
         retries[] += 1
-        resp = _response(; status=status, body=body).response
-        err = HTTP.StatusError(status, request.request_method, request.resource, resp)
+        req = _as_http_request(request)
+        resp = HTTP.Response(status, body; request=req)
+        err = HTTP.StatusError(status, resp)
         throw(AWS.AWSException(err, body))
     end
     return p
@@ -99,8 +95,9 @@ function _time_too_skewed_patch(retries)
 
     p = @patch function AWS._http_request(::AWS.AbstractBackend, request::Request, ::IO)
         retries[] += 1
-        resp = _response(; status=status, body=body).response
-        err = HTTP.StatusError(status, request.request_method, request.resource, resp)
+        req = _as_http_request(request)
+        resp = HTTP.Response(status, body; request=req)
+        err = HTTP.StatusError(status, resp)
         throw(AWS.AWSException(err, body))
     end
     return p
@@ -165,6 +162,7 @@ _http_options_patches = [
         delete!(options, :redirect)
         delete!(options, :retry)
         delete!(options, :response_stream)
+        delete!(options, :status_exception)
         return options
     end
     @patch AWS.Response(options, args...) = options
@@ -195,11 +193,11 @@ function gen_http_options_400_patches(message)
             if response_stream !== nothing
                 write(response_stream, body)
                 close(response_stream)  # Simulating current HTTP.jl 0.9.14 behaviour
-                body = IOBuffer()
+                body = nothing  # the body has been streamed, normalized to `HTTP.EmptyBody()`
             end
 
             response = HTTP.Response(400, headers; body=body, request=request)
-            exception = AWS.statuserror(400, response)
+            exception = HTTP.StatusError(400, response)
             return !status_exception ? response : throw(exception)
         end
         @patch function Downloads.request(args...; output=nothing, kwargs...)

--- a/test/unit/AWS.jl
+++ b/test/unit/AWS.jl
@@ -257,7 +257,7 @@ end
 
         # Access to response headers
         @test response.response.headers == Patches.headers
-        @test response.response.headers isa Vector
+        @test response.response.headers isa AbstractVector
 
         # Access to streaming content
         @test response.io isa IO
@@ -267,7 +267,7 @@ end
 
         # Backwards compatibility with those expecting an `HTTP.Response`
         @test response.headers == Patches.headers
-        @test response.headers isa Vector
+        @test response.headers isa AbstractVector
         @test String(response.body) == Patches.body
     end
 
@@ -285,7 +285,7 @@ end
 
         # Access to response headers
         @test response.response.headers == Patches.headers
-        @test response.response.headers isa Vector
+        @test response.response.headers isa AbstractVector
 
         # Access to streaming content
         @test response.io isa IO
@@ -295,7 +295,7 @@ end
 
         # Backwards compatibility with those expecting an `HTTP.Response`
         @test response.headers == Patches.headers
-        @test response.headers isa Vector
+        @test response.headers isa AbstractVector
         @test String(response.body) == Patches.body
     end
 

--- a/test/unit/AWSCredentials.jl
+++ b/test/unit/AWSCredentials.jl
@@ -1658,8 +1658,9 @@ end
 
     @testset "Credentials Not Found" begin
         patches = [
+            # Simulate the exception seen when falling back to IMDS when the service is unavailable
             @patch function HTTP.request(method::String, url, args...; kwargs...)
-                throw(HTTP.Exceptions.ConnectError(string(url), "host is unreachable"))
+                throw(HTTP.ConnectError(string(url), SystemError("connect", 64, nothing)))
             end
             Patches._cred_file_patch
             Patches._config_file_patch

--- a/test/unit/AWSExceptions.jl
+++ b/test/unit/AWSExceptions.jl
@@ -23,8 +23,7 @@
             "headers" => ["Content-Type" => "application/xml"],
             "status_code" => 400,
         )
-
-        expected["body"] = IOBuffer()
+        expected["body"] = HTTP.EmptyBody()
         expected["streamed_body"] = """
             <?xml version="1.0" encoding="UTF-8"?>
             <$err>
@@ -40,7 +39,7 @@
         resp = HTTP.Response(
             expected["status_code"], expected["headers"]; body=expected["body"], request=req
         )
-        status_error = AWS.statuserror(expected["status_code"], resp)
+        status_error = HTTP.StatusError(expected["status_code"], resp)
         ex = AWSException(status_error, expected["streamed_body"])
 
         _test_exception(ex, expected, msg)
@@ -50,7 +49,7 @@
 
     @testset "XMLRequest - Invalid XML" begin
         expected = Dict(
-            "body" => IOBuffer(),
+            "body" => HTTP.EmptyBody(),
             "streamed_body" => """<?xml version="1.0" encoding="UTF-8"?>InvalidXML""",
             "headers" => ["Content-Type" => "application/xml"],
             "status_code" => 404,
@@ -59,7 +58,7 @@
         resp = HTTP.Response(
             expected["status_code"], expected["headers"]; body=expected["body"], request=req
         )
-        status_error = AWS.statuserror(expected["status_code"], resp)
+        status_error = HTTP.StatusError(expected["status_code"], resp)
         ex = @test_logs (:error,) AWSException(status_error, expected["streamed_body"])
 
         @test ex.code == "404"
@@ -73,8 +72,7 @@
             "headers" => ["Content-Type" => "application/x-amz-json-1.1"],
             "status_code" => 400,
         )
-
-        expected["body"] = IOBuffer()
+        expected["body"] = HTTP.EmptyBody()
         expected["streamed_body"] = """
             {
             "__type": "$(expected["code"])",
@@ -87,7 +85,7 @@
         resp = HTTP.Response(
             expected["status_code"], expected["headers"]; body=expected["body"], request=req
         )
-        status_error = AWS.statuserror(expected["status_code"], resp)
+        status_error = HTTP.StatusError(expected["status_code"], resp)
         ex = AWSException(status_error, expected["streamed_body"])
 
         _test_exception(ex, expected, "$msg")
@@ -101,8 +99,7 @@
             "headers" => ["Content-Type" => "application/json"],
             "status_code" => 400,
         )
-
-        expected["body"] = IOBuffer()
+        expected["body"] = HTTP.EmptyBody()
         expected["streamed_body"] = "\"foo\""
 
         # This does not actually send a request, just creates the object to test with
@@ -110,7 +107,7 @@
         resp = HTTP.Response(
             expected["status_code"], expected["headers"]; body=expected["body"], request=req
         )
-        status_error = AWS.statuserror(expected["status_code"], resp)
+        status_error = HTTP.StatusError(expected["status_code"], resp)
         ex = AWSException(status_error, expected["streamed_body"])
 
         @test ex.code == expected["code"]

--- a/test/unit/IMDS.jl
+++ b/test/unit/IMDS.jl
@@ -46,9 +46,7 @@ end
 
 function response_route(method, path, response::HTTP.Response)
     handler = function (req::HTTP.Request)
-        return HTTP.Response(
-            response.version, response.status, response.headers, response.body, req
-        )
+        return HTTP.Response(response.status, response.headers; body=response.body, request=req)
     end
     return Route(method, path, handler)
 end
@@ -67,12 +65,9 @@ function _imds_patch(
         method,
         url,
         headers=[],
-        body=HTTP.nobody;
+        body=nothing;
         status_exception=true,
-        retry::Bool=true,
-        retries::Int=4,
-        retry_delays=ExponentialBackOff(; n=retries, factor=3),
-        retry_check=(args...) -> false,
+        retry_if=nothing,
         kwargs...,
     )
         uri = HTTP.URI(url)
@@ -80,9 +75,13 @@ function _imds_patch(
             error("Internal error: Unexpected HTTP call to non-IMDS service: $url")
         end
 
-        req = HTTP.Request(method, uri.path, headers, body)
-
-        function handler(req::HTTP.Request)
+        # `IMDS.request` delegates its 401-triggered token-refresh-and-retry to HTTP.jl's own
+        # retry engine via `retry_if`, rather than looping itself — so this mock (which
+        # replaces `HTTP.request` wholesale) must run a minimal retry loop of its own and
+        # consult `retry_if` the same way the real client would, or no retry would ever happen.
+        attempt = 1
+        while true
+            req = HTTP.Request(method, uri.path, headers, body)
             num_requests[] += 1
 
             resp = if listening && enabled
@@ -90,55 +89,52 @@ function _imds_patch(
             elseif listening && !enabled
                 HTTP.Response(403)
             else
-                connect_timeout = HTTP.ConnectionPool.ConnectTimeout(uri.host, uri.port)
-                throw(HTTP.Exceptions.ConnectError(string(uri), connect_timeout))
+                # Simulating the exception thrown when an HTTP service isn't listening. We are
+                # not perfectly replicating the exception thrown.
+                cause = SystemError("connect", 61, nothing)
+                throw(HTTP.ConnectError(string(uri), cause))
             end
 
-            # When `status_exception=false` retries do not occur as an exception needs to
-            # be raised for them to work. This replicates how `HTTP.request` works.
-            if status_exception && resp.status >= 300
-                ex = HTTP.Exceptions.StatusError(resp.status, req.method, req.target, resp)
-                throw(ex)
+            if resp.status >= 300
+                if !isnothing(retry_if) && retry_if(attempt, nothing, req, resp)
+                    attempt += 1
+                    headers = req.headers  # `retry_if` may have mutated the token header in place
+                    continue
+                end
+
+                # Replicate how `HTTP.request` reports non-2xx statuses.
+                status_exception && throw(HTTP.StatusError(resp.status, resp))
             end
+
             return resp
         end
-
-        retry_request = Base.retry(
-            handler;
-            delays=retry_delays,
-            check=(s, ex) -> begin
-                resp_body = get(req.context, :response_body, nothing)
-                resp = !isnothing(resp_body) ? req.response : nothing
-                retry = (
-                    (HTTP.RetryRequest.isrecoverable(ex) && HTTP.retryable(req)) || (
-                        HTTP.retryablebody(req) && retry_check(s, ex, req, resp, resp_body)
-                    )
-                )
-                return retry
-            end,
-        )
-
-        return retry_request(req)
     end
 end
+
+const ETIMEDOUT_EXCEPTION = Base.IOError("read: connection timed out (ETIMEDOUT)", -110)
 
 @testset "IMDS" begin
     @testset "is_connection_exception / is_ttl_expired_exception" begin
         url = "http://169.254.169.254/latest/api/token"
-        connect_timeout = HTTP.ConnectionPool.ConnectTimeout("169.254.169.254", 80)
-        e = HTTP.Exceptions.ConnectError(url, connect_timeout)
+        e = HTTP.ConnectError(url, ETIMEDOUT_EXCEPTION)
         @test IMDS.is_connection_exception(e)
         @test !IMDS.is_ttl_expired_exception(e)
 
-        request = HTTP.Request("PUT", "/latest/api/token", [], HTTP.nobody)
-        io_error = Base.IOError("read: connection timed out (ETIMEDOUT)", -110)
-        e = HTTP.Exceptions.RequestError(request, io_error)
+        e = ETIMEDOUT_EXCEPTION
         @test !IMDS.is_connection_exception(e)
         @test IMDS.is_ttl_expired_exception(e)
 
         e = ErrorException("non-connection error")
         @test !IMDS.is_connection_exception(e)
         @test !IMDS.is_ttl_expired_exception(e)
+
+        e = HTTP.TimeoutError("connect", 0, 0)
+        @test IMDS.is_connection_exception(e)
+        @test !IMDS.is_ttl_expired_exception(e)
+
+        e = HTTP.TimeoutError("response_header", 0, 0)
+        @test !IMDS.is_connection_exception(e)
+        @test IMDS.is_ttl_expired_exception(e)
     end
 
     @testset "refresh_token!" begin
@@ -162,7 +158,7 @@ end
         router = Router([response_route("PUT", "/latest/api/token", HTTP.Response(500))])
         apply(_imds_patch(router)) do
             session = IMDS.Session()
-            @test_throws HTTP.Exceptions.StatusError IMDS.refresh_token!(session)
+            @test_throws HTTP.StatusError IMDS.refresh_token!(session)
         end
 
         # IMDSv1 is available
@@ -192,8 +188,7 @@ end
         @testset "invalidate session token" begin
             # IMDSv2 hop limit is too low such that the TTL has expired
             connection_timeout = function (req::HTTP.Request)
-                io_error = Base.IOError("read: connection timed out (ETIMEDOUT)", -110)
-                throw(HTTP.Exceptions.RequestError(req, io_error))
+                throw(ETIMEDOUT_EXCEPTION)
             end
             router = Router([Route("PUT", "/latest/api/token", connection_timeout)])
             apply(_imds_patch(router)) do
@@ -246,7 +241,7 @@ end
         router = Router([response_route("GET", path, HTTP.Response(500))])
         apply(_imds_patch(router; num_requests)) do
             session = IMDS.Session()
-            @test_throws HTTP.Exceptions.StatusError IMDS.request(session, "GET", path)
+            @test_throws HTTP.StatusError IMDS.request(session, "GET", path)
             @test num_requests[] == 2
         end
 
@@ -318,8 +313,7 @@ end
         # https://github.com/JuliaCloud/AWS.jl/issues/654
         # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html#imds-considerations
         connection_timeout = function (req::HTTP.Request)
-            io_error = Base.IOError("read: connection timed out (ETIMEDOUT)", -110)
-            throw(HTTP.Exceptions.RequestError(req, io_error))
+            throw(ETIMEDOUT_EXCEPTION)
         end
         router = Router([
             Route("PUT", "/latest/api/token", connection_timeout),

--- a/test/unit/issues.jl
+++ b/test/unit/issues.jl
@@ -14,7 +14,7 @@
                 attempt_num += 1
                 if attempt_num <= num_attempts_to_fail
                     write(response_stream, data[1:(n - 1)]) # an incomplete stream that shouldn't be retained
-                    throw(HTTP.RequestError(HTTP.Request(), EOFError()))
+                    throw(EOFError())
                 else
                     write(response_stream, data)
                     return HTTP.Response(200, "{\"Location\": \"us-east-1\"}")
@@ -56,7 +56,7 @@
 
     @testset "Fail all 4 attempts then throw" begin
         err_t = if AWS.DEFAULT_BACKEND[] isa AWS.HTTPBackend
-            HTTP.RequestError
+            EOFError
         else
             Downloads.RequestError
         end


### PR DESCRIPTION
Takes the work done in #775 and refactors it to only support HTTP.jl 2 for our breaking release.